### PR TITLE
Add margin between radio buttons/checkboxes and their labels/strings

### DIFF
--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -157,6 +157,10 @@
   max-height: 100%;
 }
 
+.xfaRight > :is(.xfaRadio, .xfaCheckbox) {
+  margin-right: 4px;
+}
+
 .xfaTop {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
[Bugzilla Bug 1716806](https://bugzilla.mozilla.org/show_bug.cgi?id=1716806)

This PR adds margin between radio buttons/checkboxes and their labels/strings.

Links to images that illustrate the changes can be found below:

- Example 1: [Before](https://utfs.io/f/6891f291-f575-4cce-9020-fd3d55b1eb2c-x5qyyc.png) | [After](https://utfs.io/f/c581a752-dd57-41d2-a408-63a47a356007-pcx8cw.png)
- Example 2: [Before](https://utfs.io/f/c48b47e5-363e-48a0-bc3a-f06fcbe29016-7z928d.png) | [After](https://utfs.io/f/ff8d85d6-c726-4297-824c-07242ef6f8cb-3gp8pb.png)
- Example 3: [Before](https://utfs.io/f/39c0f72e-1712-4517-ac12-15d6d46bdce9-lwuyk2.png) | [After](https://utfs.io/f/1133bbe4-f204-4aff-93b7-d35916ff92a8-wabpri.png)
- Example 4: [Before](https://utfs.io/f/287391b4-454b-44bb-aa10-85814ffa2ad9-j852mn.png) | [After](https://utfs.io/f/6cddff14-6f42-44c1-8104-0d7953350e83-9x5v5f.png)

Links to the original PDFs can be found below:
- [PDF 1](https://utfs.io/f/cfc49fe6-66de-4261-bcd0-70618d1bd81d-16p.pdf)
- [PDF 2](https://utfs.io/f/bc9f26ab-9d07-40fd-908d-9b0b8d520b8d-16q.pdf)
- [PDF 3](https://utfs.io/f/c1109db7-4126-4873-8e90-d42d64bcf74a-16r.pdf)
- [PDF 4](https://utfs.io/f/e4379412-86d6-47e9-ac83-2586a13131f2-16s.pdf)

I don't have extensive experience creating PRs, so I'd be happy to receive any feedback you might have.