### PR TITLE
Extend the globally cached image main-thread copying to "complex" images as well (PR 17428 follow-up)

### DIFF
--- a/test/pdfs/issue11518.pdf.link
+++ b/test/pdfs/issue11518.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/4076920/set-2_lyst7242.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -4337,6 +4337,13 @@
     "type": "other"
   },
   {
+    "id": "issue11518",
+    "file": "pdfs/issue11518.pdf",
+    "md5": "4cced24e75c35654d47141cef348301e",
+    "link": true,
+    "type": "other"
+  },
+  {
     "id": "issue4722",
     "file": "pdfs/issue4722.pdf",
     "md5": "a42ca858af7d179358f92f47e57c0fed",


### PR DESCRIPTION
In PR #17428 this functionality was limited to "larger" images, to not affect performance negatively. However it turns out that it's also beneficial to consider more "complex" images, regardless of their size, that contain /SMask or /Mask data; see issue #11518.

Fixes #11518 (to the extent that doing so is possible, since besides improved caching the rest of the "problem" is image-decoder related and that's now handled by the OpenJPEG library).