### PR TITLE
Disable system addon updates for Firefox in testing mode

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -916,6 +916,8 @@ async function startBrowser({
     options.protocol = "webDriverBiDi";
 
     options.extraPrefsFirefox = {
+      // Disable system addon updates.
+      "extensions.systemAddon.update.enabled": false,
       // avoid to have a prompt when leaving a page with a form
       "dom.disable_beforeunload": true,
       // Disable dialog when saving a pdf


### PR DESCRIPTION
This commit fixes the following log line that currently shows up for every type of tests that involve a browser:

`System addon update list error SyntaxError: XMLHttpRequest.open: 'http://%(server)s/dummy-system-addons.xml' is not a valid URL.`

If Firefox is in testing mode, the system addons update URL is configured to a dummy URL so that it can't actually update (see for example the same value in Marionette at
https://searchfox.org/mozilla-central/source/testing/marionette/client/marionette_driver/geckoinstance.py#109), but this doesn't stop Firefox from trying to update, and when it does it logs this line because the URL is obviously invalid.

Hence this patch which disables system addon updates altogether so Firefox doesn't attempt to use the dummy URL anymore. The browser updates are all managed by Puppeteer, and regular updates have already been disabled too (see
https://github.com/puppeteer/puppeteer/blob/6937a76f0a442eca0c6381587b47298793798913/packages/browsers/src/browser-data/firefox.ts#L302-L303).

/cc @whimboo in case it's deemed useful to upstream this to Puppeteer/Marionette because it doesn't appear to be set there while it might be useful to do so.