### PR TITLE
Remove the obsolete `needle` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "jsdoc": "^4.0.3",
         "jstransformer-markdown-it": "^3.0.0",
         "merge-stream": "^2.0.0",
-        "needle": "^3.3.1",
         "path2d": "^0.2.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.4.38",
@@ -9357,18 +9356,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -11352,22 +11339,6 @@
       "dev": true,
       "bin": {
         "ncp": "bin/ncp"
-      }
-    },
-    "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-      "dev": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
       }
     },
     "node_modules/neo-async": {
@@ -18440,18 +18411,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
     },
     "node_modules/schema-utils": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "jsdoc": "^4.0.3",
     "jstransformer-markdown-it": "^3.0.0",
     "merge-stream": "^2.0.0",
-    "needle": "^3.3.1",
     "path2d": "^0.2.0",
     "pngjs": "^7.0.0",
     "postcss": "^8.4.38",


### PR DESCRIPTION
The `needle` dependency originally got introduced in #12024, almost four years ago, to be able to use pre-built binaries for the `canvas` dependency on macOS. However, nowadays the `needle` dependency isn't used by `canvas` anymore, or any other package we use for that matter, as shown by the empty NPM dependency tree:

```
$ npm ls needle
pdf.js
└── needle@3.3.1
```

Investigation showed that the `canvas` package depends on the `node-pre-gyp` package which in turn depended on `needle` (see https://github.com/Automattic/node-canvas/issues/1110#issuecomment-411232630), but in version 1.0.0 of `node-pre-gyp` from three years ago the `needle` dependency got dropped in favor of `node-fetch` (see https://github.com/mapbox/node-pre-gyp/blob/a74f5e367c0d71033620aa0112e7baf7f3515b9d/CHANGELOG.md?plain=1#L52). This explains why the NPM dependency tree is empty now and proves that we can safely get rid of this dependency now.