### PR TITLE
Fix `JpxImage` API issues (PR 17946 follow-up)

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -25,7 +25,7 @@ class JpxError extends BaseException {
 class JpxImage {
   static #module = null;
 
-  static decode(data, ignoreColorSpace) {
+  static decode(data, ignoreColorSpace = false) {
     this.#module ||= OpenJPEG();
     const imageData = this.#module.decode(data, ignoreColorSpace);
     if (!imageData) {

--- a/test/fuzz/jpx_image.fuzz.js
+++ b/test/fuzz/jpx_image.fuzz.js
@@ -18,7 +18,7 @@ function ignoredError(error) {
  */
 function fuzz(data) {
   try {
-    new JpxImage().parse(new Uint8Array(data));
+    JpxImage.decode(new Uint8Array(data));
   } catch (error) {
     if (error.message && !ignoredError(error)) {
       throw error;


### PR DESCRIPTION
This commit changes the `JpxImage.decode` method signature to define the `ignoreColorSpace` argument as optional with a default value. Note that we already set this default value in the `getBytes` method of the `src/core/decode_stream.js` file since this option only seems useful for certain special cases and therefore shouldn't be mandatory to provide.

Moreover, the JPX fuzzer is changed to use the new `JpxImage` API.