### PR TITLE
Skip any whitespace after the first object in linearized PDFs (issue 17665)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -930,7 +930,14 @@ class PDFDocument {
       // Find the end of the first object.
       stream.reset();
       if (find(stream, ENDOBJ_SIGNATURE)) {
-        startXRef = stream.pos + 6 - stream.start;
+        stream.skip(6);
+
+        let ch = stream.peekByte();
+        while (isWhiteSpace(ch)) {
+          stream.pos++;
+          ch = stream.peekByte();
+        }
+        startXRef = stream.pos - stream.start;
       }
     } else {
       // Find `startxref` by checking backwards from the end of the file.

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -880,6 +880,9 @@ class WorkerMessageHandler {
           .ensureXRef("trailer")
           .then(trailer => trailer.get("Prev"));
       });
+      handler.on("GetStartXRefPos", function (data) {
+        return pdfManager.ensureDoc("startXRef");
+      });
       handler.on("GetAnnotArray", function (data) {
         return pdfManager.getPage(data.pageIndex).then(function (page) {
           return page.annotations.map(a => a.toString());

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -768,6 +768,9 @@ class PDFDocumentProxy {
       Object.defineProperty(this, "getXRefPrevValue", {
         value: () => this._transport.getXRefPrevValue(),
       });
+      Object.defineProperty(this, "getStartXRefPos", {
+        value: () => this._transport.getStartXRefPos(),
+      });
       Object.defineProperty(this, "getAnnotArray", {
         value: pageIndex => this._transport.getAnnotArray(pageIndex),
       });
@@ -2348,6 +2351,10 @@ class WorkerTransport {
       Object.defineProperty(this, "getXRefPrevValue", {
         value: () =>
           this.messageHandler.sendWithPromise("GetXRefPrevValue", null),
+      });
+      Object.defineProperty(this, "getStartXRefPos", {
+        value: () =>
+          this.messageHandler.sendWithPromise("GetStartXRefPos", null),
       });
       Object.defineProperty(this, "getAnnotArray", {
         value: pageIndex =>

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -511,6 +511,18 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
+    it("checks the `startxref` position of a linearized pdf doc (issue 17665)", async function () {
+      const loadingTask = getDocument(buildGetDocumentParams("empty.pdf"));
+      expect(loadingTask instanceof PDFDocumentLoadingTask).toEqual(true);
+
+      const pdfDocument = await loadingTask.promise;
+
+      const startXRefPos = await pdfDocument.getStartXRefPos();
+      expect(startXRefPos).toEqual(116);
+
+      await loadingTask.destroy();
+    });
+
     it("checks that `docId`s are unique and increasing", async function () {
       const loadingTask1 = getDocument(basicApiGetDocumentParams);
       expect(loadingTask1 instanceof PDFDocumentLoadingTask).toEqual(true);


### PR DESCRIPTION
*Please note:* I don't think that we have any good way of testing this, however the code is now consistent with the non-linearized branch in the `PDFDocument.startXRef` getter.