### PR TITLE
Add viewer URL parameter to hide toolbar

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1934,6 +1934,7 @@ const PDFViewerApplication = {
     eventBus._on("zoomin", webViewerZoomIn, { signal });
     eventBus._on("zoomout", webViewerZoomOut, { signal });
     eventBus._on("zoomreset", webViewerZoomReset, { signal });
+    eventBus._on("hidetoolbar", webViewerHideToolbar, { signal });
     eventBus._on("pagenumberchanged", webViewerPageNumberChanged, { signal });
     eventBus._on("scalechanged", webViewerScaleChanged, { signal });
     eventBus._on("rotatecw", webViewerRotateCw, { signal });
@@ -2460,6 +2461,15 @@ function webViewerZoomOut() {
 }
 function webViewerZoomReset() {
   PDFViewerApplication.zoomReset();
+}
+function webViewerHideToolbar(evt) {
+  if (evt.hidden) {
+    document.getElementById("toolbarContainer").style.setProperty("display", "none");
+    document.getElementById("viewerContainer").style.setProperty("inset", 0); 
+  } else {
+    document.getElementById("toolbarContainer").style.removeProperty("display");
+    document.getElementById("viewerContainer").style.removeProperty("inset");
+  }
 }
 function webViewerPageNumberChanged(evt) {
   const pdfViewer = PDFViewerApplication.pdfViewer;

--- a/web/pdf_link_service.js
+++ b/web/pdf_link_service.js
@@ -320,6 +320,16 @@ class PDFLinkService {
       if (params.has("page")) {
         pageNumber = params.get("page") | 0 || 1;
       }
+      if (params.has("toolbar")){
+        let hidden = false;
+        if (params.get("toolbar") === "hidden"){
+          hidden = true;
+        }
+        this.eventBus.dispatch("hidetoolbar", {
+          source: this, 
+          hidden
+        });
+      }
       if (params.has("zoom")) {
         // Build the destination array.
         const zoomArgs = params.get("zoom").split(","); // scale,left,top
@@ -385,6 +395,8 @@ class PDFLinkService {
           mode: params.get("pagemode"),
         });
       }
+      
+
       // Ensure that this parameter is *always* handled last, in order to
       // guarantee that it won't be overridden (e.g. by the "page" parameter).
       if (params.has("nameddest")) {


### PR DESCRIPTION
Added a web viewer URL parameter for hiding the PDF toolbar.  `toolbar=hidden`  will hide the top toolbar, and changing it to anything else will restore the toolbar.

Example:

```
http://localhost:8888/web/viewer.html#toolbar=hidden
```