### PR TITLE
Remove the limit used to decided if a group canvas must be upscaled or not

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -45,7 +45,6 @@ import { convertBlackAndWhiteToRGBA } from "../shared/image_utils.js";
 const MIN_FONT_SIZE = 16;
 // Maximum font size that would be used during canvas fillText operations.
 const MAX_FONT_SIZE = 100;
-const MAX_GROUP_SIZE = 4096;
 
 // Defines the time the `executeOperatorList`-method is going to be executing
 // before it stops and schedules a continue of execution.
@@ -2553,18 +2552,8 @@ class CanvasGraphics {
     // too small and make the canvas at least 1x1 pixels.
     const offsetX = Math.floor(bounds[0]);
     const offsetY = Math.floor(bounds[1]);
-    let drawnWidth = Math.max(Math.ceil(bounds[2]) - offsetX, 1);
-    let drawnHeight = Math.max(Math.ceil(bounds[3]) - offsetY, 1);
-    let scaleX = 1,
-      scaleY = 1;
-    if (drawnWidth > MAX_GROUP_SIZE) {
-      scaleX = drawnWidth / MAX_GROUP_SIZE;
-      drawnWidth = MAX_GROUP_SIZE;
-    }
-    if (drawnHeight > MAX_GROUP_SIZE) {
-      scaleY = drawnHeight / MAX_GROUP_SIZE;
-      drawnHeight = MAX_GROUP_SIZE;
-    }
+    const drawnWidth = Math.max(Math.ceil(bounds[2]) - offsetX, 1);
+    const drawnHeight = Math.max(Math.ceil(bounds[3]) - offsetY, 1);
 
     this.current.startNewPathAndClipBox([0, 0, drawnWidth, drawnHeight]);
 
@@ -2582,7 +2571,6 @@ class CanvasGraphics {
 
     // Since we created a new canvas that is just the size of the bounding box
     // we have to translate the group ctx.
-    groupCtx.scale(1 / scaleX, 1 / scaleY);
     groupCtx.translate(-offsetX, -offsetY);
     groupCtx.transform(...currentTransform);
 
@@ -2593,8 +2581,6 @@ class CanvasGraphics {
         context: groupCtx,
         offsetX,
         offsetY,
-        scaleX,
-        scaleY,
         subtype: group.smask.subtype,
         backdrop: group.smask.backdrop,
         transferMap: group.smask.transferMap || null,
@@ -2605,7 +2591,6 @@ class CanvasGraphics {
       // right location.
       currentCtx.setTransform(1, 0, 0, 1, 0, 0);
       currentCtx.translate(offsetX, offsetY);
-      currentCtx.scale(scaleX, scaleY);
       currentCtx.save();
     }
     // The transparency group inherits all off the current graphics state

--- a/test/pdfs/issue14724.pdf.link
+++ b/test/pdfs/issue14724.pdf.link
@@ -1,0 +1,2 @@
+https://github.com/mozilla/pdf.js/files/8365628/Infographic_EAP_EN_v2.1.pdf
+

--- a/test/pdfs/issue14982.pdf.link
+++ b/test/pdfs/issue14982.pdf.link
@@ -1,0 +1,2 @@
+https://github.com/mozilla/pdf.js/files/8829368/Tillamook-Market-Menu-04.04.22.pdf
+

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -9965,5 +9965,21 @@
     "rounds": 1,
     "link": true,
     "type": "eq"
+  },
+  {
+    "id": "issue14724",
+    "file": "pdfs/issue14724.pdf",
+    "md5": "34ecf91792eb54d58e0e86f877017f71",
+    "rounds": 1,
+    "link": true,
+    "type": "eq"
+  },
+  {
+    "id": "issue14982",
+    "file": "pdfs/issue14982.pdf",
+    "md5": "bbd7d7f75f51a477b56b6e3f69174d06",
+    "rounds": 1,
+    "link": true,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
It fixes issues #14982 and #14724.
The main problem of upscaling a canvas is that it can induces some pixelation (see issue #14724). So this patch is just removing the limit and as a side effect it fixes issue #14982.
As far as I can tell, in looking different profiles (especially some memory profile) in using the Firefox profiler, I don't see any noticeable difference in term of memory use.