### PR TITLE
Add note about running `npm install` on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ If everything worked out, install all dependencies for PDF.js:
 
     $ npm install
 
+> [!NOTE]
+> On MacOS M1/M2 you may see some `node-gyp`-related errors when running `npm install`. This is because one of our dependencies, `"canvas"`, does not provide pre-built binaries for this platform and instead `npm` will try to build it from source. Please make sure to first install the necessary native dependencies using `brew`: https://github.com/Automattic/node-canvas#compiling.
+
 Finally, you need to start a local web server as some browsers do not allow opening
 PDF files using a `file://` URL. Run:
 


### PR DESCRIPTION
Running `npm install` on MacOS requires first installing some native libraries, so that `canvas` can be properly built:
```
brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman
```

This PR adds a link to `canvas`' building instructions, so that other people don't have to spend too much time trying to figure out why `npm install` is failing 🙂 