### PR TITLE
Remove all `waitForTimeout` usage from the annotation integration tests

### DIFF
--- a/test/integration/annotation_spec.mjs
+++ b/test/integration/annotation_spec.mjs
@@ -18,7 +18,6 @@ import {
   getQuerySelector,
   getSelector,
   loadAndWait,
-  waitForTimeout,
 } from "./test_utils.mjs";
 
 describe("Annotation highlight", () => {
@@ -170,10 +169,6 @@ describe("Checkbox annotation", () => {
           );
           for (const selector of selectors) {
             await page.click(selector);
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
-          }
-          for (const selector of selectors) {
             await page.waitForFunction(
               `document.querySelector("${selector} > :first-child").checked`
             );
@@ -230,8 +225,9 @@ describe("Text widget", () => {
         pages.map(async ([browserName, page]) => {
           await page.type(getSelector("22R"), "a");
           await page.keyboard.press("Tab");
-          // eslint-disable-next-line no-restricted-syntax
-          await waitForTimeout(10);
+          await page.waitForFunction(
+            `${getQuerySelector("22R")}.value !== "Hello world"`
+          );
 
           const text = await page.$eval(getSelector("22R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("aHello World");
@@ -517,14 +513,10 @@ describe("ResetForm action", () => {
               `document.querySelector("[data-annotation-id='25R']").hidden === false`
             );
             await page.click("#editorFreeText");
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
             await page.waitForFunction(
               `document.querySelector("[data-annotation-id='25R']").hidden === true`
             );
             await page.click("#editorFreeText");
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
             await page.waitForFunction(
               `document.querySelector("[data-annotation-id='25R']").hidden === false`
             );
@@ -587,8 +579,9 @@ describe("ResetForm action", () => {
             expect(hidden).withContext(`In ${browserName}`).toEqual(true);
             await page.focus("[data-annotation-id='20R']");
             await page.keyboard.press("Enter");
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
+            await page.waitForFunction(
+              `document.querySelector("[data-annotation-id='21R']").hidden !== true`
+            );
             hidden = await page.$eval(
               "[data-annotation-id='21R']",
               el => el.hidden
@@ -596,8 +589,9 @@ describe("ResetForm action", () => {
             expect(hidden).withContext(`In ${browserName}`).toEqual(false);
 
             await page.keyboard.press("Enter");
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
+            await page.waitForFunction(
+              `document.querySelector("[data-annotation-id='21R']").hidden !== false`
+            );
             hidden = await page.$eval(
               "[data-annotation-id='21R']",
               el => el.hidden
@@ -605,8 +599,9 @@ describe("ResetForm action", () => {
             expect(hidden).withContext(`In ${browserName}`).toEqual(true);
 
             await page.keyboard.press("Enter");
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
+            await page.waitForFunction(
+              `document.querySelector("[data-annotation-id='21R']").hidden !== true`
+            );
             hidden = await page.$eval(
               "[data-annotation-id='21R']",
               el => el.hidden
@@ -614,8 +609,9 @@ describe("ResetForm action", () => {
             expect(hidden).withContext(`In ${browserName}`).toEqual(false);
 
             await page.keyboard.press("Escape");
-            // eslint-disable-next-line no-restricted-syntax
-            await waitForTimeout(10);
+            await page.waitForFunction(
+              `document.querySelector("[data-annotation-id='21R']").hidden !== false`
+            );
             hidden = await page.$eval(
               "[data-annotation-id='21R']",
               el => el.hidden


### PR DESCRIPTION
This commit replaces all `waitForTimeout` occurrences with the appropriate `waitForFunction` calls. Note that in some places they were already present, so in those cases we could simply remove the `waitForTimeout` call altogether.

Fixes a part of #17656.