### PR TITLE
Ignore auto-formatting patches in `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Auto-format `.js` files with ESLint/Prettier
+de36b2aabab2b7fd647d9591f959c4540129541d
+# Auto-format `.css` files with Stylelint/Prettier
+8aa2718d225ad701a5b8a2788b42d221f1e4327d
+# Auto-format `.json` files with Prettier
+29de9bdce6c9785574994fda0e51533d796a9bb4


### PR DESCRIPTION
When using Prettier to auto-format (parts of) the code-base you usually end up with *huge* patches that touch lots of lines without making any actual changes.
This often adds unnecessary steps when using `git blame`, however it's easy enough to avoid this; please refer to https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view