### PR TITLE
Improve date parsing in the js sandbox

### DIFF
--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -140,11 +140,26 @@ class AForm {
     return date;
   }
 
-  _parseDate(cFormat, cDate) {
+  _parseDate(cFormat, cDate, strict = false) {
     let date = null;
     try {
       date = this._util.scand(cFormat, cDate);
     } catch {}
+    if (!date) {
+      if (strict) {
+        return null;
+      }
+      let format = cFormat;
+      if (/mm(?!m)/.test(format)) {
+        format = format.replace("mm", "m");
+      }
+      if (/dd(?!d)/.test(format)) {
+        format = format.replace("dd", "d");
+      }
+      try {
+        date = this._util.scand(format, cDate);
+      } catch {}
+    }
     if (!date) {
       date = Date.parse(cDate);
       date = isNaN(date)
@@ -379,7 +394,7 @@ class AForm {
       return;
     }
 
-    if (this._parseDate(cFormat, value) === null) {
+    if (this._parseDate(cFormat, value, /* strict = */ true) === null) {
       const invalid = GlobalConstants.IDS_INVALID_DATE;
       const invalid2 = GlobalConstants.IDS_INVALID_DATE2;
       const err = `${invalid} ${this._mkTargetName(

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -628,6 +628,10 @@ describe("Scripting", function () {
         await check("12", "mm", "2000/12/01");
         await check("2022", "yyyy", "2022/01/01");
         await check("a1$9bbbb21", "dd/mm/yyyy", "2021/09/01");
+        await check("1/2/2024", "dd/mm/yyyy", "2024/02/01");
+        await check("01/2/2024", "dd/mm/yyyy", "2024/02/01");
+        await check("1/02/2024", "dd/mm/yyyy", "2024/02/01");
+        await check("01/02/2024", "dd/mm/yyyy", "2024/02/01");
 
         // The following test isn't working as expected because
         // the quickjs date parser has been replaced by the browser one


### PR DESCRIPTION
If for example dd:mm is failing we just try with d:m which is equivalent to the regex /d{1,2}:m{1,2}/.
This way it allows the user to forget the 0 for the first days/months.