### PR TITLE
[Editor] Don't create an observer for the stamp annotation after the viewer has been closed

### DIFF
--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -538,6 +538,11 @@ class StampEditor extends AnnotationEditor {
    * Create the resize observer.
    */
   #createObserver() {
+    if (!this._uiManager._signal) {
+      // This method is called after the canvas has been created but the canvas
+      // creation is async, so it's possible that the viewer has been closed.
+      return;
+    }
     this.#observer = new ResizeObserver(entries => {
       const rect = entries[0].contentRect;
       if (rect.width && rect.height) {

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -597,18 +597,19 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
+          const selector = getEditorSelector(0);
 
           await copyImage(page, "../images/firefox_logo.png", 0);
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(selector);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(`${getEditorSelector(0)} button.delete`);
-          await page.click(`${getEditorSelector(0)} button.delete`);
+          await page.waitForSelector(`${selector} button.delete`);
+          await page.click(`${selector} button.delete`);
           await waitForSerialized(page, 0);
 
           await kbUndo(page);
           await waitForSerialized(page, 1);
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(`${selector} canvas`);
         })
       );
     });
@@ -629,13 +630,14 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
+          const selector = getEditorSelector(0);
 
           await copyImage(page, "../images/firefox_logo.png", 0);
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(selector);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(`${getEditorSelector(0)} button.delete`);
-          await page.click(`${getEditorSelector(0)} button.delete`);
+          await page.waitForSelector(`${selector} button.delete`);
+          await page.click(`${selector} button.delete`);
           await waitForSerialized(page, 0);
 
           const twoToFourteen = Array.from(new Array(13).keys(), n => n + 2);
@@ -653,7 +655,7 @@ describe("Stamp Editor", () => {
             await scrollIntoView(page, pageSelector);
           }
 
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(`${selector} canvas`);
         })
       );
     });
@@ -674,13 +676,14 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
+          const selector = getEditorSelector(0);
 
           await copyImage(page, "../images/firefox_logo.png", 0);
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(selector);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(`${getEditorSelector(0)} button.delete`);
-          await page.click(`${getEditorSelector(0)} button.delete`);
+          await page.waitForSelector(`${selector} button.delete`);
+          await page.click(`${selector} button.delete`);
           await waitForSerialized(page, 0);
 
           const twoToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
@@ -693,7 +696,7 @@ describe("Stamp Editor", () => {
 
           await kbUndo(page);
           await waitForSerialized(page, 1);
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(`${selector} canvas`);
         })
       );
     });


### PR DESCRIPTION
When running tests in PR #18296, I noticed this error:
```
JavaScript error: http://127.0.0.1:59398/build/generic/build/pdf.mjs, line 18783: TypeError: can't access property "addEventListener", this._uiManager._signal is null
```
so this patch should fix it.