### PR TITLE
Fix an query with an empty selector in integration tests

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -268,23 +268,18 @@ async function pasteFromClipboard(page, data, selector, timeout = 100) {
     const handle = await page.evaluateHandle(
       (sel, timeOut) => {
         let callback = null;
+        const element = sel ? document.querySelector(sel) : document;
         return [
           Promise.race([
             new Promise(resolve => {
               callback = e => resolve(e.clipboardData.items.length !== 0);
-              (sel ? document.querySelector(sel) : document).addEventListener(
-                "paste",
-                callback,
-                {
-                  once: true,
-                }
-              );
+              element.addEventListener("paste", callback, {
+                once: true,
+              });
             }),
             new Promise(resolve => {
               setTimeout(() => {
-                document
-                  .querySelector(sel)
-                  .removeEventListener("paste", callback);
+                element.removeEventListener("paste", callback);
                 resolve(false);
               }, timeOut);
             }),


### PR DESCRIPTION
In looking the logs from Chrome bidi tests I noticed a js syntax error which is fixed thanks to this patch.