### PR TITLE
Only disable HWA in m-c build and for local dev

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -46,9 +46,10 @@
       "default": false
     },
     "enableHWA": {
+      "title": "Enable hardware acceleration",
       "description": "Whether to enable hardware acceleration.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "enableML": {
       "type": "boolean",

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -312,7 +312,7 @@ const defaultOptions = {
   },
   enableHWA: {
     /** @type {boolean} */
-    value: false,
+    value: typeof PDFJSDev !== "undefined" && !PDFJSDev.test("MOZCENTRAL"),
     kind: OptionKind.API + OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableXfa: {


### PR DESCRIPTION
This way, we keep pdf.js working as before except for Firefox.