### PR TITLE
Remove unnecessary `signal` parameter from `removeEventListener` calls

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2044,8 +2044,8 @@ const PDFViewerApplication = {
         passive: true,
         signal,
       });
-      mainContainer.removeEventListener("scrollend", scrollend, { signal });
-      mainContainer.removeEventListener("blur", scrollend, { signal });
+      mainContainer.removeEventListener("scrollend", scrollend);
+      mainContainer.removeEventListener("blur", scrollend);
     };
     const scroll = () => {
       if (this._isCtrlKeyDown) {
@@ -2059,10 +2059,7 @@ const PDFViewerApplication = {
         return;
       }
 
-      mainContainer.removeEventListener("scroll", scroll, {
-        passive: true,
-        signal,
-      });
+      mainContainer.removeEventListener("scroll", scroll, { passive: true });
       this._isScrolling = true;
       mainContainer.addEventListener("scrollend", scrollend, { signal });
       mainContainer.addEventListener("blur", scrollend, { signal });


### PR DESCRIPTION
This parameter is not necessary, as outlined in https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#options