### PR TITLE
Re-factor `PDFPrintServiceFactory` to use import maps

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -269,7 +269,6 @@ function createWebpackConfig(
   const viewerAlias = {
     "web-alt_text_manager": "web/alt_text_manager.js",
     "web-annotation_editor_params": "web/annotation_editor_params.js",
-    "web-com": "",
     "web-download_manager": "",
     "web-external_services": "",
     "web-null_l10n": "",
@@ -291,7 +290,6 @@ function createWebpackConfig(
     libraryAlias["display-fetch_stream"] = "src/display/fetch_stream.js";
     libraryAlias["display-network"] = "src/display/network.js";
 
-    viewerAlias["web-com"] = "web/chromecom.js";
     viewerAlias["web-download_manager"] = "web/download_manager.js";
     viewerAlias["web-external_services"] = "web/chromecom.js";
     viewerAlias["web-null_l10n"] = "web/l10n.js";
@@ -306,7 +304,6 @@ function createWebpackConfig(
     libraryAlias["display-node_stream"] = "src/display/node_stream.js";
     libraryAlias["display-node_utils"] = "src/display/node_utils.js";
 
-    viewerAlias["web-com"] = "web/genericcom.js";
     viewerAlias["web-download_manager"] = "web/download_manager.js";
     viewerAlias["web-external_services"] = "web/genericcom.js";
     viewerAlias["web-null_l10n"] = "web/genericl10n.js";
@@ -321,7 +318,6 @@ function createWebpackConfig(
         viewerAlias[key] = gvAlias[key] || "web/stubs-geckoview.js";
       }
     }
-    viewerAlias["web-com"] = "web/firefoxcom.js";
     viewerAlias["web-download_manager"] = "web/firefoxcom.js";
     viewerAlias["web-external_services"] = "web/firefoxcom.js";
     viewerAlias["web-null_l10n"] = "web/l10n.js";

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -27,7 +27,6 @@
 
         "web-alt_text_manager": "../../web/alt_text_manager.js",
         "web-annotation_editor_params": "../../web/annotation_editor_params.js",
-        "web-com": "../../web/genericcom.js",
         "web-download_manager": "../../web/download_manager.js",
         "web-external_services": "../../web/genericcom.js",
         "web-null_l10n": "../../web/genericl10n.js",

--- a/web/app.js
+++ b/web/app.js
@@ -70,6 +70,7 @@ import { PDFHistory } from "./pdf_history.js";
 import { PDFLayerViewer } from "web-pdf_layer_viewer";
 import { PDFOutlineViewer } from "web-pdf_outline_viewer";
 import { PDFPresentationMode } from "web-pdf_presentation_mode";
+import { PDFPrintServiceFactory } from "web-print_service";
 import { PDFRenderingQueue } from "./pdf_rendering_queue.js";
 import { PDFScriptingManager } from "./pdf_scripting_manager.js";
 import { PDFSidebar } from "web-pdf_sidebar";
@@ -731,7 +732,7 @@ const PDFViewerApplication = {
   },
 
   get supportsPrinting() {
-    return PDFPrintServiceFactory.instance.supportsPrinting;
+    return PDFPrintServiceFactory.supportsPrinting;
   },
 
   get supportsFullscreen() {
@@ -1786,7 +1787,7 @@ const PDFViewerApplication = {
     const optionalContentConfigPromise =
       this.pdfViewer.optionalContentConfigPromise;
 
-    const printService = PDFPrintServiceFactory.instance.createPrintService(
+    const printService = PDFPrintServiceFactory.createPrintService(
       this.pdfDocument,
       pagesOverview,
       printContainer,
@@ -3234,14 +3235,4 @@ function webViewerReportTelemetry({ details }) {
   PDFViewerApplication.externalServices.reportTelemetry(details);
 }
 
-/* Abstract factory for the print service. */
-const PDFPrintServiceFactory = {
-  instance: {
-    supportsPrinting: false,
-    createPrintService() {
-      throw new Error("Not implemented: createPrintService");
-    },
-  },
-};
-
-export { PDFPrintServiceFactory, PDFViewerApplication };
+export { PDFViewerApplication };

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -20,7 +20,6 @@ import {
   shadow,
 } from "pdfjs-lib";
 import { getXfaHtmlForPrinting } from "./print_utils.js";
-import { PDFPrintServiceFactory } from "./app.js";
 
 // Creates a placeholder with div and canvas with right size for the page.
 function composePage(
@@ -194,15 +193,16 @@ class FirefoxPrintService {
   }
 }
 
-PDFPrintServiceFactory.instance = {
-  get supportsPrinting() {
+/**
+ * @implements {IPDFPrintServiceFactory}
+ */
+class PDFPrintServiceFactory {
+  static get supportsPrinting() {
     const canvas = document.createElement("canvas");
-    const value = "mozPrintCallback" in canvas;
+    return shadow(this, "supportsPrinting", "mozPrintCallback" in canvas);
+  }
 
-    return shadow(this, "supportsPrinting", value);
-  },
-
-  createPrintService(
+  static createPrintService(
     pdfDocument,
     pagesOverview,
     printContainer,
@@ -218,7 +218,7 @@ PDFPrintServiceFactory.instance = {
       optionalContentConfigPromise,
       printAnnotationStoragePromise
     );
-  },
-};
+  }
+}
 
-export { FirefoxPrintService };
+export { PDFPrintServiceFactory };

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -217,4 +217,23 @@ class IL10n {
   resume() {}
 }
 
-export { IDownloadManager, IL10n, IPDFLinkService, IRenderableView };
+/**
+ * @interface
+ */
+class IPDFPrintServiceFactory {
+  static get supportsPrinting() {
+    return false;
+  }
+
+  static createPrintService() {
+    throw new Error("Not implemented: createPrintService");
+  }
+}
+
+export {
+  IDownloadManager,
+  IL10n,
+  IPDFLinkService,
+  IPDFPrintServiceFactory,
+  IRenderableView,
+};

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { AnnotationMode, PixelsPerInch } from "pdfjs-lib";
-import { PDFPrintServiceFactory, PDFViewerApplication } from "./app.js";
+import { AnnotationMode, PixelsPerInch, shadow } from "pdfjs-lib";
 import { getXfaHtmlForPrinting } from "./print_utils.js";
+import { PDFViewerApplication } from "./app.js";
 
 let activeService = null;
 let dialog = null;
@@ -355,10 +355,15 @@ function ensureOverlay() {
   return overlayPromise;
 }
 
-PDFPrintServiceFactory.instance = {
-  supportsPrinting: true,
+/**
+ * @implements {IPDFPrintServiceFactory}
+ */
+class PDFPrintServiceFactory {
+  static get supportsPrinting() {
+    return shadow(this, "supportsPrinting", true);
+  }
 
-  createPrintService(
+  static createPrintService(
     pdfDocument,
     pagesOverview,
     printContainer,
@@ -378,7 +383,7 @@ PDFPrintServiceFactory.instance = {
       printAnnotationStoragePromise
     );
     return activeService;
-  },
-};
+  }
+}
 
-export { PDFPrintService };
+export { PDFPrintServiceFactory };

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -60,7 +60,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 
           "web-alt_text_manager": "./stubs-geckoview.js",
           "web-annotation_editor_params": "./stubs-geckoview.js",
-          "web-com": "./genericcom.js",
           "web-download_manager": "./download_manager.js",
           "web-external_services": "./genericcom.js",
           "web-null_l10n": "./genericl10n.js",

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import "web-com";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -14,7 +14,6 @@
  */
 
 import "web-com";
-import "web-print_service";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -69,7 +69,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 
           "web-alt_text_manager": "./alt_text_manager.js",
           "web-annotation_editor_params": "./annotation_editor_params.js",
-          "web-com": "./genericcom.js",
           "web-download_manager": "./download_manager.js",
           "web-external_services": "./genericcom.js",
           "web-null_l10n": "./genericl10n.js",

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import "web-com";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -14,7 +14,6 @@
  */
 
 import "web-com";
-import "web-print_service";
 import { RenderingStates, ScrollMode, SpreadMode } from "./ui_utils.js";
 import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";


### PR DESCRIPTION
This is very old code, which can (ever so slightly) be simplified now that import maps are available.