### PR TITLE
Move the `__non_webpack_import__` re-writing into the Babel plugin

### DIFF
--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -172,6 +172,22 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
           );
           path.replaceWith(t.inherits(t.valueToNode(result), path.node));
         }
+
+        if (t.isIdentifier(node.callee, { name: "__non_webpack_import__" })) {
+          if (node.arguments.length !== 1) {
+            throw new Error("Invalid `__non_webpack_import__` usage.");
+          }
+          // Replace it with a standard `import`-call and
+          // ensure that Webpack will leave it alone.
+          const source = node.arguments[0];
+          source.leadingComments = [
+            {
+              type: "CommentBlock",
+              value: "webpackIgnore: true",
+            },
+          ];
+          path.replaceWith(t.importExpression(source));
+        }
       },
       BlockStatement: {
         // Visit node in post-order so that recursive flattening

--- a/external/builder/fixtures_esprima/importalias-expected.js
+++ b/external/builder/fixtures_esprima/importalias-expected.js
@@ -1,3 +1,4 @@
 import { Test } from "import-name";
 import { Test2 } from './non-alias';
 export { Test3 } from "import-name";
+await import( /*webpackIgnore: true*/"./non-alias");

--- a/external/builder/fixtures_esprima/importalias.js
+++ b/external/builder/fixtures_esprima/importalias.js
@@ -1,3 +1,4 @@
 import { Test } from 'import-alias';
 import { Test2 } from './non-alias';
 export { Test3 } from 'import-alias';
+await __non_webpack_import__("./non-alias");


### PR DESCRIPTION
Note how we're using custom `__non_webpack_import__`-calls in the code-base, that we replace during the post-processing stage of the build, to be able to write `import`-calls that Webpack will leave alone during parsing.
This work-around is necessary since we let Babel discards all comments, given that we generally don't need/want them in the builds, hence why we cannot utilize `/* webpackIgnore: true */`-comments in the source-code.

After the changes in PR #17563 it thus seems to me that we should be able to just move this re-writing into the Babel plugin instead.

---

/cc @nicolo-ribaudo Since my knowledge of Babel is somewhat limited: Can you please check if this re-writing makes sense, or if there's a better/nicer way to implement this?