### PR TITLE
Allow to set up a hook at the end of the initialization (bug 1881319)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -198,6 +198,10 @@
       "description": "The color is a string as defined in CSS. Its goal is to help improve readability in high contrast mode",
       "type": "string",
       "default": "CanvasText"
+    },
+    "hasInitializationHook": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/test/integration/copy_paste_spec.mjs
+++ b/test/integration/copy_paste_spec.mjs
@@ -14,6 +14,7 @@
  */
 
 import {
+  awaitPromise,
   closePages,
   kbCopy,
   kbSelectAll,
@@ -44,12 +45,7 @@ describe("Copy and paste", () => {
         "tracemonkey.pdf",
         "#hiddenCopyElement",
         100,
-        async page => {
-          await page.waitForFunction(
-            () => !!window.PDFViewerApplication.eventBus
-          );
-          await waitForTextLayer(page);
-        }
+        waitForTextLayer
       );
       await mockClipboard(pages);
     });
@@ -60,7 +56,8 @@ describe("Copy and paste", () => {
 
     it("must check that we've all the contents on copy/paste", async () => {
       await Promise.all(
-        pages.map(async ([browserName, page]) => {
+        pages.map(async ([browserName, page, pageSetupPromise]) => {
+          awaitPromise(pageSetupPromise);
           await selectAll(page);
 
           const promise = waitForEvent(page, "copy");
@@ -151,12 +148,7 @@ describe("Copy and paste", () => {
         "copy_paste_ligatures.pdf",
         "#hiddenCopyElement",
         100,
-        async page => {
-          await page.waitForFunction(
-            () => !!window.PDFViewerApplication.eventBus
-          );
-          await waitForTextLayer(page);
-        }
+        waitForTextLayer
       );
       await mockClipboard(pages);
     });
@@ -167,7 +159,8 @@ describe("Copy and paste", () => {
 
     it("must check that the ligatures have been removed when the text has been copied", async () => {
       await Promise.all(
-        pages.map(async ([browserName, page]) => {
+        pages.map(async ([browserName, page, pageSetupPromise]) => {
+          awaitPromise(pageSetupPromise);
           await selectAll(page);
 
           const promise = waitForEvent(page, "copy");

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -2216,20 +2216,14 @@ describe("FreeText Editor", () => {
         "tracemonkey.pdf",
         ".annotationEditorLayer",
         100,
-        async page => {
-          await page.waitForFunction(async () => {
-            await window.PDFViewerApplication.initializedPromise;
-            return true;
-          });
-          await page.evaluate(() => {
-            window.visitedPages = [];
-            window.PDFViewerApplication.eventBus.on(
-              "pagechanging",
-              ({ pageNumber }) => {
-                window.visitedPages.push(pageNumber);
-              }
-            );
-          });
+        () => {
+          window.visitedPages = [];
+          window.PDFViewerApplication.eventBus.on(
+            "pagechanging",
+            ({ pageNumber }) => {
+              window.visitedPages.push(pageNumber);
+            }
+          );
         }
       );
     });
@@ -2469,19 +2463,13 @@ describe("FreeText Editor", () => {
         "tracemonkey.pdf",
         ".annotationEditorLayer",
         100,
-        async page => {
-          await page.waitForFunction(async () => {
-            await window.PDFViewerApplication.initializedPromise;
-            return true;
-          });
-          await page.evaluate(() => {
-            window.PDFViewerApplication.eventBus.on(
-              "annotationeditorstateschanged",
-              ({ details }) => {
-                window.editingEvents?.push(details);
-              }
-            );
-          });
+        () => {
+          window.PDFViewerApplication.eventBus.on(
+            "annotationeditorstateschanged",
+            ({ details }) => {
+              window.editingEvents?.push(details);
+            }
+          );
         }
       );
     });

--- a/web/app.js
+++ b/web/app.js
@@ -237,6 +237,23 @@ const PDFViewerApplication = {
     this.bindEvents();
     this.bindWindowEvents();
 
+    if (
+      typeof PDFJSDev !== "undefined" &&
+      PDFJSDev.test("TESTING || MOZCENTRAL") &&
+      AppOptions.get("hasInitializationHook")
+    ) {
+      await new Promise(resolve => {
+        this.eventBus.on(
+          "initializationhook",
+          ({ callback }) => {
+            callback();
+            resolve();
+          },
+          { once: true }
+        );
+      });
+    }
+
     this._initializedCapability.resolve();
   },
 
@@ -328,6 +345,9 @@ const PDFViewerApplication = {
           "highlightEditorColors",
           params.get("highlighteditorcolors")
         );
+      }
+      if (params.get("initializationhook") === "true") {
+        AppOptions.set("hasInitializationHook", true);
       }
     }
   },

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -181,6 +181,11 @@ const defaultOptions = {
     value: 0,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  hasInitializationHook: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   highlightEditorColors: {
     /** @type {string} */
     value: "yellow=#FFFF98,green=#53FFBC,blue=#80EBFF,pink=#FFCBE6,red=#FF4F5F",


### PR DESCRIPTION
With this patch it's now possible to be sure to add a listener (for example for the "pagerendered" event) before the pdf is set.