### PR TITLE
Fix transform of unary expression in Babel plugin

### DIFF
--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -92,17 +92,22 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
           }
         },
       },
-      UnaryExpression(path) {
-        const { node } = path;
-        if (node.operator === "typeof" && isPDFJSPreprocessor(node.argument)) {
-          // typeof PDFJSDev => 'object'
-          path.replaceWith(t.stringLiteral("object"));
-          return;
-        }
-        if (node.operator === "!" && t.isBooleanLiteral(node.argument)) {
-          // !true => false,  !false => true
-          path.replaceWith(t.booleanLiteral(!node.argument.value));
-        }
+      UnaryExpression: {
+        exit(path) {
+          const { node } = path;
+          if (
+            node.operator === "typeof" &&
+            isPDFJSPreprocessor(node.argument)
+          ) {
+            // typeof PDFJSDev => 'object'
+            path.replaceWith(t.stringLiteral("object"));
+            return;
+          }
+          if (node.operator === "!" && t.isBooleanLiteral(node.argument)) {
+            // !true => false,  !false => true
+            path.replaceWith(t.booleanLiteral(!node.argument.value));
+          }
+        },
       },
       LogicalExpression: {
         exit(path) {

--- a/external/builder/fixtures_esprima/evals-expected.js
+++ b/external/builder/fixtures_esprima/evals-expected.js
@@ -17,3 +17,5 @@ var i = '0';
 var j = {
   i: 1
 };
+var k = false;
+var l = true;

--- a/external/builder/fixtures_esprima/evals.js
+++ b/external/builder/fixtures_esprima/evals.js
@@ -8,3 +8,5 @@ var g = PDFJSDev.eval('OBJ');
 var h = PDFJSDev.json('$ROOT/external/builder/fixtures_esprima/evals.json');
 var i = typeof PDFJSDev === 'undefined' ? PDFJSDev.eval('FALSE') : '0';
 var j = typeof PDFJSDev !== 'undefined' ? PDFJSDev.eval('OBJ.obj') : '0';
+var k = !PDFJSDev.test('TRUE');
+var l = !PDFJSDev.test('FALSE');

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -400,7 +400,7 @@ class ExternalServices extends BaseExternalServices {
   }
 
   async getNimbusExperimentData() {
-    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("GECKOVIEW")) {
+    if (!PDFJSDev.test("GECKOVIEW")) {
       return null;
     }
     const nimbusData = await FirefoxCom.requestAsync(


### PR DESCRIPTION
The generated code in `build/.../viewer.js` is now
```js
  async getNimbusExperimentData() {
    return null;
  }
```
and the generated code in `build/.../viewer-geckoview.js` is
```js
  async getNimbusExperimentData() {
    const nimbusData = await FirefoxCom.requestAsync("getNimbusExperimentData", null);
    return nimbusData && JSON.parse(nimbusData);
  }
```

Fixes #17589