### PR TITLE
Freeze `evaluatorOptions` in the src/core/pdf_manager.js file

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -49,7 +49,7 @@ class BasePdfManager {
     // the worker-thread code.
     args.evaluatorOptions.isOffscreenCanvasSupported &&=
       FeatureTest.isOffscreenCanvasSupported;
-    this.evaluatorOptions = args.evaluatorOptions;
+    this.evaluatorOptions = Object.freeze(args.evaluatorOptions);
   }
 
   get docId() {


### PR DESCRIPTION
Given that these options are passed from the API we don't want to accidentally modify them.