### PR TITLE
Prevent XRef errors from breaking font loading (bug 1898802)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1261,7 +1261,11 @@ class PartialEvaluator {
         return this.fontCache.get(fontRef);
       }
 
-      font = this.xref.fetchIfRef(fontRef);
+      try {
+        font = this.xref.fetchIfRef(fontRef);
+      } catch (ex) {
+        warn(`loadFont - lookup failed: "${ex}".`);
+      }
     }
 
     if (!(font instanceof Dict)) {

--- a/test/pdfs/bug1898802.pdf.link
+++ b/test/pdfs/bug1898802.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9403877

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5448,6 +5448,15 @@
     "type": "eq"
   },
   {
+    "id": "bug1898802",
+    "file": "pdfs/bug1898802.pdf",
+    "md5": "65c3af306253faa8967982812aff523e",
+    "rounds": 1,
+    "link": true,
+    "lastPage": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue4890",
     "file": "pdfs/issue4890.pdf",
     "md5": "1666feb4cd26318c2bdbea6a175dce87",


### PR DESCRIPTION
Note that the referenced file is trivially corrupt, since it contains *two* PDF documents placed in the same file which doesn't make sense (and isn't how a PDF document should be updated).
However it's still a good idea to ensure that `loadFont` is able to handle errors when resolving References, since that allows us to invoke the existing fallback font handling.