### PR TITLE
Remove *some* event listeners with `signal` in the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -177,8 +177,6 @@ const PDFViewerApplication = {
   _nimbusDataPromise: null,
   _caretBrowsing: null,
   _isScrolling: false,
-  _lastScrollTop: 0,
-  _lastScrollLeft: 0,
 
   // Called once when the document is loaded.
   async initialize(appConfig) {
@@ -2002,15 +2000,20 @@ const PDFViewerApplication = {
     ) {
       return;
     }
-
-    // Using the values lastScrollTop and lastScrollLeft is a workaround to
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1881974.
-    // TODO: remove them once the bug is fixed.
-    ({ scrollTop: this._lastScrollTop, scrollLeft: this._lastScrollLeft } =
-      mainContainer);
-    const scrollend = () => {
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      // Using the values lastScrollTop and lastScrollLeft is a workaround to
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1881974.
+      // TODO: remove them once the bug is fixed.
       ({ scrollTop: this._lastScrollTop, scrollLeft: this._lastScrollLeft } =
         mainContainer);
+    }
+
+    const scrollend = () => {
+      if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+        ({ scrollTop: this._lastScrollTop, scrollLeft: this._lastScrollLeft } =
+          mainContainer);
+      }
+
       this._isScrolling = false;
       mainContainer.addEventListener("scroll", scroll, {
         passive: true,
@@ -2020,13 +2023,17 @@ const PDFViewerApplication = {
       mainContainer.removeEventListener("blur", scrollend, { signal });
     };
     const scroll = () => {
+      if (this._isCtrlKeyDown) {
+        return;
+      }
       if (
-        this._isCtrlKeyDown ||
-        (this._lastScrollTop === mainContainer.scrollTop &&
-          this._lastScrollLeft === mainContainer.scrollLeft)
+        (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) &&
+        this._lastScrollTop === mainContainer.scrollTop &&
+        this._lastScrollLeft === mainContainer.scrollLeft
       ) {
         return;
       }
+
       mainContainer.removeEventListener("scroll", scroll, {
         passive: true,
         signal,


### PR DESCRIPTION
By using the `signal` option when invoking `addEventListener`, see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal), we're able to remove an arbitrary number of event listeners with (effectively) a single line of code.
Besides getting rid of a bunch of `removeEventListener`-calls, which means shorter code, we no longer need to manually keep track of event-handling functions.

*Please note:* This can obviously be extended to more code, but I figured that starting somewhat small couldn't hurt.