### PR TITLE
Improve the `loadingParams` functionality in the API

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -386,11 +386,13 @@ function getDocument(src) {
   const transportParams = {
     disableFontFace,
     fontExtraProperties,
-    enableXfa,
     ownerDocument,
-    disableAutoFetch,
     pdfBug,
     styleElement,
+    loadingParams: {
+      disableAutoFetch,
+      enableXfa,
+    },
   };
 
   worker.promise
@@ -2364,6 +2366,7 @@ class WorkerTransport {
       ownerDocument: params.ownerDocument,
       styleElement: params.styleElement,
     });
+    this.loadingParams = params.loadingParams;
     this._params = params;
 
     this.canvasFactory = factory.canvasFactory;
@@ -3094,14 +3097,6 @@ class WorkerTransport {
     }
     const refStr = ref.gen === 0 ? `${ref.num}R` : `${ref.num}R${ref.gen}`;
     return this.#pageRefCache.get(refStr) ?? null;
-  }
-
-  get loadingParams() {
-    const { disableAutoFetch, enableXfa } = this._params;
-    return shadow(this, "loadingParams", {
-      disableAutoFetch,
-      enableXfa,
-    });
   }
 }
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1069,6 +1069,23 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
+    it("gets loadingParams", async function () {
+      const loadingTask = getDocument(
+        buildGetDocumentParams(basicApiFileName, {
+          disableAutoFetch: true,
+          enableXfa: true,
+        })
+      );
+      const pdfDoc = await loadingTask.promise;
+
+      expect(pdfDoc.loadingParams).toEqual({
+        disableAutoFetch: true,
+        enableXfa: true,
+      });
+
+      await loadingTask.destroy();
+    });
+
     it("gets page", async function () {
       const data = await pdfDocument.getPage(1);
       expect(data instanceof PDFPageProxy).toEqual(true);


### PR DESCRIPTION
 - Move the definition of the `loadingParams` Object, to simplify the code.

 - Add a unit-test, since none existed and the viewer depends on this functionality.