### PR TITLE
Fix the repository URL in the `package.json` file for `pdfjs-dist`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2226,7 +2226,7 @@ function packageJson() {
     },
     repository: {
       type: "git",
-      url: `git+${DIST_REPO_URL}.git`,
+      url: `git+https://github.com/mozilla/pdf.js.git`,
     },
     engines: {
       node: ">=18",


### PR DESCRIPTION
For provenance, enabled in PR #18352, to work the repository URL in `package.json` is required to match the repository URL of the GitHub Actions invocation. This should fix the following error we encountered publishing a new release today:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/pdfjs-dist - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/mozilla/pdfjs-dist.git", expected to match "https://github.com/mozilla/pdf.js" from provenance
```

Notes:

- The failed publish workflow can be found in full here: https://github.com/mozilla/pdf.js/actions/runs/9748332722/job/26903097065
- An example of another project running into this and fixing it is https://github.com/oblador/react-native-vector-image/actions/runs/7601589115 where https://github.com/oblador/react-native-vector-image/commit/3cf629a6363ab9ae3d105c7328169d5e99362eb3 fixed the issue. Note that they use the same `git+` format URL as we do, and the `react-pdf` project also uses it with provenance enabled successfully, so the format itself should not be the issue and only the repository name itself is.