### PR TITLE
Disable new tab page stuff in Firefox when running tests

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -946,6 +946,8 @@ async function startBrowser({
       "dom.events.asyncClipboard.clipboardItem": true,
       // It's helpful to see where the caret is.
       "accessibility.browsewithcaret": true,
+      // Disable the newtabpage stuff.
+      "browser.newtabpage.enabled": false,
       ...extraPrefsFirefox,
     };
   }


### PR DESCRIPTION
It should help to have such a garbage in the logs:
```
console.warn: TopSitesFeed: Failed to fetch data from Contile server: NetworkError when attempting to fetch resource.
JavaScript error: , line 0: TypeError: NetworkError when attempting to fetch resource.
```