### PR TITLE
Move the `debuggerSrc`-parameter into the `AppOptions`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2167,11 +2167,10 @@ async function loadFakeWorker() {
 }
 
 async function loadPDFBug(self) {
-  const { debuggerScriptPath } = self.appConfig;
   const { PDFBug } =
     typeof PDFJSDev === "undefined"
-      ? await import(debuggerScriptPath) // eslint-disable-line no-unsanitized/method
-      : await __non_webpack_import__(debuggerScriptPath);
+      ? await import(AppOptions.get("debuggerSrc")) // eslint-disable-line no-unsanitized/method
+      : await __non_webpack_import__(AppOptions.get("debuggerSrc"));
 
   self._PDFBug = PDFBug;
 }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -105,6 +105,11 @@ const defaultOptions = {
     value: 0,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  debuggerSrc: {
+    /** @type {string} */
+    value: "./debugger.mjs",
+    kind: OptionKind.VIEWER,
+  },
   defaultZoomDelay: {
     /** @type {number} */
     value: 400,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -177,7 +177,6 @@ function getViewerConfiguration() {
       ),
     },
     printContainer: document.getElementById("printContainer"),
-    debuggerScriptPath: "./debugger.mjs",
   };
 }
 


### PR DESCRIPTION
Having this parameter among a list of DOM-elements seems slightly strange now, however this is very old code hence the explanation for why this was done is for historical reasons (as is often the case).
Hence we can simply move this into `AppOptions` instead, which seems more appropriate overall.