### PR TITLE
Move the `alias`-building out of the `createWebpackConfig` function

### DIFF
--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -11,7 +11,7 @@ function isPDFJSPreprocessor(obj) {
 }
 
 function evalWithDefines(code, defines) {
-  if (!code || !code.trim()) {
+  if (!code?.trim()) {
     throw new Error("No JavaScript expression given");
   }
   return vm.runInNewContext(code, defines, { displayErrors: false });
@@ -56,12 +56,7 @@ function handlePreprocessorAction(ctx, actionName, args, path) {
     throw new Error("Unsupported action");
   } catch (e) {
     throw path.buildCodeFrameError(
-      "Could not process " +
-        PDFJS_PREPROCESSOR_NAME +
-        "." +
-        actionName +
-        ": " +
-        e.message
+      `Could not process ${PDFJS_PREPROCESSOR_NAME}.${actionName}: ${e.message}`
     );
   }
 }

--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -84,7 +84,7 @@ function preprocess(inFilename, outFilename, defines) {
           out.push(line);
         };
   function evaluateCondition(code) {
-    if (!code || !code.trim()) {
+    if (!code?.trim()) {
       throw new Error("No JavaScript expression given at " + loc());
     }
     try {

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -124,9 +124,8 @@ function transform(charEncoding, transformFunction) {
   });
 }
 
-function safeSpawnSync(command, parameters, options) {
+function safeSpawnSync(command, parameters, options = {}) {
   // Execute all commands in a shell.
-  options = options || {};
   options.shell = true;
   // `options.shell = true` requires parameters to be quoted.
   parameters = parameters.map(param => {
@@ -410,7 +409,7 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
     // Deprecated keys are allowed in the managed preferences file.
     // The code maintainer is responsible for adding migration logic to
     // extensions/chromium/options/migration.js and web/chromecom.js .
-    return !description || !description.startsWith("DEPRECATED.");
+    return !description?.startsWith("DEPRECATED.");
   });
 
   let ret = true;
@@ -520,7 +519,7 @@ function createSandboxExternal(defines) {
 
 function createTemporaryScriptingBundle(defines, extraOptions = undefined) {
   return createScriptingBundle(defines, {
-    disableVersionInfo: !!(extraOptions && extraOptions.disableVersionInfo),
+    disableVersionInfo: !!extraOptions?.disableVersionInfo,
     disableSourceMaps: true,
     disableLicenseHeader: true,
   }).pipe(gulp.dest(TMP_DIR));


### PR DESCRIPTION
 - Move the `alias`-building out of the `createWebpackConfig` function

   Over time, as we've started relying more and more on import maps, the number of aliases have increased a lot. This is now affecting the size and readability of `createWebpackConfig`, which was already fairly large and complex, hence moving the aliases to their own function should help improve things a little bit.

 - Use more optional chaining, and other modern JS, in the building code
