### PR TITLE
Remove the `mkdirp` dependency in favor of the built-in Node.js `fs.mkdirSync`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -26,7 +26,6 @@ import { fileURLToPath } from "url";
 import fs from "fs";
 import gulp from "gulp";
 import merge from "merge-stream";
-import { mkdirp } from "mkdirp";
 import path from "path";
 import postcss from "gulp-postcss";
 import postcssDarkThemeClass from "postcss-dark-theme-class";
@@ -670,7 +669,7 @@ function replaceInFile(filePath, find, replacement) {
 }
 
 function getTempFile(prefix, suffix) {
-  mkdirp.sync(BUILD_DIR + "tmp/");
+  fs.mkdirSync(BUILD_DIR + "tmp/", { recursive: true });
   const bytes = crypto.randomBytes(6).toString("hex");
   const filePath = BUILD_DIR + "tmp/" + prefix + bytes + suffix;
   fs.writeFileSync(filePath, "");
@@ -926,7 +925,7 @@ gulp.task("locale", function () {
   console.log("### Building localization files");
 
   rimraf.sync(VIEWER_LOCALE_OUTPUT);
-  mkdirp.sync(VIEWER_LOCALE_OUTPUT);
+  fs.mkdirSync(VIEWER_LOCALE_OUTPUT, { recursive: true });
 
   const subfolders = fs.readdirSync(L10N_DIR);
   subfolders.sort();
@@ -942,7 +941,7 @@ gulp.task("locale", function () {
       continue;
     }
 
-    mkdirp.sync(VIEWER_LOCALE_OUTPUT + "/" + locale);
+    fs.mkdirSync(VIEWER_LOCALE_OUTPUT + "/" + locale, { recursive: true });
 
     locales.push(locale);
 
@@ -1511,14 +1510,15 @@ gulp.task("jsdoc", function (done) {
   const JSDOC_FILES = ["src/display/api.js"];
 
   rimraf(JSDOC_BUILD_DIR, function () {
-    mkdirp(JSDOC_BUILD_DIR).then(function () {
-      const command =
-        '"node_modules/.bin/jsdoc" -d ' +
-        JSDOC_BUILD_DIR +
-        " " +
-        JSDOC_FILES.join(" ");
-      exec(command, done);
-    });
+    fs.mkdirSync(JSDOC_BUILD_DIR, { recursive: true });
+
+    const command =
+      '"node_modules/.bin/jsdoc" -d ' +
+      JSDOC_BUILD_DIR +
+      " " +
+      JSDOC_FILES.join(" ");
+
+    exec(command, done);
   });
 });
 
@@ -1862,7 +1862,7 @@ function createBaseline(done) {
 
   let initializeCommand = "git fetch origin";
   if (!checkDir(BASELINE_DIR)) {
-    mkdirp.sync(BASELINE_DIR);
+    fs.mkdirSync(BASELINE_DIR, { recursive: true });
     initializeCommand = "git clone ../../ .";
   }
 
@@ -2198,7 +2198,7 @@ gulp.task(
       console.log("### Cloning baseline distribution");
 
       rimraf.sync(DIST_DIR);
-      mkdirp.sync(DIST_DIR);
+      fs.mkdirSync(DIST_DIR, { recursive: true });
       safeSpawnSync("git", ["clone", "--depth", "1", DIST_REPO_URL, DIST_DIR]);
 
       console.log();
@@ -2346,7 +2346,7 @@ gulp.task(
 
     // Copy the mozcentral build to the mozcentral baseline directory.
     rimraf.sync(MOZCENTRAL_BASELINE_DIR);
-    mkdirp.sync(MOZCENTRAL_BASELINE_DIR);
+    fs.mkdirSync(MOZCENTRAL_BASELINE_DIR, { recursive: true });
 
     gulp
       .src([BASELINE_DIR + BUILD_DIR + "mozcentral/**/*"])

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "jsdoc": "^4.0.2",
         "jstransformer-markdown-it": "^3.0.0",
         "merge-stream": "^2.0.0",
-        "mkdirp": "^3.0.1",
         "needle": "^3.3.1",
         "path2d": "^0.2.0",
         "pngjs": "^7.0.0",
@@ -11124,21 +11123,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "jsdoc": "^4.0.2",
     "jstransformer-markdown-it": "^3.0.0",
     "merge-stream": "^2.0.0",
-    "mkdirp": "^3.0.1",
     "needle": "^3.3.1",
     "path2d": "^0.2.0",
     "pngjs": "^7.0.0",


### PR DESCRIPTION
In Node.js 10.12.0 the `recursive` option was added to `fs.mkdirSync`. This option allows us to create a directory and all its parent directories if they do not exist, making it a drop-in replacement for the `mkdirp` dependency we use.

Given that PDF.js now requires Node.js 18+ we can be sure that this option is available, so we can safely remove `mkdirp` and reduce the number of project dependencies.

_Thanks to @wojtekmaj, obviously credited as co-author of the commit, for providing the original implementation in #17696! For this patch I have extracted the `mkdirp`-only parts of that PR, with some minor changes, and tested all affected Gulp targets (using `diff -r` on the old/new build directories to recursively diff the contents of all directories and files) to make sure the output before/after this patch is identical._