### PR TITLE
[Editor] In caret browsing mode, get the caret position in the text layer (bug 1881692)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -329,6 +329,12 @@ const PDFViewerApplication = {
           params.get("highlighteditorcolors")
         );
       }
+      if (params.has("supportscaretbrowsingmode")) {
+        AppOptions.set(
+          "supportsCaretBrowsingMode",
+          params.get("supportscaretbrowsingmode") === "true"
+        );
+      }
     }
   },
 


### PR DESCRIPTION
The function caretPositionFromPoint return the position within the last visible element and sometimes there are some elements on top of the ones in the text layer.
So the idea is to hide the visible elements which aren't in the text layer in order to get the right caret position.