### PR TITLE
Throw a `JpegError` when a JPEG image has no frame data (issue 17302)

### DIFF
--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -1073,6 +1073,9 @@ class JpegImage {
       offset += 2;
     }
 
+    if (!frame) {
+      throw new JpegError("JpegImage.parse - no frame data found.");
+    }
     this.width = frame.samplesPerLine;
     this.height = frame.scanLines;
     this.jfif = jfif;


### PR DESCRIPTION
Given that there's nothing to parse in this case, since we're dealing with an invalid JPEG image, throwing an *explicit* Error makes sense here.