### PR TITLE
[api-minor] Load Node.js packages/polyfills with `process.getBuiltinModule`

### DIFF
--- a/.github/workflows/types_tests.yml
+++ b/.github/workflows/types_tests.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm ci
 
       - name: Run types tests
-        run: npx gulp typestest
+        run: npx gulp types

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -59,7 +59,6 @@ import {
   NodeCanvasFactory,
   NodeCMapReaderFactory,
   NodeFilterFactory,
-  NodePackages,
   NodeStandardFontDataFactory,
 } from "display-node_utils";
 import { CanvasGraphics } from "./canvas.js";
@@ -2125,14 +2124,6 @@ class PDFWorker {
    * @type {Promise<void>}
    */
   get promise() {
-    if (
-      typeof PDFJSDev !== "undefined" &&
-      PDFJSDev.test("GENERIC") &&
-      isNodeJS
-    ) {
-      // Ensure that all Node.js packages/polyfills have loaded.
-      return Promise.all([NodePackages.promise, this._readyCapability.promise]);
-    }
     return this._readyCapability.promise;
   }
 

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* globals process */
 
 import { AbortException, assert, MissingPDFException } from "../shared/util.js";
 import {
@@ -19,7 +20,6 @@ import {
   extractFilenameFromHeader,
   validateRangeRequestCapabilities,
 } from "./network_utils.js";
-import { NodePackages } from "./node_utils.js";
 
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   throw new Error(
@@ -33,16 +33,16 @@ function parseUrlOrPath(sourceUrl) {
   if (urlRegex.test(sourceUrl)) {
     return new URL(sourceUrl);
   }
-  const url = NodePackages.get("url");
+  const url = process.getBuiltinModule("url");
   return new URL(url.pathToFileURL(sourceUrl));
 }
 
 function createRequest(url, headers, callback) {
   if (url.protocol === "http:") {
-    const http = NodePackages.get("http");
+    const http = process.getBuiltinModule("http");
     return http.request(url, { headers }, callback);
   }
-  const https = NodePackages.get("https");
+  const https = process.getBuiltinModule("https");
   return https.request(url, { headers }, callback);
 }
 
@@ -365,7 +365,7 @@ class PDFNodeStreamFsFullReader extends BaseFullReader {
   constructor(stream) {
     super(stream);
 
-    const fs = NodePackages.get("fs");
+    const fs = process.getBuiltinModule("fs");
     fs.promises.lstat(this._url).then(
       stat => {
         // Setting right content length.
@@ -389,7 +389,7 @@ class PDFNodeStreamFsRangeReader extends BaseRangeReader {
   constructor(stream, start, end) {
     super(stream);
 
-    const fs = NodePackages.get("fs");
+    const fs = process.getBuiltinModule("fs");
     this._setReadableStream(
       fs.createReadStream(this._url, { start, end: end - 1 })
     );

--- a/src/display/stubs.js
+++ b/src/display/stubs.js
@@ -16,7 +16,6 @@
 const NodeCanvasFactory = null;
 const NodeCMapReaderFactory = null;
 const NodeFilterFactory = null;
-const NodePackages = null;
 const NodeStandardFontDataFactory = null;
 const PDFFetchStream = null;
 const PDFNetworkStream = null;
@@ -26,7 +25,6 @@ export {
   NodeCanvasFactory,
   NodeCMapReaderFactory,
   NodeFilterFactory,
-  NodePackages,
   NodeStandardFontDataFactory,
   PDFFetchStream,
   PDFNetworkStream,

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -10,7 +10,7 @@
     "module": "ESNext",
     "baseUrl": "./",
     "strict": true,
-    "types": [],
+    "types": ["node"],
     "lib": ["ESNext", "DOM"],
     "paths": {
       "pdfjs-dist": ["../../build/typestest"],

--- a/test/unit/clitests_helper.js
+++ b/test/unit/clitests_helper.js
@@ -18,7 +18,6 @@ import {
   setVerbosityLevel,
   VerbosityLevel,
 } from "../../src/shared/util.js";
-import { NodePackages } from "../../src/display/node_utils.js";
 
 // Sets longer timeout, similar to `jasmine-boot.js`.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
@@ -29,9 +28,6 @@ if (!isNodeJS) {
     "The `gulp unittestcli` command can only be used in Node.js environments."
   );
 }
-
-// Ensure that all Node.js packages/polyfills have loaded.
-await NodePackages.promise;
 
 // Reduce the amount of console "spam", by ignoring `info`/`warn` calls,
 // when running the unit-tests in Node.js/Travis.

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -24,11 +24,10 @@ if (!isNodeJS) {
   );
 }
 
-const url = await __non_webpack_import__("url");
-
 describe("node_stream", function () {
   let tempServer = null;
 
+  const url = process.getBuiltinModule("url");
   const cwdURL = url.pathToFileURL(process.cwd()) + "/";
   const pdf = new URL("./test/pdfs/tracemonkey.pdf", cwdURL).href;
   const pdfLength = 1016315;

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -20,13 +20,6 @@ import { fetchData as fetchDataDOM } from "../../src/display/display_utils.js";
 import { fetchData as fetchDataNode } from "../../src/display/node_utils.js";
 import { Ref } from "../../src/core/primitives.js";
 
-let fs, http;
-if (isNodeJS) {
-  // Native packages.
-  fs = await __non_webpack_import__("fs");
-  http = await __non_webpack_import__("http");
-}
-
 const TEST_PDFS_PATH = isNodeJS ? "./test/pdfs/" : "../pdfs/";
 
 const CMAP_URL = isNodeJS ? "./external/bcmaps/" : "../../external/bcmaps/";
@@ -132,6 +125,8 @@ function createIdFactory(pageIndex) {
 function createTemporaryNodeServer() {
   assert(isNodeJS, "Should only be used in Node.js environments.");
 
+  const fs = process.getBuiltinModule("fs"),
+    http = process.getBuiltinModule("http");
   // Create http server to serve pdf data for tests.
   const server = http
     .createServer((request, response) => {


### PR DESCRIPTION
*Note:* Unless this functionality is uplifted to the current Node.js LTS versions it'll unfortunately be several years before we can actually make this change.