### PR TITLE
Prevent errors in `AnnotationEditorUIManager.destroy` if the `altTextManager` is undefined

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -778,7 +778,7 @@ class AnnotationEditorUIManager {
     this.#activeEditor = null;
     this.#selectedEditors.clear();
     this.#commandManager.destroy();
-    this.#altTextManager.destroy();
+    this.#altTextManager?.destroy();
     if (this.#focusMainContainerTimeoutId) {
       clearTimeout(this.#focusMainContainerTimeoutId);
       this.#focusMainContainerTimeoutId = null;


### PR DESCRIPTION
Fixes a crash when loading a document in PDFSlick