### PR TITLE
Improve /Page validation for linearized documents (issue 18138)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1576,7 +1576,10 @@ class PDFDocument {
         if (type instanceof Ref) {
           type = await xref.fetchAsync(type);
         }
-        if (isName(type, "Page") || (!obj.has("Type") && !obj.has("Kids"))) {
+        if (
+          isName(type, "Page") ||
+          (!obj.has("Type") && !obj.has("Kids") && obj.has("Contents"))
+        ) {
           if (!catalog.pageKidsCountCache.has(ref)) {
             catalog.pageKidsCountCache.put(ref, 1); // Cache the Page reference.
           }

--- a/test/pdfs/issue18138.pdf.link
+++ b/test/pdfs/issue18138.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/15398373/2.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5439,6 +5439,15 @@
     "type": "eq"
   },
   {
+    "id": "issue18138",
+    "file": "pdfs/issue18138.pdf",
+    "md5": "06136495b2dee5faed2e87c4e49d17fd",
+    "rounds": 1,
+    "link": true,
+    "lastPage": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue4890",
     "file": "pdfs/issue4890.pdf",
     "md5": "1666feb4cd26318c2bdbea6a175dce87",


### PR DESCRIPTION
The referenced PDF document contains corrupt linearization-data, that doesn't point to the *first* page as intended.