### PR TITLE
Remove the `requestAnimationFrame` work-around in `L10n.prototype.destroy` (PR 18313 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/preset-env": "^7.24.7",
         "@babel/runtime": "^7.24.7",
         "@fluent/bundle": "^0.18.0",
-        "@fluent/dom": "^0.9.0",
+        "@fluent/dom": "^0.10.0",
         "@jazzer.js/core": "^2.1.0",
         "@metalsmith/layouts": "^2.7.0",
         "@metalsmith/markdown": "^1.10.0",
@@ -2230,15 +2230,16 @@
       }
     },
     "node_modules/@fluent/dom": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@fluent/dom/-/dom-0.9.0.tgz",
-      "integrity": "sha512-KElkUkHhFuliHeQaL4bDMin3MEJlXm3Mgh1lDE5JdmdO+5VW1bFZGjxpFS1qNzz8XZtsa71lL5zDPVg5vOgYtQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@fluent/dom/-/dom-0.10.0.tgz",
+      "integrity": "sha512-31a+GJRg6Xhpw9IQ8yNiHhegd10g1DvC30TMSO52bFpjJVJqfQHTuLKFSORNR5xI1oyP4RU4lGLho9+HaC/pVQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "cached-iterable": "^0.3"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=18.0.0",
         "npm": ">=7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/preset-env": "^7.24.7",
     "@babel/runtime": "^7.24.7",
     "@fluent/bundle": "^0.18.0",
-    "@fluent/dom": "^0.9.0",
+    "@fluent/dom": "^0.10.0",
     "@jazzer.js/core": "^2.1.0",
     "@metalsmith/layouts": "^2.7.0",
     "@metalsmith/markdown": "^1.10.0",

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -559,12 +559,8 @@ describe("Stamp Editor", () => {
     });
 
     afterAll(async () => {
-      // Close the pages in reverse order because the second document will have
-      // focus at the end of the test and the `testingClose` method requires
-      // (via `requestAnimationFrame` usage in the `this.l10n.destroy()` call)
-      // that the page it's called on has focus.
-      await closePages(pages2);
       await closePages(pages1);
+      await closePages(pages2);
     });
 
     it("must check that the alt-text button is here when pasting in the second tab", async () => {

--- a/web/l10n.js
+++ b/web/l10n.js
@@ -87,13 +87,6 @@ class L10n {
     }
     this.#elements.clear();
     this.#l10n.pauseObserving();
-
-    // Since `disconnectRoot`/`pauseObserving` can still trigger asynchronous
-    // operations, without any way to actually cancel them, attempt to
-    // workaround timing issues when closing the integration-tests.
-    await new Promise(resolve => {
-      window.requestAnimationFrame(resolve);
-    });
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
With `@fluent/dom 0.10.0` just published this work-around is no longer necessary.