### PR TITLE
Inline the `#finishRendering` helper in `TextLayerBuilder.prototype.render`

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -68,16 +68,6 @@ class TextLayerBuilder {
     this.div.className = "textLayer";
   }
 
-  #finishRendering() {
-    this.#renderingDone = true;
-
-    const endOfContent = document.createElement("div");
-    endOfContent.className = "endOfContent";
-    this.div.append(endOfContent);
-
-    this.#bindMouse(endOfContent);
-  }
-
   /**
    * Renders the text layer.
    * @param {PageViewport} viewport
@@ -110,7 +100,13 @@ class TextLayerBuilder {
     this.accessibilityManager?.setTextMapping(textDivs);
 
     await this.#textLayer.render();
-    this.#finishRendering();
+    this.#renderingDone = true;
+
+    const endOfContent = document.createElement("div");
+    endOfContent.className = "endOfContent";
+    this.div.append(endOfContent);
+
+    this.#bindMouse(endOfContent);
     // Ensure that the textLayer is appended to the DOM *before* handling
     // e.g. a pending search operation.
     this.#onAppend?.(this.div);


### PR DESCRIPTION
This helper method is simpler/shorter than it originally was[1] and with recent refactoring so is the `render`-method, hence we can just inline this code now.

---
[1] It used to e.g. dispatch the "textlayerrendered" event.