### PR TITLE
Close `PDFFindBar` when closing the viewer during testing

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2112,6 +2112,7 @@ const PDFViewerApplication = {
    */
   async testingClose() {
     this.l10n?.pause();
+    this.findBar?.close();
 
     this.unbindEvents();
     this.unbindWindowEvents();


### PR DESCRIPTION
By closing `PDFFindBar` we also disconnect the `ResizeObserver`, since we've seen at least one case where that's running during shutdown: http://54.193.163.58:8877/91c40554d1b07c0/output.txt