### PR TITLE
Remove the `through2` dependency in favor of the built-in Node.js `stream.Transform`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -38,7 +38,6 @@ import replace from "gulp-replace";
 import stream from "stream";
 import streamqueue from "streamqueue";
 import TerserPlugin from "terser-webpack-plugin";
-import through from "through2";
 import Vinyl from "vinyl";
 import webpack2 from "webpack";
 import webpackStream from "webpack-stream";
@@ -119,13 +118,16 @@ const DEFINES = Object.freeze({
 });
 
 function transform(charEncoding, transformFunction) {
-  return through.obj(function (vinylFile, enc, done) {
-    const transformedFile = vinylFile.clone();
-    transformedFile.contents = Buffer.from(
-      transformFunction(transformedFile.contents),
-      charEncoding
-    );
-    done(null, transformedFile);
+  return new stream.Transform({
+    objectMode: true,
+    transform(vinylFile, enc, done) {
+      const transformedFile = vinylFile.clone();
+      transformedFile.contents = Buffer.from(
+        transformFunction(transformedFile.contents),
+        charEncoding
+      );
+      done(null, transformedFile);
+    },
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "stylelint": "^16.5.0",
         "stylelint-prettier": "^5.0.0",
         "terser-webpack-plugin": "^5.3.10",
-        "through2": "^4.0.2",
         "tsc-alias": "^1.8.10",
         "ttest": "^4.0.0",
         "typescript": "^5.4.5",
@@ -20076,15 +20075,6 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
     "node_modules/through2-filter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
@@ -20103,20 +20093,6 @@
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/time-stamp": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "stylelint": "^16.5.0",
     "stylelint-prettier": "^5.0.0",
     "terser-webpack-plugin": "^5.3.10",
-    "through2": "^4.0.2",
     "tsc-alias": "^1.8.10",
     "ttest": "^4.0.0",
     "typescript": "^5.4.5",


### PR DESCRIPTION
The `through2` dependency got introduced over four years ago in #11325 to replace the unmaintained `gulp-transform` dependency. However, sadly the same holds for `through2` since the last release was also four years ago.

Fortunately the `through2` dependency can trivially be replaced with the built-in Node.js `stream.Transform` API nowadays. In fact, the `through2` dependency mentions themselves in their README already that they are "a tiny wrapper around Node.js streams.Transform". The `stream.Transform` API is available in all Node.js versions we support, and in Node.js 6 already the simplified constructor approach for `stream.Transform` got introduced to simplify creating custom stream transformers; see https://nodejs.org/docs/latest-v6.x/api/stream.html#stream_new_stream_transform_options.

This commit therefore replaces `through2` by switching to the `stream.Transform` API directly so we don't need any wrappers anymore. Note that for our case the only change we have to make is to enable object mode, see https://nodejs.org/api/stream.html#object-mode, because we pass in `VinylFile` objects instead of e.g. regular `Buffer` objects.

I have confirmed in two ways that this is indeed a drop-in replacement:

- Running the Gulp targets that call the `transform` function and diffing the resulting `build` folder before/after this patch, with `diff -r build-old/ build-new/`, to ensure that there are no unexpected changes in the output.
- Changing the Gulpfile to, instead of UTF-8, transform the files to ASCII, and diffing the resulting `build` folder to confirm that the transformation logic works and produces different results, such as:

```
diff build/lib/core/standard_fonts.js build-ascii/lib/core/standard_fonts.js
284c284
<   t["Trinité"] = true;
---
>   t["Trinit�"] = true;
```

_For reviewing I recommend to use the `?w=1` flag since it makes the diff even shorter._