### PR TITLE
Don't hide the editor layer when rotating (follow-up of #17802)

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -129,6 +129,12 @@ class AnnotationEditorLayer {
     return this.#editors.size === 0;
   }
 
+  get isInvisible() {
+    return (
+      this.isEmpty && this.#uiManager.getMode() === AnnotationEditorType.NONE
+    );
+  }
+
   /**
    * Update the toolbar if it's required to reflect the tool currently used.
    * @param {number} mode

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -3397,4 +3397,38 @@ describe("FreeText Editor", () => {
       );
     });
   });
+
+  describe("Annotation editor layer visibility", () => {
+    let pages;
+
+    beforeAll(async () => {
+      pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+    });
+
+    afterAll(async () => {
+      await closePages(pages);
+    });
+
+    it("must check that the annotation layer is visible after a rotation", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await switchToFreeText(page);
+
+          for (let i = 0; i < 4; i++) {
+            await page.waitForSelector(
+              ".page[data-page-number='1'] .annotationEditorLayer:not([hidden])",
+              {
+                timeout: 0,
+              }
+            );
+            const promise = await waitForAnnotationEditorLayer(page);
+            await page.evaluate(() => {
+              document.getElementById("pageRotateCw").click();
+            });
+            await awaitPromise(promise);
+          }
+        })
+      );
+    });
+  });
 });

--- a/web/annotation_editor_layer_builder.js
+++ b/web/annotation_editor_layer_builder.js
@@ -138,7 +138,7 @@ class AnnotationEditorLayerBuilder {
   }
 
   show() {
-    if (!this.div || this.annotationEditorLayer.isEmpty) {
+    if (!this.div || this.annotationEditorLayer.isInvisible) {
       return;
     }
     this.div.hidden = false;


### PR DESCRIPTION
Before the patch in #17802, the layer was made visible when calling updateMode after the rotation angle was set.