### PR TITLE
[api-minor] Improve the `FileSpec` implementation

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1619,8 +1619,8 @@ class Catalog {
               /* xref = */ null,
               /* skipContent = */ true
             );
-            const { filename } = fs.serializable;
-            url = filename;
+            const { rawFilename } = fs.serializable;
+            url = rawFilename;
           } else if (typeof urlDict === "string") {
             url = urlDict;
           }

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -37,7 +37,6 @@ import {
 } from "../shared/util.js";
 import {
   DOMSVGFactory,
-  getFilenameFromUrl,
   PDFDateString,
   setLayerDimensions,
 } from "./display_utils.js";
@@ -2859,15 +2858,13 @@ class FileAttachmentAnnotationElement extends AnnotationElement {
   constructor(parameters) {
     super(parameters, { isRenderable: true });
 
-    const { filename, content, description } = this.data.file;
-    this.filename = getFilenameFromUrl(filename, /* onlyStripPath = */ true);
-    this.content = content;
+    const { file } = this.data;
+    this.filename = file.filename;
+    this.content = file.content;
 
     this.linkService.eventBus?.dispatch("fileattachmentannotation", {
       source: this,
-      filename,
-      content,
-      description,
+      ...file,
     });
   }
 

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -803,13 +803,10 @@ function isPdfFile(filename) {
 /**
  * Gets the filename from a given URL.
  * @param {string} url
- * @param {boolean} [onlyStripPath]
  * @returns {string}
  */
-function getFilenameFromUrl(url, onlyStripPath = false) {
-  if (!onlyStripPath) {
-    [url] = url.split(/[#?]/, 1);
-  }
+function getFilenameFromUrl(url) {
+  [url] = url.split(/[#?]/, 1);
   return url.substring(url.lastIndexOf("/") + 1);
 }
 

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -4033,9 +4033,12 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.FILEATTACHMENT);
-      expect(data.file.filename).toEqual("Test.txt");
-      expect(data.file.content).toEqual(stringToBytes("Test attachment"));
-      expect(data.file.description).toEqual("abc");
+      expect(data.file).toEqual({
+        rawFilename: "Test.txt",
+        filename: "Test.txt",
+        content: stringToBytes("Test attachment"),
+        description: "abc",
+      });
     });
   });
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1475,12 +1475,12 @@ describe("api", function () {
       const pdfDoc = await loadingTask.promise;
       const attachments = await pdfDoc.getAttachments();
 
-      const { filename, content, description } = attachments["foo.txt"];
-      expect(filename).toEqual("foo.txt");
-      expect(content).toEqual(
-        new Uint8Array([98, 97, 114, 32, 98, 97, 122, 32, 10])
-      );
-      expect(description).toEqual("");
+      expect(attachments["foo.txt"]).toEqual({
+        rawFilename: "foo.txt",
+        filename: "foo.txt",
+        content: new Uint8Array([98, 97, 114, 32, 98, 97, 122, 32, 10]),
+        description: "",
+      });
 
       await loadingTask.destroy();
     });
@@ -1490,7 +1490,9 @@ describe("api", function () {
       const pdfDoc = await loadingTask.promise;
       const attachments = await pdfDoc.getAttachments();
 
-      const { filename, content, description } = attachments["empty.pdf"];
+      const { rawFilename, filename, content, description } =
+        attachments["empty.pdf"];
+      expect(rawFilename).toEqual("Empty page.pdf");
       expect(filename).toEqual("Empty page.pdf");
       expect(content instanceof Uint8Array).toEqual(true);
       expect(content.length).toEqual(2357);

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -189,13 +189,6 @@ describe("display_utils", function () {
       const url = "https://server.org/filename.pdf?foo=bar";
       expect(getFilenameFromUrl(url)).toEqual("filename.pdf");
     });
-
-    it("should get the filename from a relative URL, keeping the anchor", function () {
-      const url = "../../part1#part2.pdf";
-      expect(getFilenameFromUrl(url, /* onlyStripPath = */ true)).toEqual(
-        "part1#part2.pdf"
-      );
-    });
   });
 
   describe("getPdfFilenameFromUrl", function () {

--- a/web/pdf_attachment_viewer.js
+++ b/web/pdf_attachment_viewer.js
@@ -18,7 +18,6 @@
 /** @typedef {import("./download_manager.js").DownloadManager} DownloadManager */
 
 import { BaseTreeViewer } from "./base_tree_viewer.js";
-import { getFilenameFromUrl } from "pdfjs-lib";
 import { waitOnEventOrTimeout } from "./event_utils.js";
 
 /**
@@ -122,19 +121,13 @@ class PDFAttachmentViewer extends BaseTreeViewer {
     let attachmentsCount = 0;
     for (const name in attachments) {
       const item = attachments[name];
-      const content = item.content,
-        description = item.description,
-        filename = getFilenameFromUrl(
-          item.filename,
-          /* onlyStripPath = */ true
-        );
 
       const div = document.createElement("div");
       div.className = "treeItem";
 
       const element = document.createElement("a");
-      this._bindLink(element, { content, description, filename });
-      element.textContent = this._normalizeTextContent(filename);
+      this._bindLink(element, item);
+      element.textContent = this._normalizeTextContent(item.filename);
 
       div.append(element);
 
@@ -148,7 +141,7 @@ class PDFAttachmentViewer extends BaseTreeViewer {
   /**
    * Used to append FileAttachment annotations to the sidebar.
    */
-  #appendAttachment({ filename, content, description }) {
+  #appendAttachment(item) {
     const renderedPromise = this._renderedCapability.promise;
 
     renderedPromise.then(() => {
@@ -158,15 +151,12 @@ class PDFAttachmentViewer extends BaseTreeViewer {
       const attachments = this._attachments || Object.create(null);
 
       for (const name in attachments) {
-        if (filename === name) {
+        if (item.filename === name) {
           return; // Ignore the new attachment if it already exists.
         }
       }
-      attachments[filename] = {
-        filename,
-        content,
-        description,
-      };
+      attachments[item.filename] = item;
+
       this.render({
         attachments,
         keepRenderedCapability: true,


### PR DESCRIPTION
 - Check that the `filename` is actually a string, before parsing it further.
 - Use proper "shadowing" in the `filename` getter.
 - Add a bit more validation of the data in `pickPlatformItem`.
 - Last, but not least, return both the original `filename` and the (path stripped) variant needed in the display-layer and viewer.