### PR TITLE
[Firefox] Restore opening of PDF attachments (issue 17353, bug 1867764)

### DIFF
--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -112,9 +112,11 @@ class DownloadManager {
         this.#openBlobUrls.set(data, blobUrl);
       }
       // Let Firefox's content handler catch the URL and display the PDF.
-      let viewerUrl = blobUrl + "?filename=" + encodeURIComponent(filename);
+      // NOTE: This cannot use a query string for the filename, see
+      //       https://bugzilla.mozilla.org/show_bug.cgi?id=1632644#c5
+      let viewerUrl = blobUrl + "#filename=" + encodeURIComponent(filename);
       if (dest) {
-        viewerUrl += `#${escape(dest)}`;
+        viewerUrl += `&filedest=${escape(dest)}`;
       }
 
       try {

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -431,32 +431,41 @@ class PDFLinkService {
       if (params.has("nameddest")) {
         this.goToDestination(params.get("nameddest"));
       }
-    } else {
-      // Named (or explicit) destination.
-      dest = unescape(hash);
-      try {
-        dest = JSON.parse(dest);
 
-        if (!Array.isArray(dest)) {
-          // Avoid incorrectly rejecting a valid named destination, such as
-          // e.g. "4.3" or "true", because `JSON.parse` converted its type.
-          dest = dest.toString();
-        }
-      } catch {}
-
-      if (
-        typeof dest === "string" ||
-        PDFLinkService.#isValidExplicitDestination(dest)
-      ) {
-        this.goToDestination(dest);
+      if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
         return;
       }
-      console.error(
-        `PDFLinkService.setHash: "${unescape(
-          hash
-        )}" is not a valid destination.`
-      );
+      // Support opening of PDF attachments in the Firefox PDF Viewer,
+      // which uses a couple of non-standard hash parameters; refer to
+      // `DownloadManager.openOrDownloadData` in the firefoxcom.js file.
+      if (!params.has("filename") || !params.has("filedest")) {
+        return;
+      }
+      hash = params.get("filedest");
     }
+
+    // Named (or explicit) destination.
+    dest = unescape(hash);
+    try {
+      dest = JSON.parse(dest);
+
+      if (!Array.isArray(dest)) {
+        // Avoid incorrectly rejecting a valid named destination, such as
+        // e.g. "4.3" or "true", because `JSON.parse` converted its type.
+        dest = dest.toString();
+      }
+    } catch {}
+
+    if (
+      typeof dest === "string" ||
+      PDFLinkService.#isValidExplicitDestination(dest)
+    ) {
+      this.goToDestination(dest);
+      return;
+    }
+    console.error(
+      `PDFLinkService.setHash: "${unescape(hash)}" is not a valid destination.`
+    );
   }
 
   /**


### PR DESCRIPTION
This unfortunately broke in PR #17060, since I had completely forgotten about https://bugzilla.mozilla.org/show_bug.cgi?id=1632644#c5 when writing that patch.
The easiest solution, while slightly unfortunate, seems to be to add a couple of non-standard hash parameters specifically for the PDF attachment use-case in the Firefox PDF Viewer. (Note that we cannot use "nameddest" here, since we also need to support the stringified destination-Array case.)

Fixes https://github.com/mozilla/pdf.js/discussions/17353