### PR TITLE
Use a limit, in more places, when splitting strings

### DIFF
--- a/extensions/chromium/extension-router.js
+++ b/extensions/chromium/extension-router.js
@@ -47,7 +47,7 @@ limitations under the License.
     }
     var scheme = url.slice(0, schemeIndex).toLowerCase();
     if (schemes.includes(scheme)) {
-      url = url.split("#")[0];
+      url = url.split("#", 1)[0];
       if (url.charAt(schemeIndex) === ":") {
         url = encodeURIComponent(url);
       }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3955,7 +3955,7 @@ class PartialEvaluator {
 
   isSerifFont(baseFontName) {
     // Simulating descriptor flags attribute
-    const fontNameWoStyle = baseFontName.split("-")[0];
+    const fontNameWoStyle = baseFontName.split("-", 1)[0];
     return (
       fontNameWoStyle in getSerifFonts() || /serif/gi.test(fontNameWoStyle)
     );
@@ -4185,7 +4185,7 @@ class PartialEvaluator {
         const metrics = this.getBaseFontMetrics(baseFontName);
 
         // Simulating descriptor flags attribute
-        const fontNameWoStyle = baseFontName.split("-")[0];
+        const fontNameWoStyle = baseFontName.split("-", 1)[0];
         const flags =
           (this.isSerifFont(fontNameWoStyle) ? FontFlags.Serif : 0) |
           (metrics.monospace ? FontFlags.FixedPitch : 0) |

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -968,7 +968,7 @@ class Font {
     // Fallback to checking the font name, in order to improve text-selection,
     // since the /Flags-entry is often wrong (fixes issue13845.pdf).
     if (!isSerifFont && !properties.isSimulatedFlags) {
-      const baseName = name.replaceAll(/[,_]/g, "-").split("-")[0],
+      const baseName = name.replaceAll(/[,_]/g, "-").split("-", 1)[0],
         serifFonts = getSerifFonts();
       for (const namePart of baseName.split("+")) {
         if (serifFonts[namePart]) {
@@ -1286,7 +1286,7 @@ class Font {
     }
 
     amendFallbackToUnicode(properties);
-    this.loadedName = fontName.split("-")[0];
+    this.loadedName = fontName.split("-", 1)[0];
   }
 
   checkAndRepair(name, font, properties) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -745,7 +745,7 @@ class Driver {
     if (!("message" in e)) {
       return JSON.stringify(e);
     }
-    return e.message + ("stack" in e ? " at " + e.stack.split("\n")[0] : "");
+    return e.message + ("stack" in e ? " at " + e.stack.split("\n", 1)[0] : "");
   }
 
   _getLastPageNumber(task) {

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -17,7 +17,7 @@ import { getPdfFilenameFromUrl } from "pdfjs-lib";
 
 async function docProperties(pdfDocument) {
   const url = "",
-    baseUrl = url.split("#")[0];
+    baseUrl = url.split("#", 1)[0];
   // eslint-disable-next-line prefer-const
   let { info, metadata, contentDispositionFilename, contentLength } =
     await pdfDocument.getMetadata();

--- a/web/pdf_history.js
+++ b/web/pdf_history.js
@@ -385,7 +385,7 @@ class PDFHistory {
 
     let newUrl;
     if (this._updateUrl && destination?.hash) {
-      const baseUrl = document.location.href.split("#")[0];
+      const baseUrl = document.location.href.split("#", 1)[0];
       // Prevent errors in Firefox.
       if (!baseUrl.startsWith("file://")) {
         newUrl = `${baseUrl}#${destination.hash}`;


### PR DESCRIPTION
This should be a *tiny* bit more efficient, since it avoids parsing substrings that we don't care about.

*Please note:* I cannot find an ESLint rule to enforce this automatically.