### PR TITLE
Use fuzzy-matching to improve cache hit rates with `PostScriptEvaluator`

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -447,16 +447,20 @@ class PDFFunction {
     // seen in our tests.
     const MAX_CACHE_SIZE = 2048 * 4;
     let cache_available = MAX_CACHE_SIZE;
-    const tmpBuf = new Float32Array(numInputs);
+    const input = new Float32Array(numInputs);
 
     return function constructPostScriptFn(src, srcOffset, dest, destOffset) {
       let i, value;
       let key = "";
-      const input = tmpBuf;
       for (i = 0; i < numInputs; i++) {
         value = src[srcOffset + i];
         input[i] = value;
-        key += value + "_";
+        // Fuzzy-match to increase the cache hit rate which helps improve
+        // performance, at the expense of absolute rendering quality.
+        // In practice this seems fine, and in the test-suite there are no
+        // perceivable differences, which is likely because the computed value
+        // will *eventually* be clamped to the [0, 255] range during rendering.
+        key += Math.round(value * 1e8) + "_";
       }
 
       const cachedValue = cache[key];

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -280,7 +280,7 @@ function getDocument(src = {}) {
     Number.isInteger(src.maxImageSize) && src.maxImageSize > -1
       ? src.maxImageSize
       : -1;
-  const isEvalSupported = src.isEvalSupported !== false;
+  const isEvalSupported = false; // src.isEvalSupported !== false;
   const isOffscreenCanvasSupported =
     typeof src.isOffscreenCanvasSupported === "boolean"
       ? src.isOffscreenCanvasSupported

--- a/test/pdfs/pr5134.pdf.link
+++ b/test/pdfs/pr5134.pdf.link
@@ -1,0 +1,1 @@
+https://web.archive.org/web/20140211020222/http://www.coachusa.com/CoachUsaAssets/files/97/route45.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2247,6 +2247,15 @@
     "type": "eq"
   },
   {
+    "id": "pr5134",
+    "file": "pdfs/pr5134.pdf",
+    "md5": "6a701a163472e071a2519348b55cbac1",
+    "rounds": 1,
+    "link": true,
+    "firstPage": 2,
+    "type": "eq"
+  },
+  {
     "id": "issue5599",
     "file": "pdfs/issue5599.pdf",
     "md5": "529a4a9409ac024aeb57a047210280fe",


### PR DESCRIPTION
This improves performance, without any noticeable regressions when running `gulp browsertest --noChrome` locally on Windows.
Testing the new `pr5134` test-case locally in the viewer:
 - With the `master` branch and `isEvalSupported = true`, page 2 renders in approx. 350 milliseconds.
 - With the `master` branch and `isEvalSupported = false`, page 2 renders in approx. 1550 milliseconds.
 - With this patch and `isEvalSupported = false`, page 2 renders in approx. 700 milliseconds.

Hence this obviously isn't enough to close the performance gap, but it *may* still be helpful.