### PR TITLE
Get the field name from its parent when it doesn't have one when collecting fields (bug 1864136)

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -176,6 +176,28 @@ async function getFirstSerialized(page, filter = undefined) {
   return (await getSerialized(page, filter))[0];
 }
 
+function getAnnotationStorage(page) {
+  return page.evaluate(() =>
+    Object.fromEntries(
+      window.PDFViewerApplication.pdfDocument.annotationStorage.serializable.map?.entries() ||
+        []
+    )
+  );
+}
+
+function waitForEntryInStorage(page, key, value) {
+  return page.waitForFunction(
+    (k, v) => {
+      const { map } =
+        window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;
+      return map && JSON.stringify(map.get(k)) === v;
+    },
+    {},
+    key,
+    JSON.stringify(value)
+  );
+}
+
 function getEditors(page, kind) {
   return page.evaluate(aKind => {
     const elements = document.querySelectorAll(`.${aKind}Editor`);
@@ -398,6 +420,7 @@ export {
   clearInput,
   closePages,
   dragAndDropAnnotation,
+  getAnnotationStorage,
   getComputedStyleSelector,
   getEditorDimensions,
   getEditors,
@@ -427,6 +450,7 @@ export {
   scrollIntoView,
   serializeBitmapDimensions,
   waitForAnnotationEditorLayer,
+  waitForEntryInStorage,
   waitForEvent,
   waitForSelectedEditor,
   waitForSerialized,


### PR DESCRIPTION
Some fields, somewhere under the Fields entry in Acroform, could have no name (in T)
but with a parent which has a name but which isn't somewhere under Fields.
As a side-effect, this patch prevents infinite loops because of potential cycles
under Fields.