### PR TITLE
Try to shutdown Fluent "more" when closing the viewer during testing

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2111,16 +2111,15 @@ const PDFViewerApplication = {
    * @ignore
    */
   async testingClose() {
-    this.l10n?.pause();
-    this.findBar?.close();
-
     this.unbindEvents();
     this.unbindWindowEvents();
 
     this._globalAbortController?.abort();
     this._globalAbortController = null;
 
-    await this.close();
+    this.findBar?.close();
+
+    await Promise.all([this.l10n?.destroy(), this.close()]);
   },
 
   _accumulateTicks(ticks, prop) {


### PR DESCRIPTION
Even with PR #18280 fixed, we still *occasionally* see l10n-related errors when closing the integration-tests on the bots.