### PR TITLE
Fix examples/webpack/README.md. 

### DIFF
--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -27,7 +27,7 @@ otherwise the build is not guaranteed to work correctly.
 ## Worker loading
 
 If you are getting the `Setting up fake worker` warning, make sure you are
-importing `pdfjs-dist/webpack` which is the zero-configuration method for
+importing `pdfjs-dist/webpack.mjs` which is the zero-configuration method for
 Webpack users. Installing `worker-loader` is no longer necessary.
 
-    import * as pdfjsLib from 'pdfjs-dist/webpack';
+    import * as pdfjsLib from 'pdfjs-dist/webpack.mjs';


### PR DESCRIPTION
Fix `examples/webpack/README.md`. The `.mjs` extension is necessary. Close #17319