### PR TITLE
Fix rendering problem when zooming on Safari

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -155,7 +155,6 @@
 
 .pdfViewer .page canvas {
   margin: 0;
-  display: block;
 }
 
 .pdfViewer .page canvas .structTree {


### PR DESCRIPTION
Fixes: https://github.com/mozilla/pdf.js/issues/16155
@calixteman suggestion in the comment https://github.com/mozilla/pdf.js/pull/17571#issuecomment-2047832265, works well for iPad/iOS devices. 
Before the fix:


https://github.com/mozilla/pdf.js/assets/62544124/3049bdb4-6013-4850-8081-7a4c4f3f9e46




After the fix:



https://github.com/mozilla/pdf.js/assets/62544124/1ff41ce7-eb6d-4c66-8035-dce30d20335c





