### PR TITLE
Remove the `isArrayBuffer` helper function

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -24,7 +24,6 @@ import {
   getVerbosityLevel,
   info,
   InvalidPDFException,
-  isArrayBuffer,
   isNodeJS,
   MAX_IMAGE_SIZE_TO_CACHE,
   MissingPDFException,
@@ -104,10 +103,6 @@ const DefaultStandardFontDataFactory =
  */
 
 /**
- * @typedef { TypedArray | ArrayBuffer | Array<number> | string } BinaryData
- */
-
-/**
  * @typedef {Object} RefProxy
  * @property {number} num
  * @property {number} gen
@@ -118,7 +113,8 @@ const DefaultStandardFontDataFactory =
  *
  * @typedef {Object} DocumentInitParameters
  * @property {string | URL} [url] - The URL of the PDF.
- * @property {BinaryData} [data] - Binary PDF data.
+ * @property {TypedArray | ArrayBuffer | Array<number> | string} [data] -
+ *   Binary PDF data.
  *   Use TypedArrays (Uint8Array) to improve the memory usage. If PDF data is
  *   BASE64-encoded, use `atob()` to convert it to a binary string first.
  *
@@ -235,7 +231,7 @@ function getDocument(src) {
   if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     if (typeof src === "string" || src instanceof URL) {
       src = { url: src };
-    } else if (isArrayBuffer(src)) {
+    } else if (src instanceof ArrayBuffer || ArrayBuffer.isView(src)) {
       src = { data: src };
     }
   }
@@ -552,7 +548,11 @@ function getDataProp(val) {
   if (typeof val === "string") {
     return stringToBytes(val);
   }
-  if ((typeof val === "object" && !isNaN(val?.length)) || isArrayBuffer(val)) {
+  if (
+    val instanceof ArrayBuffer ||
+    ArrayBuffer.isView(val) ||
+    (typeof val === "object" && !isNaN(val?.length))
+  ) {
     return new Uint8Array(val);
   }
   throw new Error(

--- a/src/shared/murmurhash3.js
+++ b/src/shared/murmurhash3.js
@@ -17,8 +17,6 @@
  * Hashes roughly 100 KB per millisecond on i7 3.4 GHz.
  */
 
-import { isArrayBuffer } from "./util.js";
-
 const SEED = 0xc3d2e1f0;
 // Workaround for missing math precision in JS.
 const MASK_HIGH = 0xffff0000;
@@ -44,14 +42,11 @@ class MurmurHash3_64 {
           data[length++] = code & 0xff;
         }
       }
-    } else if (isArrayBuffer(input)) {
+    } else if (ArrayBuffer.isView(input)) {
       data = input.slice();
       length = data.byteLength;
     } else {
-      throw new Error(
-        "Wrong data format in MurmurHash3_64_update. " +
-          "Input must be a string or array."
-      );
+      throw new Error("Invalid data format, must be a string or TypedArray.");
     }
 
     const blockCounts = length >> 2;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -963,10 +963,6 @@ function utf8StringToString(str) {
   return unescape(encodeURIComponent(str));
 }
 
-function isArrayBuffer(v) {
-  return typeof v === "object" && v?.byteLength !== undefined;
-}
-
 function isArrayEqual(arr1, arr2) {
   if (arr1.length !== arr2.length) {
     return false;
@@ -1101,7 +1097,6 @@ export {
   ImageKind,
   info,
   InvalidPDFException,
-  isArrayBuffer,
   isArrayEqual,
   isNodeJS,
   LINE_DESCENT_FACTOR,

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -17,7 +17,6 @@ import {
   bytesToString,
   createValidAbsoluteUrl,
   getModificationDate,
-  isArrayBuffer,
   PromiseCapability,
   string32,
   stringToBytes,
@@ -50,20 +49,6 @@ describe("util", function () {
       const string = "a".repeat(length);
 
       expect(bytesToString(bytes)).toEqual(string);
-    });
-  });
-
-  describe("isArrayBuffer", function () {
-    it("handles array buffer values", function () {
-      expect(isArrayBuffer(new ArrayBuffer(0))).toEqual(true);
-      expect(isArrayBuffer(new Uint8Array(0))).toEqual(true);
-    });
-
-    it("handles non-array buffer values", function () {
-      expect(isArrayBuffer("true")).toEqual(false);
-      expect(isArrayBuffer(1)).toEqual(false);
-      expect(isArrayBuffer(null)).toEqual(false);
-      expect(isArrayBuffer(undefined)).toEqual(false);
     });
   });
 


### PR DESCRIPTION
This old helper function can now be replaced with `ArrayBuffer.isView()` and/or `instanceof ArrayBuffer` checks, as needed depending on the situation.