### PR TITLE
Exclude the `web/locale/` folder from linting (PR 17525 follow-up)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,4 +8,5 @@ external/builder/fixtures_esprima/
 external/quickjs/
 test/tmp/
 test/pdfs/
+web/locale/
 *~/

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,4 +8,5 @@ external/builder/fixtures_esprima/
 external/quickjs/
 test/tmp/
 test/pdfs/
+web/locale/
 *~/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -8,4 +8,5 @@ external/builder/fixtures_esprima/
 external/quickjs/
 test/tmp/
 test/pdfs/
+web/locale/
 *~/


### PR DESCRIPTION
Given that the contents of this folder is generated by `gulp locale` it's essentially build-output and thus shouldn't be included in linting.