### PR TITLE
Expose entireWord in updateFindControlState

### DIFF
--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -1022,4 +1022,36 @@ describe("pdf_find_controller", function () {
       pageMatchesLength: [[1, 1, 1, 1, 1, 1, 1, 1, 1]],
     });
   });
+
+  it("dispatches updatefindcontrolstate with correct properties", async function () {
+    const testOnFind = ({ eventBus }) =>
+      new Promise(function (resolve) {
+        const eventState = {
+          source: this,
+          type: "",
+          query: "Foo",
+          caseSensitive: true,
+          entireWord: true,
+          findPrevious: false,
+          matchDiacritics: false,
+        };
+        eventBus.dispatch("find", eventState);
+
+        eventBus.on("updatefindcontrolstate", function (evt) {
+          expect(evt).toEqual(
+            jasmine.objectContaining({
+              state: FindState.NOT_FOUND,
+              previous: false,
+              entireWord: true,
+              matchesCount: { current: 0, total: 0 },
+              rawQuery: "Foo",
+            })
+          );
+          resolve();
+        });
+      });
+
+    const { eventBus } = await initPdfFindController();
+    await testOnFind({ eventBus });
+  });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2516,6 +2516,7 @@ function webViewerUpdateFindMatchesCount({ matchesCount }) {
 function webViewerUpdateFindControlState({
   state,
   previous,
+  entireWord,
   matchesCount,
   rawQuery,
 }) {
@@ -2523,6 +2524,7 @@ function webViewerUpdateFindControlState({
     PDFViewerApplication.externalServices.updateFindControlState({
       result: state,
       findPrevious: previous,
+      entireWord,
       matchesCount,
       rawQuery,
     });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1133,6 +1133,7 @@ class PDFFindController {
       source: this,
       state,
       previous,
+      entireWord: this.#state?.entireWord ?? null,
       matchesCount: this.#requestMatchesCount(),
       rawQuery: this.#state?.query ?? null,
     });


### PR DESCRIPTION
This is a request to additionally expose `entireWord` state in `updateFindControlState`.

## Have a use case
I am studying Firefox findbar behavior when viewing PDF, especially the "not found" sound.
The condition of the sound requires to consider whether `entireWord` is checked.
See related implementation in https://hg.mozilla.org/mozilla-central/rev/16b902cbcf26

This PR would help if I move the implementation from cpp to jsm.