### PR TITLE
Limit the amount of console "spam" during fuzz tests (PR 17337 follow-up)

### DIFF
--- a/src/pdf.image_decoders.js
+++ b/src/pdf.image_decoders.js
@@ -13,7 +13,11 @@
  * limitations under the License.
  */
 
-import { getVerbosityLevel, setVerbosityLevel } from "./shared/util.js";
+import {
+  getVerbosityLevel,
+  setVerbosityLevel,
+  VerbosityLevel,
+} from "./shared/util.js";
 import { Jbig2Image } from "./core/jbig2.js";
 import { JpegImage } from "./core/jpg.js";
 import { JpxImage } from "./core/jpx.js";
@@ -31,4 +35,5 @@ export {
   JpegImage,
   JpxImage,
   setVerbosityLevel,
+  VerbosityLevel,
 };

--- a/test/fuzz/jbig2_image.fuzz.js
+++ b/test/fuzz/jbig2_image.fuzz.js
@@ -1,4 +1,11 @@
-import { Jbig2Image } from "../../build/image_decoders/pdf.image_decoders.mjs";
+import {
+  Jbig2Image,
+  setVerbosityLevel,
+  VerbosityLevel,
+} from "../../build/image_decoders/pdf.image_decoders.mjs";
+
+// Avoid unnecessary console "spam", by ignoring `info`/`warn` calls.
+setVerbosityLevel(VerbosityLevel.ERRORS);
 
 const ignored = ["Cannot read properties", "JBIG2 error"];
 

--- a/test/fuzz/jpeg_image.fuzz.js
+++ b/test/fuzz/jpeg_image.fuzz.js
@@ -1,4 +1,11 @@
-import { JpegImage } from "../../build/image_decoders/pdf.image_decoders.mjs";
+import {
+  JpegImage,
+  setVerbosityLevel,
+  VerbosityLevel,
+} from "../../build/image_decoders/pdf.image_decoders.mjs";
+
+// Avoid unnecessary console "spam", by ignoring `info`/`warn` calls.
+setVerbosityLevel(VerbosityLevel.ERRORS);
 
 const ignored = ["Cannot read properties", "JPEG error"];
 

--- a/test/fuzz/jpx_image.fuzz.js
+++ b/test/fuzz/jpx_image.fuzz.js
@@ -1,4 +1,11 @@
-import { JpxImage } from "../../build/image_decoders/pdf.image_decoders.mjs";
+import {
+  JpxImage,
+  setVerbosityLevel,
+  VerbosityLevel,
+} from "../../build/image_decoders/pdf.image_decoders.mjs";
+
+// Avoid unnecessary console "spam", by ignoring `info`/`warn` calls.
+setVerbosityLevel(VerbosityLevel.ERRORS);
 
 const ignored = ["Cannot read properties", "JPX error"];
 

--- a/test/unit/pdf.image_decoders_spec.js
+++ b/test/unit/pdf.image_decoders_spec.js
@@ -13,7 +13,11 @@
  * limitations under the License.
  */
 
-import { getVerbosityLevel, setVerbosityLevel } from "../../src/shared/util.js";
+import {
+  getVerbosityLevel,
+  setVerbosityLevel,
+  VerbosityLevel,
+} from "../../src/shared/util.js";
 import { Jbig2Image } from "../../src/core/jbig2.js";
 import { JpegImage } from "../../src/core/jpg.js";
 import { JpxImage } from "../../src/core/jpx.js";
@@ -35,6 +39,7 @@ describe("pdfimage_api", function () {
       JpegImage,
       JpxImage,
       setVerbosityLevel,
+      VerbosityLevel,
     });
   });
 });


### PR DESCRIPTION
Having just tested PR #17337 locally I noticed that especially the `JpxImage`-test causes a "ridiculous" amount of warning messages to be printed, which doesn't seem helpful.
Given that only actual `Error`s should be relevant here, we can easily disable this logging during the tests.