### PR TITLE
Change `PDFPrintServiceFactory.createPrintService` to take a parameter object

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1781,26 +1781,19 @@ const PDFViewerApplication = {
       return;
     }
 
-    const pagesOverview = this.pdfViewer.getPagesOverview();
-    const printContainer = this.appConfig.printContainer;
-    const printResolution = AppOptions.get("printResolution");
-    const optionalContentConfigPromise =
-      this.pdfViewer.optionalContentConfigPromise;
-
-    const printService = PDFPrintServiceFactory.createPrintService(
-      this.pdfDocument,
-      pagesOverview,
-      printContainer,
-      printResolution,
-      optionalContentConfigPromise,
-      this._printAnnotationStoragePromise
-    );
-    this.printService = printService;
+    this.printService = PDFPrintServiceFactory.createPrintService({
+      pdfDocument: this.pdfDocument,
+      pagesOverview: this.pdfViewer.getPagesOverview(),
+      printContainer: this.appConfig.printContainer,
+      printResolution: AppOptions.get("printResolution"),
+      optionalContentConfigPromise: this.pdfViewer.optionalContentConfigPromise,
+      printAnnotationStoragePromise: this._printAnnotationStoragePromise,
+    });
     this.forceRendering();
     // Disable the editor-indicator during printing (fixes bug 1790552).
     this.setTitle();
 
-    printService.layout();
+    this.printService.layout();
 
     if (this._hasAnnotationEditors) {
       this.externalServices.reportTelemetry({

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -114,14 +114,14 @@ function composePage(
 }
 
 class FirefoxPrintService {
-  constructor(
+  constructor({
     pdfDocument,
     pagesOverview,
     printContainer,
     printResolution,
     optionalContentConfigPromise = null,
-    printAnnotationStoragePromise = null
-  ) {
+    printAnnotationStoragePromise = null,
+  }) {
     this.pdfDocument = pdfDocument;
     this.pagesOverview = pagesOverview;
     this.printContainer = printContainer;
@@ -202,22 +202,8 @@ class PDFPrintServiceFactory {
     return shadow(this, "supportsPrinting", "mozPrintCallback" in canvas);
   }
 
-  static createPrintService(
-    pdfDocument,
-    pagesOverview,
-    printContainer,
-    printResolution,
-    optionalContentConfigPromise,
-    printAnnotationStoragePromise
-  ) {
-    return new FirefoxPrintService(
-      pdfDocument,
-      pagesOverview,
-      printContainer,
-      printResolution,
-      optionalContentConfigPromise,
-      printAnnotationStoragePromise
-    );
+  static createPrintService(params) {
+    return new FirefoxPrintService(params);
   }
 }
 

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -63,14 +63,14 @@ function renderPage(
 }
 
 class PDFPrintService {
-  constructor(
+  constructor({
     pdfDocument,
     pagesOverview,
     printContainer,
     printResolution,
     optionalContentConfigPromise = null,
-    printAnnotationStoragePromise = null
-  ) {
+    printAnnotationStoragePromise = null,
+  }) {
     this.pdfDocument = pdfDocument;
     this.pagesOverview = pagesOverview;
     this.printContainer = printContainer;
@@ -367,26 +367,11 @@ class PDFPrintServiceFactory {
     return shadow(this, "supportsPrinting", true);
   }
 
-  static createPrintService(
-    pdfDocument,
-    pagesOverview,
-    printContainer,
-    printResolution,
-    optionalContentConfigPromise,
-    printAnnotationStoragePromise
-  ) {
+  static createPrintService(params) {
     if (activeService) {
       throw new Error("The print service is created and active.");
     }
-    activeService = new PDFPrintService(
-      pdfDocument,
-      pagesOverview,
-      printContainer,
-      printResolution,
-      optionalContentConfigPromise,
-      printAnnotationStoragePromise
-    );
-    return activeService;
+    return (activeService = new PDFPrintService(params));
   }
 }
 


### PR DESCRIPTION
By "modernizing" the method to use a parameter object instead, we avoid having to pass along the needed parameters individually.