### PR TITLE
Tweak the issue 11878 unit-test parsing time check (PR 17428 follow-up)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3908,7 +3908,7 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
             checkedCopyLocalImage = true;
             // Ensure that the image was copied in the main-thread, rather
             // than being re-parsed in the worker-thread (which is slower).
-            expect(statsOverall).toBeLessThan(firstStatsOverall / 5);
+            expect(statsOverall).toBeLessThan(firstStatsOverall / 4);
           }
         }
       }


### PR DESCRIPTION
This unit-test has been failing occasionally in Chrome and Node.js, hence we tweak the parsing time check to reduce the likelihood of that happening.