### PR TITLE
[GENERIC viewer] Fallback to the short-format of the language code (issue 17269)

### DIFF
--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -45,8 +45,18 @@ class GenericL10n extends L10n {
    */
   static async *#generateBundles(defaultLang, baseLang) {
     const { baseURL, paths } = await this.#getPaths();
-    const langs =
-      baseLang === defaultLang ? [baseLang] : [baseLang, defaultLang];
+
+    const langs = [baseLang];
+    if (defaultLang !== baseLang) {
+      // Also fallback to the short-format of the base language
+      // (see issue 17269).
+      const shortLang = baseLang.split("-", 1)[0];
+
+      if (shortLang !== baseLang) {
+        langs.push(shortLang);
+      }
+      langs.push(defaultLang);
+    }
     for (const lang of langs) {
       const bundle = await this.#createBundle(lang, baseURL, paths);
       if (bundle) {


### PR DESCRIPTION
This shouldn't cause any issues, since `GenericL10n.#createBundle` has an early return for languages that don't exist in the `locale.json` file.