### PR TITLE
Remove the `rimraf` dependency in favor of the built-in Node.js `fs.rmSync` in the test folder

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -15,7 +15,7 @@
  */
 /* eslint-disable no-var */
 
-import { copySubtreeSync, ensureDirSync, removeDirSync } from "./testutils.mjs";
+import { copySubtreeSync, ensureDirSync } from "./testutils.mjs";
 import {
   downloadManifestFiles,
   verifyManifestFiles,
@@ -25,13 +25,10 @@ import os from "os";
 import path from "path";
 import puppeteer from "puppeteer";
 import readline from "readline";
-import rimraf from "rimraf";
 import { translateFont } from "./font/ttxdriver.mjs";
 import url from "url";
 import { WebServer } from "./webserver.mjs";
 import yargs from "yargs";
-
-const rimrafSync = rimraf.sync;
 
 function parseOptions() {
   const parsedArgs = yargs(process.argv)
@@ -213,7 +210,7 @@ function updateRefImages() {
     console.log("  Updating ref/ ... ");
     copySubtreeSync(refsTmpDir, refsDir);
     if (removeTmp) {
-      removeDirSync(refsTmpDir);
+      fs.rmSync(refsTmpDir, { recursive: true, force: true });
     }
     console.log("done");
   }
@@ -324,7 +321,7 @@ async function startRefTest(masterMode, showRefImages) {
       fs.unlinkSync(eqLog);
     }
     if (fs.existsSync(testResultDir)) {
-      removeDirSync(testResultDir);
+      fs.rmSync(testResultDir, { recursive: true, force: true });
     }
 
     startTime = Date.now();
@@ -358,7 +355,7 @@ async function startRefTest(masterMode, showRefImages) {
   function checkRefsTmp() {
     if (masterMode && fs.existsSync(refsTmpDir)) {
       if (options.noPrompts) {
-        removeDirSync(refsTmpDir);
+        fs.rmSync(refsTmpDir, { recursive: true, force: true });
         setup();
         return;
       }
@@ -370,7 +367,7 @@ async function startRefTest(masterMode, showRefImages) {
         "SHOULD THIS SCRIPT REMOVE tmp/? THINK CAREFULLY [yn] ",
         function (answer) {
           if (answer.toLowerCase() === "y") {
-            removeDirSync(refsTmpDir);
+            fs.rmSync(refsTmpDir, { recursive: true, force: true });
           }
           setup();
           reader.close();
@@ -1038,7 +1035,7 @@ async function closeSession(browser) {
     });
     if (allClosed) {
       if (tempDir) {
-        rimrafSync(tempDir);
+        fs.rmSync(tempDir, { recursive: true, force: true });
       }
       onAllSessionsClosed?.();
     }

--- a/test/testutils.mjs
+++ b/test/testutils.mjs
@@ -16,16 +16,6 @@
 
 import fs from "fs";
 import path from "path";
-import rimraf from "rimraf";
-
-const rimrafSync = rimraf.sync;
-
-function removeDirSync(dir) {
-  fs.readdirSync(dir); // Will throw if dir is not a directory
-  rimrafSync(dir, {
-    disableGlob: true,
-  });
-}
 
 function copySubtreeSync(src, dest) {
   const files = fs.readdirSync(src);
@@ -63,4 +53,4 @@ function ensureDirSync(dir) {
   }
 }
 
-export { copySubtreeSync, ensureDirSync, removeDirSync };
+export { copySubtreeSync, ensureDirSync };


### PR DESCRIPTION
In Node.js 14.14.0 the `fs.rmSync` function was added that removes files and directories. The `recursive` option is used to remove directories and their contents, making it a drop-in replacement for the `rimraf` dependency we use.

Given that PDF.js now requires Node.js 18+ we can be sure that this option is available, so we can safely remove `rimraf` and reduce the number of project dependencies in the test folder.

This commit also gets rid of the indirection via the `removeDirSync` test helper function by simply calling `fs.rmSync` directly.

Fixes a part of #16337. Note that we deliberately only do the test folder as a first step given the complications we've had with the Gulpfile in #16337. For increased safety I'm therefore splitting the work into smaller parts to reduce the scope of each change and to make testing of each changed line of code easier. For this PR I have triggered all touched code paths, manually creating required directories with dummy contents if needed, and making sure that when `test.mjs` has run that the directories are removed like before.