### PR TITLE
Ensure that saving, in the viewer, works for partially loaded documents

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1109,8 +1109,6 @@ const PDFViewerApplication = {
     await this.pdfScriptingManager.dispatchWillSave();
 
     try {
-      this._ensureDownloadComplete();
-
       const data = await this.pdfDocument.saveDocument();
       this.downloadManager.download(
         data,
@@ -1119,8 +1117,7 @@ const PDFViewerApplication = {
         options
       );
     } catch (reason) {
-      // When the PDF document isn't ready, or the PDF file is still
-      // downloading, simply fallback to a "regular" download.
+      // When the PDF document isn't ready, fallback to a "regular" download.
       console.error(`Error when saving the document: ${reason.message}`);
       await this.download(options);
     } finally {

--- a/web/app.js
+++ b/web/app.js
@@ -1073,22 +1073,12 @@ const PDFViewerApplication = {
     );
   },
 
-  /**
-   * @private
-   */
-  _ensureDownloadComplete() {
-    if (this.pdfDocument && this.downloadComplete) {
-      return;
-    }
-    throw new Error("PDF document not downloaded.");
-  },
-
   async download(options = {}) {
     let data;
     try {
-      this._ensureDownloadComplete();
-
-      data = await this.pdfDocument.getData();
+      if (this.downloadComplete) {
+        data = await this.pdfDocument.getData();
+      }
     } catch {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.


### PR DESCRIPTION
Currently saving a modified PDF document may fail *intermittently*, if it's triggered before the entire document has been downloaded.
When saving was originally added we only supported forms, and such PDF documents are usually small/simple enough for this issue to be difficult to trigger. However, with editing-support now available as well it's possible to modify much larger documents and this issue thus becomes easier to trigger.

One way to reproduce this issue *consistently* is to:
 - Open http://localhost:8888/web/viewer.html?file=/test/pdfs/pdf.pdf#disableHistory=true&disableStream=true&disableAutoFetch=true
 - Add an annotation on the first page, it doesn't matter what kind.
 - Save the document.
 - Open the resulting document, and notice that with the `master` branch the annotation is missing.