### PR TITLE
[Editor] Indicate if the highlight-thickness slider is disabled

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -1192,7 +1192,8 @@
         opacity: 0.4;
       }
 
-      &::before {
+      &::before,
+      &::after {
         content: "";
         width: 8px;
         aspect-ratio: 1;
@@ -1200,19 +1201,13 @@
         border-radius: 100%;
         background-color: var(--example-color);
       }
+      &::after {
+        width: 24px;
+      }
 
       .editorParamsSlider {
         width: unset;
         height: 14px;
-      }
-
-      &::after {
-        content: "";
-        width: 24px;
-        aspect-ratio: 1;
-        display: block;
-        border-radius: 100%;
-        background-color: var(--example-color);
       }
     }
   }

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -1188,6 +1188,10 @@
         --example-color: CanvasText;
       }
 
+      :is(& > .editorParamsSlider[disabled]) {
+        opacity: 0.4;
+      }
+
       &::before {
         content: "";
         width: 8px;


### PR DESCRIPTION
The fact that the highlight-thickness can only be changed in "free" mode isn't really obvious visually in the toolbar, so attempt to provide at least some indication of the `disabled`-state by "dimming" the slider.