### PR TITLE
Remove the "transitionend" event listener from the default viewer (issue 17347)

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -2209,10 +2209,10 @@ describe("annotation", function () {
     });
 
     it("should compress and save text", async function () {
-      if (isNodeJS && getNodeVersion().major === 21) {
+      if (isNodeJS && getNodeVersion().major >= 20) {
         pending(
-          "CompressionStream behaves differently in Node.js 21, " +
-            "compared to Firefox, Chrome, and Node.js 18/20."
+          "CompressionStream behaves differently in Node.js >= 20, " +
+            "compared to Firefox, Chrome, and Node.js 18."
         );
       }
       const textWidgetRef = Ref.get(123, 0);

--- a/web/app.js
+++ b/web/app.js
@@ -689,16 +689,6 @@ const PDFViewerApplication = {
       appConfig.toolbar?.viewFind?.classList.add("hidden");
     }
 
-    appConfig.mainContainer.addEventListener(
-      "transitionend",
-      function (evt) {
-        if (evt.target === /* mainContainer */ this) {
-          eventBus.dispatch("resize", { source: this });
-        }
-      },
-      true
-    );
-
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       if (file) {
         this.open({ url: file });

--- a/web/pdf_sidebar.js
+++ b/web/pdf_sidebar.js
@@ -329,6 +329,8 @@ class PDFSidebar {
     this.sidebarContainer.addEventListener("transitionend", evt => {
       if (evt.target === this.sidebarContainer) {
         this.outerContainer.classList.remove("sidebarMoving");
+        // Ensure that rendering is triggered after opening/closing the sidebar.
+        this.eventBus.dispatch("resize", { source: this });
       }
     });
 


### PR DESCRIPTION
Given that this event listener is only used to trigger rendering after the sidebar has been opened/closed, we can utilize the existing one in the `PDFSidebar` class for this purpose instead. That one is registered on the sidebar DOM-element, and is needed to remove a CSS-class indicating that the sidebar is moving.