### PR TITLE
Don't run beforeunload callback when closing page in integration tests

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -71,7 +71,7 @@ function closePages(pages) {
     pages.map(async ([_, page]) => {
       // Avoid to keep something from a previous test.
       await page.evaluate(() => window.localStorage.clear());
-      await page.close();
+      await page.close({ runBeforeUnload: false });
     })
   );
 }


### PR DESCRIPTION
For now, running such callbacks is disabled in Firefox but there are some plan to reenable them: https://bugzilla.mozilla.org/show_bug.cgi?id=1824220.
Having them blocks us to switch to bidi with Chrome.