### PR TITLE
Update Puppeteer to version 21.6.0 and force "CDP" protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "postcss-discard-comments": "^6.0.0",
         "postcss-nesting": "^12.0.1",
         "prettier": "^3.1.0",
-        "puppeteer": "^21.5.2",
+        "puppeteer": "^21.6.0",
         "rimraf": "^3.0.2",
         "streamqueue": "^1.1.2",
         "stylelint": "^15.11.0",
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.0.tgz",
+      "integrity": "sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
@@ -4463,9 +4463,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.33",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.33.tgz",
-      "integrity": "sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.1.tgz",
+      "integrity": "sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.1",
@@ -17651,28 +17651,31 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
-      "integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
+      "version": "21.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.0.tgz",
+      "integrity": "sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.8.0",
+        "@puppeteer/browsers": "1.9.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.2"
+        "puppeteer-core": "21.6.0"
+      },
+      "bin": {
+        "puppeteer": "lib/esm/puppeteer/node/cli.js"
       },
       "engines": {
         "node": ">=16.13.2"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
-      "integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
+      "version": "21.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
+      "integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.8.0",
-        "chromium-bidi": "0.4.33",
+        "@puppeteer/browsers": "1.9.0",
+        "chromium-bidi": "0.5.1",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1203626",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "postcss-discard-comments": "^6.0.0",
     "postcss-nesting": "^12.0.1",
     "prettier": "^3.1.0",
-    "puppeteer": "^21.5.2",
+    "puppeteer": "^21.6.0",
     "rimraf": "^3.0.2",
     "streamqueue": "^1.1.2",
     "stylelint": "^15.11.0",

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -908,6 +908,7 @@ function unitTestPostHandler(req, res) {
 async function startBrowser({ browserName, headless, startUrl }) {
   const options = {
     product: browserName,
+    protocol: "cdp",
     // Note that using `headless: true` gives a deprecation warning; see
     // https://github.com/puppeteer/puppeteer#default-runtime-settings.
     headless: headless === true ? "new" : false,


### PR DESCRIPTION
Similar to PR #17392 but also enforcing `CDP` as protocol to workaround a regression in the recent Puppeteer release.