### PR TITLE
[api-minor] Re-factor how Node.js packages/polyfills are  loaded (issue 17245)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -445,10 +445,8 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
 
 function tweakWebpackOutput(jsName) {
   const replacer = [
-    " __webpack_exports__ = {};",
-    ",__webpack_exports__={};",
-    " __webpack_exports__ = await __webpack_exports__;",
-    "\\(__webpack_exports__=await __webpack_exports__\\)",
+    " __webpack_exports__ = {};", // Normal builds.
+    ",__webpack_exports__={};", // Minified builds.
   ];
   const regex = new RegExp(`(${replacer.join("|")})`, "gm");
 
@@ -458,10 +456,6 @@ function tweakWebpackOutput(jsName) {
         return ` __webpack_exports__ = globalThis.${jsName} = {};`;
       case ",__webpack_exports__={};":
         return `,__webpack_exports__=globalThis.${jsName}={};`;
-      case " __webpack_exports__ = await __webpack_exports__;":
-        return ` __webpack_exports__ = globalThis.${jsName} = await (globalThis.${jsName}Promise = __webpack_exports__);`;
-      case "(__webpack_exports__=await __webpack_exports__)":
-        return `(__webpack_exports__=globalThis.${jsName}=await (globalThis.${jsName}Promise=__webpack_exports__))`;
     }
     return match;
   });

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -58,6 +58,7 @@ import {
   NodeCanvasFactory,
   NodeCMapReaderFactory,
   NodeFilterFactory,
+  NodePackages,
   NodeStandardFontDataFactory,
 } from "display-node_utils";
 import { CanvasGraphics } from "./canvas.js";
@@ -2089,6 +2090,14 @@ class PDFWorker {
    * @type {Promise<void>}
    */
   get promise() {
+    if (
+      typeof PDFJSDev !== "undefined" &&
+      PDFJSDev.test("GENERIC") &&
+      isNodeJS
+    ) {
+      // Ensure that all Node.js packages/polyfills have loaded.
+      return Promise.all([NodePackages.promise, this._readyCapability.promise]);
+    }
     return this._readyCapability.promise;
   }
 

--- a/src/display/stubs.js
+++ b/src/display/stubs.js
@@ -16,6 +16,7 @@
 const NodeCanvasFactory = null;
 const NodeCMapReaderFactory = null;
 const NodeFilterFactory = null;
+const NodePackages = null;
 const NodeStandardFontDataFactory = null;
 const PDFFetchStream = null;
 const PDFNetworkStream = null;
@@ -25,6 +26,7 @@ export {
   NodeCanvasFactory,
   NodeCMapReaderFactory,
   NodeFilterFactory,
+  NodePackages,
   NodeStandardFontDataFactory,
   PDFFetchStream,
   PDFNetworkStream,

--- a/test/unit/clitests_helper.js
+++ b/test/unit/clitests_helper.js
@@ -18,6 +18,7 @@ import {
   setVerbosityLevel,
   VerbosityLevel,
 } from "../../src/shared/util.js";
+import { NodePackages } from "../../src/display/node_utils.js";
 
 // Sets longer timeout, similar to `jasmine-boot.js`.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
@@ -28,6 +29,9 @@ if (!isNodeJS) {
     "The `gulp unittestcli` command can only be used in Node.js environments."
   );
 }
+
+// Ensure that all Node.js packages/polyfills have loaded.
+await NodePackages.promise;
 
 // Reduce the amount of console "spam", by ignoring `info`/`warn` calls,
 // when running the unit-tests in Node.js/Travis.

--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -13,15 +13,6 @@
  * limitations under the License.
  */
 
-// Ensure that the viewer waits for the library to complete loading,
-// to avoid breaking e.g. the standalone viewer components (see issue 17228).
-if (
-  (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
-  !globalThis.pdfjsLib
-) {
-  await globalThis.pdfjsLibPromise;
-}
-
 const {
   AbortException,
   AnnotationEditorLayer,


### PR DESCRIPTION
*Please note:* This removes top level await from the GENERIC builds of the PDF.js library.

Despite top level await being supported in all modern browsers/environments, note [the MDN compatibility data](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#browser_compatibility), it seems that many frameworks and build-tools unfortunately have trouble with it.
Hence, in order to reduce the influx of support requests regarding top level await it thus seems that we'll have to try and fix this.

Given that top level await is only needed for Node.js environments, to load packages/polyfills, we re-factor things to limit the asynchronicity to that environment.
The "best" solution, with the least likelihood of causing future problems, would probably be to await the load of Node.js packages/polyfills e.g. at the top of the `getDocument`-function. Unfortunately that doesn't work though, since that's a *synchronous* function that we cannot change without breaking "the world".

Hence we instead await the load of Node.js packages/polyfills together with the `PDFWorker` initialization, since that's the *first point* of asynchronicity during initialization/loading of a PDF document. The reason that this works is that the Node.js packages/polyfills are only needed during fetching of the PDF document respectively during rendering, neither of which can happen *until* the worker has been initialized.
Hopefully this won't cause any future problems, since looking at the history of the PDF.js project I don't believe that we've (thus far) ever needed a Node.js dependency at an earlier point.
This new pattern for accessing Node.js packages/polyfills will also require some care during development *and* importantly reviewing, to ensure that no new top level await is added in the main code-base.