### PR TITLE
Remove the `addWindowResolutionChange` listener unconditionally (PR 17767 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1915,9 +1915,6 @@ const PDFViewerApplication = {
         once: true,
       });
 
-      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-        return;
-      }
       _boundEvents.removeWindowResolutionChange ||= function () {
         mediaQueryList.removeEventListener("change", addWindowResolutionChange);
         _boundEvents.removeWindowResolutionChange = null;


### PR DESCRIPTION
Given that `PDFViewerApplication.unbindWindowEvents` can be invoked in mozilla-central tests, we should ensure that the listener is always removed.