### PR TITLE
Refactor the copy/paste logic in the integration tests and fix a race condition involving the `waitForEvent` integration test helper function

### DIFF
--- a/test/integration/copy_paste_spec.mjs
+++ b/test/integration/copy_paste_spec.mjs
@@ -15,7 +15,7 @@
 
 import {
   closePages,
-  kbCopy,
+  copy,
   kbSelectAll,
   loadAndWait,
   mockClipboard,
@@ -55,10 +55,7 @@ describe("Copy and paste", () => {
           );
           await selectAll(page);
 
-          const promise = waitForEvent(page, "copy");
-          await kbCopy(page);
-          await promise;
-
+          await copy(page);
           await page.waitForFunction(
             `document.querySelector('#viewerContainer').style.cursor !== "wait"`
           );
@@ -159,10 +156,7 @@ describe("Copy and paste", () => {
           );
           await selectAll(page);
 
-          const promise = waitForEvent(page, "copy");
-          await kbCopy(page);
-          await promise;
-
+          await copy(page);
           await page.waitForFunction(
             `document.querySelector('#viewerContainer').style.cursor !== "wait"`
           );

--- a/test/integration/copy_paste_spec.mjs
+++ b/test/integration/copy_paste_spec.mjs
@@ -23,9 +23,11 @@ import {
 } from "./test_utils.mjs";
 
 const selectAll = async page => {
-  const promise = waitForEvent(page, "selectionchange");
-  await kbSelectAll(page);
-  await promise;
+  await waitForEvent({
+    page,
+    eventName: "selectionchange",
+    action: () => kbSelectAll(page),
+  });
 
   await page.waitForFunction(() => {
     const selection = document.getSelection();

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -17,6 +17,8 @@ import {
   applyFunctionToEditor,
   awaitPromise,
   closePages,
+  copy,
+  copyToClipboard,
   getEditorDimensions,
   getEditorSelector,
   getFirstSerialized,
@@ -24,11 +26,10 @@ import {
   getSerialized,
   kbBigMoveDown,
   kbBigMoveRight,
-  kbCopy,
-  kbPaste,
   kbSelectAll,
   kbUndo,
   loadAndWait,
+  paste,
   pasteFromClipboard,
   scrollIntoView,
   serializeBitmapDimensions,
@@ -78,12 +79,10 @@ const copyImage = async (page, imagePath, number) => {
   const data = fs
     .readFileSync(path.join(__dirname, imagePath))
     .toString("base64");
-  await pasteFromClipboard(
-    page,
-    { "image/png": `data:image/png;base64,${data}` },
-    "",
-    500
-  );
+
+  await copyToClipboard(page, { "image/png": `data:image/png;base64,${data}` });
+  await pasteFromClipboard(page);
+
   await waitForImage(page, getEditorSelector(number));
 };
 
@@ -570,13 +569,13 @@ describe("Stamp Editor", () => {
         await page1.click("#editorStamp");
 
         await copyImage(page1, "../images/firefox_logo.png", 0);
-        await kbCopy(page1);
+        await copy(page1);
 
         const [, page2] = pages2[i];
         await page2.bringToFront();
         await page2.click("#editorStamp");
 
-        await kbPaste(page2);
+        await paste(page2);
 
         await waitForImage(page2, getEditorSelector(0));
       }
@@ -831,8 +830,8 @@ describe("Stamp Editor", () => {
           );
           await page.waitForSelector(`${getEditorSelector(0)} .altText.done`);
 
-          await kbCopy(page);
-          await kbPaste(page);
+          await copy(page);
+          await paste(page);
           await page.waitForSelector(`${getEditorSelector(1)} .altText.done`);
           await waitForSerialized(page, 2);
 

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -292,7 +292,13 @@ async function mockClipboard(pages) {
   );
 }
 
-async function pasteFromClipboard(page, data, selector, timeout = 100) {
+async function copy(page) {
+  const promise = waitForEvent(page, "copy");
+  await kbCopy(page);
+  await promise;
+}
+
+async function copyToClipboard(page, data) {
   await page.evaluate(async dat => {
     const items = Object.create(null);
     for (const [type, value] of Object.entries(dat)) {
@@ -305,7 +311,15 @@ async function pasteFromClipboard(page, data, selector, timeout = 100) {
     }
     await navigator.clipboard.write([new ClipboardItem(items)]);
   }, data);
+}
 
+async function paste(page) {
+  const promise = waitForEvent(page, "paste");
+  await kbPaste(page);
+  await promise;
+}
+
+async function pasteFromClipboard(page, selector = null) {
   const validator = e => e.clipboardData.items.length !== 0;
   let hasPasteEvent = false;
   while (!hasPasteEvent) {
@@ -634,6 +648,8 @@ export {
   clearInput,
   closePages,
   closeSinglePage,
+  copy,
+  copyToClipboard,
   createPromise,
   dragAndDropAnnotation,
   firstPageOnTop,
@@ -654,7 +670,6 @@ export {
   kbBigMoveLeft,
   kbBigMoveRight,
   kbBigMoveUp,
-  kbCopy,
   kbDeleteLastWord,
   kbFocusNext,
   kbFocusPrevious,
@@ -662,12 +677,12 @@ export {
   kbGoToEnd,
   kbModifierDown,
   kbModifierUp,
-  kbPaste,
   kbRedo,
   kbSelectAll,
   kbUndo,
   loadAndWait,
   mockClipboard,
+  paste,
   pasteFromClipboard,
   scrollIntoView,
   serializeBitmapDimensions,


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Note that this patch should fix the `waitForEvent` timeout logs (but not the `waitForEvent` validation logs yet) and reduce the likelyhood of the `FreeText Editor Paste some html must check that pasting html just keep the text` integration test, and other related integration tests, failing (but not completely fix it yet). I'm fairly sure I now know how to fix it completely, but that'll be done in a follow-up which builds on top of this patch and the previous patches.

Fixes a part of #17931.