### PR TITLE
[Editor] Only focus the canvas for mouse events when drawing in the canvas

### DIFF
--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -660,8 +660,13 @@ class InkEditor extends AnnotationEditor {
 
     event.preventDefault();
 
-    if (event.type !== "mouse") {
-      this.div.focus();
+    if (
+      event.pointerType !== "mouse" &&
+      !this.div.contains(document.activeElement)
+    ) {
+      this.div.focus({
+        preventScroll: true /* See issue #17327 */,
+      });
     }
 
     this.#startDrawing(event.offsetX, event.offsetY);


### PR DESCRIPTION
And if we've to focus it, we must prevent scrolling to avoid to draw at an unexpected position.