### PR TITLE
Fix the timeout logic in the `waitForEvent` integration test helper function

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -189,16 +189,22 @@ async function getSpanRectFromText(page, pageNumber, text) {
 async function waitForEvent(page, eventName, timeout = 5000) {
   const handle = await page.evaluateHandle(
     (name, timeOut) => {
-      let callback = null;
+      let callback = null,
+        timeoutId = null;
       return [
         Promise.race([
           new Promise(resolve => {
             // add event listener and wait for event to fire before returning
-            callback = () => resolve(false);
+            callback = () => {
+              if (timeoutId) {
+                clearTimeout(timeoutId);
+              }
+              resolve(false);
+            };
             document.addEventListener(name, callback, { once: true });
           }),
           new Promise(resolve => {
-            setTimeout(() => {
+            timeoutId = setTimeout(() => {
               document.removeEventListener(name, callback);
               resolve(true);
             }, timeOut);


### PR DESCRIPTION
Debugging #17931, by printing all parts of the event lifecycle including timestamps, uncovered that some events for which a timeout was logged actually did get triggered correctly in the browser. Going over the code and discovering https://stackoverflow.com/questions/47107465/puppeteer-how-to-listen-to-object-events#comment117661238_65534026 showed what went wrong: if the event we wait for is triggered then `Promise.race` resolves, but that doesn't automatically cancel the timeout. The tests didn't fail on this because `Promise.race` resolved correctly, but slightly later once the timeout was reached we would see spurious log lines about timeouts for the already-triggered events.

This commit fixes the issue by canceling the timeout if the event we're waiting for has triggered.

Note that this patch gets rid of the _incorrect_ timeout logs, but this doesn't solve the problem of the _correct_ timeout logs yet (but it's preparatory work for follow-up patches that address that problem).

Fixes a part of #17931.