### PR TITLE
Remove the `DownloadManager.downloadUrl` method

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1081,18 +1081,21 @@ const PDFViewerApplication = {
   },
 
   async download(options = {}) {
-    const url = this._downloadUrl,
-      filename = this._docFilename;
+    let data;
     try {
       this._ensureDownloadComplete();
 
-      const data = await this.pdfDocument.getData();
-      this.downloadManager.download(data, url, filename, options);
+      data = await this.pdfDocument.getData();
     } catch {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.
-      this.downloadManager.downloadUrl(url, filename, options);
     }
+    this.downloadManager.download(
+      data,
+      this._downloadUrl,
+      this._docFilename,
+      options
+    );
   },
 
   async save(options = {}) {
@@ -1102,13 +1105,16 @@ const PDFViewerApplication = {
     this._saveInProgress = true;
     await this.pdfScriptingManager.dispatchWillSave();
 
-    const url = this._downloadUrl,
-      filename = this._docFilename;
     try {
       this._ensureDownloadComplete();
 
       const data = await this.pdfDocument.saveDocument();
-      this.downloadManager.download(data, url, filename, options);
+      this.downloadManager.download(
+        data,
+        this._downloadUrl,
+        this._docFilename,
+        options
+      );
     } catch (reason) {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply fallback to a "regular" download.

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -49,14 +49,6 @@ function download(blobUrl, filename) {
 class DownloadManager {
   #openBlobUrls = new WeakMap();
 
-  downloadUrl(url, filename, _options) {
-    if (!createValidAbsoluteUrl(url, "http://example.com")) {
-      console.error(`downloadUrl - not a valid URL: ${url}`);
-      return; // restricted/invalid URL
-    }
-    download(url + "#pdfjs.action=download", filename);
-  }
-
   downloadData(data, filename, contentType) {
     const blobUrl = URL.createObjectURL(
       new Blob([data], { type: contentType })
@@ -114,9 +106,18 @@ class DownloadManager {
   }
 
   download(data, url, filename, _options) {
-    const blobUrl = URL.createObjectURL(
-      new Blob([data], { type: "application/pdf" })
-    );
+    let blobUrl;
+    if (data) {
+      blobUrl = URL.createObjectURL(
+        new Blob([data], { type: "application/pdf" })
+      );
+    } else {
+      if (!createValidAbsoluteUrl(url, "http://example.com")) {
+        console.error(`download - not a valid URL: ${url}`);
+        return;
+      }
+      blobUrl = url + "#pdfjs.action=download";
+    }
     download(blobUrl, filename);
   }
 }

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -82,14 +82,6 @@ class FirefoxCom {
 class DownloadManager {
   #openBlobUrls = new WeakMap();
 
-  downloadUrl(url, filename, options = {}) {
-    FirefoxCom.request("download", {
-      originalUrl: url,
-      filename,
-      options,
-    });
-  }
-
   downloadData(data, filename, contentType) {
     const blobUrl = URL.createObjectURL(
       new Blob([data], { type: contentType })
@@ -141,9 +133,9 @@ class DownloadManager {
   }
 
   download(data, url, filename, options = {}) {
-    const blobUrl = URL.createObjectURL(
-      new Blob([data], { type: "application/pdf" })
-    );
+    const blobUrl = data
+      ? URL.createObjectURL(new Blob([data], { type: "application/pdf" }))
+      : null;
 
     FirefoxCom.request("download", {
       blobUrl,

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -138,13 +138,6 @@ class IRenderableView {
  */
 class IDownloadManager {
   /**
-   * @param {string} url
-   * @param {string} filename
-   * @param {Object} [options]
-   */
-  downloadUrl(url, filename, options) {}
-
-  /**
    * @param {Uint8Array} data
    * @param {string} filename
    * @param {string} [contentType]


### PR DESCRIPTION
This method has only a single call-site in the viewer, since it's used as a fallback, and the functionality can be moved into the `DownloadManager.download` method instead.