### PR TITLE
Don't throw if there's not enough data to get the header in `FlateStream` (issue 18298)

### DIFF
--- a/src/core/flate_stream.js
+++ b/src/core/flate_stream.js
@@ -296,10 +296,15 @@ class FlateStream extends DecodeStream {
   }
 
   readBlock() {
-    let buffer, len;
+    let buffer, hdr, len;
     const str = this.str;
     // read block header
-    let hdr = this.getBits(3);
+    try {
+      hdr = this.getBits(3);
+    } catch (ex) {
+      this.#endsStreamOnError(ex.message);
+      return;
+    }
     if (hdr & 1) {
       this.eof = true;
     }

--- a/test/pdfs/issue18298.pdf.link
+++ b/test/pdfs/issue18298.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/15908428/example-malformed.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5439,6 +5439,15 @@
     "type": "eq"
   },
   {
+    "id": "issue18298",
+    "file": "pdfs/issue18298.pdf",
+    "md5": "30a6108220c41ec88fa92ff45924a6cb",
+    "rounds": 1,
+    "link": true,
+    "lastPage": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue18138",
     "file": "pdfs/issue18138.pdf",
     "md5": "06136495b2dee5faed2e87c4e49d17fd",


### PR DESCRIPTION
Following in the footsteps of PR #17340.