### PR TITLE
Remove `PDFViewerApplication.initPassiveLoading` and directly invoke the `open`-method from the extension-specific code

### DIFF
--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -417,12 +417,11 @@ class Preferences extends BasePreferences {
 }
 
 class ExternalServices extends BaseExternalServices {
-  initPassiveLoading(callbacks) {
-    // defaultUrl is set in viewer.js
+  initPassiveLoading() {
     ChromeCom.resolvePDFFile(
       AppOptions.get("defaultUrl"),
       function (url, length, originalUrl) {
-        callbacks.onOpenWithURL(url, length, originalUrl);
+        viewerApp.open({ url, length, originalUrl });
       }
     );
   }

--- a/web/chromecom.js
+++ b/web/chromecom.js
@@ -108,10 +108,11 @@ const ChromeCom = {
         // Even without this check, the file load in frames is still blocked,
         // but this may change in the future (https://crbug.com/550151).
         if (origin && !/^file:|^chrome-extension:/.test(origin)) {
-          viewerApp._documentError(
-            `Blocked ${origin} from loading ${file}. Refused to load ` +
-              "a local file in a non-local page for security reasons."
-          );
+          viewerApp._documentError(null, {
+            message:
+              `Blocked ${origin} from loading ${file}. Refused to load ` +
+              "a local file in a non-local page for security reasons.",
+          });
           return;
         }
         isAllowedFileSchemeAccess(function (isAllowedAccess) {

--- a/web/external_services.js
+++ b/web/external_services.js
@@ -24,7 +24,7 @@ class BaseExternalServices {
 
   updateFindMatchesCount(data) {}
 
-  initPassiveLoading(callbacks) {}
+  initPassiveLoading() {}
 
   reportTelemetry(data) {}
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -323,7 +323,7 @@ class ExternalServices extends BaseExternalServices {
     FirefoxCom.request("updateFindMatchesCount", data);
   }
 
-  initPassiveLoading(callbacks) {
+  initPassiveLoading() {
     let pdfDataRangeTransport;
 
     window.addEventListener("message", function windowMessage(e) {
@@ -340,7 +340,7 @@ class ExternalServices extends BaseExternalServices {
       switch (args.pdfjsLoadAction) {
         case "supportsRangedLoading":
           if (args.done && !args.data) {
-            callbacks.onError();
+            viewerApp._documentError(null);
             break;
           }
           pdfDataRangeTransport = new FirefoxComDataRangeTransport(
@@ -350,7 +350,7 @@ class ExternalServices extends BaseExternalServices {
             args.filename
           );
 
-          callbacks.onOpenWithTransport(pdfDataRangeTransport);
+          viewerApp.open({ range: pdfDataRangeTransport });
           break;
         case "range":
           pdfDataRangeTransport.onDataRange(args.begin, args.chunk);
@@ -369,14 +369,14 @@ class ExternalServices extends BaseExternalServices {
           pdfDataRangeTransport?.onDataProgressiveDone();
           break;
         case "progress":
-          callbacks.onProgress(args.loaded, args.total);
+          viewerApp.progress(args.loaded / args.total);
           break;
         case "complete":
           if (!args.data) {
-            callbacks.onError(args.errorCode);
+            viewerApp._documentError(null, { message: args.errorCode });
             break;
           }
-          callbacks.onOpenWithData(args.data, args.filename);
+          viewerApp.open({ data: args.data, filename: args.filename });
           break;
       }
     });


### PR DESCRIPTION
 - Move the error message localization into `PDFViewerApplication._otherError`

   When reporting errors in the viewer we currently localize the error messages "manually" at every call-site, which seems like unnecessary repetition.

 - Remove `PDFViewerApplication.initPassiveLoading` and directly invoke the `open`-method from the extension-specific code

   This old method is essentially just adding, a small amount of, unnecessary indirection and we can easily invoke `PDFViewerApplication.open` directly from the extension-specific code instead.