### PR TITLE
Add language attribute to canvas

### DIFF
--- a/test/pdfs/issue16843.pdf.link
+++ b/test/pdfs/issue16843.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/12366234/16_2020-044.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2203,6 +2203,15 @@
     "type": "eq"
   },
   {
+    "id": "issue16843-text",
+    "file": "pdfs/issue16843.pdf",
+    "md5": "2845b2f7f02690c388c24c488297028a",
+    "rounds": 1,
+    "link": true,
+    "lastPage": 1,
+    "type": "text"
+  },
+  {
     "id": "issue5509",
     "file": "pdfs/issue5509.pdf",
     "md5": "1975ef8db7355b1d691bc79d0749574b",


### PR DESCRIPTION
Fixes issue #16843.

In certain cases, the text layer was misaligned due to a difference 
between the `lang` attribute of the viewer and the canvas. This commit addresses the problem by adding the `lang` attribute to the canvas. The issue was caused because PDF.js uses serif/sans-serif fonts to generate the text layer and relies on system fonts. The difference in the `lang` attribute led to different fonts being picked, causing the misalignment.

Before the change:
<img width="783" alt="image" src="https://github.com/mozilla/pdf.js/assets/62544124/13ef8c40-a1cc-4bfa-bfe4-dc5f57a2b8c4">

After the change:
<img width="726" alt="image" src="https://github.com/mozilla/pdf.js/assets/62544124/5f82333b-4fd3-4b83-afa1-6f5d2498dec2">

Thanks, @nicolo-ribaudo for helping with this. 