### PR TITLE
Add test for drawing delay with CSS-only zoom

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -359,6 +359,12 @@ const PDFViewerApplication = {
           params.get("highlighteditorcolors")
         );
       }
+      if (params.has("maxcanvaspixels")) {
+        AppOptions.set(
+          "maxCanvasPixels",
+          Number(params.get("maxcanvaspixels"))
+        );
+      }
       if (params.has("supportscaretbrowsingmode")) {
         AppOptions.set(
           "supportsCaretBrowsingMode",


### PR DESCRIPTION
This commit adds a test for https://github.com/nicolo-ribaudo/pdf.js/commit/0603d1ac1843bc4098d74382beda6cc511350ccd. Before the fix the `pagerendered` events would be fired just 2-3 milliseconds after the call to `increaseScale`/`decreaseScale`.

~~I know that you are trying to move away from `waitForTimeout`, but I don't know how else to test this. I cannot simply wait for an event to be emitted, because I am testing that it is _not_ emitted.~~