### PR TITLE
Limit all `compatibilityParams` handling to the GENERIC viewer

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -161,8 +161,7 @@ class PDFPageView {
       options.annotationMode ?? AnnotationMode.ENABLE_FORMS;
     this.imageResourcesPath = options.imageResourcesPath || "";
     this.maxCanvasPixels =
-      options.maxCanvasPixels ??
-      (AppOptions.getCompat("maxCanvasPixels") || 2 ** 25);
+      options.maxCanvasPixels ?? AppOptions.get("maxCanvasPixels");
     this.pageColors = options.pageColors || null;
 
     this.eventBus = options.eventBus;


### PR DESCRIPTION
With recent improvements to the `AppOptions`, e.g. with better validation and testing, one remaining "annoyance" is the `compatibilityParams` handling. Especially since there's only *a single* parameter left, limited to GENERIC builds.

To further reduce the amount of unnecessary code in e.g. the Firefox PDF Viewer, we can move the `compatibilityParams` handling into the user-options instead since that keeps the previous precedence order between default/user-options.