### PR TITLE
Remove the `ignoreErrors` option from the `FontFaceObject` class

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -383,7 +383,6 @@ function getDocument(src) {
     },
   };
   const transportParams = {
-    ignoreErrors,
     disableFontFace,
     fontExtraProperties,
     enableXfa,
@@ -2750,8 +2749,7 @@ class WorkerTransport {
 
       switch (type) {
         case "Font":
-          const { disableFontFace, fontExtraProperties, ignoreErrors, pdfBug } =
-            this._params;
+          const { disableFontFace, fontExtraProperties, pdfBug } = this._params;
 
           if ("error" in exportedData) {
             const exportedError = exportedData.error;
@@ -2766,7 +2764,6 @@ class WorkerTransport {
               : null;
           const font = new FontFaceObject(exportedData, {
             disableFontFace,
-            ignoreErrors,
             inspectFont,
           });
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2750,7 +2750,8 @@ class WorkerTransport {
 
       switch (type) {
         case "Font":
-          const params = this._params;
+          const { disableFontFace, fontExtraProperties, ignoreErrors, pdfBug } =
+            this._params;
 
           if ("error" in exportedData) {
             const exportedError = exportedData.error;
@@ -2760,12 +2761,12 @@ class WorkerTransport {
           }
 
           const inspectFont =
-            params.pdfBug && globalThis.FontInspector?.enabled
+            pdfBug && globalThis.FontInspector?.enabled
               ? (font, url) => globalThis.FontInspector.fontAdded(font, url)
               : null;
           const font = new FontFaceObject(exportedData, {
-            disableFontFace: params.disableFontFace,
-            ignoreErrors: params.ignoreErrors,
+            disableFontFace,
+            ignoreErrors,
             inspectFont,
           });
 
@@ -2773,7 +2774,7 @@ class WorkerTransport {
             .bind(font)
             .catch(() => messageHandler.sendWithPromise("FontFallback", { id }))
             .finally(() => {
-              if (!params.fontExtraProperties && font.data) {
+              if (!fontExtraProperties && font.data) {
                 // Immediately release the `font.data` property once the font
                 // has been attached to the DOM, since it's no longer needed,
                 // rather than waiting for a `PDFDocumentProxy.cleanup` call.

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -360,17 +360,13 @@ class FontLoader {
 }
 
 class FontFaceObject {
-  constructor(
-    translatedData,
-    { disableFontFace = false, ignoreErrors = false, inspectFont = null }
-  ) {
+  constructor(translatedData, { disableFontFace = false, inspectFont = null }) {
     this.compiledGlyphs = Object.create(null);
     // importing translated data
     for (const i in translatedData) {
       this[i] = translatedData[i];
     }
     this.disableFontFace = disableFontFace === true;
-    this.ignoreErrors = ignoreErrors === true;
     this._inspectFont = inspectFont;
   }
 
@@ -430,9 +426,6 @@ class FontFaceObject {
     try {
       cmds = objs.get(this.loadedName + "_path_" + character);
     } catch (ex) {
-      if (!this.ignoreErrors) {
-        throw ex;
-      }
       warn(`getPathGenerator - ignoring character: "${ex}".`);
     }
 


### PR DESCRIPTION
 - The `stopAtErrors` API option, which is the inverse of the "internal" `ignoreErrors` option, is explicitly documented as applying to *parsing* (i.e. the worker-thread) while the `FontFaceObject` class is used during rendering (i.e. the main-thread); see https://github.com/mozilla/pdf.js/blob/b6765403a1b08aa80a21cb0809741875a925ab4d/src/display/api.js#L164-L167

 - A glyph that fails in the `FontRendererFactory`, on the worker-thread, will already cause (overall) parsing to stop when `ignoreErrors === false` hence checking the option on the main-thread as well seems redundant; see https://github.com/mozilla/pdf.js/blob/b6765403a1b08aa80a21cb0809741875a925ab4d/src/core/evaluator.js#L4527-L4533

 - Removing this option simplifies the code, and slightly reduces the number of options that we need to handle in the main-thread code.