### PR TITLE
Remove support for `require` statements from the build system

### DIFF
--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -170,17 +170,6 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
           );
           path.replaceWith(t.inherits(t.valueToNode(result), path.node));
         }
-
-        // require('string')
-        if (
-          t.isIdentifier(node.callee, { name: "require" }) &&
-          node.arguments.length === 1 &&
-          t.isStringLiteral(node.arguments[0]) &&
-          ctx.map?.[node.arguments[0].value]
-        ) {
-          const requireName = node.arguments[0];
-          requireName.value = requireName.raw = ctx.map[requireName.value];
-        }
       },
       BlockStatement: {
         // Visit node in post-order so that recursive flattening

--- a/external/builder/fixtures_esprima/importalias-expected.js
+++ b/external/builder/fixtures_esprima/importalias-expected.js
@@ -1,5 +1,3 @@
 import { Test } from "import-name";
 import { Test2 } from './non-alias';
 export { Test3 } from "import-name";
-var Imp = require("import-name");
-var Imp2 = require('./non-alias');

--- a/external/builder/fixtures_esprima/importalias.js
+++ b/external/builder/fixtures_esprima/importalias.js
@@ -1,5 +1,3 @@
 import { Test } from 'import-alias';
 import { Test2 } from './non-alias';
 export { Test3 } from 'import-alias';
-var Imp = require('import-alias');
-var Imp2 = require('./non-alias');


### PR DESCRIPTION
This part of the (modern) preprocessor is now dead code, since we no longer use `require` statements anywhere in the main code-base.

Note that as part of the changes leading up to PDF.js version `4` we removed all[1] the remaining `require` statements, and we also have an ESLint rule to ensure that no new ones are accidentally added.

---
[1] With two small exceptions, in benchmarking-code and in the Webpack-example.