### PR TITLE
Update `JpxImage.parseImageProperties` to support TypedArray data in IMAGE_DECODERS builds

### DIFF
--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -15,6 +15,7 @@
 
 import { BaseException } from "../shared/util.js";
 import OpenJPEG from "../../external/openjpeg/openjpeg.js";
+import { Stream } from "./stream.js";
 
 class JpxError extends BaseException {
   constructor(msg) {
@@ -39,6 +40,13 @@ class JpxImage {
   }
 
   static parseImageProperties(stream) {
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("IMAGE_DECODERS")) {
+      if (stream instanceof ArrayBuffer || ArrayBuffer.isView(stream)) {
+        stream = new Stream(stream);
+      } else {
+        throw new JpxError("Invalid data format, must be a TypedArray.");
+      }
+    }
     // No need to use OpenJPEG here since we're only getting very basic
     // information which are located in the first bytes of the file.
     let newByte = stream.getByte();


### PR DESCRIPTION
Given that the `decode` method only returns the actual image-data, a user would now need to invoke `parseImageProperties` to obtain e.g. the width and height.
This method only accepts `BaseStream`-instances, which are (obviously) not exposed, hence we extend it in IMAGE_DECODERS builds to wrap TypedArray data into the expected format.