### PR TITLE
Avoid to aria-hide the structure tree (bug 1894849)

### DIFF
--- a/test/integration/accessibility_spec.mjs
+++ b/test/integration/accessibility_spec.mjs
@@ -31,6 +31,18 @@ describe("accessibility", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await page.waitForSelector(".structTree");
+          const isVisible = await page.evaluate(() => {
+            let elem = document.querySelector(".structTree");
+            while (elem) {
+              if (elem.getAttribute("aria-hidden") === "true") {
+                return false;
+              }
+              elem = elem.parentElement;
+            }
+            return true;
+          });
+
+          expect(isVisible).withContext(`In ${browserName}`).toBeTrue();
 
           // Check the headings match up.
           const head1 = await page.$eval(

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -908,7 +908,6 @@ class PDFPageView {
     // overflow will be hidden in Firefox.
     const canvasWrapper = document.createElement("div");
     canvasWrapper.classList.add("canvasWrapper");
-    canvasWrapper.setAttribute("aria-hidden", true);
     this.#addLayer(canvasWrapper, "canvasWrapper");
 
     if (


### PR DESCRIPTION
If one ancestor of the structure tree has the attribute aria-hidden then it's invisible for screen readers.