### PR TITLE
Run minification directly during Webpack building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "streamqueue": "^1.1.2",
         "stylelint": "^16.2.1",
         "stylelint-prettier": "^5.0.0",
-        "terser": "^5.27.1",
+        "terser-webpack-plugin": "^5.3.10",
         "through2": "^4.0.2",
         "tsc-alias": "^1.8.8",
         "ttest": "^4.0.0",
@@ -13371,7 +13371,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13387,19 +13386,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13414,7 +13410,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13432,7 +13427,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "streamqueue": "^1.1.2",
     "stylelint": "^16.2.1",
     "stylelint-prettier": "^5.0.0",
-    "terser": "^5.27.1",
+    "terser-webpack-plugin": "^5.3.10",
     "through2": "^4.0.2",
     "tsc-alias": "^1.8.8",
     "ttest": "^4.0.0",


### PR DESCRIPTION
Rather than first building the library and then use Terser "manually" to minify the files, we can utilize a Webpack plugin to combine these steps which helps to simplify the gulpfile.