### PR TITLE
[Editor] Avoid to have a color picker for highlighting twice in the main toolbar

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -121,12 +121,17 @@ class Toolbar {
     this.#bindListeners(options);
 
     if (options.editorHighlightColorPicker) {
-      this.eventBus._on("annotationeditoruimanager", ({ uiManager }) => {
-        this.#setAnnotationEditorUIManager(
-          uiManager,
-          options.editorHighlightColorPicker
-        );
-      });
+      this.eventBus._on(
+        "annotationeditoruimanager",
+        ({ uiManager }) => {
+          this.#setAnnotationEditorUIManager(
+            uiManager,
+            options.editorHighlightColorPicker
+          );
+        },
+        // Once the color picker has been added, we don't want to add it again.
+        { once: true }
+      );
     }
 
     this.reset();


### PR DESCRIPTION
When opening a pdf from the secondary toolbar, a second color picker is added. So in order to avoid that, we just stop listening for annotationeditoruimanager in the toolbar.