### PR TITLE
Change `DownloadManager.download` to use Uint8Array-data

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1083,13 +1083,11 @@ const PDFViewerApplication = {
       this._ensureDownloadComplete();
 
       const data = await this.pdfDocument.getData();
-      const blob = new Blob([data], { type: "application/pdf" });
-
-      await this.downloadManager.download(blob, url, filename, options);
+      this.downloadManager.download(data, url, filename, options);
     } catch {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.
-      await this.downloadManager.downloadUrl(url, filename, options);
+      this.downloadManager.downloadUrl(url, filename, options);
     }
   },
 
@@ -1106,9 +1104,7 @@ const PDFViewerApplication = {
       this._ensureDownloadComplete();
 
       const data = await this.pdfDocument.saveDocument();
-      const blob = new Blob([data], { type: "application/pdf" });
-
-      await this.downloadManager.download(blob, url, filename, options);
+      this.downloadManager.download(data, url, filename, options);
     } catch (reason) {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply fallback to a "regular" download.

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -113,8 +113,10 @@ class DownloadManager {
     return false;
   }
 
-  download(blob, url, filename, _options) {
-    const blobUrl = URL.createObjectURL(blob);
+  download(data, url, filename, _options) {
+    const blobUrl = URL.createObjectURL(
+      new Blob([data], { type: "application/pdf" })
+    );
     download(blobUrl, filename);
   }
 }

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -140,8 +140,10 @@ class DownloadManager {
     return false;
   }
 
-  download(blob, url, filename, options = {}) {
-    const blobUrl = URL.createObjectURL(blob);
+  download(data, url, filename, options = {}) {
+    const blobUrl = URL.createObjectURL(
+      new Blob([data], { type: "application/pdf" })
+    );
 
     FirefoxCom.request("download", {
       blobUrl,

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -160,12 +160,12 @@ class IDownloadManager {
   openOrDownloadData(data, filename, dest = null) {}
 
   /**
-   * @param {Blob} blob
+   * @param {Uint8Array} data
    * @param {string} url
    * @param {string} filename
    * @param {Object} [options]
    */
-  download(blob, url, filename, options) {}
+  download(data, url, filename, options) {}
 }
 
 /**


### PR DESCRIPTION
Part of this code is really old and pre-dates general availability of things such as `Blob` and `URL.createObjectURL`. To avoid having to duplicate the Blob-creation in the viewer, we can move this into `DownloadManager.download` instead.

Also, remove a couple of unnecessary `await` statements since the methods in question are synchronous.