### PR TITLE
Use shorter arrow functions where possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -244,7 +244,6 @@
     // ECMAScript 6
     "constructor-super": "error",
     "no-class-assign": "error",
-    "no-confusing-arrow": "error",
     "no-const-assign": "error",
     "no-dupe-class-members": "error",
     "no-duplicate-imports": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -242,6 +242,7 @@
     }],
 
     // ECMAScript 6
+    "arrow-body-style": ["error", "as-needed"],
     "constructor-super": "error",
     "no-class-assign": "error",
     "no-const-assign": "error",

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -4824,9 +4824,7 @@ class StampAnnotation extends MarkupAnnotation {
 
     const jpegBufferPromise = canvas
       .convertToBlob({ type: "image/jpeg", quality: 1 })
-      .then(blob => {
-        return blob.arrayBuffer();
-      });
+      .then(blob => blob.arrayBuffer());
 
     const xobjectName = Name.get("XObject");
     const imageName = Name.get("Image");

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -79,6 +79,7 @@ class AnnotationFactory {
       // with "GoToE" actions, from throwing and thus breaking parsing:
       pdfManager.ensureCatalog("attachments"),
     ]).then(
+      // eslint-disable-next-line arrow-body-style
       ([acroForm, xfaDatasets, structTreeRoot, baseUrl, attachments]) => {
         return {
           pdfManager,
@@ -2133,11 +2134,8 @@ class WidgetAnnotation extends Annotation {
       value,
     };
 
-    const encoder = val => {
-      return isAscii(val)
-        ? val
-        : stringToUTF16String(val, /* bigEndian = */ true);
-    };
+    const encoder = val =>
+      isAscii(val) ? val : stringToUTF16String(val, /* bigEndian = */ true);
     dict.set("V", Array.isArray(value) ? value.map(encoder) : encoder(value));
     this.amendSavedDict(annotationStorage, dict);
 

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -893,14 +893,13 @@ class Catalog {
         case "PrintPageRange":
           // The number of elements must be even.
           if (Array.isArray(value) && value.length % 2 === 0) {
-            const isValid = value.every((page, i, arr) => {
-              return (
+            const isValid = value.every(
+              (page, i, arr) =>
                 Number.isInteger(page) &&
                 page > 0 &&
                 (i === 0 || page >= arr[i - 1]) &&
                 page <= this.numPages
-              );
-            });
+            );
             if (isValid) {
               prefValue = value;
             }

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -691,9 +691,9 @@ async function createBuiltInCMap(name, fetchBuiltInCMap) {
   const cMap = new CMap(true);
 
   if (compressionType === CMapCompressionType.BINARY) {
-    return new BinaryCMapReader().process(cMapData, cMap, useCMap => {
-      return extendCMap(cMap, fetchBuiltInCMap, useCMap);
-    });
+    return new BinaryCMapReader().process(cMapData, cMap, useCMap =>
+      extendCMap(cMap, fetchBuiltInCMap, useCMap)
+    );
   }
   if (compressionType === CMapCompressionType.NONE) {
     const lexer = new Lexer(new Stream(cMapData));

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1577,6 +1577,7 @@ class PDFDocument {
     } else {
       promise = catalog.getPageDict(pageIndex);
     }
+    // eslint-disable-next-line arrow-body-style
     promise = promise.then(([pageDict, ref]) => {
       return new Page({
         pdfManager: this.pdfManager,

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1039,14 +1039,15 @@ class PartialEvaluator {
 
             return translated;
           })
-          .catch(reason => {
-            return new TranslatedFont({
-              loadedName: "g_font_error",
-              font: new ErrorFont(`Type3 font load error: ${reason}`),
-              dict: translated.font,
-              evaluatorOptions: this.options,
-            });
-          });
+          .catch(
+            reason =>
+              new TranslatedFont({
+                loadedName: "g_font_error",
+                font: new ErrorFont(`Type3 font load error: ${reason}`),
+                dict: translated.font,
+                evaluatorOptions: this.options,
+              })
+          );
       })
       .then(translated => {
         state.font = translated.font;
@@ -1129,6 +1130,7 @@ class PartialEvaluator {
         case "Font":
           isSimpleGState = false;
 
+          // eslint-disable-next-line arrow-body-style
           promise = promise.then(() => {
             return this.handleSetFont(
               resources,
@@ -1154,6 +1156,7 @@ class PartialEvaluator {
           if (value instanceof Dict) {
             isSimpleGState = false;
 
+            // eslint-disable-next-line arrow-body-style
             promise = promise.then(() => {
               return this.handleSMask(
                 value,
@@ -1214,6 +1217,7 @@ class PartialEvaluator {
     fallbackFontDict = null,
     cssFontInfo = null
   ) {
+    // eslint-disable-next-line arrow-body-style
     const errorFont = async () => {
       return new TranslatedFont({
         loadedName: "g_font_error",

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2093,9 +2093,7 @@ class Font {
           endOffset: 0,
         });
       }
-      locaEntries.sort((a, b) => {
-        return a.offset - b.offset;
-      });
+      locaEntries.sort((a, b) => a.offset - b.offset);
       // Now the offsets are sorted, calculate the end offset of each glyph.
       // The last loca entry's endOffset is not calculated since it's the end
       // of the data and will be stored on the previous entry's endOffset.
@@ -2103,9 +2101,7 @@ class Font {
         locaEntries[i].endOffset = locaEntries[i + 1].offset;
       }
       // Re-sort so glyphs aren't out of order.
-      locaEntries.sort((a, b) => {
-        return a.index - b.index;
-      });
+      locaEntries.sort((a, b) => a.index - b.index);
       // Calculate the endOffset of the "first" glyph correctly when there are
       // *multiple* empty ones at the start of the data (fixes issue14618.pdf).
       for (i = 0; i < numGlyphs; i++) {

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -344,10 +344,9 @@ async function incrementalUpdate({
 
   // Add a ref for the new xref and sort them
   newRefs.push({ ref: refForXrefTable, data: "" });
-  newRefs = newRefs.sort((a, b) => {
-    // compare the refs
-    return a.ref.num - b.ref.num;
-  });
+  newRefs = newRefs.sort(
+    (a, b) => /* compare the refs */ a.ref.num - b.ref.num
+  );
 
   const xrefTableData = [[0, 1, 0xffff]];
   const indexes = [0, 1];

--- a/src/core/xfa/utils.js
+++ b/src/core/xfa/utils.js
@@ -129,12 +129,10 @@ function getRelevant(data) {
   return data
     .trim()
     .split(/\s+/)
-    .map(e => {
-      return {
-        excluded: e[0] === "-",
-        viewname: e.substring(1),
-      };
-    });
+    .map(e => ({
+      excluded: e[0] === "-",
+      viewname: e.substring(1),
+    }));
 }
 
 function getColor(data, def = [0, 0, 0]) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1838,9 +1838,10 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
 
     const getItems = event => {
       const options = event.target.options;
-      return Array.prototype.map.call(options, option => {
-        return { displayValue: option.textContent, exportValue: option.value };
-      });
+      return Array.prototype.map.call(options, option => ({
+        displayValue: option.textContent,
+        exportValue: option.value,
+      }));
     };
 
     if (this.enableScripting && this.hasJSActions) {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -771,19 +771,13 @@ class PDFDocumentProxy {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.
       Object.defineProperty(this, "getXFADatasets", {
-        value: () => {
-          return this._transport.getXFADatasets();
-        },
+        value: () => this._transport.getXFADatasets(),
       });
       Object.defineProperty(this, "getXRefPrevValue", {
-        value: () => {
-          return this._transport.getXRefPrevValue();
-        },
+        value: () => this._transport.getXRefPrevValue(),
       });
       Object.defineProperty(this, "getAnnotArray", {
-        value: pageIndex => {
-          return this._transport.getAnnotArray(pageIndex);
-        },
+        value: pageIndex => this._transport.getAnnotArray(pageIndex),
       });
     }
   }
@@ -1628,9 +1622,7 @@ class PDFPageProxy {
     if (this._transport._htmlForXfa) {
       // TODO: We need to revisit this once the XFA foreground patch lands and
       // only do this for non-foreground XFA.
-      return this.getXfa().then(xfa => {
-        return XfaText.textContent(xfa);
-      });
+      return this.getXfa().then(xfa => XfaText.textContent(xfa));
     }
     const readableStream = this.streamTextContent(params);
 
@@ -2358,21 +2350,16 @@ class WorkerTransport {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.
       Object.defineProperty(this, "getXFADatasets", {
-        value: () => {
-          return this.messageHandler.sendWithPromise("GetXFADatasets", null);
-        },
+        value: () =>
+          this.messageHandler.sendWithPromise("GetXFADatasets", null),
       });
       Object.defineProperty(this, "getXRefPrevValue", {
-        value: () => {
-          return this.messageHandler.sendWithPromise("GetXRefPrevValue", null);
-        },
+        value: () =>
+          this.messageHandler.sendWithPromise("GetXRefPrevValue", null),
       });
       Object.defineProperty(this, "getAnnotArray", {
-        value: pageIndex => {
-          return this.messageHandler.sendWithPromise("GetAnnotArray", {
-            pageIndex,
-          });
-        },
+        value: pageIndex =>
+          this.messageHandler.sendWithPromise("GetAnnotArray", { pageIndex }),
       });
     }
   }
@@ -2737,9 +2724,7 @@ class WorkerTransport {
 
           this.fontLoader
             .bind(font)
-            .catch(reason => {
-              return messageHandler.sendWithPromise("FontFallback", { id });
-            })
+            .catch(() => messageHandler.sendWithPromise("FontFallback", { id }))
             .finally(() => {
               if (!params.fontExtraProperties && font.data) {
                 // Immediately release the `font.data` property once the font
@@ -3013,9 +2998,7 @@ class WorkerTransport {
   getOptionalContentConfig() {
     return this.messageHandler
       .sendWithPromise("GetOptionalContentConfig", null)
-      .then(results => {
-        return new OptionalContentConfig(results);
-      });
+      .then(results => new OptionalContentConfig(results));
   }
 
   getPermissions() {
@@ -3192,9 +3175,7 @@ class RenderTask {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.
       Object.defineProperty(this, "getOperatorList", {
-        value: () => {
-          return this.#internalRenderTask.operatorList;
-        },
+        value: () => this.#internalRenderTask.operatorList,
       });
     }
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3013,14 +3013,12 @@ class WorkerTransport {
     }
     const promise = this.messageHandler
       .sendWithPromise(name, null)
-      .then(results => {
-        return {
-          info: results[0],
-          metadata: results[1] ? new Metadata(results[1]) : null,
-          contentDispositionFilename: this._fullReader?.filename ?? null,
-          contentLength: this._fullReader?.contentLength ?? null,
-        };
-      });
+      .then(results => ({
+        info: results[0],
+        metadata: results[1] ? new Metadata(results[1]) : null,
+        contentDispositionFilename: this._fullReader?.filename ?? null,
+        contentLength: this._fullReader?.contentLength ?? null,
+      }));
     this.#methodPromises.set(name, promise);
     return promise;
   }

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2359,8 +2359,8 @@ class CanvasGraphics {
       const color = IR[1];
       const baseTransform = this.baseTransform || getCurrentTransform(this.ctx);
       const canvasGraphicsFactory = {
-        createCanvasGraphics: ctx => {
-          return new CanvasGraphics(
+        createCanvasGraphics: ctx =>
+          new CanvasGraphics(
             ctx,
             this.commonObjs,
             this.objs,
@@ -2370,8 +2370,7 @@ class CanvasGraphics {
               optionalContentConfig: this.optionalContentConfig,
               markedContentStack: this.markedContentStack,
             }
-          );
-        },
+          ),
       };
       pattern = new TilingPattern(
         IR,

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -466,15 +466,13 @@ class DOMCMapReaderFactory extends BaseCMapReaderFactory {
     return fetchData(
       url,
       /* type = */ this.isCompressed ? "arraybuffer" : "text"
-    ).then(data => {
-      return {
-        cMapData:
-          data instanceof ArrayBuffer
-            ? new Uint8Array(data)
-            : stringToBytes(data),
-        compressionType,
-      };
-    });
+    ).then(data => ({
+      cMapData:
+        data instanceof ArrayBuffer
+          ? new Uint8Array(data)
+          : stringToBytes(data),
+      compressionType,
+    }));
   }
 }
 

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -483,9 +483,9 @@ class DOMStandardFontDataFactory extends BaseStandardFontDataFactory {
    * @ignore
    */
   _fetchData(url) {
-    return fetchData(url, /* type = */ "arraybuffer").then(data => {
-      return new Uint8Array(data);
-    });
+    return fetchData(url, /* type = */ "arraybuffer").then(
+      data => new Uint8Array(data)
+    );
   }
 }
 

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -606,15 +606,14 @@ class AnnotationEditorUIManager {
   static get _keyboardManager() {
     const proto = AnnotationEditorUIManager.prototype;
 
-    const arrowChecker = self => {
-      // If the focused element is an input, we don't want to handle the arrow.
-      // For example, sliders can be controlled with the arrow keys.
-      return (
-        self.#container.contains(document.activeElement) &&
-        document.activeElement.tagName !== "BUTTON" &&
-        self.hasSomethingToControl()
-      );
-    };
+    /**
+     * If the focused element is an input, we don't want to handle the arrow.
+     * For example, sliders can be controlled with the arrow keys.
+     */
+    const arrowChecker = self =>
+      self.#container.contains(document.activeElement) &&
+      document.activeElement.tagName !== "BUTTON" &&
+      self.hasSomethingToControl();
 
     const textInputChecker = (_self, { target: el }) => {
       if (el instanceof HTMLInputElement) {

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -147,9 +147,8 @@ class PDFFetchStreamReader {
         this._reader = response.body.getReader();
         this._headersCapability.resolve();
 
-        const getResponseHeader = name => {
-          return response.headers.get(name);
-        };
+        const getResponseHeader = name => response.headers.get(name);
+
         const { allowRangeRequests, suggestedLength } =
           validateRangeRequestCapabilities({
             getResponseHeader,

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -279,9 +279,8 @@ class PDFNetworkStreamFullRequestReader {
     const fullRequestXhrId = this._fullRequestId;
     const fullRequestXhr = this._manager.getRequestXhr(fullRequestXhrId);
 
-    const getResponseHeader = name => {
-      return fullRequestXhr.getResponseHeader(name);
-    };
+    const getResponseHeader = name => fullRequestXhr.getResponseHeader(name);
+
     const { allowRangeRequests, suggestedLength } =
       validateRangeRequestCapabilities({
         getResponseHeader,

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -326,11 +326,11 @@ class PDFNodeStreamFullReader extends BaseFullReader {
       this._headersCapability.resolve();
       this._setReadableStream(response);
 
-      const getResponseHeader = name => {
-        // Make sure that headers name are in lower case, as mentioned
-        // here: https://nodejs.org/api/http.html#http_message_headers.
-        return this._readableStream.headers[name.toLowerCase()];
-      };
+      // Make sure that headers name are in lower case, as mentioned
+      // here: https://nodejs.org/api/http.html#http_message_headers.
+      const getResponseHeader = name =>
+        this._readableStream.headers[name.toLowerCase()];
+
       const { allowRangeRequests, suggestedLength } =
         validateRangeRequestCapabilities({
           getResponseHeader,

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -98,9 +98,7 @@ class NodeCMapReaderFactory extends BaseCMapReaderFactory {
    * @ignore
    */
   _fetchData(url, compressionType) {
-    return fetchData(url).then(data => {
-      return { cMapData: data, compressionType };
-    });
+    return fetchData(url).then(data => ({ cMapData: data, compressionType }));
   }
 }
 

--- a/src/pdf.sandbox.js
+++ b/src/pdf.sandbox.js
@@ -141,9 +141,7 @@ class Sandbox {
 }
 
 function QuickJSSandbox() {
-  return ModuleLoader().then(module => {
-    return new Sandbox(window, module);
-  });
+  return ModuleLoader().then(module => new Sandbox(window, module));
 }
 
 export { QuickJSSandbox };

--- a/src/scripting_api/util.js
+++ b/src/scripting_api/util.js
@@ -212,66 +212,26 @@ class Util extends PDFObject {
     }
 
     const handlers = {
-      mmmm: data => {
-        return this._months[data.month];
-      },
-      mmm: data => {
-        return this._months[data.month].substring(0, 3);
-      },
-      mm: data => {
-        return (data.month + 1).toString().padStart(2, "0");
-      },
-      m: data => {
-        return (data.month + 1).toString();
-      },
-      dddd: data => {
-        return this._days[data.dayOfWeek];
-      },
-      ddd: data => {
-        return this._days[data.dayOfWeek].substring(0, 3);
-      },
-      dd: data => {
-        return data.day.toString().padStart(2, "0");
-      },
-      d: data => {
-        return data.day.toString();
-      },
-      yyyy: data => {
-        return data.year.toString();
-      },
-      yy: data => {
-        return (data.year % 100).toString().padStart(2, "0");
-      },
-      HH: data => {
-        return data.hours.toString().padStart(2, "0");
-      },
-      H: data => {
-        return data.hours.toString();
-      },
-      hh: data => {
-        return (1 + ((data.hours + 11) % 12)).toString().padStart(2, "0");
-      },
-      h: data => {
-        return (1 + ((data.hours + 11) % 12)).toString();
-      },
-      MM: data => {
-        return data.minutes.toString().padStart(2, "0");
-      },
-      M: data => {
-        return data.minutes.toString();
-      },
-      ss: data => {
-        return data.seconds.toString().padStart(2, "0");
-      },
-      s: data => {
-        return data.seconds.toString();
-      },
-      tt: data => {
-        return data.hours < 12 ? "am" : "pm";
-      },
-      t: data => {
-        return data.hours < 12 ? "a" : "p";
-      },
+      mmmm: data => this._months[data.month],
+      mmm: data => this._months[data.month].substring(0, 3),
+      mm: data => (data.month + 1).toString().padStart(2, "0"),
+      m: data => (data.month + 1).toString(),
+      dddd: data => this._days[data.dayOfWeek],
+      ddd: data => this._days[data.dayOfWeek].substring(0, 3),
+      dd: data => data.day.toString().padStart(2, "0"),
+      d: data => data.day.toString(),
+      yyyy: data => data.year.toString(),
+      yy: data => (data.year % 100).toString().padStart(2, "0"),
+      HH: data => data.hours.toString().padStart(2, "0"),
+      H: data => data.hours.toString(),
+      hh: data => (1 + ((data.hours + 11) % 12)).toString().padStart(2, "0"),
+      h: data => (1 + ((data.hours + 11) % 12)).toString(),
+      MM: data => data.minutes.toString().padStart(2, "0"),
+      M: data => data.minutes.toString(),
+      ss: data => data.seconds.toString().padStart(2, "0"),
+      s: data => data.seconds.toString(),
+      tt: data => (data.hours < 12 ? "am" : "pm"),
+      t: data => (data.hours < 12 ? "a" : "p"),
     };
 
     const data = {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1039,9 +1039,9 @@ function normalizeUnicode(str) {
       /([\u00a0\u00b5\u037e\u0eb3\u2000-\u200a\u202f\u2126\ufb00-\ufb04\ufb06\ufb20-\ufb36\ufb38-\ufb3c\ufb3e\ufb40-\ufb41\ufb43-\ufb44\ufb46-\ufba1\ufba4-\ufba9\ufbae-\ufbb1\ufbd3-\ufbdc\ufbde-\ufbe7\ufbea-\ufbf8\ufbfc-\ufbfd\ufc00-\ufc5d\ufc64-\ufcf1\ufcf5-\ufd3d\ufd88\ufdf4\ufdfa-\ufdfb\ufe71\ufe77\ufe79\ufe7b\ufe7d]+)|(\ufb05+)/gu;
     NormalizationMap = new Map([["ﬅ", "ſt"]]);
   }
-  return str.replaceAll(NormalizeRegex, (_, p1, p2) => {
-    return p1 ? p1.normalize("NFKC") : NormalizationMap.get(p2);
-  });
+  return str.replaceAll(NormalizeRegex, (_, p1, p2) =>
+    p1 ? p1.normalize("NFKC") : NormalizationMap.get(p2)
+  );
 }
 
 function getUuid() {

--- a/test/driver.js
+++ b/test/driver.js
@@ -106,6 +106,7 @@ async function inlineImages(node, silentErrors = false) {
           }
           return response.blob();
         })
+        // eslint-disable-next-line arrow-body-style
         .then(blob => {
           return new Promise((resolve, reject) => {
             const reader = new FileReader();
@@ -117,6 +118,7 @@ async function inlineImages(node, silentErrors = false) {
             reader.readAsDataURL(blob);
           });
         })
+        // eslint-disable-next-line arrow-body-style
         .then(dataUrl => {
           return new Promise((resolve, reject) => {
             image.onload = resolve;

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -237,9 +237,10 @@ describe("FreeText Editor", () => {
           await clearAll(page);
 
           for (const n of [0, 1, 2]) {
-            const hasEditor = await page.evaluate(sel => {
-              return !!document.querySelector(sel);
-            }, getEditorSelector(n));
+            const hasEditor = await page.evaluate(
+              sel => !!document.querySelector(sel),
+              getEditorSelector(n)
+            );
 
             expect(hasEditor).withContext(`In ${browserName}`).toEqual(false);
           }

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -38,8 +38,8 @@ const getXY = (page, selector) =>
     return `${bbox.x}::${bbox.y}`;
   }, selector);
 
-const getSpanRectFromText = (page, pageNumber, text) => {
-  return page.evaluate(
+const getSpanRectFromText = (page, pageNumber, text) =>
+  page.evaluate(
     (number, content) => {
       for (const el of document.querySelectorAll(
         `.page[data-page-number="${number}"] > .textLayer > span`
@@ -54,7 +54,6 @@ const getSpanRectFromText = (page, pageNumber, text) => {
     pageNumber,
     text
   );
-};
 
 describe("Highlight Editor", () => {
   describe("Editor must be removed without exception", () => {

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -265,9 +265,10 @@ async function serializeBitmapDimensions(page) {
     const { map } =
       window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;
     return map
-      ? Array.from(map.values(), x => {
-          return { width: x.bitmap.width, height: x.bitmap.height };
-        })
+      ? Array.from(map.values(), x => ({
+          width: x.bitmap.width,
+          height: x.bitmap.height,
+        }))
       : [];
   });
 }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -942,14 +942,10 @@ describe("api", function () {
       );
 
       const loadingTask1 = getDocument(basicApiGetDocumentParams);
-      const promise1 = loadingTask1.promise.then(pdfDoc => {
-        return pdfDoc.numPages;
-      });
+      const promise1 = loadingTask1.promise.then(pdfDoc => pdfDoc.numPages);
 
       const loadingTask2 = getDocument(tracemonkeyGetDocumentParams);
-      const promise2 = loadingTask2.promise.then(pdfDoc => {
-        return pdfDoc.numPages;
-      });
+      const promise2 = loadingTask2.promise.then(pdfDoc => pdfDoc.numPages);
 
       const [numPages1, numPages2] = await Promise.all([promise1, promise2]);
       expect(numPages1).toEqual(3);
@@ -3901,9 +3897,9 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
             true
           );
           expect(
-            currentImgData.data.every((value, index) => {
-              return value === firstImgData.data[index];
-            })
+            currentImgData.data.every(
+              (value, index) => value === firstImgData.data[index]
+            )
           ).toEqual(true);
 
           if (i === NUM_PAGES_THRESHOLD) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2689,9 +2689,7 @@ describe("api", function () {
 
       const viewPromises = [];
       for (let i = 0; i < numPages; i++) {
-        viewPromises[i] = pdfDoc.getPage(i + 1).then(pdfPage => {
-          return pdfPage.view;
-        });
+        viewPromises[i] = pdfDoc.getPage(i + 1).then(pdfPage => pdfPage.view);
       }
 
       const [page1, page2, page3] = await Promise.all(viewPromises);
@@ -3412,7 +3410,9 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
           })
         );
 
+        // eslint-disable-next-line arrow-body-style
         const result1 = loadingTask1.promise.then(pdfDoc => {
+          // eslint-disable-next-line arrow-body-style
           return pdfDoc.getPage(1).then(pdfPage => {
             return pdfPage.getOperatorList().then(opList => {
               expect(opList.fnArray.length).toBeGreaterThan(100);
@@ -3425,7 +3425,9 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
           });
         });
 
+        // eslint-disable-next-line arrow-body-style
         const result2 = loadingTask2.promise.then(pdfDoc => {
+          // eslint-disable-next-line arrow-body-style
           return pdfDoc.getPage(1).then(pdfPage => {
             return pdfPage.getOperatorList().then(opList => {
               expect(opList.fnArray.length).toEqual(0);

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -377,9 +377,7 @@ describe("CFFCompiler", function () {
     bytes = new Uint8Array(bytes);
     return new CFFParser(
       {
-        getBytes: () => {
-          return bytes;
-        },
+        getBytes: () => bytes,
       },
       {},
       SEAC_ANALYSIS_ENABLED

--- a/test/unit/message_handler_spec.js
+++ b/test/unit/message_handler_spec.js
@@ -24,9 +24,7 @@ import { MessageHandler } from "../../src/shared/message_handler.js";
 describe("message_handler", function () {
   // Sleep function to wait for sometime, similar to setTimeout but faster.
   function sleep(ticks) {
-    return Promise.resolve().then(() => {
-      return ticks && sleep(ticks - 1);
-    });
+    return Promise.resolve().then(() => ticks && sleep(ticks - 1));
   }
 
   describe("sendWithStream", function () {

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -62,9 +62,7 @@ describe("node_stream", function () {
             const [start, end] = request.headers.range
               .split("=")[1]
               .split("-")
-              .map(x => {
-                return Number(x);
-              });
+              .map(x => Number(x));
             const stream = fs.createReadStream(filePath, { start, end });
             response.writeHead(206, {
               "Content-Type": "application/pdf",

--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -121,9 +121,7 @@ function testSearch({
       }
     }
 
-    const totalMatches = matchesPerPage.reduce((a, b) => {
-      return a + b;
-    });
+    const totalMatches = matchesPerPage.reduce((a, b) => a + b);
 
     if (updateFindControlState) {
       eventBus.on(

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -52,9 +52,9 @@ describe("Scripting", function () {
       send_queue.set(command, { command, value });
     };
     // eslint-disable-next-line no-unsanitized/method
-    const promise = import(sandboxBundleSrc).then(pdfjsSandbox => {
-      return pdfjsSandbox.QuickJSSandbox();
-    });
+    const promise = import(sandboxBundleSrc).then(pdfjsSandbox =>
+      pdfjsSandbox.QuickJSSandbox()
+    );
     sandbox = {
       createSandbox(data) {
         promise.then(sbx => sbx.create(data));

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -152,14 +152,12 @@ describe("Scripting", function () {
     });
 
     it("should get field using a path", async () => {
-      const base = value => {
-        return {
-          id: getId(),
-          value,
-          actions: {},
-          type: "text",
-        };
-      };
+      const base = value => ({
+        id: getId(),
+        value,
+        actions: {},
+        type: "text",
+      });
       const data = {
         objects: {
           A: [base(1)],

--- a/web/app.js
+++ b/web/app.js
@@ -1764,9 +1764,7 @@ const PDFViewerApplication = {
       .catch(() => {
         /* Avoid breaking printing; ignoring errors. */
       })
-      .then(() => {
-        return this.pdfDocument?.annotationStorage.print;
-      });
+      .then(() => this.pdfDocument?.annotationStorage.print);
 
     if (this.printService) {
       // There is no way to suppress beforePrint/afterPrint events,

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -129,6 +129,7 @@ class PDFDocumentProperties {
       this.#parseFileSize(contentLength),
       this.#parseDate(info.CreationDate),
       this.#parseDate(info.ModDate),
+      // eslint-disable-next-line arrow-body-style
       this.pdfDocument.getPage(currentPageNumber).then(pdfPage => {
         return this.#parsePageSize(getPageSizeInches(pdfPage), pagesRotation);
       }),

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -842,12 +842,11 @@ class PDFFindController {
       const extractTextCapability = new PromiseCapability();
       this._extractTextPromises[i] = extractTextCapability.promise;
 
+      // eslint-disable-next-line arrow-body-style
       promise = promise.then(() => {
         return this._pdfDocument
           .getPage(i + 1)
-          .then(pdfPage => {
-            return pdfPage.getTextContent(textOptions);
-          })
+          .then(pdfPage => pdfPage.getTextContent(textOptions))
           .then(
             textContent => {
               const strBuf = [];

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -54,9 +54,7 @@ function addLinkAttributes(link, { url, target, rel, enabled = true } = {}) {
   } else {
     link.href = "";
     link.title = `Disabled: ${url}`;
-    link.onclick = () => {
-      return false;
-    };
+    link.onclick = () => false;
   }
 
   let targetStr = ""; // LinkTarget.NONE

--- a/web/pdf_scripting_manager.component.js
+++ b/web/pdf_scripting_manager.component.js
@@ -30,13 +30,9 @@ class PDFScriptingManagerComponents extends PDFScriptingManager {
     }
 
     options.externalServices ||= {
-      createScripting: () => {
-        return new GenericScripting(options.sandboxBundleSrc);
-      },
+      createScripting: () => new GenericScripting(options.sandboxBundleSrc),
     };
-    options.docProperties ||= pdfDocument => {
-      return docProperties(pdfDocument);
-    };
+    options.docProperties ||= pdfDocument => docProperties(pdfDocument);
     super(options);
   }
 }

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -206,20 +206,18 @@ function parseQueryString(query) {
   return params;
 }
 
-const InvisibleCharactersRegExp = /[\x00-\x1F]/g;
+const InvisibleCharsRegExp = /[\x00-\x1F]/g;
 
 /**
  * @param {string} str
  * @param {boolean} [replaceInvisible]
  */
 function removeNullCharacters(str, replaceInvisible = false) {
-  if (!InvisibleCharactersRegExp.test(str)) {
+  if (!InvisibleCharsRegExp.test(str)) {
     return str;
   }
   if (replaceInvisible) {
-    return str.replaceAll(InvisibleCharactersRegExp, m => {
-      return m === "\x00" ? "" : " ";
-    });
+    return str.replaceAll(InvisibleCharsRegExp, m => (m === "\x00" ? "" : " "));
   }
   return str.replaceAll("\x00", "");
 }


### PR DESCRIPTION
For arrow functions that are both simple and short, we can avoid using explicit `return` to shorten them even further without hurting readability.

For the `gulp mozcentral` build-target this reduces the overall size of the output by just under 1 kilo-byte (which isn't a lot but still can't hurt).