### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -52,7 +52,7 @@ jobs:
           INPUT_PATH: build/gh-pages
 
       - name: Upload the website
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: github-pages
           path: ${{ runner.temp }}/website.tar


### PR DESCRIPTION
Reverts mozilla/pdf.js#17435 since updating the demo viewer is now broken.