### PR TITLE
[Editor] Use a null instead of an empty stats object when sending the telemetry

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -214,7 +214,7 @@ class AnnotationStorage {
   }
 
   get editorStats() {
-    const stats = Object.create(null);
+    let stats = null;
     const typeToEditor = new Map();
     for (const value of this.#storage.values()) {
       if (!(value instanceof AnnotationEditor)) {
@@ -228,6 +228,7 @@ class AnnotationStorage {
       if (!typeToEditor.has(type)) {
         typeToEditor.set(type, Object.getPrototypeOf(value).constructor);
       }
+      stats ||= Object.create(null);
       const map = (stats[type] ||= new Map());
       for (const [key, val] of Object.entries(editorStats)) {
         if (key === "type") {


### PR DESCRIPTION
It avoids to have an exception here:
https://searchfox.org/mozilla-central/rev/202c48686136360a23b73a49b611a19e64f3e1b8/toolkit/components/pdfjs/content/PdfJsTelemetry.sys.mjs#67-71