### PR TITLE
[api-minor] Remove the image-related error message prefixes

### DIFF
--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -20,7 +20,7 @@ import { CCITTFaxDecoder } from "./ccitt.js";
 
 class Jbig2Error extends BaseException {
   constructor(msg) {
-    super(`JBIG2 error: ${msg}`, "Jbig2Error");
+    super(msg, "Jbig2Error");
   }
 }
 
@@ -2593,4 +2593,4 @@ class Jbig2Image {
   }
 }
 
-export { Jbig2Image };
+export { Jbig2Error, Jbig2Image };

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -19,7 +19,7 @@ import { readUint16 } from "./core_utils.js";
 
 class JpegError extends BaseException {
   constructor(msg) {
-    super(`JPEG error: ${msg}`, "JpegError");
+    super(msg, "JpegError");
   }
 }
 
@@ -1580,4 +1580,4 @@ class JpegImage {
   }
 }
 
-export { JpegImage };
+export { JpegError, JpegImage };

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -18,7 +18,7 @@ import OpenJPEG from "../../external/openjpeg/openjpeg.js";
 
 class JpxError extends BaseException {
   constructor(msg) {
-    super(`JPX error: ${msg}`, "JpxError");
+    super(msg, "JpxError");
   }
 }
 
@@ -68,4 +68,4 @@ class JpxImage {
   }
 }
 
-export { JpxImage };
+export { JpxError, JpxImage };

--- a/src/pdf.image_decoders.js
+++ b/src/pdf.image_decoders.js
@@ -18,9 +18,9 @@ import {
   setVerbosityLevel,
   VerbosityLevel,
 } from "./shared/util.js";
-import { Jbig2Image } from "./core/jbig2.js";
-import { JpegImage } from "./core/jpg.js";
-import { JpxImage } from "./core/jpx.js";
+import { Jbig2Error, Jbig2Image } from "./core/jbig2.js";
+import { JpegError, JpegImage } from "./core/jpg.js";
+import { JpxError, JpxImage } from "./core/jpx.js";
 
 /* eslint-disable-next-line no-unused-vars */
 const pdfjsVersion =
@@ -31,8 +31,11 @@ const pdfjsBuild =
 
 export {
   getVerbosityLevel,
+  Jbig2Error,
   Jbig2Image,
+  JpegError,
   JpegImage,
+  JpxError,
   JpxImage,
   setVerbosityLevel,
   VerbosityLevel,

--- a/test/fuzz/jbig2_image.fuzz.js
+++ b/test/fuzz/jbig2_image.fuzz.js
@@ -1,4 +1,5 @@
 import {
+  Jbig2Error,
   Jbig2Image,
   setVerbosityLevel,
   VerbosityLevel,
@@ -7,9 +8,12 @@ import {
 // Avoid unnecessary console "spam", by ignoring `info`/`warn` calls.
 setVerbosityLevel(VerbosityLevel.ERRORS);
 
-const ignored = ["Cannot read properties", "JBIG2 error"];
+const ignored = ["Cannot read properties"];
 
 function ignoredError(error) {
+  if (error instanceof Jbig2Error) {
+    return true;
+  }
   return ignored.some(message => error.message.includes(message));
 }
 

--- a/test/fuzz/jpeg_image.fuzz.js
+++ b/test/fuzz/jpeg_image.fuzz.js
@@ -1,4 +1,5 @@
 import {
+  JpegError,
   JpegImage,
   setVerbosityLevel,
   VerbosityLevel,
@@ -7,9 +8,12 @@ import {
 // Avoid unnecessary console "spam", by ignoring `info`/`warn` calls.
 setVerbosityLevel(VerbosityLevel.ERRORS);
 
-const ignored = ["Cannot read properties", "JPEG error"];
+const ignored = ["Cannot read properties"];
 
 function ignoredError(error) {
+  if (error instanceof JpegError) {
+    return true;
+  }
   return ignored.some(message => error.message.includes(message));
 }
 

--- a/test/fuzz/jpx_image.fuzz.js
+++ b/test/fuzz/jpx_image.fuzz.js
@@ -1,4 +1,5 @@
 import {
+  JpxError,
   JpxImage,
   setVerbosityLevel,
   VerbosityLevel,
@@ -7,9 +8,12 @@ import {
 // Avoid unnecessary console "spam", by ignoring `info`/`warn` calls.
 setVerbosityLevel(VerbosityLevel.ERRORS);
 
-const ignored = ["Cannot read properties", "JPX error"];
+const ignored = ["Cannot read properties"];
 
 function ignoredError(error) {
+  if (error instanceof JpxError) {
+    return true;
+  }
   return ignored.some(message => error.message.includes(message));
 }
 

--- a/test/unit/pdf.image_decoders_spec.js
+++ b/test/unit/pdf.image_decoders_spec.js
@@ -18,9 +18,9 @@ import {
   setVerbosityLevel,
   VerbosityLevel,
 } from "../../src/shared/util.js";
-import { Jbig2Image } from "../../src/core/jbig2.js";
-import { JpegImage } from "../../src/core/jpg.js";
-import { JpxImage } from "../../src/core/jpx.js";
+import { Jbig2Error, Jbig2Image } from "../../src/core/jbig2.js";
+import { JpegError, JpegImage } from "../../src/core/jpg.js";
+import { JpxError, JpxImage } from "../../src/core/jpx.js";
 
 describe("pdfimage_api", function () {
   it("checks that the *official* PDF.js-image decoders API exposes the expected functionality", async function () {
@@ -35,8 +35,11 @@ describe("pdfimage_api", function () {
     // hence we copy the data to allow using a simple comparison below.
     expect({ ...pdfimageAPI }).toEqual({
       getVerbosityLevel,
+      Jbig2Error,
       Jbig2Image,
+      JpegError,
       JpegImage,
+      JpxError,
       JpxImage,
       setVerbosityLevel,
       VerbosityLevel,


### PR DESCRIPTION
Other custom errors, based on `BaseException`, do not use such a format.