### PR TITLE
When updating, write the xref table in the same format as the previous one (bug 1878916)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -611,6 +611,19 @@ function getRotationMatrix(rotation, width, height) {
   }
 }
 
+/**
+ * Get the number of bytes to use to represent the given positive integer.
+ * If n is zero, the function returns 0 which means that we don't need to waste
+ * a byte to represent it.
+ * @param {number} x - a positive integer.
+ * @returns {number}
+ */
+function getSizeInBytes(x) {
+  // n bits are required for numbers up to 2^n - 1.
+  // So for a number x, we need ceil(log2(1 + x)) bits.
+  return Math.ceil(Math.ceil(Math.log2(1 + x)) / 8);
+}
+
 export {
   arrayBuffersToBytes,
   codePointIter,
@@ -622,6 +635,7 @@ export {
   getLookupTableFactory,
   getNewAnnotationsMap,
   getRotationMatrix,
+  getSizeInBytes,
   isAscii,
   isWhiteSpace,
   log2,

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -35,7 +35,7 @@ import {
   getNewAnnotationsMap,
   XRefParseException,
 } from "./core_utils.js";
-import { Dict, Ref } from "./primitives.js";
+import { Dict, isDict, Ref } from "./primitives.js";
 import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
 import { AnnotationFactory } from "./annotation.js";
 import { clearGlobalCaches } from "./cleanup_helper.js";
@@ -726,6 +726,8 @@ class WorkerMessageHandler {
           acroFormRef,
           acroForm,
           xfaData,
+          // Use the same kind of XRef as the previous one.
+          useXrefStream: isDict(xref.topDict, "XRef"),
         }).finally(() => {
           xref.resetNewTemporaryRef();
         });

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -19,6 +19,7 @@ import {
   escapePDFName,
   escapeString,
   getInheritableProperty,
+  getSizeInBytes,
   isAscii,
   isWhiteSpace,
   log2,
@@ -466,6 +467,23 @@ describe("core_utils", function () {
       ).toEqual(
         "\xfe\xff\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f\x4e\x16\x75\x4c\x30\x6e"
       );
+    });
+  });
+
+  describe("getSizeInBytes", function () {
+    it("should get the size in bytes to use to represent a positive integer", function () {
+      expect(getSizeInBytes(0)).toEqual(0);
+      for (let i = 1; i <= 0xff; i++) {
+        expect(getSizeInBytes(i)).toEqual(1);
+      }
+
+      for (let i = 0x100; i <= 0xffff; i += 0x100) {
+        expect(getSizeInBytes(i)).toEqual(2);
+      }
+
+      for (let i = 0x10000; i <= 0xffffff; i += 0x10000) {
+        expect(getSizeInBytes(i)).toEqual(3);
+      }
     });
   });
 });

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -37,26 +37,55 @@ describe("Writer", function () {
         info: {},
       };
 
-      let data = await incrementalUpdate({ originalData, xrefInfo, newRefs });
+      let data = await incrementalUpdate({
+        originalData,
+        xrefInfo,
+        newRefs,
+        useXrefStream: true,
+      });
       data = bytesToString(data);
 
-      const expected =
+      let expected =
         "\nabc\n" +
         "defg\n" +
         "789 0 obj\n" +
-        "<< /Size 790 /Prev 314 /Type /XRef /Index [0 1 123 1 456 1 789 1] " +
-        "/ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)] " +
-        "/W [1 1 2] /Length 16>> stream\n" +
-        "\x00\x01\xff\xff" +
-        "\x01\x01\x00\x2d" +
-        "\x01\x05\x00\x4e" +
-        "\x01\x0a\x00\x00\n" +
+        "<< /Prev 314 /Size 790 /Type /XRef /Index [123 1 456 1 789 1] " +
+        "/W [1 1 1] /ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)] " +
+        "/Length 9>> stream\n" +
+        "\x01\x01\x2d" +
+        "\x01\x05\x4e" +
+        "\x01\x0a\x00\n" +
         "endstream\n" +
         "endobj\n" +
         "startxref\n" +
         "10\n" +
         "%%EOF\n";
+      expect(data).toEqual(expected);
 
+      data = await incrementalUpdate({
+        originalData,
+        xrefInfo,
+        newRefs,
+        useXrefStream: false,
+      });
+      data = bytesToString(data);
+
+      expected =
+        "\nabc\n" +
+        "defg\n" +
+        "xref\n" +
+        "123 1\n" +
+        "0000000001 00045 n\r\n" +
+        "456 1\n" +
+        "0000000005 00078 n\r\n" +
+        "789 1\n" +
+        "0000000010 00000 n\r\n" +
+        "trailer\n" +
+        "<< /Prev 314 /Size 789 " +
+        "/ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)]>>\n" +
+        "startxref\n" +
+        "10\n" +
+        "%%EOF\n";
       expect(data).toEqual(expected);
     });
 
@@ -74,17 +103,21 @@ describe("Writer", function () {
         info: {},
       };
 
-      let data = await incrementalUpdate({ originalData, xrefInfo, newRefs });
+      let data = await incrementalUpdate({
+        originalData,
+        xrefInfo,
+        newRefs,
+        useXrefStream: true,
+      });
       data = bytesToString(data);
 
       const expected =
         "\nabc\n" +
         "789 0 obj\n" +
-        "<< /Size 790 /Prev 314 /Type /XRef /Index [0 1 123 1 789 1] " +
-        "/W [1 1 2] /Length 12>> stream\n" +
-        "\x00\x01\xff\xff" +
-        "\x01\x01\x00\x2d" +
-        "\x01\x05\x00\x00\n" +
+        "<< /Prev 314 /Size 790 /Type /XRef /Index [123 1 789 1] " +
+        "/W [1 1 1] /Length 6>> stream\n" +
+        "\x01\x01\x2d" +
+        "\x01\x05\x00\n" +
         "endstream\n" +
         "endobj\n" +
         "startxref\n" +
@@ -187,6 +220,7 @@ describe("Writer", function () {
         acroForm,
         xfaData,
         xref: {},
+        useXrefStream: true,
       });
       data = bytesToString(data);
 
@@ -202,8 +236,8 @@ describe("Writer", function () {
         "endstream\n" +
         "endobj\n" +
         "131415 0 obj\n" +
-        "<< /Size 131416 /Prev 314 /Type /XRef /Index [0 1 789 1 101112 1 131415 1] /W [1 1 2] /Length 16>> stream\n" +
-        "\u0000\u0001ÿÿ\u0001\u0001\u0000\u0000\u0001[\u0000\u0000\u0001¹\u0000\u0000\n" +
+        "<< /Prev 314 /Size 131416 /Type /XRef /Index [789 1 101112 1 131415 1] /W [1 1 0] /Length 6>> stream\n" +
+        "\x01\x01\x01[\x01¹\n" +
         "endstream\n" +
         "endobj\n" +
         "startxref\n" +


### PR DESCRIPTION
The specs are unclear about what kind of xref table format must be used.
In checking the validity of some pdfs in the preflight tool from Acrobat we can guess that having the same format is the correct way to do.
The pdf in the mentioned bug, after having been changed, wasn't correctly displayed in neither Chrome nor Acrobat: it's now fixed.