### PR TITLE
[Editor] Fix the CSS properties of the canvas when it's used in a stampEditor (bug 1895909)

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -291,16 +291,18 @@ function getAnnotationStorage(page) {
   );
 }
 
-function waitForEntryInStorage(page, key, value) {
+function waitForEntryInStorage(page, key, value, checker = (x, y) => x === y) {
   return page.waitForFunction(
-    (k, v) => {
+    (k, v, c) => {
       const { map } =
         window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;
-      return map && JSON.stringify(map.get(k)) === v;
+      // eslint-disable-next-line no-eval
+      return map && eval(`(${c})`)(JSON.stringify(map.get(k)), v);
     },
     {},
     key,
-    JSON.stringify(value)
+    JSON.stringify(value),
+    checker.toString()
   );
 }
 

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -502,11 +502,13 @@
 .annotationEditorLayer .stampEditor {
   width: auto;
   height: auto;
-}
 
-.annotationEditorLayer .stampEditor canvas {
-  width: 100%;
-  height: 100%;
+  canvas {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+  }
 }
 
 .annotationEditorLayer {

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -69,12 +69,30 @@
   @media screen and (forced-colors: active) {
     --hcm-highlight-filter: invert(100%);
   }
-}
 
-.pdfViewer .canvasWrapper {
-  overflow: hidden;
-  width: 100%;
-  height: 100%;
+  .canvasWrapper {
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+
+    canvas {
+      margin: 0;
+      display: block;
+
+      &[hidden] {
+        display: none;
+      }
+
+      &[zooming] {
+        width: 100%;
+        height: 100%;
+      }
+
+      .structTree {
+        contain: strict;
+      }
+    }
+  }
 }
 
 .pdfViewer .page {
@@ -152,24 +170,6 @@
   margin-inline: 5px;
 }
 /*#endif*/
-
-.pdfViewer .page canvas {
-  margin: 0;
-  display: block;
-}
-
-.pdfViewer .page canvas .structTree {
-  contain: strict;
-}
-
-.pdfViewer .page canvas[hidden] {
-  display: none;
-}
-
-.pdfViewer .page canvas[zooming] {
-  width: 100%;
-  height: 100%;
-}
 
 .pdfViewer .page.loadingIcon::after {
   position: absolute;


### PR DESCRIPTION
And move the page canvas properties under canvasWrapper in order to avoid future regressions.