### PR TITLE
Remove DNS resolver workaround from the test framework

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -20,7 +20,6 @@ import {
   downloadManifestFiles,
   verifyManifestFiles,
 } from "./downloadutils.mjs";
-import dns from "dns";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -33,21 +32,6 @@ import { WebServer } from "./webserver.mjs";
 import yargs from "yargs";
 
 const rimrafSync = rimraf.sync;
-
-// Chrome uses host `127.0.0.1` in the browser's websocket endpoint URL while
-// Firefox uses `localhost`, which before Node.js 17 also resolved to the IPv4
-// address `127.0.0.1` by Node.js' DNS resolver. However, this behavior changed
-// in Node.js 17 where the default is to prefer an IPv6 address if one is
-// offered (which varies based on the OS and/or how the `localhost` hostname
-// resolution is configured), so it can now also resolve to `::1`. This causes
-// Firefox to not start anymore since it doesn't bind on the `::1` interface.
-// To avoid this, we switch Node.js' DNS resolver back to preferring IPv4
-// since we connect to a local browser anyway. Only do this for Node.js versions
-// that actually have this API since it got introduced in Node.js 14.18.0 and
-// it's not relevant for older versions anyway.
-if (dns.setDefaultResultOrder !== undefined) {
-  dns.setDefaultResultOrder("ipv4first");
-}
 
 function parseOptions() {
   const parsedArgs = yargs(process.argv)


### PR DESCRIPTION
The `if` statement is no longer necessary because the Node.js versions that didn't provide `dns.setDefaultResultOrder` are no longer supported, but looking into this a bit more it turns out that the entire workaround is no longer necessary because the issue got fixed in Firefox 105 in bug 1769994. Indeed, Firefox now starts nicely with the workaround removed.

Reverts 60ed3cd297c4045b90f4114a74e5baa4ef1c5056.