### PR TITLE
Improve the implementation of the `PDFDocument.fingerprints`-getter

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -26,6 +26,7 @@ import {
   stringToBytes,
   stringToPDFString,
   stringToUTF8String,
+  toHexUtil,
   unreachable,
   Util,
   warn,
@@ -1572,8 +1573,8 @@ class PDFDocument {
     }
 
     return shadow(this, "fingerprints", [
-      hashOriginal.toHex(),
-      hashModified?.toHex() ?? null,
+      toHexUtil(hashOriginal),
+      hashModified ? toHexUtil(hashModified) : null,
     ]);
   }
 

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -90,6 +90,7 @@ import {
   XFAObject,
   XFAObjectArray,
 } from "./xfa_object.js";
+import { fromBase64Util, Util, warn } from "../../shared/util.js";
 import {
   getBBox,
   getColor,
@@ -102,7 +103,6 @@ import {
   getStringOption,
   HTMLResult,
 } from "./utils.js";
-import { Util, warn } from "../../shared/util.js";
 import { getMetrics } from "./fonts.js";
 import { recoverJsURL } from "../core_utils.js";
 import { searchNode } from "./som.js";
@@ -3427,7 +3427,7 @@ class Image extends StringObject {
     }
 
     if (!buffer && this.transferEncoding === "base64") {
-      buffer = Uint8Array.fromBase64(this[$content]);
+      buffer = fromBase64Util(this[$content]);
     }
 
     if (!buffer) {

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -102,7 +102,7 @@ import {
   getStringOption,
   HTMLResult,
 } from "./utils.js";
-import { stringToBytes, Util, warn } from "../../shared/util.js";
+import { Util, warn } from "../../shared/util.js";
 import { getMetrics } from "./fonts.js";
 import { recoverJsURL } from "../core_utils.js";
 import { searchNode } from "./som.js";
@@ -3427,7 +3427,7 @@ class Image extends StringObject {
     }
 
     if (!buffer && this.transferEncoding === "base64") {
-      buffer = stringToBytes(atob(this[$content]));
+      buffer = Uint8Array.fromBase64(this[$content]);
     }
 
     if (!buffer) {

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -15,7 +15,6 @@
 
 import {
   assert,
-  bytesToString,
   FontRenderOps,
   isNodeJS,
   shadow,
@@ -399,9 +398,8 @@ class FontFaceObject {
     if (!this.data || this.disableFontFace) {
       return null;
     }
-    const data = bytesToString(this.data);
     // Add the @font-face rule to the document.
-    const url = `url(data:${this.mimetype};base64,${btoa(data)});`;
+    const url = `url(data:${this.mimetype};base64,${this.data.toBase64()});`;
     let rule;
     if (!this.cssFontInfo) {
       rule = `@font-face {font-family:"${this.loadedName}";src:${url}}`;

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -19,6 +19,7 @@ import {
   isNodeJS,
   shadow,
   string32,
+  toBase64Util,
   unreachable,
   warn,
 } from "../shared/util.js";
@@ -399,7 +400,7 @@ class FontFaceObject {
       return null;
     }
     // Add the @font-face rule to the document.
-    const url = `url(data:${this.mimetype};base64,${this.data.toBase64()});`;
+    const url = `url(data:${this.mimetype};base64,${toBase64Util(this.data)});`;
     let rule;
     if (!this.cssFontInfo) {
       rule = `@font-face {font-family:"${this.loadedName}";src:${url}}`;

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1097,6 +1097,35 @@ const FontRenderOps = {
   TRANSLATE: 8,
 };
 
+// TODO: Remove this once `Uint8Array.prototype.toHex` is generally available.
+function toHexUtil(arr) {
+  if (Uint8Array.prototype.toHex) {
+    return arr.toHex();
+  }
+  const buf = [];
+  for (const num of arr) {
+    buf.push(num.toString(16).padStart(2, "0"));
+  }
+  return buf.join("");
+}
+
+// TODO: Remove this once `Uint8Array.prototype.toBase64` is generally
+//       available.
+function toBase64Util(arr) {
+  if (Uint8Array.prototype.toBase64) {
+    return arr.toBase64();
+  }
+  return btoa(bytesToString(arr));
+}
+
+// TODO: Remove this once `Uint8Array.fromBase64` is generally available.
+function fromBase64Util(str) {
+  if (Uint8Array.fromBase64) {
+    return Uint8Array.fromBase64(str);
+  }
+  return stringToBytes(atob(str));
+}
+
 export {
   AbortException,
   AnnotationActionEventType,
@@ -1120,6 +1149,7 @@ export {
   FONT_IDENTITY_MATRIX,
   FontRenderOps,
   FormatError,
+  fromBase64Util,
   getModificationDate,
   getUuid,
   getVerbosityLevel,
@@ -1149,6 +1179,8 @@ export {
   stringToPDFString,
   stringToUTF8String,
   TextRenderingMode,
+  toBase64Util,
+  toHexUtil,
   UnexpectedResponseException,
   UnknownErrorException,
   unreachable,


### PR DESCRIPTION
 - Add explicit `length` validation of the /ID entries. Given the `EMPTY_FINGERPRINT` constant we're already *implicitly* assuming a particular length.

 - Move the constants into the `fingerprints`-getter, since they're not used anywhere else.

 - Replace the `hexString` helper function with the standard `Uint8Array.prototype.toHex` method; see https://github.com/tc39/proposal-arraybuffer-base64