### PR TITLE
Actually disable `TextLayerRenderTask.prototype.#processItems` when `MAX_TEXT_DIVS_TO_RENDER` is reached (PR 18089 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -192,6 +192,8 @@ function layout(params) {
 }
 
 class TextLayerRenderTask {
+  #disableProcessItems = false;
+
   #reader = null;
 
   #textContentSource = null;
@@ -278,6 +280,9 @@ class TextLayerRenderTask {
   }
 
   #processItems(items, lang) {
+    if (this.#disableProcessItems) {
+      return;
+    }
     if (!this._layoutTextParams.ctx) {
       this._textDivProperties.set(this._rootContainer, { lang });
       this._layoutTextParams.ctx = getCtx(lang);
@@ -291,7 +296,7 @@ class TextLayerRenderTask {
       if (textDivs.length > MAX_TEXT_DIVS_TO_RENDER) {
         warn("Ignoring additional textDivs for performance reasons.");
 
-        this._processItems = () => {}; // Avoid multiple warnings for one page.
+        this.#disableProcessItems = true; // Avoid multiple warnings for one page.
         return;
       }
 


### PR DESCRIPTION
I broke this accidentally in PR #18089, sorry about that!
Note that since `#processItems` is private we can no longer just "replace" the method as was done in PR #18052.