### PR TITLE
Access `PDFViewerApplication.findBar` safely in more spots (PR 15831 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2286,7 +2286,7 @@ function webViewerNamedAction(evt) {
 
     case "Find":
       if (!PDFViewerApplication.supportsIntegratedFind) {
-        PDFViewerApplication?.findBar.toggle();
+        PDFViewerApplication.findBar?.toggle();
       }
       break;
 
@@ -2517,7 +2517,7 @@ function webViewerUpdateFindMatchesCount({ matchesCount }) {
   if (PDFViewerApplication.supportsIntegratedFind) {
     PDFViewerApplication.externalServices.updateFindMatchesCount(matchesCount);
   } else {
-    PDFViewerApplication.findBar.updateResultsCount(matchesCount);
+    PDFViewerApplication.findBar?.updateResultsCount(matchesCount);
   }
 }
 


### PR DESCRIPTION
Note that this patch is the result of code-inspection, and the code as written doesn't (currently) cause any bugs in e.g. the GeckoView PDF Viewer.