### PR TITLE
Improve how the wait-cursor is toggled when copying all text

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -71,6 +71,10 @@
     --hcm-highlight-filter: invert(100%);
   }
 
+  &.copyAll {
+    cursor: wait;
+  }
+
   .canvasWrapper {
     overflow: hidden;
     width: 100%;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -740,12 +740,15 @@ class PDFViewer {
       // getAllText and we could just get text from the Selection object.
 
       // Select all the document.
-      const savedCursor = this.container.style.cursor;
-      this.container.style.cursor = "wait";
+      const { classList } = this.viewer;
+      classList.add("copyAll");
 
-      const interruptCopy = ev =>
-        (this.#interruptCopyCondition = ev.key === "Escape");
-      window.addEventListener("keydown", interruptCopy);
+      const ac = new AbortController();
+      window.addEventListener(
+        "keydown",
+        ev => (this.#interruptCopyCondition = ev.key === "Escape"),
+        { signal: ac.signal }
+      );
 
       this.getAllText()
         .then(async text => {
@@ -761,8 +764,8 @@ class PDFViewer {
         .finally(() => {
           this.#getAllTextInProgress = false;
           this.#interruptCopyCondition = false;
-          window.removeEventListener("keydown", interruptCopy);
-          this.container.style.cursor = savedCursor;
+          ac.abort();
+          classList.remove("copyAll");
         });
 
       event.preventDefault();


### PR DESCRIPTION
 - Use a CSS rule to display the wait-cursor during copying. Since copying may take a little while in long documents, there's a theoretical risk that something else could change the cursor in the meantime and just resetting to the saved-cursor could thus be incorrect.

 - Remove the `interruptCopyCondition` listener with an AbortController, since that's slightly shorter code.