### PR TITLE
Restore `display: block` in other `canvas`es

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -155,7 +155,14 @@
 
 .pdfViewer .page canvas {
   margin: 0;
+  display: block;
 }
+
+/*#if GENERIC*/
+.pdfViewer .page .canvasWrapper canvas {
+  display: unset;
+}
+/*#endif*/
 
 .pdfViewer .page canvas .structTree {
   contain: strict;


### PR DESCRIPTION
> **Restore `display: block` in other canvases**
>
> 77e2182 removed `display: block` from `.pdfViewer .page canvas` to workaround a Safari bug > when zooming the canvas tha renders the PDF page. However, `.pdfViewer .page canvas` was also targeting `canvases` used for images and drawings in the annotation layers, which need to use `display: block` to ensure proper positioning (since they have siblings).
> 
> This PR adds back `display: block`, only removing it for `canvas`es inside `.canvasWrapper`.
> 
> Fixes [bug 1895909](https://bugzilla.mozilla.org/show_bug.cgi?id=1895909).

I can try adding an integration test if needed.