### PR TITLE
[api-minor] Remove the use of (get/put)ImageData when drawing SMasks (bug 1874013)

### DIFF
--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -30,6 +30,14 @@ class BaseFilterFactory {
     return "none";
   }
 
+  addAlphaFilter(map) {
+    return "none";
+  }
+
+  addLuminosityFilter(map) {
+    return "none";
+  }
+
   addHighlightHCMFilter(filterName, fgColor, bgColor, newFgColor, newBgColor) {
     return "none";
   }

--- a/test/pdfs/issue17779.pdf.link
+++ b/test/pdfs/issue17779.pdf.link
@@ -1,0 +1,2 @@
+https://github.com/mozilla/pdf.js/files/14522359/p95.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -9957,5 +9957,13 @@
         "id": "51R"
       }
     }
+  },
+  {
+    "id": "issue17779",
+    "file": "pdfs/issue17779.pdf",
+    "md5": "764b72e8e56e22662b321b308254fd2b",
+    "rounds": 1,
+    "link": true,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
and implement then in using some SVG filters and composition. Composing in using destination-in in order to multiply RGB components by the alpha from the mask isn't perfect: it'd be a way better to natively have alpha masks support, it induces some small rounding errors and consequently computed RGB are approximatively correct.
In term of performance, it's a real improvement, for example, the pdf in issue #17779 is now rendered in few seconds.
There are still some room for improvement, but overall it should be a way better.