### PR TITLE
Re-factor the `L10n`-implementations to use lowercase language-codes internally

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -896,10 +896,11 @@ gulp.task("locale", function () {
     locales.push(locale);
 
     if (checkFile(dirPath + "/viewer.ftl")) {
-      viewerOutput[locale] = `${locale}/viewer.ftl`;
+      // The L10n-implementations, in the viewer, use lowercase language-codes
+      // internally.
+      viewerOutput[locale.toLowerCase()] = `${locale}/viewer.ftl`;
     }
   }
-
   const glob = locales.length === 1 ? locales[0] : `{${locales.join(",")}}`;
 
   return merge([

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -48,7 +48,7 @@ class GenericExternalServices extends DefaultExternalServices {
   }
 
   static async createL10n() {
-    return new GenericL10n(AppOptions.get("locale") || "en-US");
+    return new GenericL10n(AppOptions.get("locale"));
   }
 
   static createScripting({ sandboxBundleSrc }) {

--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -30,7 +30,7 @@ class GenericL10n extends L10n {
         [],
         GenericL10n.#generateBundles.bind(
           GenericL10n,
-          "en-US",
+          "en-us",
           this.getLanguage()
         )
       )

--- a/web/l10n.js
+++ b/web/l10n.js
@@ -16,6 +16,8 @@
 /** @typedef {import("./interfaces").IL10n} IL10n */
 
 /**
+ * NOTE: The L10n-implementations should use lowercase language-codes
+ *       internally.
  * @implements {IL10n}
  */
 class L10n {
@@ -86,24 +88,27 @@ class L10n {
   }
 
   static #fixupLangCode(langCode) {
+    // Use only lowercase language-codes internally, and fallback to English.
+    langCode = langCode?.toLowerCase() || "en-us";
+
     // Try to support "incompletely" specified language codes (see issue 13689).
     const PARTIAL_LANG_CODES = {
-      en: "en-US",
-      es: "es-ES",
-      fy: "fy-NL",
-      ga: "ga-IE",
-      gu: "gu-IN",
-      hi: "hi-IN",
-      hy: "hy-AM",
-      nb: "nb-NO",
-      ne: "ne-NP",
-      nn: "nn-NO",
-      pa: "pa-IN",
-      pt: "pt-PT",
-      sv: "sv-SE",
-      zh: "zh-CN",
+      en: "en-us",
+      es: "es-es",
+      fy: "fy-nl",
+      ga: "ga-ie",
+      gu: "gu-in",
+      hi: "hi-in",
+      hy: "hy-am",
+      nb: "nb-no",
+      ne: "ne-np",
+      nn: "nn-no",
+      pa: "pa-in",
+      pt: "pt-pt",
+      sv: "sv-se",
+      zh: "zh-cn",
     };
-    return PARTIAL_LANG_CODES[langCode?.toLowerCase()] || langCode;
+    return PARTIAL_LANG_CODES[langCode] || langCode;
   }
 
   static #isRTL(lang) {

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -50,7 +50,7 @@ class ConstL10n extends L10n {
   }
 
   static get instance() {
-    return shadow(this, "instance", new ConstL10n("en-US"));
+    return shadow(this, "instance", new ConstL10n("en-us"));
   }
 }
 

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -19,7 +19,7 @@ import { PDFDateString, PromiseCapability } from "pdfjs-lib";
 const DEFAULT_FIELD_CONTENT = "-";
 
 // See https://en.wikibooks.org/wiki/Lentis/Conversion_to_the_Metric_Standard_in_the_United_States
-const NON_METRIC_LOCALES = ["en-US", "en-LR", "my"];
+const NON_METRIC_LOCALES = ["en-us", "en-lr", "my"];
 
 // Should use the format: `width x height`, in portrait orientation. The names,
 // which are l10n-ids, should be lowercase.


### PR DESCRIPTION
This is consistent with the implementation used in the (now removed) webL10n-library, and by only using lowercase language-codes internally in the `L10n`-implementations we should avoid future issues e.g. when users manually set the `locale`-option (in the default viewer).