### PR TITLE
Don't register a pending `TextLayer` until `render` is invoked (PR 18104 follow-up)

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -122,7 +122,6 @@ class TextLayer {
 
     setLayerDimensions(container, viewport);
 
-    TextLayer.#pendingTextLayers.add(this);
     // Always clean-up the temporary canvas once rendering is no longer pending.
     this.#capability.promise
       .catch(() => {
@@ -167,6 +166,7 @@ class TextLayer {
       }, this.#capability.reject);
     };
     this.#reader = this.#textContentSource.getReader();
+    TextLayer.#pendingTextLayers.add(this);
     pump();
 
     return this.#capability.promise;
@@ -423,6 +423,7 @@ class TextLayer {
       return;
     }
     this.#ascentCache.clear();
+
     for (const { canvas } of this.#canvasContexts.values()) {
       canvas.remove();
     }


### PR DESCRIPTION
After the re-factoring in PR #18104 there's now a *theoretical* risk that a pending `TextLayer` is never removed, which we can avoid by not registering it until `render` is invoked.
Note that this doesn't affect the viewer or tests, but if a third-party user calls `new TextLayer(...)` without a following call of either the `render`- or `cancel`-method we'd block global clean-up without this patch.