### PR TITLE
Remove the `rimraf` dependency in favor of the built-in Node.js `fs.rmSync`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "postcss-nesting": "^12.1.4",
         "prettier": "^3.2.5",
         "puppeteer": "^22.8.1",
-        "rimraf": "^3.0.2",
         "streamqueue": "^1.1.2",
         "stylelint": "^16.5.0",
         "stylelint-prettier": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "postcss-nesting": "^12.1.4",
     "prettier": "^3.2.5",
     "puppeteer": "^22.8.1",
-    "rimraf": "^3.0.2",
     "streamqueue": "^1.1.2",
     "stylelint": "^16.5.0",
     "stylelint-prettier": "^5.0.0",


### PR DESCRIPTION
In Node.js 14.14.0 the `fs.rmSync` function was added that removes files and directories. The `recursive` option is used to remove directories and their contents, making it a drop-in replacement for the `rimraf` dependency we use.

Given that PDF.js now requires Node.js 18+ we can be sure that this option is available, so we can safely remove `rimraf` and reduce the number of project dependencies.

Fixes #16337.

_Thanks to @wojtekmaj, obviously credited as co-author of the commit, for providing the original implementation in #17696! For this patch, similar to what we did for the previous part in #17938, I have extracted the `rimraf`-only parts of that PR, with some changes to make sure that all Gulp targets work exactly as before, and tested all affected Gulp targets (using `diff -r` on the old/new build directories to recursively diff the contents of all directories and files) to make sure the output before/after this patch is identical._