### PR TITLE
Fix the RTL-rule for the `editorHighlightShowAll` button, such that it works outside of the Firefox PDF Viewer

### DIFF
--- a/web/toggle_button.css
+++ b/web/toggle_button.css
@@ -151,7 +151,9 @@
     background-color: var(--toggle-dot-background-color-on-pressed);
   }
 
-  &[aria-pressed="true"]:-moz-locale-dir(rtl)::before,
+  /*#if MOZCENTRAL*/
+  /*&[aria-pressed="true"]:-moz-locale-dir(rtl)::before,*/
+  /*#endif*/
   &[aria-pressed="true"]:dir(rtl)::before {
     translate: calc(-1 * var(--toggle-dot-transform-x));
   }


### PR DESCRIPTION
These CSS rules were imported straight from mozilla-central, and contains a property that causes the RTL-rule to be skipped everywhere else (even when using the development viewer in Firefox).