### PR TITLE
Improve the security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Need help?
     url: https://github.com/mozilla/pdf.js/discussions
     about: If you need help on how to use PDF.js, please open a discussion where other community members can reply
-  - name: Security report
-    url: https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox&component=PDF%20Viewer&groups=firefox-core-security
-    about: Please report security vulnerabilities in Firefox's bug tracker, making sure that the checkbox in the "Security" section is selected

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,6 +8,6 @@ Mozilla takes the security of our software seriously. If you believe you have fo
 
 Instead, please report security vulnerabilities in [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox&component=PDF%20Viewer&groups=firefox-core-security) and make sure that the checkbox in the "Security" section is checked so the required access controls are automatically configured:
 
-![Security checkbox](security.png)
+![Security checkbox](https://github.com/mozilla/pdf.js/blob/master/.github/security.png)
 
 The Mozilla security team will process the bug as described in [Mozilla's security bugs policy](https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs).


### PR DESCRIPTION
This commit fixes two issues that have been found after commit 2beae7a landed, namely:

- The security checkbox image is not rendering at https://github.com/mozilla/pdf.js/security/policy because the `SECURITY.md` file is apparently served differently there (because it does work as expected at https://github.com/mozilla/pdf.js/blob/master/.github/SECURITY.md), which causes the relative link not to work. We switch to an absolute link to fix the issue.
- If a security policy is defined it turns out that GitHub automatically adds a row to the "New issue" page; see https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository where it states "When someone creates an issue in your repository, they will see a link to your project's security policy". Since we now have two rows at https://github.com/mozilla/pdf.js/issues/new/choose about the security policy, we remove our own version in favor of the standard GitHub-provided one.