### PR TITLE
Workaround WebKit canvas rendering bug when zooming PDFs

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -71,7 +71,9 @@
 
 .pdfViewer .canvasWrapper {
   overflow: hidden;
-  width: 100%;
+  /* See  `width: inherit` comment in `.pdfViewer .page canvas[zooming]` for the reason
+   * we use `inherit` and not `100%`. */
+  width: inherit;
   height: 100%;
   z-index: 1;
 }
@@ -166,7 +168,25 @@
 }
 
 .pdfViewer .page canvas[zooming] {
-  width: 100%;
+  /* WebKit has a bug when rendering canvases that have their width defined as
+   * relative to their container, and their parent is resized. This causes a
+   * "tearing" effect when zooming in PDFs past a certain threshold, which
+   * is devide-dependent but tends to be between 120% and 200%.
+   *
+   * The DOM structure around the canvas is as follows:
+   *   div.pdfViewer [ --scale-factor: ...; ]
+   *     > div.page [ width: round(var(--scale-factor) * ..., 1px); ]
+   *       > div.canvasWrapper
+   *         > canvas
+   *
+   * Setting `width: inherit` on the div.canvasWrapper and on the canvas is
+   * equivalent to explicitly specifying the same `width` property in pixels
+   * as in div.page, thus making Safari properly redraw the canvas on resize.
+   *
+   * See https://bugs.webkit.org/show_bug.cgi?id=267986 for more details
+   * on the WebKit bug.
+   */
+  width: inherit;
   height: 100%;
 }
 


### PR DESCRIPTION
WebKit has a bug when rendering canvases that have their width defined as relative to their container, and their parent is resized. This causes a This causes a "tearing" effect when zooming in PDFs past a certain threshold, which is device-dependent but tends to be between 120% and 200%.

The DOM structure around the canvas is as follows:
```
div.pdfViewer [ --scale-factor: ...; ]
  > div.page [ width: round(var(--scale-factor) * ..., 1px); ]
    > div.canvasWrapper
      > canvas
```

Setting `width: inherit` on the div.canvasWrapper and on the canvas is equivalent to explicitly specifying the same `width` property in pixels as in div.page, thus making Safari properly redraw the canvas on resize.

See https://bugs.webkit.org/show_bug.cgi?id=267986 for more details on the WebKit bug.

Fixes #16155, fixes #16329, fixes #17459, fixes #17713

https://github.com/mozilla/pdf.js/discussions/17459 shows a good video of what the rendering bug fixed by this PR is.

---

Note that it's very easy to fix this for downstream consumers of pdf.js. I think adding this CSS to their page is enough:
```css
.pdfViewer .canvasWrapper,
.pdfViewer .page canvas[zooming] {
  width: inherit !important;
}
```
however, I'm opening this PR because
1. I noticed that multiple people submitted issues about it
2. the fix is very minimal and does not impact other browser, given than in this case `width: 100%` and `width: inherit` _should_ have the same behavior.

Marking as a draft because I tested it on an iPad but I'm waiting for something with an iPhone to confirm that this indeed works for them too :)