### PR TITLE
Cancel the `requestAnimationFrame` in the `watchScroll` helper (PR 18193 follow-up)

### DIFF
--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -193,6 +193,11 @@ function watchScroll(viewAreaElement, callback, abortSignal = undefined) {
     useCapture: true,
     signal: abortSignal,
   });
+  abortSignal?.addEventListener(
+    "abort",
+    () => window.cancelAnimationFrame(rAF),
+    { once: true }
+  );
   return state;
 }
 


### PR DESCRIPTION
While the event listener is removed during testing, the `requestAnimationFrame` isn't cancelled and that occasionally shows up when the integration-tests are run on the bots.