### PR TITLE
Override the minimum font size when rendering the text layer

### DIFF
--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -296,4 +296,47 @@ describe("Text layer", () => {
       });
     });
   });
+
+  describe("when the browser enforces a minimum font size", () => {
+    let browser;
+    let page;
+
+    beforeAll(async () => {
+      // Only testing in Firefox because, while Chrome has a setting similar to
+      // font.minimum-size.x-western, it is not exposed through its API.
+      browser = await startBrowser({
+        browserName: "firefox",
+        startUrl: "",
+        extraPrefsFirefox: { "font.minimum-size.x-western": 40 },
+      });
+      page = await browser.newPage();
+      await page.goto(
+        `${global.integrationBaseUrl}?file=/test/pdfs/tracemonkey.pdf#zoom=100`
+      );
+      await page.bringToFront();
+      await page.waitForSelector(
+        `.page[data-page-number = "1"] .endOfContent`,
+        { timeout: 0 }
+      );
+    });
+
+    afterAll(async () => {
+      await closeSinglePage(page);
+      await browser.close();
+    });
+
+    it("renders spans with the right size", async () => {
+      const rect = await getSpanRectFromText(
+        page,
+        1,
+        "Dynamic languages such as JavaScript are more difﬁcult to com-"
+      );
+
+      // The difference between `a` and `b`, as a percentage of the lower one
+      const getPercentDiff = (a, b) => Math.max(a, b) / Math.min(a, b) - 1;
+
+      expect(getPercentDiff(rect.width, 315)).toBeLessThan(0.03);
+      expect(getPercentDiff(rect.height, 12)).toBeLessThan(0.03);
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/issues/14426

Commit message:

> **Overrride the minimum font size when rendering the text layer**
>
> Browsers have an accessibility option that allows user to enforce a minimum font size for all text rendered in the page, regardless of what the font-size CSS property says. For example, it can be found in Firefox under `font.minimum-size.x-western`.
>
> When rendering the <span>s in the text layer, this causes the text layer to not be aligned anymore with the underlying canvas. While normally accessibility features should not be worked around, in this case it is *not* improving accessibility:
> - the text is transparent, so making it bigger doesn't make it more readable
> - the selection UX for users with that accessibility option enabled is worse than for other users (it's basically unusable).
>
> While there is tecnically no way to ignore that minimum font size, this commit does it by multiplying all the `font-size`s in the text layer by minFontSize, and then scaling all the `<span>`s down by 1/minFontSize.

This PR detects the min font size similarly to https://github.com/mozilla/pdf.js/pull/14427, with a few changes:
- the minimum font size is only computed once, rather than for every rendered element
- I used `getBoundingClientRect().height` rather than `getComputedStyle().fontSize`, because `getComputedStyle().fontSize` returns the minimum font size in Chrome and Safari but not in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1903360)

~~Marking as draft because I still have to run all the tests locally, and add a new test.~~