### PR TITLE
[Editor] Always give the focus to the ink editor when starting drawing (bug 1867588)

### DIFF
--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -660,10 +660,7 @@ class InkEditor extends AnnotationEditor {
 
     event.preventDefault();
 
-    if (
-      event.pointerType !== "mouse" &&
-      !this.div.contains(document.activeElement)
-    ) {
+    if (!this.div.contains(document.activeElement)) {
       this.div.focus({
         preventScroll: true /* See issue #17327 */,
       });


### PR DESCRIPTION
This way, when the editor is blurred, it can be committed and everything works fine.
It fixes issue #17373.