### PR TITLE
Use the `fetchData` helper function in more cases

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -399,6 +399,8 @@ async function fetchData(url, type = "text") {
     switch (type) {
       case "arraybuffer":
         return response.arrayBuffer();
+      case "blob":
+        return response.blob();
       case "json":
         return response.json();
     }
@@ -419,6 +421,7 @@ async function fetchData(url, type = "text") {
         let data;
         switch (type) {
           case "arraybuffer":
+          case "blob":
           case "json":
             data = request.response;
             break;

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -27,7 +27,12 @@ import {
   Util,
   warn,
 } from "../../shared/util.js";
-import { getColorValues, getRGB, PixelsPerInch } from "../display_utils.js";
+import {
+  fetchData,
+  getColorValues,
+  getRGB,
+  PixelsPerInch,
+} from "../display_utils.js";
 
 function bindEvents(obj, element, names) {
   for (const name of names) {
@@ -116,12 +121,7 @@ class ImageManager {
       let image;
       if (typeof rawData === "string") {
         data.url = rawData;
-
-        const response = await fetch(rawData);
-        if (!response.ok) {
-          throw new Error(response.statusText);
-        }
-        image = await response.blob();
+        image = await fetchData(rawData, "blob");
       } else {
         image = data.file = rawData;
       }

--- a/web/l10n_utils.js
+++ b/web/l10n_utils.js
@@ -15,10 +15,10 @@
 
 /** @typedef {import("./interfaces").IL10n} IL10n */
 
+import { fetchData, shadow } from "pdfjs-lib";
 import { FluentBundle, FluentResource } from "fluent-bundle";
 import { DOMLocalization } from "fluent-dom";
 import { L10n } from "./l10n.js";
-import { shadow } from "pdfjs-lib";
 
 /**
  * @implements {IL10n}
@@ -32,14 +32,14 @@ class ConstL10n extends L10n {
   }
 
   static async *#generateBundles(lang) {
-    let text;
-    if (typeof PDFJSDev === "undefined") {
-      const url = new URL(`./locale/${lang}/viewer.ftl`, window.location.href);
-      const data = await fetch(url);
-      text = await data.text();
-    } else {
-      text = PDFJSDev.eval("DEFAULT_FTL");
-    }
+    const text =
+      typeof PDFJSDev === "undefined"
+        ? await fetchData(
+            new URL(`./locale/${lang}/viewer.ftl`, window.location.href),
+            /* type = */ "text"
+          )
+        : PDFJSDev.eval("DEFAULT_FTL");
+
     const resource = new FluentResource(text);
     const bundle = new FluentBundle(lang);
     const errors = bundle.addResource(resource);


### PR DESCRIPTION
 - Extend the `fetchData` helper function to also support fetching of "blob" data.

 - Use the `fetchData` helper function more in the code-base, when fetching non-PDF data. Given that the Fetch API isn't supported for all protocols, this should improve compatibility for the PDF.js library.