### PR TITLE
Introduce a GitHub Actions workflow for publishing a release and fix `npm publish` warnings about the `package.json` format

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,38 @@
+name: Publish release
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the `pdfjs-dist` library
+        run: npx gulp dist
+
+      - name: Publish the `pdfjs-dist` library to NPM
+        run: npm publish ./build/dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2226,11 +2226,12 @@ function packageJson() {
     },
     repository: {
       type: "git",
-      url: DIST_REPO_URL,
+      url: `git+${DIST_REPO_URL}.git`,
     },
     engines: {
       node: ">=18",
     },
+    scripts: {},
   };
 
   return createStringSource(

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2240,7 +2240,7 @@ function packageJson() {
 }
 
 gulp.task(
-  "dist-pre",
+  "dist",
   gulp.series(
     "generic",
     "generic-legacy",
@@ -2368,7 +2368,7 @@ gulp.task(
 
 gulp.task(
   "dist-install",
-  gulp.series("dist-pre", function createDistInstall(done) {
+  gulp.series("dist", function createDistInstall(done) {
     let distPath = DIST_DIR;
     const opts = {};
     const installPath = process.env.PDFJS_INSTALL_PATH;
@@ -2377,47 +2377,6 @@ gulp.task(
       distPath = path.relative(installPath, distPath);
     }
     safeSpawnSync("npm", ["install", distPath], opts);
-    done();
-  })
-);
-
-gulp.task(
-  "dist",
-  gulp.series("dist-pre", function createDist(done) {
-    const VERSION = getVersionJSON().version;
-
-    console.log();
-    console.log("### Committing changes");
-
-    let reason = process.env.PDFJS_UPDATE_REASON;
-    // Attempt to work-around the broken link, see https://github.com/mozilla/pdf.js/issues/10391
-    if (typeof reason === "string") {
-      const reasonParts =
-        /^(See )(mozilla\/pdf\.js)@tags\/(v\d+\.\d+\.\d+)\s*$/.exec(reason);
-
-      if (reasonParts) {
-        reason =
-          reasonParts[1] +
-          "https://github.com/" +
-          reasonParts[2] +
-          "/releases/tag/" +
-          reasonParts[3];
-      }
-    }
-    const message =
-      "PDF.js version " + VERSION + (reason ? " - " + reason : "");
-    safeSpawnSync("git", ["add", "*"], { cwd: DIST_DIR });
-    safeSpawnSync("git", ["commit", "-am", message], { cwd: DIST_DIR });
-    safeSpawnSync("git", ["tag", "-a", "v" + VERSION, "-m", message], {
-      cwd: DIST_DIR,
-    });
-
-    console.log();
-    console.log("Done. Push with");
-    console.log(
-      "  cd " + DIST_DIR + "; git push --tags " + DIST_REPO_URL + " master"
-    );
-    console.log();
     done();
   })
 );


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Notes:

- This PR depends on https://github.com/mozilla/botio-files-pdfjs/pull/45 being merged _and_ deployed to the bots first (to avoid publishing twice).
- This PR depends on the `NPM_TOKEN` repository secret being configured in this repository, with the same token that the bots currently have.
- This PR is made now in the hope that we can use the new flow for the upcoming release.
- I have tested the workflow in my fork by making two small changes: adding the `on: pull_request` trigger so that I could trigger the workflow from my branch (because releases require it to be merged to `master` first which is inconvenient for testing) and adding the `--dry-run` option to the `npm publish` command so that we can see what e.g. the release tarball would contain without actually having to publish anything yet. You can find the logs of the dry-run for the first commit at https://github.com/timvandermeij/pdf.js/actions/runs/9732441891/job/26858099909?pr=11 and with the second commit applied at https://github.com/timvandermeij/pdf.js/actions/runs/9732541964/job/26858344999?pr=11 (showing that the warnings are now gone). Release tarball correctness can be verified by comparing the file listing in the logs to the file listing on https://www.npmjs.com/package/pdfjs-dist/v/latest?activeTab=code, and seeing that the "total files" property of 334 and the "unpacked size" property of 36 MB matches what's listed on NPM for the current release.
- The Git publishing logic is removed because publishing to the `pdfjs-dist` repository has been broken for a long time and the current logic fails to run on GitHub Actions. To keep the scope of this patch small and to only port the logic we actually need and have functional right now I'll make a follow-up issue for revamping the Git publishing part in a separate scope (because that'll have to be re-implemented anyway).

Fixes a part of #11851.