### PR TITLE
Don't display annotations with a PMD (barcode stuff) entry (bug 1899804)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2681,10 +2681,18 @@ class TextWidgetAnnotation extends WidgetAnnotation {
   constructor(params) {
     super(params);
 
+    const { dict } = params;
+
+    if (dict.has("PMD")) {
+      // It's used to display a barcode but it isn't specified so we just hide
+      // it to avoid any confusion.
+      this.flags |= AnnotationFlag.HIDDEN;
+      this.data.hidden = true;
+      warn("Barcodes are not supported");
+    }
+
     this.data.hasOwnCanvas = this.data.readOnly && !this.data.noHTML;
     this._hasText = true;
-
-    const dict = params.dict;
 
     // The field value is always a string.
     if (typeof this.data.fieldValue !== "string") {

--- a/test/pdfs/bug1899804.pdf.link
+++ b/test/pdfs/bug1899804.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9406437

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -10064,5 +10064,22 @@
     "rounds": 1,
     "link": true,
     "type": "eq"
+  },
+  {
+    "id": "bug1899804_print",
+    "file": "pdfs/bug1899804.pdf",
+    "md5": "53d82575d6d5d314404ede8970073e1b",
+    "rounds": 1,
+    "link": true,
+    "type": "eq",
+    "print": true
+  },
+  {
+    "id": "bug1899804",
+    "file": "pdfs/bug1899804.pdf",
+    "md5": "53d82575d6d5d314404ede8970073e1b",
+    "rounds": 1,
+    "link": true,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
There's no specification for that (even if it's possible to have an idea from the xfa specs) so we just want to hide them in order to avoid to display something wrong.