### PR TITLE
[api-minor] Simplify how the list of points are structured

### DIFF
--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -670,7 +670,7 @@ class HighlightEditor extends AnnotationEditor {
     }
     const [pageWidth, pageHeight] = this.pageDimensions;
     const boxes = this.#boxes;
-    const quadPoints = new Array(boxes.length * 8);
+    const quadPoints = new Float32Array(boxes.length * 8);
     let i = 0;
     for (const { x, y, width, height } of boxes) {
       const sx = x * pageWidth;

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -303,7 +303,20 @@ async function getSerialized(page, filter = undefined) {
   const values = await page.evaluate(() => {
     const { map } =
       window.PDFViewerApplication.pdfDocument.annotationStorage.serializable;
-    return map ? [...map.values()] : [];
+    if (!map) {
+      return [];
+    }
+    const vals = Array.from(map.values());
+    for (const value of vals) {
+      for (const [k, v] of Object.entries(value)) {
+        // Puppeteer don't serialize typed array correctly, so we convert them
+        // to arrays.
+        if (ArrayBuffer.isView(v)) {
+          value[k] = Array.from(v);
+        }
+      }
+    }
+    return vals;
   });
   return filter ? values.map(filter) : values;
 }

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -261,24 +261,11 @@ describe("annotation", function () {
 
     it("should process quadpoints in the standard order", function () {
       rect = [10, 10, 20, 20];
-      dict.set(
-        "QuadPoints",
-        [10, 20, 20, 20, 10, 10, 20, 10, 11, 19, 19, 19, 11, 11, 19, 11]
-      );
-      expect(getQuadPoints(dict, rect)).toEqual([
-        [
-          { x: 10, y: 20 },
-          { x: 20, y: 20 },
-          { x: 10, y: 10 },
-          { x: 20, y: 10 },
-        ],
-        [
-          { x: 11, y: 19 },
-          { x: 19, y: 19 },
-          { x: 11, y: 11 },
-          { x: 19, y: 11 },
-        ],
-      ]);
+      const quadPoints = [
+        10, 20, 20, 20, 10, 10, 20, 10, 11, 19, 19, 19, 11, 11, 19, 11,
+      ];
+      dict.set("QuadPoints", quadPoints);
+      expect(getQuadPoints(dict, rect)).toEqual(Float32Array.from(quadPoints));
     });
 
     it("should normalize and process quadpoints in non-standard orders", function () {
@@ -296,14 +283,9 @@ describe("annotation", function () {
 
       for (const nonStandardOrder of nonStandardOrders) {
         dict.set("QuadPoints", nonStandardOrder);
-        expect(getQuadPoints(dict, rect)).toEqual([
-          [
-            { x: 10, y: 20 },
-            { x: 20, y: 20 },
-            { x: 10, y: 10 },
-            { x: 20, y: 10 },
-          ],
-        ]);
+        expect(getQuadPoints(dict, rect)).toEqual(
+          Float32Array.from([10, 20, 20, 20, 10, 10, 20, 10])
+        );
       }
     });
   });
@@ -1382,14 +1364,9 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.LINK);
-      expect(data.quadPoints).toEqual([
-        [
-          { x: 10, y: 20 },
-          { x: 20, y: 20 },
-          { x: 10, y: 10 },
-          { x: 20, y: 10 },
-        ],
-      ]);
+      expect(data.quadPoints).toEqual(
+        Float32Array.from([10, 20, 20, 20, 10, 10, 20, 10])
+      );
     });
   });
 
