### PR TITLE
Close the page in the text layer caret selection integration test

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -81,16 +81,16 @@ function awaitPromise(promise) {
 }
 
 function closePages(pages) {
-  return Promise.all(
-    pages.map(async ([_, page]) => {
-      // Avoid to keep something from a previous test.
-      await page.evaluate(async () => {
-        await window.PDFViewerApplication.testingClose();
-        window.localStorage.clear();
-      });
-      await page.close({ runBeforeUnload: false });
-    })
-  );
+  return Promise.all(pages.map(([_, page]) => closeSinglePage(page)));
+}
+
+async function closeSinglePage(page) {
+  // Avoid to keep something from a previous test.
+  await page.evaluate(async () => {
+    await window.PDFViewerApplication.testingClose();
+    window.localStorage.clear();
+  });
+  await page.close({ runBeforeUnload: false });
 }
 
 async function waitForSandboxTrip(page) {
@@ -634,6 +634,7 @@ export {
   awaitPromise,
   clearInput,
   closePages,
+  closeSinglePage,
   createPromise,
   dragAndDropAnnotation,
   firstPageOnTop,

--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 
-import { closePages, getSpanRectFromText, loadAndWait } from "./test_utils.mjs";
+import {
+  closePages,
+  closeSinglePage,
+  getSpanRectFromText,
+  loadAndWait,
+} from "./test_utils.mjs";
 import { startBrowser } from "../test.mjs";
 
 describe("Text layer", () => {
@@ -227,6 +232,7 @@ describe("Text layer", () => {
         );
       });
       afterAll(async () => {
+        await closeSinglePage(page);
         await browser.close();
       });
 


### PR DESCRIPTION
This integration test is currently the only one that spawns a separate browser instance. However, while it closes the browser once it's done, it doesn't close the page (and therefore doesn't call the `testingClose` method) like the other integration tests do.

This commit fixes this difference by closing the page before closing the browser, thereby ensuring all regular cleanup logic gets called and we avoid (intermittent) shutdown tracebacks in the logs. This allows upcoming integration tests that spawn a separate browser instance to reuse this pattern to cleanly end the test.

Given that we integrate the `closeSinglePage` code from #17962 for this patch, @calixteman is credited as the co-author.