### PR TITLE
Only accept numbers when building character width array.

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4067,11 +4067,11 @@ class PartialEvaluator {
     const differences = properties.differences;
     const encoding = properties.defaultEncoding;
     for (let charCode = 0; charCode < 256; charCode++) {
-      if (charCode in differences && widthsByGlyphName[differences[charCode]]) {
+      if (charCode in differences && widthsByGlyphName[differences[charCode]] && typeof widthsByGlyphName[differences[charCode]] === 'number') {
         widths[charCode] = widthsByGlyphName[differences[charCode]];
         continue;
       }
-      if (charCode in encoding && widthsByGlyphName[encoding[charCode]]) {
+      if (charCode in encoding && widthsByGlyphName[encoding[charCode]] && typeof widthsByGlyphName[encoding[charCode]] === 'number') {
         widths[charCode] = widthsByGlyphName[encoding[charCode]];
         continue;
       }


### PR DESCRIPTION
When a document contains certain Monospace fonts, such as Courier, the width array contains only a single entry.  The "buildCharCodeToWidth" function attempts to copy the character widths from this array to another.  As many modern browsers now include an "at" function on the array prototype, character '@' matches on this function, rather than a number (aka width).  A downstream clone operation then fails resulting in issues similar to the following:

Warning: getOperatorList - ignoring errors during "GetOperatorList..."
https://github.com/mozilla/pdf.js/issues/13771

Despite the above issue being resolved, the problem still occurs when cloning the "widths" array, which is an allowed property.  The mysterious "at" function comes from the array prototype.

Credit to Nathan W. for the research on this issue.