### PR TITLE
Target ES2022 when building the TypeScript definitions (issue 17932)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2022",
     "allowJs": true,
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
This should avoid the latest JS features appearing in the TypeScript definitions, and given the currently supported browsers/environments (in PDF.js) we shouldn't need to target an even older ES-version.

*Edit:* I again question the value of offering TypeScript definitions, since they cause nothing but maintenance overhead that is *unfortunately often not* shouldered by the actual TypeScript users.