### PR TITLE
Remove unneeded awaits for events from input actions

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -3017,27 +3017,9 @@ describe("FreeText Editor", () => {
             `${getEditorSelector(0)} .overlay.enabled`
           );
 
-          let promise = page.evaluate(
-            () =>
-              new Promise(resolve => {
-                document.addEventListener("selectionchange", resolve, {
-                  once: true,
-                });
-              })
-          );
           await page.click("#pageNumber");
-          await promise;
 
-          promise = page.evaluate(
-            () =>
-              new Promise(resolve => {
-                document
-                  .getElementById("pageNumber")
-                  .addEventListener("keyup", resolve, { once: true });
-              })
-          );
           await page.keyboard.press("Backspace");
-          await promise;
 
           let content = await page.$eval("#pageNumber", el =>
             el.innerText.trimEnd()


### PR DESCRIPTION
This logic is problematic to run with WebDriver BiDi, because if we don't await on the script evaluation, we have no guarantee that the script was fully run before the code goes to the next step. In this case, for example, the event listener is set up after the input actions are triggered, so the event is never caught and promise is never resolved.
It looks like it's not really needed here, neither for WebDriver BiDi nor for CDP.