### PR TITLE
Change BaseException prototype

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -469,7 +469,7 @@ const BaseException = (function BaseExceptionClosure() {
     this.message = message;
     this.name = name;
   }
-  BaseException.prototype = new Error();
+  BaseException.prototype = Object.create(Error.prototype);
   BaseException.constructor = BaseException;
 
   return BaseException;


### PR DESCRIPTION
While developing a website using SvelteKit I started getting errors when trying to use pdfjs. However the error came from vite, because it could not properly handle the error thrown by pdfjs.

After debugging for a bit I found that the root of the issue was that vite assumes a "stack" property on errors, which is fair considering that pretty much every implementation has that, but the error thrown did not have this property. After changing vite's error handling a bit I found the real underlying issue - just a simple [MissingPDFException: Missing PDF "...".] because I messed up the path.

I reverted my changes to vite's error handling and started looking for the cause of it not working as intended when I found the line `BaseException.prototype = new Error();` which looked weird to me and after a bit of googling I found [this StackOverflow](https://stackoverflow.com/questions/783818/how-do-i-create-a-custom-error-in-javascript) question where people recommended using `CustomError.prototype = Object.create(Error.prototype)`. I quickly tested it and now I directly got the exception printed in console, not something unrelated.

Being satisfied with finding the cause I then fixed the path to the PDF being wrong and now it is working as intended. Just wish I would not have wasted this much time on an issue this simple.