### PR TITLE
Update the `Path2D` polyfill for Node.js environments

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2155,7 +2155,7 @@ function packageJson() {
     license: DIST_LICENSE,
     optionalDependencies: {
       canvas: "^2.11.2",
-      "path2d-polyfill": "^2.0.1",
+      path2d: "^0.1.2",
     },
     browser: {
       canvas: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "merge-stream": "^2.0.0",
         "mkdirp": "^3.0.1",
         "needle": "^3.3.1",
-        "path2d-polyfill": "^2.1.1",
+        "path2d": "^0.1.2",
         "pngjs": "^7.0.0",
         "postcss": "^8.4.35",
         "postcss-dark-theme-class": "^1.2.1",
@@ -13358,6 +13358,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13373,16 +13374,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13397,6 +13401,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13414,6 +13419,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -16192,24 +16198,12 @@
       }
     },
     "node_modules/path2d": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.1.1.tgz",
-      "integrity": "sha512-/+S03c8AGsDYKKBtRDqieTJv2GlkMb0bWjnqOgtF6MkjdUQ9a8ARAtxWf9NgKLGm2+WQr6+/tqJdU8HNGsIDoA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.1.2.tgz",
+      "integrity": "sha512-LW++2uxgHNL/FANhgGTPo/yDDQcgsVbKotwIVbpTgTBgRlKUpjOpjp3s3+KjG4OWCQ/r6z+WLDljH1/fC03PWw==",
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/path2d-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.1.1.tgz",
-      "integrity": "sha512-4Rka5lN+rY/p0CdD8+E+BFv51lFaFvJOrlOhyQ+zjzyQrzyh3ozmxd1vVGGDdIbUFSBtIZLSnspxTgPT0iJhvA==",
-      "dev": true,
-      "dependencies": {
-        "path2d": "0.1.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/pend": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "merge-stream": "^2.0.0",
     "mkdirp": "^3.0.1",
     "needle": "^3.3.1",
-    "path2d-polyfill": "^2.1.1",
+    "path2d": "^0.1.2",
     "pngjs": "^7.0.0",
     "postcss": "^8.4.35",
     "postcss-dark-theme-class": "^1.2.1",

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -27,7 +27,7 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   );
 }
 
-let fs, canvas, path2d_polyfill;
+let fs, canvas, path2d;
 if (isNodeJS) {
   // Native packages.
   fs = await __non_webpack_import__("fs");
@@ -36,7 +36,7 @@ if (isNodeJS) {
     canvas = await __non_webpack_import__("canvas");
   } catch {}
   try {
-    path2d_polyfill = await __non_webpack_import__("path2d-polyfill");
+    path2d = await __non_webpack_import__("path2d");
   } catch {}
 }
 
@@ -59,11 +59,17 @@ if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("SKIP_BABEL")) {
       return;
     }
     const CanvasRenderingContext2D = canvas?.CanvasRenderingContext2D;
-    const polyfillPath2D = path2d_polyfill?.polyfillPath2D;
+    const applyPath2DToCanvasRenderingContext =
+      path2d?.applyPath2DToCanvasRenderingContext;
+    const Path2D = path2d?.Path2D;
 
-    if (CanvasRenderingContext2D && polyfillPath2D) {
-      globalThis.CanvasRenderingContext2D = CanvasRenderingContext2D;
-      polyfillPath2D(globalThis);
+    if (
+      CanvasRenderingContext2D &&
+      applyPath2DToCanvasRenderingContext &&
+      Path2D
+    ) {
+      applyPath2DToCanvasRenderingContext(CanvasRenderingContext2D);
+      globalThis.Path2D = Path2D;
     } else {
       warn("Cannot polyfill `Path2D`, rendering may be broken.");
     }


### PR DESCRIPTION
The polyfill that we use was recently split into two packages, and it now consists of a "core" package and a browser-specific package that build upon the former.
Hence we need to update to use the "core" package, and slightly tweak the code that loads/initializes the polyfill; see also https://www.npmjs.com/package/path2d

This patch was tested successfully with the [pdf2png example](https://github.com/mozilla/pdf.js/tree/master/examples/node/pdf2png), after running `gulp dist-install` locally, using [this PDF document](https://bug810214.bmoattachments.org/attachment.cgi?id=9254990) which contains Type3-fonts that render using `Path2D`.