### PR TITLE
Simplify the signature of the `PDFDataTransportStream` constructor

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -405,18 +405,10 @@ function getDocument(src) {
       const networkStreamPromise = new Promise(function (resolve) {
         let networkStream;
         if (rangeTransport) {
-          networkStream = new PDFDataTransportStream(
-            {
-              length,
-              initialData: rangeTransport.initialData,
-              progressiveDone: rangeTransport.progressiveDone,
-              contentDispositionFilename:
-                rangeTransport.contentDispositionFilename,
-              disableRange,
-              disableStream,
-            },
-            rangeTransport
-          );
+          networkStream = new PDFDataTransportStream(rangeTransport, {
+            disableRange,
+            disableStream,
+          });
         } else if (!data) {
           if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
             throw new Error("Not implemented: createPDFNetworkStream");

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -24,20 +24,15 @@ import { isPdfFile } from "./display_utils.js";
 /** @implements {IPDFStream} */
 class PDFDataTransportStream {
   constructor(
-    {
-      length,
-      initialData,
-      progressiveDone = false,
-      contentDispositionFilename = null,
-      disableRange = false,
-      disableStream = false,
-    },
-    pdfDataRangeTransport
+    pdfDataRangeTransport,
+    { disableRange = false, disableStream = false }
   ) {
     assert(
       pdfDataRangeTransport,
       'PDFDataTransportStream - missing required "pdfDataRangeTransport" argument.'
     );
+    const { length, initialData, progressiveDone, contentDispositionFilename } =
+      pdfDataRangeTransport;
 
     this._queuedChunks = [];
     this._progressiveDone = progressiveDone;
@@ -62,23 +57,23 @@ class PDFDataTransportStream {
     this._fullRequestReader = null;
     this._rangeReaders = [];
 
-    this._pdfDataRangeTransport.addRangeListener((begin, chunk) => {
+    pdfDataRangeTransport.addRangeListener((begin, chunk) => {
       this._onReceiveData({ begin, chunk });
     });
 
-    this._pdfDataRangeTransport.addProgressListener((loaded, total) => {
+    pdfDataRangeTransport.addProgressListener((loaded, total) => {
       this._onProgress({ loaded, total });
     });
 
-    this._pdfDataRangeTransport.addProgressiveReadListener(chunk => {
+    pdfDataRangeTransport.addProgressiveReadListener(chunk => {
       this._onReceiveData({ chunk });
     });
 
-    this._pdfDataRangeTransport.addProgressiveDoneListener(() => {
+    pdfDataRangeTransport.addProgressiveDoneListener(() => {
       this._onProgressiveDone();
     });
 
-    this._pdfDataRangeTransport.transportReady();
+    pdfDataRangeTransport.transportReady();
   }
 
   _onReceiveData({ begin, chunk }) {


### PR DESCRIPTION
Given that we need to pass in a `PDFDataRangeTransport`-instance a number of the needed parameters can be obtained from it, rather than having to specify them manually.