### PR TITLE
[api-minor] Simplify API to implement zoom in custom viewers

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -743,26 +743,23 @@ const PDFViewerApplication = {
     return this._initializedCapability.promise;
   },
 
-  zoomIn(steps, scaleFactor) {
+  updateZoom(steps, scaleFactor) {
     if (this.pdfViewer.isInPresentationMode) {
       return;
     }
-    this.pdfViewer.increaseScale({
+    this.pdfViewer.updateScale({
       drawingDelay: AppOptions.get("defaultZoomDelay"),
       steps,
       scaleFactor,
     });
   },
 
-  zoomOut(steps, scaleFactor) {
-    if (this.pdfViewer.isInPresentationMode) {
-      return;
-    }
-    this.pdfViewer.decreaseScale({
-      drawingDelay: AppOptions.get("defaultZoomDelay"),
-      steps,
-      scaleFactor,
-    });
+  zoomIn() {
+    this.updateZoom(1);
+  },
+
+  zoomOut() {
+    this.updateZoom(-1);
   },
 
   zoomReset() {
@@ -2635,13 +2632,7 @@ function webViewerWheel(evt) {
         scaleFactor,
         "_wheelUnusedFactor"
       );
-      if (scaleFactor < 1) {
-        PDFViewerApplication.zoomOut(null, scaleFactor);
-      } else if (scaleFactor > 1) {
-        PDFViewerApplication.zoomIn(null, scaleFactor);
-      } else {
-        return;
-      }
+      PDFViewerApplication.updateZoom(null, scaleFactor);
     } else {
       const delta = normalizeWheelEventDirection(evt);
 
@@ -2673,13 +2664,7 @@ function webViewerWheel(evt) {
         );
       }
 
-      if (ticks < 0) {
-        PDFViewerApplication.zoomOut(-ticks);
-      } else if (ticks > 0) {
-        PDFViewerApplication.zoomIn(ticks);
-      } else {
-        return;
-      }
+      PDFViewerApplication.updateZoom(ticks);
     }
 
     // After scaling the page via zoomIn/zoomOut, the position of the upper-
@@ -2794,26 +2779,14 @@ function webViewerTouchMove(evt) {
       distance / pDistance,
       "_touchUnusedFactor"
     );
-    if (newScaleFactor < 1) {
-      PDFViewerApplication.zoomOut(null, newScaleFactor);
-    } else if (newScaleFactor > 1) {
-      PDFViewerApplication.zoomIn(null, newScaleFactor);
-    } else {
-      return;
-    }
+    PDFViewerApplication.updateZoom(null, newScaleFactor);
   } else {
     const PIXELS_PER_LINE_SCALE = 30;
     const ticks = PDFViewerApplication._accumulateTicks(
       (distance - pDistance) / PIXELS_PER_LINE_SCALE,
       "_touchUnusedTicks"
     );
-    if (ticks < 0) {
-      PDFViewerApplication.zoomOut(-ticks);
-    } else if (ticks > 0) {
-      PDFViewerApplication.zoomIn(ticks);
-    } else {
-      return;
-    }
+    PDFViewerApplication.updateZoom(ticks);
   }
 
   PDFViewerApplication._centerAtPos(


### PR DESCRIPTION
Closes #18076

This PR extends the zoom/scale API to simplify the logic in custom viewer wrappers:
- the first commit provides an `updateScale` function that does both `increaseScale`/`decreaseScale`. Ad you can see from the commit itself, it significantly reduces code duplication both in embedders (see the changes in `web/app.js`) and in `web/pdf_viewer.js` itself
- the second commits moves the "preserve zoom origin when zooming" logic from the app to the viewer, since embedders that want to implement pinch-to-zoom or zoom-around-cursor would need to also implement it (and figuring out exactly what the logic needs to be can be challenging). Part of the "scroll after zoom" logic was already in the viewer, now all of it is roughly in the same place.

Note that this PR increases the net number of lines because it adds a test, but ignoring the new test it would be +56 -95.

@Snuffleupagus In https://github.com/mozilla/pdf.js/pull/18098#issuecomment-2112821398 you said that you probably do not want `updateScale`, but I still uploaded it since it de-duplicates a significant amount of code. What do you think about it? (the second commit could be done independently from the first one)

---

Commits:

> **Unify `increaseScale`/`decreaseScale` logic as `updateScale`**
>
> `updateScale` receives a `drawingDelay`, a `scaleFactor` and/or a number of `steps`.
> If `scaleFactor` is a positive number different from `1` the current scale is multiplied by
> that number. Otherwise, if `steps` if a positive integer the current scale is multiplied by
> `DEFAULT_SCALE_DELTA` `steps` times. Finally, if `steps` is a negative integer, the
> current scale is divided by `DEFAULT_SCALE_DELTA` `abs(steps)` times.

> **Add `origin` parameter to `updateScale`**
>
> This parameter allows defining which point should remain
> fixed while scaling the document. It can be used, for example,
> to implement "zoom around the cursor" or "zoom around
> pinch center".
>
> The logic was previously implemented in `web/app.js`, but
> moving it to the viewer scaling utilities themselves makes it
> easier to implement similar zooming functionalities in
> other embedders.