### PR TITLE
Fix the "must check that invisible fields are made visible" scripting integration test

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -2104,9 +2104,10 @@ describe("Interaction", () => {
           expect(visibility).withContext(`In ${browserName}`).toEqual("hidden");
 
           await page.click(getSelector("11R"));
-          // eslint-disable-next-line no-restricted-syntax
-          await waitForTimeout(10);
 
+          await page.waitForFunction(
+            `${getComputedStyleSelector("7R")}.visibility !== "hidden"`
+          );
           visibility = await page.$eval(
             getSelector("7R"),
             el => getComputedStyle(el).visibility
@@ -2115,6 +2116,9 @@ describe("Interaction", () => {
             .withContext(`In ${browserName}`)
             .toEqual("visible");
 
+          await page.waitForFunction(
+            `${getComputedStyleSelector("8R")}.visibility !== "hidden"`
+          );
           visibility = await page.$eval(
             getSelector("8R"),
             el => getComputedStyle(el).visibility


### PR DESCRIPTION
We should not wait for an arbitrary amount of time, which can easily cause intermittent failures, but wait for a property value change instead. Note that this patch mirrors the approach we already use in other scripting integration tests that also check for a visibility change; see e.g. the "must show a text field and then make in invisible when content is removed" test.

Fixes #17939.
Fixes a part of #17656.