### PR TITLE
Fix resetting of cursor-tools when closing the document (PR 17464 follow-up)

### DIFF
--- a/web/pdf_cursor_tools.js
+++ b/web/pdf_cursor_tools.js
@@ -106,7 +106,14 @@ class PDFCursorTools {
 
   #addEventListeners() {
     this.eventBus._on("switchcursortool", evt => {
-      this.switchTool(evt.tool);
+      if (!evt.reset) {
+        this.switchTool(evt.tool);
+      } else if (this.#prevActive !== null) {
+        annotationEditorMode = AnnotationEditorType.NONE;
+        presentationModeState = PresentationModeState.NORMAL;
+
+        enableActive();
+      }
     });
 
     let annotationEditorMode = AnnotationEditorType.NONE,
@@ -130,15 +137,6 @@ class PDFCursorTools {
         this.switchTool(prevActive);
       }
     };
-
-    this.eventBus._on("secondarytoolbarreset", evt => {
-      if (this.#prevActive !== null) {
-        annotationEditorMode = AnnotationEditorType.NONE;
-        presentationModeState = PresentationModeState.NORMAL;
-
-        enableActive();
-      }
-    });
 
     this.eventBus._on("annotationeditormodechanged", ({ mode }) => {
       annotationEditorMode = mode;

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -182,6 +182,7 @@ class SecondaryToolbar {
     this.#updateUIState();
 
     // Reset the Scroll/Spread buttons too, since they're document specific.
+    this.eventBus.dispatch("switchcursortool", { source: this, reset: true });
     this.#scrollModeChanged({ mode: ScrollMode.VERTICAL });
     this.#spreadModeChanged({ mode: SpreadMode.NONE });
   }


### PR DESCRIPTION
With the removal of the "secondarytoolbarreset" event in PR #17464 resetting of cursor-tools state accidentally broke.