### PR TITLE
Don't recommend installing `gulp-cli` globally in the README and on the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PDF.js is built into version 19+ of Firefox.
 
 + The official extension for Chrome can be installed from the [Chrome Web Store](https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm).
 *This extension is maintained by [@Rob--W](https://github.com/Rob--W).*
-+ Build Your Own - Get the code as explained below and issue `gulp chromium`. Then open
++ Build Your Own - Get the code as explained below and issue `npx gulp chromium`. Then open
 Chrome, go to `Tools > Extension` and load the (unpackaged) extension from the
 directory `build/chromium`.
 
@@ -52,14 +52,8 @@ To get a local copy of the current code, clone it using git:
     $ cd pdf.js
 
 Next, install Node.js via the [official package](https://nodejs.org) or via
-[nvm](https://github.com/creationix/nvm). You need to install the gulp package
-globally (see also [gulp's getting started](https://github.com/gulpjs/gulp/tree/master/docs/getting-started)):
-
-    $ npm install -g gulp-cli@^2.3.0
-
-If you prefer to not install `gulp-cli` globally, you have to prefix all the `gulp` commands with `npx` (for example, `npx gulp server` instead of `gulp server`).
-
-If everything worked out, install all dependencies for PDF.js:
+[nvm](https://github.com/creationix/nvm). If everything worked out, install
+all dependencies for PDF.js:
 
     $ npm install
 
@@ -69,7 +63,7 @@ If everything worked out, install all dependencies for PDF.js:
 Finally, you need to start a local web server as some browsers do not allow opening
 PDF files using a `file://` URL. Run:
 
-    $ gulp server
+    $ npx gulp server
 
 and then you can open:
 
@@ -86,11 +80,11 @@ It is also possible to view all test PDF files on the right side by opening:
 In order to bundle all `src/` files into two production scripts and build the generic
 viewer, run:
 
-    $ gulp generic
+    $ npx gulp generic
 
 If you need to support older browsers, run:
 
-    $ gulp generic-legacy
+    $ npx gulp generic-legacy
 
 This will generate `pdf.js` and `pdf.worker.js` in the `build/generic/build/` directory (respectively `build/generic-legacy/build/`).
 Both scripts are needed but only `pdf.js` needs to be included since `pdf.worker.js` will
@@ -116,7 +110,7 @@ You can play with the PDF.js API directly from your browser using the live demos
 
 + [Interactive examples](https://mozilla.github.io/pdf.js/examples/index.html#interactive-examples)
 
-More examples can be found in the [examples folder](https://github.com/mozilla/pdf.js/tree/master/examples/). Some of them are using the pdfjs-dist package, which can be built and installed in this repo directory via `gulp dist-install` command.
+More examples can be found in the [examples folder](https://github.com/mozilla/pdf.js/tree/master/examples/). Some of them are using the pdfjs-dist package, which can be built and installed in this repo directory via `npx gulp dist-install` command.
 
 For an introduction to the PDF.js code, check out the presentation by our
 contributor Julian Viereck:

--- a/docs/contents/getting_started/index.md
+++ b/docs/contents/getting_started/index.md
@@ -119,7 +119,7 @@ Note that we only mention the most relevant files and folders.
 
 ## Trying the Viewer
 
-With the prebuilt or source version, open `web/viewer.html` in a browser and the test pdf should load. Note: the worker is not enabled for file:// urls, so use a server. If you're using the source build and have node, you can run `gulp server`.
+With the prebuilt or source version, open `web/viewer.html` in a browser and the test pdf should load. Note: the worker is not enabled for file:// urls, so use a server. If you're using the source build and have node, you can run `npx gulp server`.
 
 ## More Information
 


### PR DESCRIPTION
It's recommended to always install dependencies locally in the project folder because global dependencies can easily conflict with other projects and, because they are not managed by the project, diverge from versions defined in e.g. `package.json`. Previously we installed `gulp-cli` globally because at the time we lacked a convenient mechanism to use Gulp otherwise, but nowadays NPM provides the `npx` command for that purpose and recommends using it over global installations (see https://docs.npmjs.com/downloading-and-installing-packages-globally and PR #17489 that provided the ground work for using it).

This commit therefore updates our README and website to no longer recommend installing `gulp-cli` globally but instead installing it locally from the already existing entries in `package.json` like all other dependencies we use. Not only does this remove the special-casing for `gulp-cli` which simplifies the installation procedure, it also ensures that the version ranges provided in `package.json` are respected.

This change is similar to the change in commit 92de2b7.

Fixes #18232.
Fixes 98ef8a1.

_This should be final patch in the `npx` usage series, after the previous patches and updating all wiki pages. I somehow missed these occurrences before, but a new search didn't yield other occurrences anymore._