### PR TITLE
Fix unreferenced CSS variables (PR 17533 follow-up)

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -64,6 +64,8 @@
   padding-bottom: var(--pdfViewer-padding-bottom);
 
   --hcm-highlight-filter: none;
+  --hcm-highlight-selected-filter: none;
+
   @media screen and (forced-colors: active) {
     --hcm-highlight-filter: invert(100%);
   }

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -52,7 +52,6 @@
     --highlight-selected-bg-color: rgb(0 100 0 / 0.25);
     --highlight-backdrop-filter: none;
     --highlight-selected-backdrop-filter: none;
-    --mix-blend-mode: exclusion;
 
     @media screen and (forced-colors: active) {
       --highlight-bg-color: transparent;


### PR DESCRIPTION
The latest mozilla-central update has test failures, because some CSS variables are not "properly" referenced; in particular:
 - Give `--hcm-highlight-selected-filter` a default value, of `none`, similar to the previously existing HCM filter.
 - Remove the `--mix-blend-mode` variable, since it's unused.