### PR TITLE
Disable source-map generation in the minified builds (PR 17686 follow-up)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -208,6 +208,7 @@ function createWebpackConfig(
     !bundleDefines.MOZCENTRAL &&
     !bundleDefines.CHROME &&
     !bundleDefines.LIB &&
+    !bundleDefines.MINIFIED &&
     !bundleDefines.TESTING &&
     !disableSourceMaps;
   const isModule = output.library?.type === "module";


### PR DESCRIPTION
As part of the changes in PR #17686 we "accidentally" enabled source-maps for the *minified* builds, which seems unnecessary since those have never been included in the `pdfjs-dist` output.
Locally this patch reduces the run-time of `gulp minified` by ~15 percent.