### PR TITLE
Use `npm ci`, not `npm install`, on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run external tests
         run: npx gulp externaltest

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Use Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run lint
         run: npx gulp lint

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -27,7 +27,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build the `pdfjs-dist` library
         run: npx gulp dist

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build the website
         run: npx gulp web

--- a/.github/workflows/types_tests.yml
+++ b/.github/workflows/types_tests.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run types tests
         run: npx gulp typestest


### PR DESCRIPTION
This PR switches from `npm install` to `npm ci` on CI. This enables some additional checks to ensure repo integrity when using CI/CD. 

Read more: https://docs.npmjs.com/cli/v10/commands/npm-ci