### PR TITLE
Remove most `waitForTimeout` usage from the freetext editor integration tests

### DIFF
--- a/test/integration/annotation_spec.mjs
+++ b/test/integration/annotation_spec.mjs
@@ -74,13 +74,7 @@ describe("Annotation highlight", () => {
         pages.map(async ([browserName, page]) => {
           for (const i of [23, 22, 14]) {
             await page.click(`[data-annotation-id='${i}R']`);
-            await page.waitForFunction(
-              id =>
-                document.activeElement ===
-                document.querySelector(`#pdfjs_internal_id_${id}R`),
-              {},
-              i
-            );
+            await page.waitForSelector(`#pdfjs_internal_id_${i}R:focus`);
           }
         })
       );

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -56,9 +56,6 @@ const copyPaste = async page => {
   await kbCopy(page);
   await promise;
 
-  // eslint-disable-next-line no-restricted-syntax
-  await waitForTimeout(10);
-
   promise = waitForEvent(page, "paste");
   await kbPaste(page);
   await promise;
@@ -1364,9 +1361,6 @@ describe("FreeText Editor", () => {
           // Enter in editing mode.
           await switchToFreeText(page);
 
-          // eslint-disable-next-line no-restricted-syntax
-          await waitForTimeout(200);
-
           // Disable editing mode.
           await page.click("#editorFreeText");
           await page.waitForSelector(
@@ -2411,14 +2405,7 @@ describe("FreeText Editor", () => {
 
           // The editor must be moved in the DOM and potentially the focus
           // will be lost, hence there's a callback will get back the focus.
-          // eslint-disable-next-line no-restricted-syntax
-          await waitForTimeout(200);
-
-          const focused = await page.evaluate(sel => {
-            const editor = document.querySelector(sel);
-            return editor === document.activeElement;
-          }, getEditorSelector(1));
-          expect(focused).withContext(`In ${browserName}`).toEqual(true);
+          await page.waitForSelector(`${getEditorSelector(1)}:focus`);
 
           expect(await pos(0))
             .withContext(`In ${browserName}`)

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1591,18 +1591,12 @@ describe("Highlight Editor", () => {
           await page.focus(getEditorSelector(1));
 
           await kbFocusPrevious(page);
-          await page.waitForFunction(
-            sel => document.querySelector(sel) === document.activeElement,
-            {},
-            `.page[data-page-number="1"] > .textLayer`
+          await page.waitForSelector(
+            `.page[data-page-number="1"] > .textLayer:focus`
           );
 
           await kbFocusNext(page);
-          await page.waitForFunction(
-            sel => document.querySelector(sel) === document.activeElement,
-            {},
-            getEditorSelector(1)
-          );
+          await page.waitForSelector(`${getEditorSelector(1)}:focus`);
         })
       );
     });


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Fixes a part of #17656.