### PR TITLE
Don't install `gulp-cli` globally in the GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install Gulp
-        run: npm install -g gulp-cli
-
-      - name: Install other dependencies
+      - name: Install dependencies
         run: npm install
 
       - name: Run external tests
-        run: gulp externaltest
+        run: npx gulp externaltest
 
       - name: Run CLI unit tests
-        run: gulp unittestcli
+        run: npx gulp unittestcli

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -45,10 +45,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install Gulp
-        run: npm install -g gulp-cli
-
-      - name: Install other dependencies
+      - name: Install dependencies
         run: npm install
 
       - name: Use Python 3.12
@@ -61,4 +58,4 @@ jobs:
         run: pip install fonttools
 
       - name: Run font tests
-        run: gulp fonttest --headless
+        run: npx gulp fonttest --headless

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,14 +24,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install Gulp
-        run: npm install -g gulp-cli
-
-      - name: Install other dependencies
+      - name: Install dependencies
         run: npm install
 
       - name: Run lint
-        run: gulp lint
+        run: npx gulp lint
 
       - name: Run lint-chromium
-        run: gulp lint-chromium
+        run: npx gulp lint-chromium

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -26,14 +26,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install Gulp
-        run: npm install -g gulp-cli
-
-      - name: Install other dependencies
+      - name: Install dependencies
         run: npm install
 
       - name: Build the website
-        run: gulp web
+        run: npx gulp web
 
       - name: Archive the website
         shell: sh

--- a/.github/workflows/types_tests.yml
+++ b/.github/workflows/types_tests.yml
@@ -24,11 +24,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install Gulp
-        run: npm install -g gulp-cli
-
-      - name: Install other dependencies
+      - name: Install dependencies
         run: npm install
 
       - name: Run types tests
-        run: gulp typestest
+        run: npx gulp typestest


### PR DESCRIPTION
It's recommended to always install dependencies locally in the project folder because global dependencies can easily conflict with other projects and, because they are not managed by the project, diverge from versions defined in e.g. `package.json`. Previously we installed `gulp-cli` globally because at the time we lacked a convenient mechanism to use Gulp otherwise, but nowadays NPM provides the `npx` command for that purpose and recommends using it over global installations (see https://docs.npmjs.com/downloading-and-installing-packages-globally and PR #17489 that provided the ground work for using it).

This commit therefore updates our GitHub Actions workflows to no longer install `gulp-cli` globally but instead install it locally from the already existing entries in `package.json` like all other dependencies we use. Not only does this remove the special-casing for `gulp-cli` which simplifies the workflow definitions, it also ensures that the version ranges provided in `package.json` are respected. This makes the local and workflow setups more similar, but is also relevant for the upcoming upgrade to Gulp 5 which from a quick try is a bit involved and having `package.json` be the single source of truth for the dependency versions we use is therefore important.

_Thanks to @nicolo-ribaudo for bringing this isolation measure to the attention!_