### PR TITLE
Implement a unit test for the `BaseException` class

### DIFF
--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -14,6 +14,7 @@
  */
 
 import {
+  BaseException,
   bytesToString,
   createValidAbsoluteUrl,
   getModificationDate,
@@ -23,6 +24,25 @@ import {
 } from "../../src/shared/util.js";
 
 describe("util", function () {
+  describe("BaseException", function () {
+    it("can initialize exception classes derived from BaseException", function () {
+      class DerivedException extends BaseException {
+        constructor(message) {
+          super(message, "DerivedException");
+          this.foo = "bar";
+        }
+      }
+
+      const exception = new DerivedException("Something went wrong");
+      expect(exception instanceof DerivedException).toEqual(true);
+      expect(exception instanceof BaseException).toEqual(true);
+      expect(exception.message).toEqual("Something went wrong");
+      expect(exception.name).toEqual("DerivedException");
+      expect(exception.foo).toEqual("bar");
+      expect(exception.stack).toContain("BaseExceptionClosure");
+    });
+  });
+
   describe("bytesToString", function () {
     it("handles non-array arguments", function () {
       expect(function () {


### PR DESCRIPTION
The issue from #18003 hasn't been shown to be caused by PDF.js, but it did surface that we don't have (direct) unit test coverage for the `BaseException` class. This made it more difficult to prove that the `stack` property was already available on exception instances, but more importantly it caused the CI to be green even though the suggested change would have caused the `stack` property to disappear.

To avoid future regressions, for e.g. similar changes or a rewrite from a closure to a proper class, this commit introduces a dedicated unit test for `BaseException` that asserts that our exception instances indeed expose all expected properties.