### PR TITLE
Validate explicit destinations on the worker-thread to prevent `DataCloneError` (issue 17981)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2933,10 +2933,9 @@ class WorkerTransport {
   getPageIndex(ref) {
     if (
       typeof ref !== "object" ||
-      ref === null ||
-      !Number.isInteger(ref.num) ||
+      !Number.isInteger(ref?.num) ||
       ref.num < 0 ||
-      !Number.isInteger(ref.gen) ||
+      !Number.isInteger(ref?.gen) ||
       ref.gen < 0
     ) {
       return Promise.reject(new Error("Invalid pageIndex request."));

--- a/test/pdfs/issue17981.pdf.link
+++ b/test/pdfs/issue17981.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/15061082/unhandled_get_annotations.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2112,6 +2112,16 @@
     "type": "eq"
   },
   {
+    "id": "issue17981",
+    "file": "pdfs/issue17981.pdf",
+    "md5": "3fd6d2bdcad8ff7cc5c0575da0b70266",
+    "rounds": 1,
+    "link": true,
+    "lastPage": 1,
+    "type": "eq",
+    "annotations": true
+  },
+  {
     "id": "issue9105_other",
     "file": "pdfs/issue9105_other.pdf",
     "md5": "4c8b9c2cceb9c5d621e1d50b3dc38efc",


### PR DESCRIPTION
*Note:* This borrows a helper function from the viewer, however the code cannot be directly shared since the worker-thread has access to various primitives.