### PR TITLE
Avoid wrong scrolling when calling zoomReset

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -55,4 +55,36 @@ describe("PDF viewer", () => {
       );
     });
   });
+
+  describe("Zoom commands", () => {
+    let pages;
+
+    beforeAll(async () => {
+      pages = await loadAndWait("tracemonkey.pdf", ".textLayer .endOfContent");
+    });
+
+    afterAll(async () => {
+      await closePages(pages);
+    });
+
+    it("must check that zoom commands don't scroll the document", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          for (let i = 0; i < 10; i++) {
+            await page.evaluate(() => window.PDFViewerApplication.zoomIn());
+            await page.evaluate(() => window.PDFViewerApplication.zoomReset());
+            await page.waitForSelector(
+              `.page[data-page-number="1"] .textLayer .endOfContent`
+            );
+            const scrollTop = await page.evaluate(
+              () => document.getElementById("viewerContainer").scrollTop
+            );
+            expect(scrollTop < 100)
+              .withContext(`In ${browserName}`)
+              .toBe(true);
+          }
+        })
+      );
+    });
+  });
 });

--- a/web/annotation_editor_layer_builder.js
+++ b/web/annotation_editor_layer_builder.js
@@ -127,7 +127,6 @@ class AnnotationEditorLayerBuilder {
       return;
     }
     this.annotationEditorLayer.destroy();
-    this.div.remove();
   }
 
   hide() {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -104,7 +104,7 @@ const LAYERS_ORDER = new Map([
   ["textLayer", 1],
   ["annotationLayer", 2],
   ["annotationEditorLayer", 3],
-  ["xfaLayer", 2],
+  ["xfaLayer", 3],
 ]);
 
 /**
@@ -235,7 +235,12 @@ class PDFPageView {
 
   #addLayer(div, name) {
     const pos = LAYERS_ORDER.get(name);
+    const oldDiv = this.#layers[pos];
     this.#layers[pos] = div;
+    if (oldDiv) {
+      oldDiv.replaceWith(div);
+      return;
+    }
     for (let i = pos - 1; i >= 0; i--) {
       const layer = this.#layers[i];
       if (layer) {


### PR DESCRIPTION
The goal of this patch is to fix the test:
https://searchfox.org/mozilla-central/source/toolkit/components/pdfjs/test/browser_pdfjs_zoom.js

It's a regression due to #17790.