### PR TITLE
Remove useless message handlers

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -87,8 +87,11 @@ class WorkerMessageHandler {
       setVerbosityLevel(data.verbosity);
     });
 
-    handler.on("GetDocRequest", function (data) {
-      return WorkerMessageHandler.createDocumentHandler(data, port);
+    handler.on("GetDocRequest", function ({ source, singleUse }) {
+      if (singleUse) {
+        handler.destroy();
+      }
+      return WorkerMessageHandler.createDocumentHandler(source, port);
     });
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1000,6 +1000,7 @@ const PDFViewerApplication = {
     const loadingTask = getDocument({
       ...apiParams,
       ...args,
+      singleUse: true,
     });
     this.pdfLoadingTask = loadingTask;
 


### PR DESCRIPTION
These handlers are used to initiate the communication between the content thread and the worker and they aren't used once the document is loaded, hence we can remove them.