### PR TITLE
Set a print listener as soon as possible in the autoprint integration test

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -46,9 +46,11 @@ function loadAndWait(filename, selector, zoom, pageSetup) {
       }
 
       await page.bringToFront();
-      await page.waitForSelector(selector, {
-        timeout: 0,
-      });
+      if (selector) {
+        await page.waitForSelector(selector, {
+          timeout: 0,
+        });
+      }
       return [session.name, page];
     })
   );


### PR DESCRIPTION
This test intermittently fails, likely because the auto-print is triggered fast enough that we don't manage to get it.
So this patch aims to try to set a listener very early in order to be sure that we'll be aware that a print has been triggered.