### PR TITLE
Re-factor how the `sandboxBundleSrc` option is passed to `PDFScriptingManager`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -110,7 +110,7 @@ class DefaultExternalServices {
     throw new Error("Not implemented: createL10n");
   }
 
-  static createScripting(options) {
+  static createScripting() {
     throw new Error("Not implemented: createScripting");
   }
 
@@ -395,10 +395,6 @@ const PDFViewerApplication = {
 
     const pdfScriptingManager = new PDFScriptingManager({
       eventBus,
-      sandboxBundleSrc:
-        typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC || CHROME")
-          ? AppOptions.get("sandboxBundleSrc")
-          : null,
       externalServices,
       docProperties: this._scriptingDocProperties.bind(this),
     });

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -439,8 +439,8 @@ class ChromeExternalServices extends DefaultExternalServices {
     return new GenericL10n(navigator.language);
   }
 
-  static createScripting({ sandboxBundleSrc }) {
-    return new GenericScripting(sandboxBundleSrc);
+  static createScripting() {
+    return new GenericScripting(AppOptions.get("sandboxBundleSrc"));
   }
 }
 PDFViewerApplication.externalServices = ChromeExternalServices;

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -402,7 +402,7 @@ class FirefoxExternalServices extends DefaultExternalServices {
     return new L10n(localeProperties, document.l10n);
   }
 
-  static createScripting(options) {
+  static createScripting() {
     return FirefoxScripting;
   }
 

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -51,8 +51,8 @@ class GenericExternalServices extends DefaultExternalServices {
     return new GenericL10n(AppOptions.get("locale"));
   }
 
-  static createScripting({ sandboxBundleSrc }) {
-    return new GenericScripting(sandboxBundleSrc);
+  static createScripting() {
+    return new GenericScripting(AppOptions.get("sandboxBundleSrc"));
   }
 }
 PDFViewerApplication.externalServices = GenericExternalServices;

--- a/web/pdf_scripting_manager.component.js
+++ b/web/pdf_scripting_manager.component.js
@@ -30,8 +30,8 @@ class PDFScriptingManagerComponents extends PDFScriptingManager {
     }
 
     options.externalServices ||= {
-      createScripting: ({ sandboxBundleSrc }) => {
-        return new GenericScripting(sandboxBundleSrc);
+      createScripting: () => {
+        return new GenericScripting(options.sandboxBundleSrc);
       },
     };
     options.docProperties ||= pdfDocument => {

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -21,8 +21,8 @@ import { PromiseCapability, shadow } from "pdfjs-lib";
 /**
  * @typedef {Object} PDFScriptingManagerOptions
  * @property {EventBus} eventBus - The application event bus.
- * @property {string} sandboxBundleSrc - The path and filename of the scripting
- *   bundle.
+ * @property {string} [sandboxBundleSrc] - The path and filename of the
+ *   scripting bundle.
  * @property {Object} [externalServices] - The factory that is used when
  *   initializing scripting; must contain a `createScripting` method.
  *   PLEASE NOTE: Primarily intended for the default viewer use-case.
@@ -47,8 +47,6 @@ class PDFScriptingManager {
 
   #ready = false;
 
-  #sandboxBundleSrc = null;
-
   #scripting = null;
 
   #willPrintCapability = null;
@@ -56,16 +54,8 @@ class PDFScriptingManager {
   /**
    * @param {PDFScriptingManagerOptions} options
    */
-  constructor({
-    eventBus,
-    sandboxBundleSrc = null,
-    externalServices = null,
-    docProperties = null,
-  }) {
+  constructor({ eventBus, externalServices = null, docProperties = null }) {
     this.#eventBus = eventBus;
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC || CHROME")) {
-      this.#sandboxBundleSrc = sandboxBundleSrc;
-    }
     this.#externalServices = externalServices;
     this.#docProperties = docProperties;
   }
@@ -421,9 +411,7 @@ class PDFScriptingManager {
     if (this.#scripting) {
       throw new Error("#initScripting: Scripting already exists.");
     }
-    return this.#externalServices.createScripting({
-      sandboxBundleSrc: this.#sandboxBundleSrc,
-    });
+    return this.#externalServices.createScripting();
   }
 
   async #destroyScripting() {


### PR DESCRIPTION
Given that this option isn't used in the Firefox PDF Viewer, we can (ever so slightly) reduce the amount of code needed.