### PR TITLE
Support Annotations with corrupt /BS-entries

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -999,12 +999,15 @@ class Annotation {
     }
     if (borderStyle.has("BS")) {
       const dict = borderStyle.get("BS");
-      const dictType = dict.get("Type");
 
-      if (!dictType || isName(dictType, "Border")) {
-        this.borderStyle.setWidth(dict.get("W"), this.rectangle);
-        this.borderStyle.setStyle(dict.get("S"));
-        this.borderStyle.setDashArray(dict.getArray("D"));
+      if (dict instanceof Dict) {
+        const dictType = dict.get("Type");
+
+        if (!dictType || isName(dictType, "Border")) {
+          this.borderStyle.setWidth(dict.get("W"), this.rectangle);
+          this.borderStyle.setStyle(dict.get("S"));
+          this.borderStyle.setDashArray(dict.getArray("D"));
+        }
       }
     } else if (borderStyle.has("Border")) {
       const array = borderStyle.getArray("Border");

--- a/test/pdfs/pypdf2332.pdf.link
+++ b/test/pdfs/pypdf2332.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/py-pdf/pypdf/files/13606678/output.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4902,6 +4902,15 @@
        "rounds": 1,
        "type": "eq"
     },
+    {  "id": "pypdf2332",
+       "file": "pdfs/pypdf2332.pdf",
+       "md5": "883d2cf4d0ed16e32c917498fe9843dd",
+       "rounds": 1,
+       "link": true,
+       "lastPage": 1,
+       "type": "eq",
+       "annotations": true
+    },
     {  "id": "issue6151",
        "file": "pdfs/issue6151.pdf",
        "md5": "926f8c6b25e6f0978759f7947d70e079",

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -35,7 +35,6 @@ import {
 import {
   CMAP_URL,
   createIdFactory,
-  getNodeVersion,
   STANDARD_FONT_DATA_URL,
   XRefMock,
 } from "./test_utils.js";
@@ -2209,10 +2208,9 @@ describe("annotation", function () {
     });
 
     it("should compress and save text", async function () {
-      if (isNodeJS && getNodeVersion().major >= 20) {
+      if (isNodeJS) {
         pending(
-          "CompressionStream behaves differently in Node.js >= 20, " +
-            "compared to Firefox, Chrome, and Node.js 18."
+          "CompressionStream behaves differently in Node.js, compared to Firefox and Chrome."
         );
       }
       const textWidgetRef = Ref.get(123, 0);

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -144,22 +144,11 @@ function createIdFactory(pageIndex) {
   return page._localIdFactory;
 }
 
-function getNodeVersion() {
-  if (!isNodeJS) {
-    throw new Error("getNodeVersion - only valid in Node.js environments.");
-  }
-  const [major, minor, patch] = process.versions.node
-    .split(".")
-    .map(parseFloat);
-  return { major, minor, patch };
-}
-
 export {
   buildGetDocumentParams,
   CMAP_URL,
   createIdFactory,
   DefaultFileReaderFactory,
-  getNodeVersion,
   STANDARD_FONT_DATA_URL,
   TEST_PDFS_PATH,
   XRefMock,


### PR DESCRIPTION
There's obviously a few things wrong with the Annotations in the referenced PDF document, however parsing of an Annotation shouldn't just break if the /BS-entry isn't a dictionary.

*The PDF document was found here:* https://github.com/py-pdf/pypdf/issues/2332#issuecomment-1846281416