### PR TITLE
Include the generated API documentation directly on the API page

### DIFF
--- a/docs/contents/api/index.md
+++ b/docs/contents/api/index.md
@@ -6,4 +6,6 @@ slug: api
 
 # API
 
-We're currently working on <a href="draft/index.html">better API docs</a>, but the API is well documented in [api.js](https://github.com/mozilla/pdf.js/blob/master/src/display/api.js).
+The generated API documentation, from the inline comments in [api.js](https://github.com/mozilla/pdf.js/blob/master/src/display/api.js), is available below.
+
+<iframe src="draft/index.html" title="PDF.js API documentation"></iframe>

--- a/docs/contents/css/main.css
+++ b/docs/contents/css/main.css
@@ -24,6 +24,12 @@ main {
     border-radius: 4px;
     padding: 10px;
   }
+
+  iframe {
+    border: none;
+    height: calc(0.55 * 100vh);
+    width: 100%;
+  }
 }
 
 footer {


### PR DESCRIPTION
This should make the API documentation slightly quicker to access for users by removing an extra click. Moreover, it makes the API documentation blend in with the rest of the website/theme (one of the points in #6526).

Fixes #18249.