### PR TITLE
Add a new helper, in the viewer, to close everything during testing

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -80,10 +80,7 @@ function closePages(pages) {
     pages.map(async ([_, page]) => {
       // Avoid to keep something from a previous test.
       await page.evaluate(async () => {
-        const viewer = window.PDFViewerApplication;
-        viewer.unbindWindowEvents();
-        viewer.unbindEvents();
-        await viewer.close();
+        await window.PDFViewerApplication.testingClose();
         window.localStorage.clear();
       });
       await page.close({ runBeforeUnload: false });

--- a/web/app.js
+++ b/web/app.js
@@ -2105,14 +2105,21 @@ const PDFViewerApplication = {
   unbindWindowEvents() {
     this._windowAbortController?.abort();
     this._windowAbortController = null;
-    if (
-      (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) ||
-      AppOptions.get("isInAutomation")
-    ) {
-      this._globalAbortController?.abort();
-      this._globalAbortController = null;
-      this.l10n?.pause();
-    }
+  },
+
+  /**
+   * @ignore
+   */
+  async testingClose() {
+    this.l10n?.pause();
+
+    this.unbindEvents();
+    this.unbindWindowEvents();
+
+    this._globalAbortController?.abort();
+    this._globalAbortController = null;
+
+    await this.close();
   },
 
   _accumulateTicks(ticks, prop) {


### PR DESCRIPTION
This has two advantages, as far as I'm concerned:
 - The tests don't need to manually invoke multiple functions to properly clean-up, which reduces the risk of missing something.
 - By collecting all the relevant clean-up in one method, rather than spreading it out, we get a much better overview of exactly what is being reset.