### PR TITLE
Pin GitHub actions to Node.js 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, lts/*, latest]
+        node-version: [18, lts/*, 21]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
> Node.js 22 was just released, and it seems like it's not compatible with the `canvas` package. This commit pins the version on GitHub actions to Node.js 21 as a temporary workaround.
>
> This commit should be reverted once https://github.com/Automattic/node-canvas/issues/2377 is fixed.

I noticed CI failing in #17923 and #18001 due to the new Node.js release, and while I don't know enough about node-gyp to fix it this should at least allow running tests until when it's fixed upstream. You might need to to the same in the Bot that runs the tests.