### PR TITLE
fix: issue #18240 - Auto scaling on page scroll on Fit to Width. 

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1192,6 +1192,7 @@ class PDFViewer {
     if (this.pagesCount === 0) {
       return;
     }
+    this.#setScale(this.currentScaleValue, { noScroll: false });
     this.update();
   }
 


### PR DESCRIPTION
fix to issue : #18240

Called setScale inside _scrollUpdate to update scale factor whenever currentPage is changed. This can solve issue of Fit to width for mis-oriented pdf's 

Attached Output : 

https://github.com/mozilla/pdf.js/assets/80917122/f12508e3-d995-4379-8277-2429ed678f45

