### PR TITLE
Fix the "must check that a field has the correct value when a choice is changed" scripting integration test

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -1932,18 +1932,14 @@ describe("Interaction", () => {
           expect(text).withContext(`In ${browserName}`).toEqual("");
 
           await page.select(getSelector("6R"), "Yes");
-          // eslint-disable-next-line no-restricted-syntax
-          await waitForTimeout(10);
-
+          await page.waitForFunction(`${getQuerySelector("44R")}.value !== ""`);
           text = await page.$eval(getSelector("44R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("Yes");
 
           await clearInput(page, getSelector("44R"));
 
           await page.select(getSelector("6R"), "No");
-          // eslint-disable-next-line no-restricted-syntax
-          await waitForTimeout(10);
-
+          await page.waitForFunction(`${getQuerySelector("44R")}.value !== ""`);
           text = await page.$eval(getSelector("44R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("No");
         })


### PR DESCRIPTION
We should not wait for an arbitrary amount of time, which can easily cause intermittent failures, but wait for a value change instead. Note that this patch mirrors the approach we already use in other scripting integration tests that also check for a value change; see e.g. the "must check that a field has the correct formatted value" test.

Fixes #17944.
Fixes a part of #17656.