### PR TITLE
Collect a few non-MOZCENTRAL `AppOptions` default values together

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -343,26 +343,12 @@ const defaultOptions = {
   },
 };
 if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-  defaultOptions.viewerCssTheme = {
-    /** @type {number} */
-    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME") ? 2 : 0,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  };
-}
-if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   defaultOptions.defaultUrl = {
     /** @type {string} */
-    value: "compressed.tracemonkey-pldi-09.pdf",
-    kind: OptionKind.VIEWER,
-  };
-  defaultOptions.disablePreferences = {
-    /** @type {boolean} */
-    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER,
-  };
-  defaultOptions.locale = {
-    /** @type {string} */
-    value: navigator.language || "en-US",
+    value:
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")
+        ? ""
+        : "compressed.tracemonkey-pldi-09.pdf",
     kind: OptionKind.VIEWER,
   };
   defaultOptions.sandboxBundleSrc = {
@@ -373,21 +359,28 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
         : "../build/pdf.sandbox.mjs",
     kind: OptionKind.VIEWER,
   };
-} else if (PDFJSDev.test("CHROME")) {
-  defaultOptions.defaultUrl = {
-    /** @type {string} */
-    value: "",
+  defaultOptions.viewerCssTheme = {
+    /** @type {number} */
+    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME") ? 2 : 0,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  };
+}
+if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+  defaultOptions.disablePreferences = {
+    /** @type {boolean} */
+    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
     kind: OptionKind.VIEWER,
   };
+  defaultOptions.locale = {
+    /** @type {string} */
+    value: navigator.language || "en-US",
+    kind: OptionKind.VIEWER,
+  };
+} else if (PDFJSDev.test("CHROME")) {
   defaultOptions.disableTelemetry = {
     /** @type {boolean} */
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  };
-  defaultOptions.sandboxBundleSrc = {
-    /** @type {string} */
-    value: "../build/pdf.sandbox.js",
-    kind: OptionKind.VIEWER,
   };
 }
 


### PR DESCRIPTION
Ideally we want as few build-specific branches as possible when defining the default values, to improve readability, hence this change cannot hurt.