### PR TITLE
Only show the full webserver's directory listing

### DIFF
--- a/test/webserver.mjs
+++ b/test/webserver.mjs
@@ -211,12 +211,11 @@ WebServer.prototype = {
           "<html><frameset cols=*,200><frame name=pdf>" +
             '<frame src="' +
             encodeURI(pathPart) +
-            '?side"></frameset></html>',
+            '"></frameset></html>',
           "utf8"
         );
         return;
       }
-      var all = queryPart === "all";
       fs.readdir(dir, function (err, files) {
         if (err) {
           res.end();
@@ -224,7 +223,7 @@ WebServer.prototype = {
         }
         res.write(
           '<html><head><meta charset="utf-8"></head><body>' +
-            "<h1>PDFs of " +
+            "<h1>Index of " +
             pathPart +
             "</h1>\n"
         );
@@ -252,7 +251,7 @@ WebServer.prototype = {
               href = "/web/viewer.html?file=" + encodeURIComponent(item);
               label = file;
               extraAttributes = ' target="pdf"';
-            } else if (all) {
+            } else {
               href = encodeURI(item);
               label = file;
             }
@@ -271,12 +270,6 @@ WebServer.prototype = {
         });
         if (files.length === 0) {
           res.write("<p>no files found</p>\n");
-        }
-        if (!all && queryPart !== "side") {
-          res.write(
-            "<hr><p>(only PDF files are shown, " +
-              '<a href="?all">show all</a>)</p>\n'
-          );
         }
         res.end("</body></html>");
       });


### PR DESCRIPTION
The webserver by default shows a directory listing that is reduced to only PDF files and folders. However, in practice this is rarely useful because other files (like `web/viewer.html`) are accessed more often and that now always requires an extra click. Moreover, it doesn't match directory listing behavior of known webservers like Nginx or Apache. This commit thefore aligns the behavior and header with other webserver implementations to provide better defaults and simplify the code.