### PR TITLE
Prevent duplicate names in unit/integration tests

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -10,8 +10,8 @@
     "jasmine/new-line-between-declarations": "off",
     "jasmine/no-focused-tests": "error",
     "jasmine/no-pending-tests": "off",
-    "jasmine/no-spec-dupes": "off",
-    "jasmine/no-suite-dupes": "off",
+    "jasmine/no-spec-dupes": ["error", "branch"],
+    "jasmine/no-suite-dupes": ["error", "branch"],
     "jasmine/prefer-jasmine-matcher": "off",
     "jasmine/prefer-toHaveBeenCalledWith": "off"
   }

--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -72,7 +72,8 @@ describe("find bar", () => {
       );
     });
   });
-  describe("highlight all", () => {
+
+  describe("highlight all (XFA)", () => {
     let pages;
 
     beforeAll(async () => {

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -999,7 +999,7 @@ describe("Scripting", function () {
         });
       });
 
-      it("should format a date", async () => {
+      it("should format a date (cFormat)", async () => {
         const refId = getId();
         const data = {
           objects: {

--- a/test/unit/xfa_parser_spec.js
+++ b/test/unit/xfa_parser_spec.js
@@ -1021,7 +1021,7 @@ describe("XFAParser", function () {
       ).toBe("SW1");
     });
 
-    it("should make basic binding with extra subform", function () {
+    it("should make basic binding with extra subform (consumeData)", function () {
       const xml = `
 <?xml version="1.0"?>
 <xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/">


### PR DESCRIPTION
Having identical names for different test-cases may result in less helpful output, which we can avoid with the use of the ESLint Jasmine plugin.
This patch enables the rules at the `branch` level, to limit the amount/scope of the changes slightly. (We could thus make this rule more strict in the future, if that's deemed useful.)

Please refer to:
 - https://github.com/tlvince/eslint-plugin-jasmine/blob/master/docs/rules/no-spec-dupes.md
 - https://github.com/tlvince/eslint-plugin-jasmine/blob/master/docs/rules/no-suite-dupes.md