### PR TITLE
Tweak how the `hexNumbers` Array, used by `Util.makeHexColor`, is built

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -641,7 +641,7 @@ class FeatureTest {
   }
 }
 
-const hexNumbers = [...Array(256).keys()].map(n =>
+const hexNumbers = Array.from(Array(256).keys(), n =>
   n.toString(16).padStart(2, "0")
 );
 


### PR DESCRIPTION
*Please note:* This is a micro optimization, hence I fully understand if the patch is rejected.

Currently we create two temporary Arrays and have to iterate twice in total when building the final `hexNumbers` Array.
With this patch there's only one temporary Array and a single iteration required to build the final `hexNumbers` Array.