### PR TITLE
[GENERIC viewer] Generate the `fileInput` DOM-element dynamically

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -602,8 +602,12 @@ const PDFViewerApplication = {
     }
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      const fileInput = appConfig.openFileInput;
+      const fileInput = (this._openFileInput = document.createElement("input"));
+      fileInput.id = "fileInput";
+      fileInput.hidden = true;
+      fileInput.type = "file";
       fileInput.value = null;
+      document.body.append(fileInput);
 
       fileInput.addEventListener("change", function (evt) {
         const { files } = evt.target;
@@ -2383,8 +2387,7 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
 
   // eslint-disable-next-line no-var
   var webViewerOpenFile = function (evt) {
-    const fileInput = PDFViewerApplication.appConfig.openFileInput;
-    fileInput.click();
+    PDFViewerApplication._openFileInput?.click();
   };
 }
 

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -123,10 +123,5 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
-
-<!--#if !MOZCENTRAL-->
-    <input type="file" id="fileInput" class="hidden">
-<!--#endif-->
-
   </body>
 </html>

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -57,10 +57,6 @@ function getViewerConfiguration() {
       cancelButton: document.getElementById("passwordCancel"),
     },
     printContainer: document.getElementById("printContainer"),
-    openFileInput:
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
-        ? document.getElementById("fileInput")
-        : null,
   };
 }
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -565,9 +565,5 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
-
-<!--#if GENERIC-->
-    <input type="file" id="fileInput" class="hidden">
-<!--#endif-->
   </body>
 </html>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -177,10 +177,6 @@ function getViewerConfiguration() {
       ),
     },
     printContainer: document.getElementById("printContainer"),
-    openFileInput:
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
-        ? document.getElementById("fileInput")
-        : null,
     debuggerScriptPath: "./debugger.mjs",
   };
 }


### PR DESCRIPTION
Given that only the GENERIC viewer supports opening more than one PDF document, we can simplify things a tiny bit by instead generating the necessary DOM-element in JavaScript.