### PR TITLE
[api-minor] Update the minimum supported Safari version to 16.4

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -84,7 +84,7 @@ const ENV_TARGETS = [
   "last 2 versions",
   "Chrome >= 98",
   "Firefox ESR",
-  "Safari >= 15.4",
+  "Safari >= 16.4",
   "Node >= 18",
   "> 1%",
   "not IE > 0",

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -67,10 +67,7 @@ async function writeStream(stream, buffer, transform) {
   // The number 256 is arbitrary, but it should be reasonable.
   const MIN_LENGTH_FOR_COMPRESSING = 256;
 
-  if (
-    typeof CompressionStream !== "undefined" &&
-    (bytes.length >= MIN_LENGTH_FOR_COMPRESSING || isFilterZeroFlateDecode)
-  ) {
+  if (bytes.length >= MIN_LENGTH_FOR_COMPRESSING || isFilterZeroFlateDecode) {
     try {
       const cs = new CompressionStream("deflate");
       const writer = cs.writable.getWriter();

--- a/web/app.js
+++ b/web/app.js
@@ -399,9 +399,6 @@ const PDFViewerApplication = {
     const container = appConfig.mainContainer,
       viewer = appConfig.viewerContainer;
     const annotationEditorMode = AppOptions.get("annotationEditorMode");
-    const isOffscreenCanvasSupported =
-      AppOptions.get("isOffscreenCanvasSupported") &&
-      FeatureTest.isOffscreenCanvasSupported;
     const pageColors =
       AppOptions.get("forcePageColors") ||
       window.matchMedia("(forced-colors: active)").matches
@@ -478,7 +475,7 @@ const PDFViewerApplication = {
 
     if (appConfig.annotationEditorParams) {
       if (annotationEditorMode !== AnnotationEditorType.DISABLE) {
-        if (AppOptions.get("enableStampEditor") && isOffscreenCanvasSupported) {
+        if (AppOptions.get("enableStampEditor")) {
           appConfig.toolbar?.editorStampButton?.classList.remove("hidden");
         }
 


### PR DESCRIPTION
This patch updates the minimum supported browsers as follows:
 - Safari 16.4, which was released on 2023-03-27; see https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes

Nowadays we usually we try, where feasible and possible, to support browsers/environments that are about two years old. The reasons for limiting support to a slightly more recent Safari version include:
 - Safari has always been slower, compared to other browsers, at implementing e.g. new JavaScript features.
 - Trying to provide support for Safari is often difficult, and over the years we have seen *a lot* of bugs that are specific to Safari.
 - Safari is, and has been for many years, only listed as "mostly" supported in the FAQ.
 - This allows us to remove feature-testing, only relevant to Safari, from the main code-base.

By limiting support to only "recent" browsers we reduce the risk of holding back improvements of the built-in Firefox PDF Viewer, and also (significantly) reduce the maintenance/support burden for the PDF.js core contributors.

*Please note:* As always, the minimum supported browser version assumes that a `legacy`-build of the PDF.js library is being used; see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support