### PR TITLE
[Document Text Content] Support including text content character data

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -631,6 +631,8 @@ class Page {
     includeMarkedContent,
     disableNormalization,
     sink,
+    keepWhiteSpace,
+    includeTextContentChars,
   }) {
     const contentStreamPromise = this.getContentStream();
     const resourcesPromise = this.loadResources([
@@ -668,6 +670,8 @@ class Page {
       sink,
       viewBox: this.view,
       lang,
+      keepWhiteSpace,
+      includeTextContentChars,
     });
   }
 

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2975,7 +2975,7 @@ class PartialEvaluator {
             width: scaledDim,
             unicode: glyph.unicode,
             transform: textChunk.prevTransform
-          })
+          });
         }
       }
     }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2969,12 +2969,12 @@ class PartialEvaluator {
         }
 
         // Include each character and its width in output if option is enabled.
-        if(includeTextContentChars) {
+        if (includeTextContentChars) {
           textChunk.chars.push({
             char: glyph.fontChar,
             width: scaledDim,
             unicode: glyph.unicode,
-            transform: textChunk.prevTransform
+            transform: textChunk.prevTransform,
           });
         }
       }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -89,7 +89,6 @@ const DefaultPartialEvaluatorOptions = Object.freeze({
   useSystemFonts: true,
   cMapUrl: null,
   standardFontDataUrl: null,
-  includeTextContentChars: false,
 });
 
 const PatternType = {
@@ -2334,6 +2333,7 @@ class PartialEvaluator {
     lang = null,
     markedContentData = null,
     disableNormalization = false,
+    includeTextContentChars = false,
     keepWhiteSpace = false,
   }) {
     // Ensure that `resources`/`stateManager` is correctly initialized,
@@ -2969,8 +2969,8 @@ class PartialEvaluator {
         }
 
         // Include each character and its width in output if option is enabled.
-        if(self.options.includeTextContentChars) {
-          textChunk.charsArray.push({
+        if(includeTextContentChars) {
+          textChunk.chars.push({
             char: glyph.fontChar,
             width: scaledDim,
             unicode: glyph.unicode,

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3339,6 +3339,7 @@ class PartialEvaluator {
                     markedContentData,
                     disableNormalization,
                     keepWhiteSpace,
+                    includeTextContentChars,
                   })
                   .then(function () {
                     if (!sinkWrapper.enqueueInvoked) {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -89,6 +89,7 @@ const DefaultPartialEvaluatorOptions = Object.freeze({
   useSystemFonts: true,
   cMapUrl: null,
   standardFontDataUrl: null,
+  includeTextContentChars: false,
 });
 
 const PatternType = {
@@ -2352,6 +2353,7 @@ class PartialEvaluator {
     const textContentItem = {
       initialized: false,
       str: [],
+      chars: [],
       totalWidth: 0,
       totalHeight: 0,
       width: 0,
@@ -2559,6 +2561,7 @@ class PartialEvaluator {
       textContentItem.spaceInFlowMin = fontSize * SPACE_IN_FLOW_MIN_FACTOR;
       textContentItem.spaceInFlowMax = fontSize * SPACE_IN_FLOW_MAX_FACTOR;
       textContentItem.hasEOL = false;
+      textContentItem.chars = [];
 
       textContentItem.initialized = true;
       return textContentItem;
@@ -2606,6 +2609,7 @@ class PartialEvaluator {
         transform: textChunk.transform,
         fontName: textChunk.fontName,
         hasEOL: textChunk.hasEOL,
+        chars: textChunk.chars,
       };
     }
 
@@ -2962,6 +2966,16 @@ class PartialEvaluator {
           } else {
             textState.translateTextMatrix(0, -charSpacing);
           }
+        }
+
+        // Include each character and its width in output if option is enabled.
+        if(self.options.includeTextContentChars) {
+          textChunk.charsArray.push({
+            char: glyph.fontChar,
+            width: scaledDim,
+            unicode: glyph.unicode,
+            transform: textChunk.prevTransform
+          })
         }
       }
     }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -780,7 +780,13 @@ class WorkerMessageHandler {
     });
 
     handler.on("GetTextContent", function (data, sink) {
-      const { pageIndex, includeMarkedContent, disableNormalization, includeTextContentChars, keepWhiteSpace } = data;
+      const {
+        pageIndex,
+        includeMarkedContent,
+        disableNormalization,
+        includeTextContentChars,
+        keepWhiteSpace,
+      } = data;
 
       pdfManager.getPage(pageIndex).then(function (page) {
         const task = new WorkerTask("GetTextContent: page " + pageIndex);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -780,7 +780,7 @@ class WorkerMessageHandler {
     });
 
     handler.on("GetTextContent", function (data, sink) {
-      const { pageIndex, includeMarkedContent, disableNormalization } = data;
+      const { pageIndex, includeMarkedContent, disableNormalization, includeTextContentChars, keepWhiteSpace } = data;
 
       pdfManager.getPage(pageIndex).then(function (page) {
         const task = new WorkerTask("GetTextContent: page " + pageIndex);
@@ -796,6 +796,8 @@ class WorkerMessageHandler {
             sink,
             includeMarkedContent,
             disableNormalization,
+            includeTextContentChars,
+            keepWhiteSpace,
           })
           .then(
             function () {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1162,7 +1162,7 @@ class PDFDocumentProxy {
  * @property {string} str - Text content.
  * @property {string} dir - Text direction: 'ttb', 'ltr' or 'rtl'.
  * @property {Array<any>} transform - Transformation matrix.
- * @property {Array<TextCharItem>} chars - Character list for text string. 
+ * @property {Array<TextCharItem>} chars - Character list for text string.
  * @property {number} width - Width in device space.
  * @property {number} height - Height in device space.
  * @property {string} fontName - Font name used by PDF.js for converted font.

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -176,9 +176,6 @@ const DefaultStandardFontDataFactory =
  *   `OffscreenCanvas` in the worker. Primarily used to improve performance of
  *   image conversion/rendering.
  *   The default value is `true` in web environments and `false` in Node.js.
-* @property {boolean} [includeTextContentChars] - Determines if we include
- *   an array of character data in the TextContent output.
- *   The default value is `false`.
  * @property {number} [canvasMaxAreaInBytes] - The integer value is used to
  *   know when an image must be resized (uses `OffscreenCanvas` in the worker).
  *   If it's -1 then a possibly slow algorithm is used to guess the max value.
@@ -384,7 +381,6 @@ function getDocument(src) {
       useSystemFonts,
       cMapUrl: useWorkerFetch ? cMapUrl : null,
       standardFontDataUrl: useWorkerFetch ? standardFontDataUrl : null,
-      includeTextContentChars,
     },
   };
   const transportParams = {
@@ -1132,6 +1128,9 @@ class PDFDocumentProxy {
  *   content items in the items array of TextContent. The default is `false`.
  * @property {boolean} [disableNormalization] - When true the text is *not*
  *   normalized in the worker-thread. The default is `false`.
+ * @property {boolean} [keepWhiteSpace] - When true keep whitespace characters.
+ * @property {boolean} [includeTextContentChars] - When true include character
+ *  array in text content.
  */
 
 /**
@@ -1630,6 +1629,8 @@ class PDFPageProxy {
   streamTextContent({
     includeMarkedContent = false,
     disableNormalization = false,
+    keepWhiteSpace = false,
+    includeTextContentChars = false,
   } = {}) {
     const TEXT_CONTENT_CHUNK_SIZE = 100;
 
@@ -1639,6 +1640,8 @@ class PDFPageProxy {
         pageIndex: this._pageIndex,
         includeMarkedContent: includeMarkedContent === true,
         disableNormalization: disableNormalization === true,
+        keepWhiteSpace: keepWhiteSpace === true,
+        includeTextContentChars: includeMarkedContent === true,
       },
       {
         highWaterMark: TEXT_CONTENT_CHUNK_SIZE,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -176,6 +176,9 @@ const DefaultStandardFontDataFactory =
  *   `OffscreenCanvas` in the worker. Primarily used to improve performance of
  *   image conversion/rendering.
  *   The default value is `true` in web environments and `false` in Node.js.
+* @property {boolean} [includeTextContentChars] - Determines if we include
+ *   an array of character data in the TextContent output.
+ *   The default value is `false`.
  * @property {number} [canvasMaxAreaInBytes] - The integer value is used to
  *   know when an image must be resized (uses `OffscreenCanvas` in the worker).
  *   If it's -1 then a possibly slow algorithm is used to guess the max value.
@@ -381,6 +384,7 @@ function getDocument(src) {
       useSystemFonts,
       cMapUrl: useWorkerFetch ? cMapUrl : null,
       standardFontDataUrl: useWorkerFetch ? standardFontDataUrl : null,
+      includeTextContentChars,
     },
   };
   const transportParams = {
@@ -1131,6 +1135,16 @@ class PDFDocumentProxy {
  */
 
 /**
+ * Text character in content.
+ *
+ * @typedef {Object} TextCharItem
+ * @property {string} char - Character glyph.
+ * @property {number} width - Scaled width of character.
+ * @property {string} unicode - Character unicode.
+ * @property {Array<any>} transform - Transformation matrix.
+ */
+
+/**
  * Page text content.
  *
  * @typedef {Object} TextContent
@@ -1149,6 +1163,7 @@ class PDFDocumentProxy {
  * @property {string} str - Text content.
  * @property {string} dir - Text direction: 'ttb', 'ltr' or 'rtl'.
  * @property {Array<any>} transform - Transformation matrix.
+ * @property {Array<TextCharItem>} chars - Character list for text string. 
  * @property {number} width - Width in device space.
  * @property {number} height - Height in device space.
  * @property {string} fontName - Font name used by PDF.js for converted font.

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1641,7 +1641,7 @@ class PDFPageProxy {
         includeMarkedContent: includeMarkedContent === true,
         disableNormalization: disableNormalization === true,
         keepWhiteSpace: keepWhiteSpace === true,
-        includeTextContentChars: includeMarkedContent === true,
+        includeTextContentChars: includeTextContentChars === true,
       },
       {
         highWaterMark: TEXT_CONTENT_CHUNK_SIZE,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3176,6 +3176,7 @@ page 1 / 3`);
       expect(items[0]).toEqual({
         dir: "ltr",
         fontName,
+        chars: [],
         height: 18,
         str: "Issue 8276",
         transform: [18, 0, 0, 18, 441.81, 708.4499999999999],


### PR DESCRIPTION
Adds optional params to allow for returning character data when getting text content, as well as retention of spaces by force. This allows for consumers to calculate the size and location of individual words.