### PR TITLE
[Editor] Init the default highlight color before creating the first editor instance

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -110,7 +110,7 @@ class AnnotationEditorLayer {
     if (!AnnotationEditorLayer._initialized) {
       AnnotationEditorLayer._initialized = true;
       for (const editorType of editorTypes) {
-        editorType.initialize(l10n);
+        editorType.initialize(l10n, uiManager);
       }
     }
     uiManager.registerEditorTypes(editorTypes);

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -185,7 +185,7 @@ class AnnotationEditor {
    * Initialize the l10n stuff for this type of editor.
    * @param {Object} l10n
    */
-  static initialize(l10n, options = null) {
+  static initialize(l10n, _uiManager, options) {
     AnnotationEditor._l10nPromise ||= new Map(
       [
         "pdfjs-editor-alt-text-button-label",

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -144,8 +144,8 @@ class FreeTextEditor extends AnnotationEditor {
   }
 
   /** @inheritdoc */
-  static initialize(l10n) {
-    AnnotationEditor.initialize(l10n, {
+  static initialize(l10n, uiManager) {
+    AnnotationEditor.initialize(l10n, uiManager, {
       strings: ["pdfjs-free-text-default-content"],
     });
     const style = getComputedStyle(document.documentElement);

--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -59,8 +59,6 @@ class HighlightEditor extends AnnotationEditor {
 
   constructor(params) {
     super({ ...params, name: "highlightEditor" });
-    HighlightEditor._defaultColor ||=
-      this._uiManager.highlightColors?.values().next().value || "#fff066";
     this.color = params.color || HighlightEditor._defaultColor;
     this.#opacity = params.opacity || HighlightEditor._defaultOpacity;
     this.#boxes = params.boxes || null;
@@ -97,8 +95,10 @@ class HighlightEditor extends AnnotationEditor {
     ];
   }
 
-  static initialize(l10n) {
-    AnnotationEditor.initialize(l10n);
+  static initialize(l10n, uiManager) {
+    AnnotationEditor.initialize(l10n, uiManager);
+    HighlightEditor._defaultColor ||=
+      uiManager.highlightColors?.values().next().value || "#fff066";
   }
 
   static updateDefaultParams(type, value) {

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -84,8 +84,8 @@ class InkEditor extends AnnotationEditor {
   }
 
   /** @inheritdoc */
-  static initialize(l10n) {
-    AnnotationEditor.initialize(l10n);
+  static initialize(l10n, uiManager) {
+    AnnotationEditor.initialize(l10n, uiManager);
   }
 
   /** @inheritdoc */

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -55,8 +55,8 @@ class StampEditor extends AnnotationEditor {
   }
 
   /** @inheritdoc */
-  static initialize(l10n) {
-    AnnotationEditor.initialize(l10n);
+  static initialize(l10n, uiManager) {
+    AnnotationEditor.initialize(l10n, uiManager);
   }
 
   static get supportedTypes() {

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -16,7 +16,7 @@
 import os from "os";
 const isMac = os.platform() === "darwin";
 
-function loadAndWait(filename, selector, zoom, pageSetup) {
+function loadAndWait(filename, selector, zoom, pageSetup, options) {
   return Promise.all(
     global.integrationSessions.map(async session => {
       const page = await session.browser.newPage();
@@ -36,9 +36,16 @@ function loadAndWait(filename, selector, zoom, pageSetup) {
         });
       });
 
+      let app_options = "";
+      if (options) {
+        // Options must be handled in app.js::_parseHashParams.
+        for (const [key, value] of Object.entries(options)) {
+          app_options += `&${key}=${encodeURIComponent(value)}`;
+        }
+      }
       const url = `${
         global.integrationBaseUrl
-      }?file=/test/pdfs/${filename}#zoom=${zoom ?? "page-fit"}`;
+      }?file=/test/pdfs/${filename}#zoom=${zoom ?? "page-fit"}${app_options}`;
 
       await page.goto(url);
       if (pageSetup) {

--- a/web/app.js
+++ b/web/app.js
@@ -353,6 +353,16 @@ const PDFViewerApplication = {
     ) {
       AppOptions.set("locale", params.get("locale"));
     }
+
+    // Set some specific preferences for tests.
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) {
+      if (params.has("highlighteditorcolors")) {
+        AppOptions.set(
+          "highlightEditorColors",
+          params.get("highlighteditorcolors")
+        );
+      }
+    }
   },
 
   /**

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -203,7 +203,7 @@ const defaultOptions = {
   },
   pdfBugEnabled: {
     /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined",
+    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   printResolution: {


### PR DESCRIPTION
We want to be able to draw an highlight with the default color but without having an instance of the HighlightEditor.