@@ -4330,7 +4307,8 @@ describe("annotation", function () {
       const inkDict = new Dict();
       inkDict.set("Type", Name.get("Annot"));
       inkDict.set("Subtype", Name.get("Ink"));
-      inkDict.set("InkList", [[1, 1, 1, 2, 2, 2, 3, 3]]);
+      const inkList = [1, 1, 1, 2, 2, 2, 3, 3];
+      inkDict.set("InkList", [inkList]);
 
       const inkRef = Ref.get(142, 0);
       const xref = new XRefMock([{ ref: inkRef, data: inkDict }]);
@@ -4343,22 +4321,16 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.INK);
       expect(data.inkLists.length).toEqual(1);
-      expect(data.inkLists[0]).toEqual([
-        { x: 1, y: 1 },
-        { x: 1, y: 2 },
-        { x: 2, y: 2 },
-        { x: 3, y: 3 },
-      ]);
+      expect(data.inkLists[0]).toEqual(Float32Array.from(inkList));
     });
 
     it("should handle multiple ink lists", async function () {
       const inkDict = new Dict();
       inkDict.set("Type", Name.get("Annot"));
       inkDict.set("Subtype", Name.get("Ink"));
-      inkDict.set("InkList", [
-        [1, 1, 1, 2],
-        [3, 3, 4, 5],
-      ]);
+      const inkList0 = [1, 1, 1, 2];
+      const inkList1 = [3, 3, 4, 5];
+      inkDict.set("InkList", [inkList0, inkList1]);
 
       const inkRef = Ref.get(143, 0);
       const xref = new XRefMock([{ ref: inkRef, data: inkDict }]);
@@ -4371,14 +4343,8 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.INK);
       expect(data.inkLists.length).toEqual(2);
-      expect(data.inkLists[0]).toEqual([
-        { x: 1, y: 1 },
-        { x: 1, y: 2 },
-      ]);
-      expect(data.inkLists[1]).toEqual([
-        { x: 3, y: 3 },
-        { x: 4, y: 5 },
-      ]);
+      expect(data.inkLists[0]).toEqual(Float32Array.from(inkList0));
+      expect(data.inkLists[1]).toEqual(Float32Array.from(inkList1));
     });
 
     it("should create a new Ink annotation", async function () {
@@ -4605,14 +4571,9 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-      expect(data.quadPoints).toEqual([
-        [
-          { x: 10, y: 20 },
-          { x: 20, y: 20 },
-          { x: 10, y: 10 },
-          { x: 20, y: 10 },
-        ],
-      ]);
+      expect(data.quadPoints).toEqual(
+        Float32Array.from([10, 20, 20, 20, 10, 10, 20, 10])
+      );
     });
 
     it("should set quadpoints to null when empty", async function () {
@@ -4742,7 +4703,7 @@ describe("annotation", function () {
             thickness: 3.14,
             quadPoints: null,
             outlines: {
-              outline: Float64Array.from([
+              outline: Float32Array.from([
                 NaN,
                 NaN,
                 8,
@@ -4756,7 +4717,7 @@ describe("annotation", function () {
                 14,
                 15,
               ]),
-              points: [Float64Array.from([16, 17, 18, 19])],
+              points: [Float32Array.from([16, 17, 18, 19])],
             },
           },
         ]
@@ -4805,7 +4766,7 @@ describe("annotation", function () {
               thickness: 3.14,
               quadPoints: null,
               outlines: {
-                outline: Float64Array.from([
+                outline: Float32Array.from([
                   NaN,
                   NaN,
                   8,
@@ -4819,7 +4780,7 @@ describe("annotation", function () {
                   14,
                   15,
                 ]),
-                points: [Float64Array.from([16, 17, 18, 19])],
+                points: [Float32Array.from([16, 17, 18, 19])],
               },
             },
           ]
@@ -4882,14 +4843,9 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
-      expect(data.quadPoints).toEqual([
-        [
-          { x: 10, y: 20 },
-          { x: 20, y: 20 },
-          { x: 10, y: 10 },
-          { x: 20, y: 10 },
-        ],
-      ]);
+      expect(data.quadPoints).toEqual(
+        Float32Array.from([10, 20, 20, 20, 10, 10, 20, 10])
+      );
     });
   });
 
@@ -4929,14 +4885,9 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
-      expect(data.quadPoints).toEqual([
-        [
-          { x: 10, y: 20 },
-          { x: 20, y: 20 },
-          { x: 10, y: 10 },
-          { x: 20, y: 10 },
-        ],
-      ]);
+      expect(data.quadPoints).toEqual(
+        Float32Array.from([10, 20, 20, 20, 10, 10, 20, 10])
+      );
     });
   });
 
@@ -4976,14 +4927,9 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
-      expect(data.quadPoints).toEqual([
-        [
-          { x: 10, y: 20 },
-          { x: 20, y: 20 },
-          { x: 10, y: 10 },
-          { x: 20, y: 10 },
-        ],
-      ]);
+      expect(data.quadPoints).toEqual(
+        Float32Array.from([10, 20, 20, 20, 10, 10, 20, 10])
+      );
     });
   });
 });


### PR DESCRIPTION
Instead of sending to the main thread an array of Objects for a list of points (or quadpoints), we'll send just a basic float buffer.
It should slightly improve performances (especially when cloning the data) and use slightly less memory.