### PR TITLE
Use `fs/promises` in the Node.js-specific code in the `src/`-folder

### DIFF
--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -424,21 +424,22 @@ class PDFNodeStreamFsFullReader extends BaseFullReader {
       path = path.replace(/^\//, "");
     }
 
-    fs.lstat(path, (error, stat) => {
-      if (error) {
+    fs.promises.lstat(path).then(
+      stat => {
+        // Setting right content length.
+        this._contentLength = stat.size;
+
+        this._setReadableStream(fs.createReadStream(path));
+        this._headersCapability.resolve();
+      },
+      error => {
         if (error.code === "ENOENT") {
           error = new MissingPDFException(`Missing PDF "${path}".`);
         }
         this._storedError = error;
         this._headersCapability.reject(error);
-        return;
       }
-      // Setting right content length.
-      this._contentLength = stat.size;
-
-      this._setReadableStream(fs.createReadStream(path));
-      this._headersCapability.resolve();
-    });
+    );
   }
 }
 

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -71,15 +71,7 @@ if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("SKIP_BABEL")) {
 }
 
 const fetchData = function (url) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(url, (error, data) => {
-      if (error || !data) {
-        reject(new Error(error));
-        return;
-      }
-      resolve(new Uint8Array(data));
-    });
-  });
+  return fs.promises.readFile(url).then(data => new Uint8Array(data));
 };
 
 class NodeFilterFactory extends BaseFilterFactory {}


### PR DESCRIPTION
This is available in all Node.js versions that we currently support, and using it allows us to remove callback-functions; please see https://nodejs.org/docs/latest-v18.x/api/fs.html#promises-api