### PR TITLE
Refactor the toolbar html & css to improve its overall accessibility (bug 1171799, bug 1855695)

### DIFF
--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -43,7 +43,7 @@ describe("find bar", () => {
           await page.click("#viewFindButton");
           await page.waitForSelector("#viewFindButton", { hidden: false });
           await page.type("#findInput", "a");
-          await page.click("#findHighlightAll");
+          await page.click("#findHighlightAll + label");
           await page.waitForSelector(".textLayer .highlight");
 
           // The PDF file contains the text 'AB BA' in a monospace font on a

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -1227,18 +1227,9 @@
 }
 
 #highlightParamsToolbarContainer {
-  height: auto;
-  padding-inline: 10px;
-  padding-block: 10px 16px;
   gap: 16px;
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-
-  .editorParamsLabel {
-    width: fit-content;
-    inset-inline-start: 0;
-  }
+  padding-inline: 10px;
+  padding-block-end: 12px;
 
   .colorPicker {
     display: flex;
@@ -1262,6 +1253,7 @@
         align-items: center;
         background: none;
         flex: 0 0 auto;
+        padding: 0;
 
         .swatch {
           width: 24px;
@@ -1291,7 +1283,6 @@
     align-self: stretch;
 
     .editorParamsLabel {
-      width: 100%;
       height: auto;
       align-self: stretch;
     }

--- a/web/app.js
+++ b/web/app.js
@@ -516,7 +516,11 @@ const PDFViewerApplication = {
     }
 
     if (!this.supportsIntegratedFind && appConfig.findBar) {
-      this.findBar = new PDFFindBar(appConfig.findBar, eventBus);
+      this.findBar = new PDFFindBar(
+        appConfig.findBar,
+        appConfig.principalContainer,
+        eventBus
+      );
     }
 
     if (appConfig.annotationEditorParams) {

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -25,9 +25,11 @@ const MATCHES_COUNT_LIMIT = 1000;
  * is done by PDFFindController.
  */
 class PDFFindBar {
+  #mainContainer;
+
   #resizeObserver = new ResizeObserver(this.#resizeObserverCallback.bind(this));
 
-  constructor(options, eventBus) {
+  constructor(options, mainContainer, eventBus) {
     this.opened = false;
 
     this.bar = options.bar;
@@ -42,6 +44,7 @@ class PDFFindBar {
     this.findPreviousButton = options.findPreviousButton;
     this.findNextButton = options.findNextButton;
     this.eventBus = eventBus;
+    this.#mainContainer = mainContainer;
 
     // Add event listeners to the DOM elements.
     this.toggleButton.addEventListener("click", () => {
@@ -170,7 +173,7 @@ class PDFFindBar {
       //  - The width of the viewer itself changes.
       //  - The width of the findbar changes, by toggling the visibility
       //    (or localization) of find count/status messages.
-      this.#resizeObserver.observe(this.bar.parentNode);
+      this.#resizeObserver.observe(this.#mainContainer);
       this.#resizeObserver.observe(this.bar);
 
       this.opened = true;
@@ -200,7 +203,7 @@ class PDFFindBar {
     }
   }
 
-  #resizeObserverCallback(entries) {
+  #resizeObserverCallback() {
     const { bar } = this;
     // The find bar has an absolute position and thus the browser extends
     // its width to the maximum possible width once the find bar does not fit

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -21,7 +21,7 @@ import {
   DEFAULT_SCALE_VALUE,
   MAX_SCALE,
   MIN_SCALE,
-  toggleCheckedBtn,
+  toggleExpandedBtn,
 } from "./ui_utils.js";
 
 /**
@@ -270,22 +270,22 @@ class Toolbar {
       editorStampParamsToolbar,
     } = this.#opts;
 
-    toggleCheckedBtn(
+    toggleExpandedBtn(
       editorFreeTextButton,
       mode === AnnotationEditorType.FREETEXT,
       editorFreeTextParamsToolbar
     );
-    toggleCheckedBtn(
+    toggleExpandedBtn(
       editorHighlightButton,
       mode === AnnotationEditorType.HIGHLIGHT,
       editorHighlightParamsToolbar
     );
-    toggleCheckedBtn(
+    toggleExpandedBtn(
       editorInkButton,
       mode === AnnotationEditorType.INK,
       editorInkParamsToolbar
     );
-    toggleCheckedBtn(
+    toggleExpandedBtn(
       editorStampButton,
       mode === AnnotationEditorType.STAMP,
       editorStampParamsToolbar

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -93,13 +93,13 @@ See https://github.com/adobe-type-tools/cmap-resources
 
   </head>
 
-  <body tabindex="1">
+  <body tabindex="0">
     <div id="outerContainer">
 
       <div id="mainContainer">
 
         <div id="floatingToolbar">
-          <button id="download" class="toolbarButton" type="button" title="Download" tabindex="31" data-l10n-id="pdfjs-download-button">
+          <button id="download" class="toolbarButton" type="button" title="Download" tabindex="0" data-l10n-id="pdfjs-download-button">
             <span data-l10n-id="pdfjs-download-button-label">Download</span>
           </button>
         </div>

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -26,9 +26,15 @@
   --sidebar-transition-duration: 200ms;
   --sidebar-transition-timing-function: ease;
 
+  --toolbar-height: 32px;
+  --toolbar-horizontal-padding: 1px;
+  --toolbar-vertical-padding: 2px;
+  --icon-size: 16px;
+
   --toolbar-icon-opacity: 0.7;
   --doorhanger-icon-opacity: 0.9;
   --editor-toolbar-base-offset: 105px;
+  --doorhanger-height: 8px;
 
   --main-color: rgb(12 12 13);
   --body-bg-color: rgb(212 212 215);
@@ -213,9 +219,14 @@
   }
 }
 
-* {
-  padding: 0;
-  margin: 0;
+@keyframes progressIndeterminate {
+  0% {
+    transform: translateX(calc(-142px * var(--dir-factor)));
+  }
+
+  100% {
+    transform: translateX(0);
+  }
 }
 
 html,
@@ -225,6 +236,7 @@ body {
 }
 
 body {
+  margin: 0;
   background-color: var(--body-bg-color);
   scrollbar-color: var(--scrollbar-color) var(--scrollbar-bg-color);
 
@@ -270,6 +282,7 @@ body {
   width: 100%;
   height: 100%;
   position: relative;
+  margin: 0;
 }
 
 #sidebarContainer {
@@ -290,6 +303,7 @@ body {
 #outerContainer:is(.sidebarMoving, .sidebarOpen) #sidebarContainer {
   visibility: visible;
 }
+
 #outerContainer.sidebarOpen #sidebarContainer {
   inset-inline-start: 0;
 }
@@ -298,6 +312,9 @@ body {
   position: absolute;
   inset: 0;
   min-width: 350px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 #sidebarContent {
@@ -315,6 +332,7 @@ body {
   inset: var(--toolbar-height) 0 0;
   outline: none;
 }
+
 #viewerContainer:not(.pdfPresentationMode) {
   transition-duration: var(--sidebar-transition-duration);
   transition-timing-function: var(--sidebar-transition-timing-function);
@@ -325,18 +343,12 @@ body {
   transition-property: inset-inline-start;
 }
 
-.toolbar {
-  position: relative;
-  inset-inline: 0;
-  z-index: 9999;
-  cursor: default;
+#sidebarContainer :is(input, button, select) {
   font: message-box;
 }
 
-:is(.toolbar, .editorParamsToolbar, #sidebarContainer)
-  :is(input, button, select) {
-  outline: none;
-  font: message-box;
+.toolbar {
+  z-index: 9999;
 }
 
 #toolbarContainer {
@@ -349,6 +361,36 @@ body {
   background-color: var(--sidebar-toolbar-bg-color);
   box-shadow: var(--toolbarSidebar-box-shadow);
   border-bottom: var(--toolbarSidebar-border-bottom);
+  padding: var(--toolbar-vertical-padding) var(--toolbar-horizontal-padding);
+  justify-content: space-between;
+
+  #toolbarSidebarLeft {
+    width: auto;
+    height: 100%;
+
+    #viewThumbnail::before {
+      mask-image: var(--toolbarButton-viewThumbnail-icon);
+    }
+
+    #viewOutline::before {
+      mask-image: var(--toolbarButton-viewOutline-icon);
+      transform: scaleX(var(--dir-factor));
+    }
+
+    #viewAttachments::before {
+      mask-image: var(--toolbarButton-viewAttachments-icon);
+    }
+
+    #viewLayers::before {
+      mask-image: var(--toolbarButton-viewLayers-icon);
+    }
+  }
+
+  #toolbarSidebarRight {
+    width: auto;
+    height: 100%;
+    padding-inline-end: 2px;
+  }
 }
 
 #sidebarResizer {
@@ -360,179 +402,14 @@ body {
   cursor: ew-resize;
 }
 
-#toolbarContainer,
-.editorParamsToolbar {
-  position: relative;
-  height: var(--toolbar-height);
-  background-color: var(--toolbar-bg-color);
-  box-shadow: var(--toolbar-box-shadow);
-  border-bottom: var(--toolbar-border-bottom);
-}
-
-#toolbarViewer {
-  height: var(--toolbar-height);
-}
-
-#loadingBar {
-  /* Define these variables here, and not in :root, to avoid reflowing the
-     entire viewer when updating progress (see issue 15958). */
-  --progressBar-percent: 0%;
-  --progressBar-end-offset: 0;
-
-  position: absolute;
-  inset-inline: 0 var(--progressBar-end-offset);
-  height: 4px;
-  background-color: var(--progressBar-bg-color);
-  border-bottom: 1px solid var(--toolbar-border-color);
-  transition-property: inset-inline-start;
-  transition-duration: var(--sidebar-transition-duration);
-  transition-timing-function: var(--sidebar-transition-timing-function);
-}
-
 #outerContainer.sidebarOpen #loadingBar {
   inset-inline-start: var(--sidebar-width);
-}
-
-#loadingBar .progress {
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  width: 100%;
-  transform: scaleX(var(--progressBar-percent));
-  transform-origin: calc(50% - 50% * var(--dir-factor)) 0;
-  height: 100%;
-  background-color: var(--progressBar-color);
-  overflow: hidden;
-  transition: transform 200ms;
-}
-
-@keyframes progressIndeterminate {
-  0% {
-    transform: translateX(calc(-142px * var(--dir-factor)));
-  }
-  100% {
-    transform: translateX(0);
-  }
-}
-
-#loadingBar.indeterminate .progress {
-  transform: none;
-  background-color: var(--progressBar-bg-color);
-  transition: none;
-}
-
-#loadingBar.indeterminate .progress .glimmer {
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  height: 100%;
-  width: calc(100% + 150px);
-  background: repeating-linear-gradient(
-    135deg,
-    var(--progressBar-blend-color) 0,
-    var(--progressBar-bg-color) 5px,
-    var(--progressBar-bg-color) 45px,
-    var(--progressBar-color) 55px,
-    var(--progressBar-color) 95px,
-    var(--progressBar-blend-color) 100px
-  );
-  animation: progressIndeterminate 1s linear infinite;
 }
 
 #outerContainer.sidebarResizing
   :is(#sidebarContainer, #viewerContainer, #loadingBar) {
   /* Improve responsiveness and avoid visual glitches when the sidebar is resized. */
   transition-duration: 0s;
-}
-
-.editorParamsToolbar {
-  background-color: var(--doorhanger-bg-color);
-  top: var(--toolbar-height);
-  position: absolute;
-  z-index: 30000;
-  height: auto;
-  inset-inline-end: 4px;
-  padding: 6px 0 10px;
-  margin: 4px 2px;
-  font: message-box;
-  font-size: 12px;
-  line-height: 14px;
-  text-align: left;
-  cursor: default;
-}
-
-.editorParamsToolbarContainer {
-  width: 220px;
-  margin-bottom: -4px;
-}
-
-.editorParamsToolbarContainer > .editorParamsSetter {
-  min-height: 26px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-inline: 10px;
-}
-
-.editorParamsToolbarContainer .editorParamsLabel {
-  padding-inline-end: 10px;
-  flex: none;
-  font: menu;
-  font-size: 13px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
-  color: var(--main-color);
-}
-
-.editorParamsToolbarContainer .editorParamsColor {
-  width: 32px;
-  height: 32px;
-  flex: none;
-}
-
-.editorParamsToolbarContainer .editorParamsSlider {
-  background-color: transparent;
-  width: 90px;
-  flex: 0 1 0;
-}
-
-.editorParamsToolbarContainer .editorParamsSlider::-moz-range-progress {
-  background-color: black;
-}
-
-/*#if !MOZCENTRAL*/
-.editorParamsToolbarContainer .editorParamsSlider::-webkit-slider-runnable-track,
-/*#endif*/
-.editorParamsToolbarContainer .editorParamsSlider::-moz-range-track {
-  background-color: black;
-}
-
-/*#if !MOZCENTRAL*/
-.editorParamsToolbarContainer .editorParamsSlider::-webkit-slider-thumb,
-/*#endif*/
-.editorParamsToolbarContainer .editorParamsSlider::-moz-range-thumb {
-  background-color: white;
-}
-
-#editorStampParamsToolbar {
-  inset-inline-end: calc(var(--editor-toolbar-base-offset) + 0px);
-}
-
-#editorInkParamsToolbar {
-  inset-inline-end: calc(var(--editor-toolbar-base-offset) + 28px);
-}
-
-#editorFreeTextParamsToolbar {
-  inset-inline-end: calc(var(--editor-toolbar-base-offset) + 56px);
-}
-
-#editorHighlightParamsToolbar {
-  inset-inline-end: calc(var(--editor-toolbar-base-offset) + 84px);
-}
-
-#editorStampAddImage::before {
-  mask-image: var(--editorParams-stampAddImage-icon);
 }
 
 .doorHanger,
@@ -542,84 +419,63 @@ body {
     0 1px 5px var(--doorhanger-border-color),
     0 0 0 1px var(--doorhanger-border-color);
   border: var(--doorhanger-border-color-whcm);
-}
-:is(.doorHanger, .doorHangerRight)::after,
-:is(.doorHanger, .doorHangerRight)::before {
-  bottom: 100%;
-  border: 8px solid rgb(0 0 0 / 0);
-  content: " ";
-  height: 0;
-  width: 0;
-  position: absolute;
-  pointer-events: none;
-  opacity: var(--doorhanger-triangle-opacity-whcm);
-}
-.doorHanger::after {
-  inset-inline-start: 10px;
-  margin-inline-start: -8px;
-  border-bottom-color: var(--toolbar-bg-color);
-}
-.doorHangerRight::after {
-  inset-inline-end: 10px;
-  margin-inline-end: -8px;
-  border-bottom-color: var(--doorhanger-bg-color);
-}
-:is(.doorHanger, .doorHangerRight)::before {
-  border-bottom-color: var(--doorhanger-border-color);
-  border-width: 9px;
-}
-.doorHanger::before {
-  inset-inline-start: 10px;
-  margin-inline-start: -9px;
-}
-.doorHangerRight::before {
-  inset-inline-end: 10px;
-  margin-inline-end: -9px;
+  background-color: var(--doorhanger-bg-color);
+  inset-block-start: calc(100% + var(--doorhanger-height) - 2px);
+
+  &::after,
+  &::before {
+    bottom: 100%;
+    border-style: solid;
+    border-color: transparent;
+    content: "";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    opacity: var(--doorhanger-triangle-opacity-whcm);
+  }
+
+  &::before {
+    border-width: calc(var(--doorhanger-height) + 2px);
+    border-bottom-color: var(--doorhanger-border-color);
+  }
+
+  &::after {
+    border-width: var(--doorhanger-height);
+  }
 }
 
-#toolbarViewerMiddle {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+.doorHangerRight {
+  inset-inline-end: calc(50% - var(--doorhanger-height) - 1px);
+
+  &::before {
+    inset-inline-end: -1px;
+  }
+
+  &::after {
+    border-bottom-color: var(--doorhanger-bg-color);
+    inset-inline-end: 1px;
+  }
 }
 
-#toolbarViewerLeft,
-#toolbarSidebarLeft {
-  float: var(--inline-start);
-}
-#toolbarViewerRight,
-#toolbarSidebarRight {
-  float: var(--inline-end);
-}
+.doorHanger {
+  inset-inline-start: calc(50% - var(--doorhanger-height) - 1px);
 
-#toolbarViewerLeft > *,
-#toolbarViewerMiddle > *,
-#toolbarViewerRight > *,
-#toolbarSidebarLeft *,
-#toolbarSidebarRight * {
-  position: relative;
-  float: var(--inline-start);
-}
+  &::before {
+    inset-inline-start: -1px;
+  }
 
-#toolbarViewerLeft {
-  padding-inline-start: 1px;
-}
-#toolbarViewerRight {
-  padding-inline-end: 1px;
-}
-#toolbarSidebarRight {
-  padding-inline-end: 2px;
+  &::after {
+    border-bottom-color: var(--toolbar-bg-color);
+    inset-inline-start: 1px;
+  }
 }
 
 .splitToolbarButton {
   margin: 2px;
   display: inline-block;
 }
-.splitToolbarButton > .toolbarButton {
-  float: var(--inline-start);
-}
 
-.toolbarButton,
 .dialogButton {
   border: none;
   background: none;
@@ -636,40 +492,14 @@ body {
   color: var(--dialog-button-hover-color);
 }
 
-.toolbarButton > span {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  overflow: hidden;
-}
-
-:is(.toolbarButton, .dialogButton)[disabled] {
-  opacity: 0.5;
-}
-
-.splitToolbarButton > .toolbarButton:is(:hover, :focus-visible),
-.dropdownToolbarButton:hover {
-  background-color: var(--button-hover-color);
-}
-.splitToolbarButton > .toolbarButton {
-  position: relative;
-  margin: 0;
-}
-#toolbarSidebar .splitToolbarButton > .toolbarButton {
-  margin-inline-end: 2px;
-}
-
 .splitToolbarButtonSeparator {
   float: var(--inline-start);
-  margin: 4px 0;
   width: 0;
-  height: 20px;
+  height: 62%;
   border-left: 1px solid var(--separator-color);
   border-right: none;
 }
 
-.toolbarButton,
-.dropdownToolbarButton,
 .dialogButton {
   min-width: 16px;
   margin: 2px 1px;
@@ -684,75 +514,7 @@ body {
   box-sizing: border-box;
 }
 
-.toolbarButton:is(:hover, :focus-visible) {
-  background-color: var(--button-hover-color);
-}
-
-.toolbarButton.toggled,
-.splitToolbarButton.toggled > .toolbarButton.toggled {
-  background-color: var(--toggled-btn-bg-color);
-  color: var(--toggled-btn-color);
-}
-
-.toolbarButton.toggled:hover,
-.splitToolbarButton.toggled > .toolbarButton.toggled:hover {
-  outline: var(--toggled-hover-btn-outline) !important;
-}
-
-.toolbarButton.toggled::before {
-  background-color: var(--toggled-btn-color);
-}
-
-.toolbarButton.toggled:hover:active,
-.splitToolbarButton.toggled > .toolbarButton.toggled:hover:active {
-  background-color: var(--toggled-hover-active-btn-color);
-}
-
-.dropdownToolbarButton {
-  display: flex;
-  width: fit-content;
-  min-width: 140px;
-  padding: 0;
-  background-color: var(--dropdown-btn-bg-color);
-  border: var(--dropdown-btn-border);
-}
-.dropdownToolbarButton::after {
-  top: 6px;
-  inset-inline-end: 6px;
-  pointer-events: none;
-  mask-image: var(--toolbarButton-menuArrow-icon);
-}
-
-.dropdownToolbarButton > select {
-  appearance: none;
-  width: inherit;
-  min-width: inherit;
-  height: 28px;
-  font-size: 12px;
-  color: var(--main-color);
-  margin: 0;
-  padding-block: 1px 2px;
-  padding-inline: 6px 38px;
-  border: none;
-  background-color: var(--dropdown-btn-bg-color);
-}
-.dropdownToolbarButton > select:is(:hover, :focus-visible) {
-  background-color: var(--button-hover-color);
-  color: var(--toggled-btn-color);
-}
-.dropdownToolbarButton > select > option {
-  background: var(--doorhanger-bg-color);
-  color: var(--main-color);
-}
-
-.toolbarButtonSpacer {
-  width: 30px;
-  display: inline-block;
-  height: 1px;
-}
-
-:is(.toolbarButton, .treeItemToggler)::before,
-.dropdownToolbarButton::after {
+.treeItemToggler::before {
   /* All matching images have a size of 16x16
    * All relevant containers have a size of 28x28 */
   position: absolute;
@@ -763,20 +525,6 @@ body {
   content: "";
   background-color: var(--toolbar-icon-bg-color);
   mask-size: cover;
-}
-
-.dropdownToolbarButton:is(:hover, :focus-visible, :active)::after {
-  background-color: var(--toolbar-icon-hover-bg-color);
-}
-
-.toolbarButton::before {
-  opacity: var(--toolbar-icon-opacity);
-  top: 6px;
-  left: 6px;
-}
-
-.toolbarButton:is(:hover, :focus-visible)::before {
-  background-color: var(--toolbar-icon-hover-bg-color);
 }
 
 #sidebarToggleButton::before {
@@ -805,6 +553,10 @@ body {
   mask-image: var(--toolbarButton-zoomIn-icon);
 }
 
+#presentationMode::before {
+  mask-image: var(--toolbarButton-presentationMode-icon);
+}
+
 #editorFreeTextButton::before {
   mask-image: var(--toolbarButton-editorFreeText-icon);
 }
@@ -821,29 +573,22 @@ body {
   mask-image: var(--toolbarButton-editorStamp-icon);
 }
 
-#printButton::before {
+:is(#printButton, #secondaryPrint)::before {
   mask-image: var(--toolbarButton-print-icon);
 }
 
-#downloadButton::before {
+/*#if GENERIC*/
+#secondaryOpenFile::before {
+  mask-image: var(--toolbarButton-openFile-icon);
+}
+/*#endif*/
+
+:is(#downloadButton, #secondaryDownload)::before {
   mask-image: var(--toolbarButton-download-icon);
 }
 
-#viewThumbnail::before {
-  mask-image: var(--toolbarButton-viewThumbnail-icon);
-}
-
-#viewOutline::before {
-  mask-image: var(--toolbarButton-viewOutline-icon);
-  transform: scaleX(var(--dir-factor));
-}
-
-#viewAttachments::before {
-  mask-image: var(--toolbarButton-viewAttachments-icon);
-}
-
-#viewLayers::before {
-  mask-image: var(--toolbarButton-viewLayers-icon);
+#viewBookmark::before {
+  mask-image: var(--toolbarButton-bookmark-icon);
 }
 
 #currentOutlineItem::before {
@@ -870,12 +615,14 @@ body {
 
 .verticalToolbarSeparator {
   display: block;
-  margin: 5px 2px;
+  margin-inline: 2px;
   width: 0;
-  height: 22px;
+  height: 80%;
   border-left: 1px solid var(--separator-color);
   border-right: none;
+  box-sizing: border-box;
 }
+
 .horizontalToolbarSeparator {
   display: block;
   margin: 6px 0;
@@ -883,6 +630,29 @@ body {
   border-bottom: none;
   height: 0;
   width: 100%;
+}
+
+.toggleButton {
+  display: inline;
+
+  &:is(:hover, :has(> input:focus-visible)) {
+    color: var(--toggled-btn-color);
+    background-color: var(--button-hover-color);
+  }
+
+  &:has(> input:checked) {
+    color: var(--toggled-btn-color);
+    background-color: var(--toggled-btn-bg-color);
+  }
+
+  & > input {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
 }
 
 .toolbarField {
@@ -897,14 +667,10 @@ body {
   font-size: 12px;
   line-height: 16px;
   outline: none;
-}
 
-.toolbarField[type="checkbox"] {
-  opacity: 0;
-  position: absolute !important;
-  left: 0;
-  margin: 10px 0 3px;
-  margin-inline-start: 7px;
+  &:focus {
+    border-color: #0a84ff;
+  }
 }
 
 #pageNumber {
@@ -921,7 +687,7 @@ body {
   /*#endif*/
 
   .loadingInput:has(> &.loading)::after {
-    display: block;
+    display: inline;
     visibility: visible;
 
     transition-property: visibility;
@@ -930,13 +696,14 @@ body {
 }
 
 .loadingInput {
+  position: relative;
+
   &::after {
     position: absolute;
     visibility: hidden;
     display: none;
-    top: calc(50% - 8px);
-    width: 16px;
-    height: 16px;
+    width: var(--icon-size);
+    height: var(--icon-size);
 
     content: "";
     background-color: var(--toolbar-icon-bg-color);
@@ -947,30 +714,10 @@ body {
   &.start::after {
     inset-inline-start: 4px;
   }
+
   &.end::after {
     inset-inline-end: 4px;
   }
-}
-
-.toolbarField:focus {
-  border-color: #0a84ff;
-}
-
-.toolbarLabel {
-  min-width: 16px;
-  padding: 7px;
-  margin: 2px;
-  border-radius: 2px;
-  color: var(--main-color);
-  font-size: 12px;
-  line-height: 14px;
-  text-align: left;
-  user-select: none;
-  cursor: default;
-}
-
-#numPages.toolbarLabel {
-  padding-inline-start: 3px;
 }
 
 #thumbnailView,
@@ -984,6 +731,7 @@ body {
   overflow: auto;
   user-select: none;
 }
+
 #thumbnailView {
   width: calc(100% - 60px);
   padding: 10px 30px 0;
@@ -1016,6 +764,7 @@ a:focus > .thumbnail,
 .thumbnail:hover {
   border-color: var(--thumbnail-hover-color);
 }
+
 .thumbnail.selected {
   border-color: var(--thumbnail-selected-color) !important;
 }
@@ -1025,10 +774,12 @@ a:focus > .thumbnail,
   height: var(--thumbnail-height);
   opacity: 0.9;
 }
+
 a:focus > .thumbnail > .thumbnailImage,
 .thumbnail:hover > .thumbnailImage {
   opacity: 0.95;
 }
+
 .thumbnail.selected > .thumbnailImage {
   opacity: 1 !important;
 }
@@ -1065,9 +816,11 @@ a:focus > .thumbnail > .thumbnailImage,
 #layersView .treeItem > a * {
   cursor: pointer;
 }
+
 #layersView .treeItem > a > label {
   padding-inline-start: 4px;
 }
+
 #layersView .treeItem > a > label > input {
   float: var(--inline-start);
   margin-top: 1px;
@@ -1080,14 +833,17 @@ a:focus > .thumbnail > .thumbnailImage,
   width: 0;
   color: rgb(255 255 255 / 0.5);
 }
+
 .treeItemToggler::before {
   inset-inline-end: 4px;
   mask-image: var(--treeitem-expanded-icon);
 }
+
 .treeItemToggler.treeItemsHidden::before {
   mask-image: var(--treeitem-collapsed-icon);
   transform: scaleX(var(--dir-factor));
 }
+
 .treeItemToggler.treeItemsHidden ~ .treeItems {
   display: none;
 }
@@ -1111,7 +867,7 @@ a:focus > .thumbnail > .thumbnailImage,
   display: none;
 
   #sidebarContainer:has(#outlineView:not(.hidden)) & {
-    display: inherit;
+    display: inline flex;
   }
 }
 
@@ -1137,6 +893,7 @@ dialog {
   border-radius: 4px;
   box-shadow: 0 1px 4px rgb(0 0 0 / 0.3);
 }
+
 dialog::backdrop {
   background-color: rgb(0 0 0 / 0.2);
 }
@@ -1174,6 +931,7 @@ dialog :link {
 #passwordDialog {
   text-align: center;
 }
+
 #passwordDialog .toolbarField {
   width: 200px;
 }
@@ -1181,18 +939,22 @@ dialog :link {
 #documentPropertiesDialog {
   text-align: left;
 }
+
 #documentPropertiesDialog .row > * {
   min-width: 100px;
   text-align: start;
 }
+
 #documentPropertiesDialog .row > span {
   width: 125px;
   word-wrap: break-word;
 }
+
 #documentPropertiesDialog .row > p {
   max-width: 225px;
   word-wrap: break-word;
 }
+
 #documentPropertiesDialog .buttonRow {
   margin-top: 10px;
 }
@@ -1200,14 +962,17 @@ dialog :link {
 .grab-to-pan-grab {
   cursor: grab !important;
 }
+
 .grab-to-pan-grab
   *:not(input):not(textarea):not(button):not(select):not(:link) {
   cursor: inherit !important;
 }
+
 .grab-to-pan-grab:active,
 .grab-to-pan-grabbing {
   cursor: grabbing !important;
 }
+
 .grab-to-pan-grabbing {
   position: fixed;
   background: rgb(0 0 0 / 0);
@@ -1218,22 +983,81 @@ dialog :link {
 }
 
 .toolbarButton {
-  &.labeled {
-    border-radius: 0;
+  height: 100%;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--main-color);
+  outline: none;
+  border-radius: 2px;
+  box-sizing: border-box;
+  font: message-box;
+  flex: none;
+  position: relative;
+
+  > span {
     display: inline-block;
-    height: auto;
-    margin: 0;
-    padding: 0 0 1px;
-    padding-inline-start: 36px;
-    position: relative;
-    min-height: 26px;
-    min-width: 100%;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+  }
+
+  &::before {
+    opacity: var(--toolbar-icon-opacity);
+    display: inline-block;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    content: "";
+    background-color: var(--toolbar-icon-bg-color);
+    mask-size: cover;
+    mask-position: center;
+  }
+
+  &.toggled {
+    background-color: var(--toggled-btn-bg-color);
+    color: var(--toggled-btn-color);
+
+    &::before {
+      background-color: var(--toggled-btn-color);
+    }
+
+    &:hover {
+      outline: var(--toggled-hover-btn-outline) !important;
+
+      &:active {
+        background-color: var(--toggled-hover-active-btn-color);
+      }
+    }
+  }
+
+  &:is(:hover, :focus-visible) {
+    background-color: var(--button-hover-color);
+
+    &::before {
+      background-color: var(--toolbar-icon-hover-bg-color);
+    }
+  }
+
+  &:is([disabled="disabled"], [disabled]) {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  &.labeled {
+    width: 100%;
+    min-height: var(--menuitem-height);
+    justify-content: flex-start;
+    gap: 8px;
+    padding-inline-start: 12px;
+    aspect-ratio: unset;
     text-align: start;
     white-space: normal;
-    width: auto;
+    cursor: default;
 
     &:is(a) {
-      padding-top: 5px;
       text-decoration: none;
 
       &[href="#"] {
@@ -1243,50 +1067,132 @@ dialog :link {
     }
 
     &::before {
-      inset-inline-start: 12px;
       opacity: var(--doorhanger-icon-opacity);
-      top: 5px;
     }
 
-    &:not(.toggled):is(:hover, :focus-visible) {
+    &:is(:hover, :focus-visible) {
       background-color: var(--doorhanger-hover-bg-color);
       color: var(--doorhanger-hover-color);
     }
 
     > span {
-      display: unset;
-      padding-inline-end: 4px;
+      display: inline-block;
+      width: max-content;
+      height: auto;
+    }
+  }
+}
+
+.toolbarButtonWithContainer {
+  height: 100%;
+  aspect-ratio: 1;
+  display: inline-block;
+  position: relative;
+  flex: none;
+
+  > .toolbarButton {
+    width: 100%;
+    height: 100%;
+  }
+
+  .menuContainer {
+    width: 100%;
+    height: auto;
+    max-height: calc(
+      var(--viewer-container-height) - var(--toolbar-height) -
+        var(--doorhanger-height)
+    );
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding-block: 5px;
+    overflow-y: auto;
+  }
+
+  .editorParamsToolbar {
+    height: auto;
+    width: 220px;
+    position: absolute;
+    z-index: 30000;
+    cursor: default;
+
+    #editorStampAddImage::before {
+      mask-image: var(--editorParams-stampAddImage-icon);
+    }
+
+    .editorParamsLabel {
+      flex: none;
+      font: menu;
+      font-size: 13px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 150%;
+      color: var(--main-color);
+      width: fit-content;
+      inset-inline-start: 0;
+    }
+
+    .editorParamsToolbarContainer {
+      width: 100%;
+      height: auto;
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+      padding-inline: 10px;
+      padding-block: 10px;
+
+      > .editorParamsSetter {
+        min-height: 26px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .editorParamsColor {
+        width: 32px;
+        height: 32px;
+        flex: none;
+        padding: 0;
+      }
+
+      .editorParamsSlider {
+        background-color: transparent;
+        width: 90px;
+        flex: 0 1 0;
+        font: message-box;
+
+        &::-moz-range-progress {
+          background-color: black;
+        }
+
+        /*#if !MOZCENTRAL*/
+        &::-webkit-slider-runnable-track,
+        /*#endif*/
+        &::-moz-range-track {
+          background-color: black;
+        }
+
+        /*#if !MOZCENTRAL*/
+        &::-webkit-slider-thumb,
+        /*#endif*/
+        &::-moz-range-thumb {
+          background-color: white;
+        }
+      }
     }
   }
 }
 
 #secondaryToolbar {
-  background-color: var(--doorhanger-bg-color);
-  cursor: default;
-  font: message-box;
-  font-size: 12px;
   height: auto;
-  inset-inline-end: 4px;
-  line-height: 14px;
-  margin: 4px 2px;
-  padding: 6px 0 10px;
+  width: 220px;
   position: absolute;
-  text-align: left;
-  top: var(--toolbar-height);
   z-index: 30000;
-
-  :is(button, a) {
-    font: message-box;
-    outline: none;
-  }
+  cursor: default;
+  min-height: 26px;
+  max-height: calc(var(--viewer-container-height) - 40px);
 
   #secondaryToolbarButtonContainer {
-    margin-bottom: -4px;
-    max-height: calc(var(--viewer-container-height) - 40px);
-    max-width: 220px;
-    min-height: 26px;
-    overflow-y: auto;
-
     /*#if GENERIC*/
     #secondaryOpenFile::before {
       mask-image: var(--toolbarButton-openFile-icon);
@@ -1372,80 +1278,30 @@ dialog :link {
 }
 
 #findbar {
-  background-color: var(--toolbar-bg-color);
-  cursor: default;
-  font: message-box;
-  font-size: 12px;
+  --input-horizontal-padding: 4px;
+  --findbar-padding: 2px;
+
+  width: max-content;
+  max-width: 90vw;
+  min-height: var(--toolbar-height);
   height: auto;
-  inset-inline-start: 64px;
-  line-height: 14px;
-  margin: 4px 2px;
-  min-width: 300px;
-  padding: 0 4px;
   position: absolute;
-  text-align: left;
-  top: var(--toolbar-height);
   z-index: 30000;
+  cursor: default;
+  padding: 0;
+  min-width: 300px;
+  background-color: var(--toolbar-bg-color);
+  box-sizing: border-box;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 
-  * {
-    float: var(--inline-start);
-    position: relative;
-  }
-
-  > div {
+  > * {
     height: var(--toolbar-height);
+    padding: var(--findbar-padding);
   }
 
-  :is(button, input) {
-    font: message-box;
-    outline: none;
-  }
-
-  input {
-    &[type="checkbox"] {
-      pointer-events: none;
-
-      &:checked + .toolbarLabel {
-        background-color: var(--toggled-btn-bg-color) !important;
-        color: var(--toggled-btn-color);
-      }
-    }
-  }
-
-  label {
-    user-select: none;
-  }
-
-  :is(label:hover, input:focus-visible + label) {
-    background-color: var(--button-hover-color);
-    color: var(--toggled-btn-color);
-  }
-
-  #findbarInputContainer {
-    margin-inline-end: 4px;
-
-    #findInput {
-      width: 200px;
-
-      /*#if !MOZCENTRAL*/
-      &::-webkit-input-placeholder {
-        color: rgb(191 191 191);
-      }
-      /*#endif*/
-
-      &::placeholder {
-        font-style: normal;
-      }
-
-      .loadingInput:has(> &[data-status="pending"])::after {
-        display: block;
-        visibility: visible;
-      }
-
-      &[data-status="notFound"] {
-        background-color: rgb(255 102 102);
-      }
-    }
+  #findInputContainer {
+    margin-inline-start: 2px;
 
     #findPreviousButton::before {
       mask-image: var(--findbarButton-previous-icon);
@@ -1454,45 +1310,83 @@ dialog :link {
     #findNextButton::before {
       mask-image: var(--findbarButton-next-icon);
     }
+
+    #findInput {
+      width: 200px;
+      padding: 5px var(--input-horizontal-padding);
+
+      /*#if !MOZCENTRAL*/
+      &::-webkit-input-placeholder {
+        color: rgb(191 191 191);
+      }
+      /*#endif*/
+      &::placeholder {
+        font-style: normal;
+      }
+
+      .loadingInput:has(> &[data-status="pending"])::after {
+        display: inline;
+        visibility: visible;
+        inset-inline-end: calc(var(--input-horizontal-padding) + 1px);
+      }
+
+      &[data-status="notFound"] {
+        background-color: rgb(255 102 102);
+      }
+    }
   }
 
   #findbarMessageContainer {
+    display: none;
+    gap: 4px;
+
+    &:has(> :is(#findResultsCount, #findMsg):not(:empty)) {
+      display: inline flex;
+    }
+
     #findResultsCount {
       background-color: rgb(217 217 217);
       color: rgb(82 82 82);
-      margin: 5px;
-      padding: 4px 5px;
-      text-align: center;
+      padding-block: 4px;
+
+      &:empty {
+        display: none;
+      }
     }
 
     #findMsg {
       &[data-status="notFound"] {
         font-weight: bold;
       }
-    }
 
-    *:empty {
-      display: none;
-    }
-  }
-
-  &.wrapContainers {
-    > div {
-      clear: both;
-    }
-
-    > #findbarMessageContainer {
-      height: auto;
-
-      > * {
-        clear: both;
+      &:empty {
+        display: none;
       }
     }
   }
 
-  @media all and (max-width: 690px) {
-    & {
-      inset-inline-start: 34px;
+  &.wrapContainers {
+    flex-direction: column;
+    align-items: flex-start;
+    height: max-content;
+
+    .toolbarLabel {
+      margin: 0 4px;
+    }
+
+    #findbarMessageContainer {
+      flex-wrap: wrap;
+      flex-flow: column nowrap;
+      align-items: flex-start;
+      height: max-content;
+
+      #findResultsCount {
+        height: calc(var(--toolbar-height) - 2 * var(--findbar-padding));
+      }
+
+      #findMsg {
+        min-height: var(--toolbar-height);
+      }
     }
   }
 }
@@ -1509,15 +1403,19 @@ dialog :link {
   body {
     background: rgb(0 0 0 / 0) none;
   }
+
   body[data-pdfjsprinting] #outerContainer {
     display: none;
   }
+
   body[data-pdfjsprinting] #printContainer {
     display: block;
   }
+
   #printContainer {
     height: 100%;
   }
+
   /* wrapper around (scaled) print canvas elements */
   #printContainer > .printedPage {
     page-break-after: always;
@@ -1559,13 +1457,261 @@ dialog :link {
   display: none !important;
 }
 
-@media all and (max-width: 900px) {
-  #toolbarViewerMiddle {
-    display: table;
-    margin: auto;
-    left: auto;
-    position: inherit;
-    transform: none;
+.toolbarLabel {
+  width: max-content;
+  min-width: 16px;
+  height: 100%;
+  padding-inline: 4px;
+  margin: 2px;
+  border-radius: 2px;
+  color: var(--main-color);
+  font-size: 12px;
+  line-height: 14px;
+  text-align: left;
+  user-select: none;
+  cursor: default;
+  box-sizing: border-box;
+
+  display: inline flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  > label {
+    width: 100%;
+  }
+}
+
+.toolbarHorizontalGroup {
+  height: 100%;
+  display: inline flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1px;
+  box-sizing: border-box;
+}
+
+.dropdownToolbarButton {
+  display: inline flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+
+  width: fit-content;
+  min-width: 140px;
+  padding: 0;
+  background-color: var(--dropdown-btn-bg-color);
+  border: var(--dropdown-btn-border);
+  border-radius: 2px;
+  color: var(--main-color);
+  font-size: 12px;
+  line-height: 14px;
+  user-select: none;
+  cursor: default;
+  box-sizing: border-box;
+  outline: none;
+
+  &:hover {
+    background-color: var(--button-hover-color);
+  }
+
+  > select {
+    appearance: none;
+    width: inherit;
+    min-width: inherit;
+    height: 28px;
+    font: message-box;
+    font-size: 12px;
+    color: var(--main-color);
+    margin: 0;
+    padding-block: 1px 2px;
+    padding-inline: 6px 38px;
+    border: none;
+    outline: none;
+    background-color: var(--dropdown-btn-bg-color);
+
+    > option {
+      background: var(--doorhanger-bg-color);
+      color: var(--main-color);
+    }
+
+    &:is(:hover, :focus-visible) {
+      background-color: var(--button-hover-color);
+      color: var(--toggled-btn-color);
+    }
+  }
+
+  &::after {
+    /* All matching images have a size of 16x16
+     * All relevant containers have a size of 28x28 */
+    position: absolute;
+    display: inline;
+    width: var(--icon-size);
+    height: var(--icon-size);
+
+    content: "";
+    background-color: var(--toolbar-icon-bg-color);
+    mask-size: cover;
+
+    inset-inline-end: 4px;
+    pointer-events: none;
+    mask-image: var(--toolbarButton-menuArrow-icon);
+  }
+
+  &:is(:hover, :focus-visible, :active)::after {
+    background-color: var(--toolbar-icon-hover-bg-color);
+  }
+}
+
+#toolbarContainer {
+  --menuitem-height: calc(var(--toolbar-height) - 6px);
+
+  height: var(--toolbar-height);
+  padding: var(--toolbar-vertical-padding) var(--toolbar-horizontal-padding);
+  position: relative;
+  box-sizing: border-box;
+  font: message-box;
+  background-color: var(--toolbar-bg-color);
+  box-shadow: var(--toolbar-box-shadow);
+  border-bottom: var(--toolbar-border-bottom);
+
+  #toolbarViewer {
+    width: 100%;
+    height: 100%;
+    justify-content: space-between;
+
+    > * {
+      flex: none;
+    }
+
+    input {
+      font: message-box;
+    }
+
+    .toolbarButtonSpacer {
+      width: 30px;
+      display: block;
+      height: 1px;
+    }
+
+    #toolbarViewerLeft #numPages.toolbarLabel {
+      padding-inline-start: 3px;
+      flex: none;
+    }
+  }
+
+  #loadingBar {
+    /* Define these variables here, and not in :root, to avoid reflowing the
+       entire viewer when updating progress (see issue 15958). */
+    --progressBar-percent: 0%;
+    --progressBar-end-offset: 0;
+
+    position: absolute;
+    top: var(--toolbar-height);
+    inset-inline: 0 var(--progressBar-end-offset);
+    height: 4px;
+    background-color: var(--progressBar-bg-color);
+    border-bottom: 1px solid var(--toolbar-border-color);
+    transition-property: inset-inline-start;
+    transition-duration: var(--sidebar-transition-duration);
+    transition-timing-function: var(--sidebar-transition-timing-function);
+
+    .progress {
+      position: absolute;
+      top: 0;
+      inset-inline-start: 0;
+      width: 100%;
+      transform: scaleX(var(--progressBar-percent));
+      transform-origin: calc(50% - 50% * var(--dir-factor)) 0;
+      height: 100%;
+      background-color: var(--progressBar-color);
+      overflow: hidden;
+      transition: transform 200ms;
+    }
+
+    &.indeterminate .progress {
+      transform: none;
+      background-color: var(--progressBar-bg-color);
+      transition: none;
+
+      .glimmer {
+        position: absolute;
+        top: 0;
+        inset-inline-start: 0;
+        height: 100%;
+        width: calc(100% + 150px);
+        background: repeating-linear-gradient(
+          135deg,
+          var(--progressBar-blend-color) 0,
+          var(--progressBar-bg-color) 5px,
+          var(--progressBar-bg-color) 45px,
+          var(--progressBar-color) 55px,
+          var(--progressBar-color) 95px,
+          var(--progressBar-blend-color) 100px
+        );
+        animation: progressIndeterminate 1s linear infinite;
+      }
+    }
+  }
+}
+
+#secondaryToolbar {
+  #firstPage::before {
+    mask-image: var(--secondaryToolbarButton-firstPage-icon);
+  }
+
+  #lastPage::before {
+    mask-image: var(--secondaryToolbarButton-lastPage-icon);
+  }
+
+  #pageRotateCcw::before {
+    mask-image: var(--secondaryToolbarButton-rotateCcw-icon);
+  }
+
+  #pageRotateCw::before {
+    mask-image: var(--secondaryToolbarButton-rotateCw-icon);
+  }
+
+  #cursorSelectTool::before {
+    mask-image: var(--secondaryToolbarButton-selectTool-icon);
+  }
+
+  #cursorHandTool::before {
+    mask-image: var(--secondaryToolbarButton-handTool-icon);
+  }
+
+  #scrollPage::before {
+    mask-image: var(--secondaryToolbarButton-scrollPage-icon);
+  }
+
+  #scrollVertical::before {
+    mask-image: var(--secondaryToolbarButton-scrollVertical-icon);
+  }
+
+  #scrollHorizontal::before {
+    mask-image: var(--secondaryToolbarButton-scrollHorizontal-icon);
+  }
+
+  #scrollWrapped::before {
+    mask-image: var(--secondaryToolbarButton-scrollWrapped-icon);
+  }
+
+  #spreadNone::before {
+    mask-image: var(--secondaryToolbarButton-spreadNone-icon);
+  }
+
+  #spreadOdd::before {
+    mask-image: var(--secondaryToolbarButton-spreadOdd-icon);
+  }
+
+  #spreadEven::before {
+    mask-image: var(--secondaryToolbarButton-spreadEven-icon);
+  }
+
+  #documentProperties::before {
+    mask-image: var(--secondaryToolbarButton-documentProperties-icon);
   }
 }
 
@@ -1586,7 +1732,7 @@ dialog :link {
     display: none !important;
   }
   #outerContainer .visibleMediumView:not(.hidden, [hidden]) {
-    display: inherit !important;
+    display: inline-block !important;
   }
 }
 
@@ -1595,7 +1741,8 @@ dialog :link {
   .hiddenSmallView * {
     display: none !important;
   }
-  .toolbarButtonSpacer {
+
+  #toolbarContainer #toolbarViewer .toolbarButtonSpacer {
     width: 0;
   }
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -93,33 +93,33 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
   </head>
 
-  <body tabindex="1">
+  <body tabindex="0">
     <div id="outerContainer">
 
       <div id="sidebarContainer">
-        <div id="toolbarSidebar">
+        <div id="toolbarSidebar" class="toolbarHorizontalGroup">
           <div id="toolbarSidebarLeft">
-            <div id="sidebarViewButtons" class="splitToolbarButton toggled" role="radiogroup">
-              <button id="viewThumbnail" class="toolbarButton toggled" type="button" title="Show Thumbnails" tabindex="2" data-l10n-id="pdfjs-thumbs-button" role="radio" aria-checked="true" aria-controls="thumbnailView">
+            <div id="sidebarViewButtons" class="toolbarHorizontalGroup toggled" role="radiogroup">
+              <button id="viewThumbnail" class="toolbarButton toggled" type="button" title="Show Thumbnails" tabindex="0" data-l10n-id="pdfjs-thumbs-button" role="radio" aria-checked="true" aria-controls="thumbnailView">
                  <span data-l10n-id="pdfjs-thumbs-button-label">Thumbnails</span>
               </button>
-              <button id="viewOutline" class="toolbarButton" type="button" title="Show Document Outline (double-click to expand/collapse all items)" tabindex="3" data-l10n-id="pdfjs-document-outline-button" role="radio" aria-checked="false" aria-controls="outlineView">
+              <button id="viewOutline" class="toolbarButton" type="button" title="Show Document Outline (double-click to expand/collapse all items)" tabindex="0" data-l10n-id="pdfjs-document-outline-button" role="radio" aria-checked="false" aria-controls="outlineView">
                  <span data-l10n-id="pdfjs-document-outline-button-label">Document Outline</span>
               </button>
-              <button id="viewAttachments" class="toolbarButton" type="button" title="Show Attachments" tabindex="4" data-l10n-id="pdfjs-attachments-button" role="radio" aria-checked="false" aria-controls="attachmentsView">
+              <button id="viewAttachments" class="toolbarButton" type="button" title="Show Attachments" tabindex="0" data-l10n-id="pdfjs-attachments-button" role="radio" aria-checked="false" aria-controls="attachmentsView">
                  <span data-l10n-id="pdfjs-attachments-button-label">Attachments</span>
               </button>
-              <button id="viewLayers" class="toolbarButton" type="button" title="Show Layers (double-click to reset all layers to the default state)" tabindex="5" data-l10n-id="pdfjs-layers-button" role="radio" aria-checked="false" aria-controls="layersView">
+              <button id="viewLayers" class="toolbarButton" type="button" title="Show Layers (double-click to reset all layers to the default state)" tabindex="0" data-l10n-id="pdfjs-layers-button" role="radio" aria-checked="false" aria-controls="layersView">
                  <span data-l10n-id="pdfjs-layers-button-label">Layers</span>
               </button>
             </div>
           </div>
 
           <div id="toolbarSidebarRight">
-            <div id="outlineOptionsContainer">
+            <div id="outlineOptionsContainer" class="toolbarHorizontalGroup">
               <div class="verticalToolbarSeparator"></div>
 
-              <button id="currentOutlineItem" class="toolbarButton" type="button" disabled="disabled" title="Find Current Outline Item" tabindex="6" data-l10n-id="pdfjs-current-outline-item-button">
+              <button id="currentOutlineItem" class="toolbarButton" type="button" disabled="disabled" title="Find Current Outline Item" tabindex="0" data-l10n-id="pdfjs-current-outline-item-button">
                 <span data-l10n-id="pdfjs-current-outline-item-button-label">Current Outline Item</span>
               </button>
             </div>
@@ -139,272 +139,89 @@ See https://github.com/adobe-type-tools/cmap-resources
       </div>  <!-- sidebarContainer -->
 
       <div id="mainContainer">
-        <div class="findbar hidden doorHanger" id="findbar">
-          <div id="findbarInputContainer">
-            <span class="loadingInput end">
-              <input id="findInput" class="toolbarField" title="Find" placeholder="Find in document…" tabindex="91" data-l10n-id="pdfjs-find-input" aria-invalid="false">
-            </span>
-            <div class="splitToolbarButton">
-              <button id="findPreviousButton" class="toolbarButton" type="button" title="Find the previous occurrence of the phrase" tabindex="92" data-l10n-id="pdfjs-find-previous-button">
-                <span data-l10n-id="pdfjs-find-previous-button-label">Previous</span>
-              </button>
-              <div class="splitToolbarButtonSeparator"></div>
-              <button id="findNextButton" class="toolbarButton" type="button" title="Find the next occurrence of the phrase" tabindex="93" data-l10n-id="pdfjs-find-next-button">
-                <span data-l10n-id="pdfjs-find-next-button-label">Next</span>
-              </button>
-            </div>
-          </div>
-
-          <div id="findbarOptionsOneContainer">
-            <input type="checkbox" id="findHighlightAll" class="toolbarField" tabindex="94">
-            <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="pdfjs-find-highlight-checkbox">Highlight All</label>
-            <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
-            <label for="findMatchCase" class="toolbarLabel" data-l10n-id="pdfjs-find-match-case-checkbox-label">Match Case</label>
-          </div>
-          <div id="findbarOptionsTwoContainer">
-            <input type="checkbox" id="findMatchDiacritics" class="toolbarField" tabindex="96">
-            <label for="findMatchDiacritics" class="toolbarLabel" data-l10n-id="pdfjs-find-match-diacritics-checkbox-label">Match Diacritics</label>
-            <input type="checkbox" id="findEntireWord" class="toolbarField" tabindex="97">
-            <label for="findEntireWord" class="toolbarLabel" data-l10n-id="pdfjs-find-entire-word-checkbox-label">Whole Words</label>
-          </div>
-
-          <div id="findbarMessageContainer" aria-live="polite">
-            <span id="findResultsCount" class="toolbarLabel"></span>
-            <span id="findMsg" class="toolbarLabel"></span>
-          </div>
-        </div>  <!-- findbar -->
-
-        <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
-          <div id="highlightParamsToolbarContainer" class="editorParamsToolbarContainer">
-            <div id="editorHighlightColorPicker" class="colorPicker">
-              <span id="highlightColorPickerLabel" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-colorpicker-label">Highlight color</span>
-            </div>
-            <div id="editorHighlightThickness">
-              <label for="editorFreeHighlightThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-highlight-thickness-input">Thickness</label>
-              <div class="thicknessPicker">
-                <input type="range" id="editorFreeHighlightThickness" class="editorParamsSlider" data-l10n-id="pdfjs-editor-free-highlight-thickness-title" value="12" min="8" max="24" step="1" tabindex="101">
-              </div>
-            </div>
-            <div id="editorHighlightVisibility">
-              <div class="divider"></div>
-              <div class="toggler">
-                <label for="editorHighlightShowAll" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-show-all-button-label">Show all</label>
-                <button id="editorHighlightShowAll" class="toggle-button" type="button" data-l10n-id="pdfjs-editor-highlight-show-all-button" aria-pressed="true" tabindex="102"></button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
-          <div class="editorParamsToolbarContainer">
-            <div class="editorParamsSetter">
-              <label for="editorFreeTextColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-color-input">Color</label>
-              <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="103">
-            </div>
-            <div class="editorParamsSetter">
-              <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-size-input">Size</label>
-              <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="104">
-            </div>
-          </div>
-        </div>
-
-        <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
-          <div class="editorParamsToolbarContainer">
-            <div class="editorParamsSetter">
-              <label for="editorInkColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-color-input">Color</label>
-              <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="105">
-            </div>
-            <div class="editorParamsSetter">
-              <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-thickness-input">Thickness</label>
-              <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="106">
-            </div>
-            <div class="editorParamsSetter">
-              <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input">Opacity</label>
-              <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="100" min="1" max="100" step="1" tabindex="107">
-            </div>
-          </div>
-        </div>
-
-        <div class="editorParamsToolbar hidden doorHangerRight" id="editorStampParamsToolbar">
-          <div class="editorParamsToolbarContainer">
-            <button id="editorStampAddImage" class="toolbarButton labeled" type="button" title="Add image" tabindex="108" data-l10n-id="pdfjs-editor-stamp-add-image-button">
-              <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label">Add image</span>
-            </button>
-          </div>
-        </div>
-
-        <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
-          <div id="secondaryToolbarButtonContainer">
-<!--#if GENERIC-->
-            <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" title="Open File" tabindex="51" data-l10n-id="pdfjs-open-file-button">
-              <span data-l10n-id="pdfjs-open-file-button-label">Open</span>
-            </button>
-<!--#endif-->
-
-            <button id="secondaryPrint" class="toolbarButton labeled visibleMediumView" type="button" title="Print" tabindex="52" data-l10n-id="pdfjs-print-button">
-              <span data-l10n-id="pdfjs-print-button-label">Print</span>
-            </button>
-
-            <button id="secondaryDownload" class="toolbarButton labeled visibleMediumView" type="button" title="Save" tabindex="53" data-l10n-id="pdfjs-save-button">
-              <span data-l10n-id="pdfjs-save-button-label">Save</span>
-            </button>
-
-<!--#if GENERIC-->
-            <div class="horizontalToolbarSeparator"></div>
-<!--#else-->
-<!--        <div class="horizontalToolbarSeparator visibleMediumView"></div>-->
-<!--#endif-->
-
-            <button id="presentationMode" class="toolbarButton labeled" type="button" title="Switch to Presentation Mode" tabindex="54" data-l10n-id="pdfjs-presentation-mode-button">
-              <span data-l10n-id="pdfjs-presentation-mode-button-label">Presentation Mode</span>
-            </button>
-
-            <a href="#" id="viewBookmark" class="toolbarButton labeled" title="Current Page (View URL from Current Page)" tabindex="55" data-l10n-id="pdfjs-bookmark-button">
-              <span data-l10n-id="pdfjs-bookmark-button-label">Current Page</span>
-            </a>
-
-            <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>
-
-            <button id="firstPage" class="toolbarButton labeled" type="button" title="Go to First Page" tabindex="56" data-l10n-id="pdfjs-first-page-button">
-              <span data-l10n-id="pdfjs-first-page-button-label">Go to First Page</span>
-            </button>
-            <button id="lastPage" class="toolbarButton labeled" type="button" title="Go to Last Page" tabindex="57" data-l10n-id="pdfjs-last-page-button">
-              <span data-l10n-id="pdfjs-last-page-button-label">Go to Last Page</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <button id="pageRotateCw" class="toolbarButton labeled" type="button" title="Rotate Clockwise" tabindex="58" data-l10n-id="pdfjs-page-rotate-cw-button">
-              <span data-l10n-id="pdfjs-page-rotate-cw-button-label">Rotate Clockwise</span>
-            </button>
-            <button id="pageRotateCcw" class="toolbarButton labeled" type="button" title="Rotate Counterclockwise" tabindex="59" data-l10n-id="pdfjs-page-rotate-ccw-button">
-              <span data-l10n-id="pdfjs-page-rotate-ccw-button-label">Rotate Counterclockwise</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <div id="cursorToolButtons" role="radiogroup">
-              <button id="cursorSelectTool" class="toolbarButton labeled toggled" type="button" title="Enable Text Selection Tool" tabindex="60" data-l10n-id="pdfjs-cursor-text-select-tool-button" role="radio" aria-checked="true">
-                <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label">Text Selection Tool</span>
-              </button>
-              <button id="cursorHandTool" class="toolbarButton labeled" type="button" title="Enable Hand Tool" tabindex="61" data-l10n-id="pdfjs-cursor-hand-tool-button" role="radio" aria-checked="false">
-                <span data-l10n-id="pdfjs-cursor-hand-tool-button-label">Hand Tool</span>
-              </button>
-            </div>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <div id="scrollModeButtons" role="radiogroup">
-              <button id="scrollPage" class="toolbarButton labeled" type="button" title="Use Page Scrolling" tabindex="62" data-l10n-id="pdfjs-scroll-page-button" role="radio" aria-checked="false">
-                <span data-l10n-id="pdfjs-scroll-page-button-label">Page Scrolling</span>
-              </button>
-              <button id="scrollVertical" class="toolbarButton labeled toggled" type="button" title="Use Vertical Scrolling" tabindex="63" data-l10n-id="pdfjs-scroll-vertical-button" role="radio" aria-checked="true">
-                <span data-l10n-id="pdfjs-scroll-vertical-button-label" >Vertical Scrolling</span>
-              </button>
-              <button id="scrollHorizontal" class="toolbarButton labeled" type="button" title="Use Horizontal Scrolling" tabindex="64" data-l10n-id="pdfjs-scroll-horizontal-button" role="radio" aria-checked="false">
-                <span data-l10n-id="pdfjs-scroll-horizontal-button-label">Horizontal Scrolling</span>
-              </button>
-              <button id="scrollWrapped" class="toolbarButton labeled" type="button" title="Use Wrapped Scrolling" tabindex="65" data-l10n-id="pdfjs-scroll-wrapped-button" role="radio" aria-checked="false">
-                <span data-l10n-id="pdfjs-scroll-wrapped-button-label">Wrapped Scrolling</span>
-              </button>
-            </div>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <div id="spreadModeButtons" role="radiogroup">
-              <button id="spreadNone" class="toolbarButton labeled toggled" type="button" title="Do not join page spreads" tabindex="66" data-l10n-id="pdfjs-spread-none-button" role="radio" aria-checked="true">
-                <span data-l10n-id="pdfjs-spread-none-button-label">No Spreads</span>
-              </button>
-              <button id="spreadOdd" class="toolbarButton labeled" type="button" title="Join page spreads starting with odd-numbered pages" tabindex="67" data-l10n-id="pdfjs-spread-odd-button" role="radio" aria-checked="false">
-                <span data-l10n-id="pdfjs-spread-odd-button-label">Odd Spreads</span>
-              </button>
-              <button id="spreadEven" class="toolbarButton labeled" type="button" title="Join page spreads starting with even-numbered pages" tabindex="68" data-l10n-id="pdfjs-spread-even-button" role="radio" aria-checked="false">
-                <span data-l10n-id="pdfjs-spread-even-button-label">Even Spreads</span>
-              </button>
-            </div>
-
-            <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
-            <button id="imageAltTextSettings" type="button" class="toolbarButton labeled hidden" title="Image alt text settings" tabindex="69" data-l10n-id="pdfjs-image-alt-text-settings-button" aria-controls="altTextSettingsDialog">
-              <span data-l10n-id="pdfjs-image-alt-text-settings-button-label">Image alt text settings</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <button id="documentProperties" class="toolbarButton labeled" type="button" title="Document Properties…" tabindex="70" data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
-              <span data-l10n-id="pdfjs-document-properties-button-label">Document Properties…</span>
-            </button>
-          </div>
-        </div>  <!-- secondaryToolbar -->
-
         <div class="toolbar">
           <div id="toolbarContainer">
-            <div id="toolbarViewer">
-              <div id="toolbarViewerLeft">
-                <button id="sidebarToggleButton" class="toolbarButton" type="button" title="Toggle Sidebar" tabindex="11" data-l10n-id="pdfjs-toggle-sidebar-button" aria-expanded="false" aria-controls="sidebarContainer">
+            <div id="toolbarViewer" class="toolbarHorizontalGroup">
+              <div id="toolbarViewerLeft" class="toolbarHorizontalGroup">
+                <button id="sidebarToggleButton" class="toolbarButton" type="button" title="Toggle Sidebar" tabindex="0" data-l10n-id="pdfjs-toggle-sidebar-button" aria-expanded="false" aria-haspopup="true" aria-controls="sidebarContainer">
                   <span data-l10n-id="pdfjs-toggle-sidebar-button-label">Toggle Sidebar</span>
                 </button>
                 <div class="toolbarButtonSpacer"></div>
-                <button id="viewFindButton" class="toolbarButton" type="button" title="Find in Document" tabindex="12" data-l10n-id="pdfjs-findbar-button" aria-expanded="false" aria-controls="findbar">
-                  <span data-l10n-id="pdfjs-findbar-button-label">Find</span>
-                </button>
-                <div class="splitToolbarButton hiddenSmallView">
-                  <button class="toolbarButton" title="Previous Page" id="previous" type="button" tabindex="13" data-l10n-id="pdfjs-previous-button">
+                <div class="toolbarButtonWithContainer">
+                  <button id="viewFindButton" class="toolbarButton" type="button" title="Find in Document" tabindex="0" data-l10n-id="pdfjs-findbar-button" aria-expanded="false" aria-controls="findbar">
+                    <span data-l10n-id="pdfjs-findbar-button-label">Find</span>
+                  </button>
+                  <div class="hidden doorHanger toolbarHorizontalGroup" id="findbar">
+                    <div id="findInputContainer" class="toolbarHorizontalGroup">
+                      <span class="loadingInput end toolbarHorizontalGroup">
+                        <input id="findInput" class="toolbarField" title="Find" placeholder="Find in document…" tabindex="0" data-l10n-id="pdfjs-find-input" aria-invalid="false">
+                      </span>
+                      <div class="toolbarHorizontalGroup">
+                        <button id="findPreviousButton" class="toolbarButton" type="button" title="Find the previous occurrence of the phrase" tabindex="0" data-l10n-id="pdfjs-find-previous-button">
+                          <span data-l10n-id="pdfjs-find-previous-button-label">Previous</span>
+                        </button>
+                        <div class="splitToolbarButtonSeparator"></div>
+                        <button id="findNextButton" class="toolbarButton" type="button" title="Find the next occurrence of the phrase" tabindex="0" data-l10n-id="pdfjs-find-next-button">
+                          <span data-l10n-id="pdfjs-find-next-button-label">Next</span>
+                        </button>
+                      </div>
+                    </div>
+
+                    <div id="findbarOptionsOneContainer" class="toolbarHorizontalGroup">
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findHighlightAll" tabindex="0" />
+                        <label for="findHighlightAll" data-l10n-id="pdfjs-find-highlight-checkbox">Highlight All</label>
+                      </div>
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findMatchCase" tabindex="0" />
+                        <label for="findMatchCase" data-l10n-id="pdfjs-find-match-case-checkbox-label">Match Case</label>
+                      </div>
+                    </div>
+                    <div id="findbarOptionsTwoContainer" class="toolbarHorizontalGroup">
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findMatchDiacritics" tabindex="0" />
+                        <label for="findMatchDiacritics" data-l10n-id="pdfjs-find-match-diacritics-checkbox-label">Match Diacritics</label>
+                      </div>
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findEntireWord" tabindex="0" />
+                        <label for="findEntireWord" data-l10n-id="pdfjs-find-entire-word-checkbox-label">Whole Words</label>
+                      </div>
+                    </div>
+
+                    <div id="findbarMessageContainer" class="toolbarHorizontalGroup" aria-live="polite">
+                      <span id="findResultsCount" class="toolbarLabel"></span>
+                      <span id="findMsg" class="toolbarLabel"></span>
+                    </div>
+                  </div>  <!-- findbar -->
+                </div>
+                <div class="toolbarHorizontalGroup hiddenSmallView">
+                  <button class="toolbarButton" title="Previous Page" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button">
                     <span data-l10n-id="pdfjs-previous-button-label">Previous</span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button class="toolbarButton" title="Next Page" id="next" type="button" tabindex="14" data-l10n-id="pdfjs-next-button">
+                  <button class="toolbarButton" type="button" title="Next Page" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
                     <span data-l10n-id="pdfjs-next-button-label">Next</span>
                   </button>
                 </div>
-                <span class="loadingInput start">
-                  <input type="number" id="pageNumber" class="toolbarField" title="Page" value="1" min="1" tabindex="15" data-l10n-id="pdfjs-page-input" autocomplete="off">
-                </span>
-                <span id="numPages" class="toolbarLabel"></span>
-              </div>
-              <div id="toolbarViewerRight">
-                <div id="editorModeButtons" class="splitToolbarButton toggled" role="radiogroup">
-                  <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled" title="Highlight" role="radio" aria-checked="false" aria-controls="editorHighlightParamsToolbar" tabindex="31" data-l10n-id="pdfjs-editor-highlight-button">
-                    <span data-l10n-id="pdfjs-editor-highlight-button-label">Highlight</span>
-                  </button>
-                  <button id="editorFreeTextButton" class="toolbarButton" type="button" disabled="disabled" title="Text" role="radio" aria-checked="false" aria-controls="editorFreeTextParamsToolbar" tabindex="32" data-l10n-id="pdfjs-editor-free-text-button">
-                    <span data-l10n-id="pdfjs-editor-free-text-button-label">Text</span>
-                  </button>
-                  <button id="editorInkButton" class="toolbarButton" type="button" disabled="disabled" title="Draw" role="radio" aria-checked="false" aria-controls="editorInkParamsToolbar" tabindex="33" data-l10n-id="pdfjs-editor-ink-button">
-                    <span data-l10n-id="pdfjs-editor-ink-button-label">Draw</span>
-                  </button>
-                  <button id="editorStampButton" class="toolbarButton" type="button" disabled="disabled" title="Add or edit images" role="radio" aria-checked="false" aria-controls="editorStampParamsToolbar" tabindex="34" data-l10n-id="pdfjs-editor-stamp-button">
-                    <span data-l10n-id="pdfjs-editor-stamp-button-label">Add or edit images</span>
-                  </button>
+                <div class="toolbarHorizontalGroup">
+                  <span class="loadingInput start toolbarHorizontalGroup">
+                    <input type="number" id="pageNumber" class="toolbarField" title="Page" value="1" min="1" tabindex="0" data-l10n-id="pdfjs-page-input" autocomplete="off">
+                  </span>
+                  <span id="numPages" class="toolbarLabel"></span>
                 </div>
-
-                <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
-
-                <button id="printButton" class="toolbarButton hiddenMediumView" type="button" title="Print" tabindex="41" data-l10n-id="pdfjs-print-button">
-                  <span data-l10n-id="pdfjs-print-button-label">Print</span>
-                </button>
-
-                <button id="downloadButton" class="toolbarButton hiddenMediumView" type="button" title="Save" tabindex="42" data-l10n-id="pdfjs-save-button">
-                  <span data-l10n-id="pdfjs-save-button-label">Save</span>
-                </button>
-
-                <div class="verticalToolbarSeparator hiddenMediumView"></div>
-
-                <button id="secondaryToolbarToggleButton" class="toolbarButton" type="button" title="Tools" tabindex="43" data-l10n-id="pdfjs-tools-button" aria-expanded="false" aria-controls="secondaryToolbar">
-                  <span data-l10n-id="pdfjs-tools-button-label">Tools</span>
-                </button>
               </div>
-              <div id="toolbarViewerMiddle">
-                <div class="splitToolbarButton">
-                  <button id="zoomOutButton" class="toolbarButton" type="button" title="Zoom Out" tabindex="21" data-l10n-id="pdfjs-zoom-out-button">
+              <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
+                <div class="toolbarHorizontalGroup">
+                  <button id="zoomOutButton" class="toolbarButton" type="button" title="Zoom Out" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
                     <span data-l10n-id="pdfjs-zoom-out-button-label">Zoom Out</span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button id="zoomInButton" class="toolbarButton" type="button" title="Zoom In" tabindex="22" data-l10n-id="pdfjs-zoom-in-button">
+                  <button id="zoomInButton" class="toolbarButton" type="button" title="Zoom In" tabindex="0" data-l10n-id="pdfjs-zoom-in-button">
                     <span data-l10n-id="pdfjs-zoom-in-button-label">Zoom In</span>
-                   </button>
+                  </button>
                 </div>
                 <span id="scaleSelectContainer" class="dropdownToolbarButton">
-                  <select id="scaleSelect" title="Zoom" tabindex="23" data-l10n-id="pdfjs-zoom-select">
+                  <select id="scaleSelect" title="Zoom" tabindex="0" data-l10n-id="pdfjs-zoom-select">
                     <option id="pageAutoOption" title="" value="auto" selected="selected" data-l10n-id="pdfjs-page-scale-auto">Automatic Zoom</option>
                     <option id="pageActualOption" title="" value="page-actual" data-l10n-id="pdfjs-page-scale-actual">Actual Size</option>
                     <option id="pageFitOption" title="" value="page-fit" data-l10n-id="pdfjs-page-scale-fit">Page Fit</option>
@@ -420,6 +237,211 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <option title="" value="4" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 400 }'>400%</option>
                   </select>
                 </span>
+              </div>
+              <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
+                <div id="editorModeButtons" class="toolbarHorizontalGroup" role="radiogroup">
+                  <div id="editorHighlight" class="toolbarButtonWithContainer">
+                    <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled" title="Highlight" role="radio" aria-expanded="false" aria-haspopup="true" aria-controls="editorHighlightParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-highlight-button">
+                      <span data-l10n-id="pdfjs-editor-highlight-button-label">Highlight</span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
+                      <div id="highlightParamsToolbarContainer" class="editorParamsToolbarContainer">
+                        <div id="editorHighlightColorPicker" class="colorPicker">
+                          <span id="highlightColorPickerLabel" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-colorpicker-label">Highlight color</span>
+                        </div>
+                        <div id="editorHighlightThickness">
+                          <label for="editorFreeHighlightThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-highlight-thickness-input">Thickness</label>
+                          <div class="thicknessPicker">
+                            <input type="range" id="editorFreeHighlightThickness" class="editorParamsSlider" data-l10n-id="pdfjs-editor-free-highlight-thickness-title" value="12" min="8" max="24" step="1" tabindex="0">
+                          </div>
+                        </div>
+                        <div id="editorHighlightVisibility">
+                          <div class="divider"></div>
+                          <div class="toggler">
+                            <label for="editorHighlightShowAll" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-show-all-button-label">Show all</label>
+                            <button id="editorHighlightShowAll" class="toggle-button" type="button" data-l10n-id="pdfjs-editor-highlight-show-all-button" aria-pressed="true" tabindex="0"></button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorFreeText" class="toolbarButtonWithContainer">
+                    <button id="editorFreeTextButton" class="toolbarButton" type="button" disabled="disabled" title="Text" role="radio" aria-expanded="false" aria-haspopup="true" aria-controls="editorFreeTextParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-free-text-button">
+                      <span data-l10n-id="pdfjs-editor-free-text-button-label">Text</span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
+                      <div class="editorParamsToolbarContainer">
+                        <div class="editorParamsSetter">
+                          <label for="editorFreeTextColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-color-input">Color</label>
+                          <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0">
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-size-input">Size</label>
+                          <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="0">
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorInk" class="toolbarButtonWithContainer">
+                    <button id="editorInkButton" class="toolbarButton" type="button" disabled="disabled" title="Draw" role="radio" aria-expanded="false" aria-haspopup="true" aria-controls="editorInkParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-ink-button">
+                      <span data-l10n-id="pdfjs-editor-ink-button-label">Draw</span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
+                      <div class="editorParamsToolbarContainer">
+                        <div class="editorParamsSetter">
+                          <label for="editorInkColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-color-input">Color</label>
+                          <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0">
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-thickness-input">Thickness</label>
+                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="0">
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input">Opacity</label>
+                          <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="100" min="1" max="100" step="1" tabindex="0">
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorStamp" class="toolbarButtonWithContainer">
+                    <button id="editorStampButton" class="toolbarButton" type="button" disabled="disabled" title="Add or edit images" role="radio" aria-expanded="false" aria-haspopup="true" aria-controls="editorStampParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-stamp-button">
+                      <span data-l10n-id="pdfjs-editor-stamp-button-label">Add or edit images</span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorStampParamsToolbar">
+                      <div class="menuContainer">
+                        <button id="editorStampAddImage" class="toolbarButton labeled" type="button" title="Add image" tabindex="0" data-l10n-id="pdfjs-editor-stamp-add-image-button">
+                          <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label">Add image</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
+
+                <div class="toolbarHorizontalGroup hiddenMediumView">
+                  <button id="printButton" class="toolbarButton" type="button" title="Print" tabindex="0" data-l10n-id="pdfjs-print-button">
+                    <span data-l10n-id="pdfjs-print-button-label">Print</span>
+                  </button>
+
+                  <button id="downloadButton" class="toolbarButton" type="button" title="Save" tabindex="0" data-l10n-id="pdfjs-save-button">
+                    <span data-l10n-id="pdfjs-save-button-label">Save</span>
+                  </button>
+                </div>
+
+                <div class="verticalToolbarSeparator hiddenMediumView"></div>
+
+                <div id="secondaryToolbarToggle" class="toolbarButtonWithContainer">
+                  <button id="secondaryToolbarToggleButton" class="toolbarButton" type="button" title="Tools" tabindex="0" data-l10n-id="pdfjs-tools-button" aria-expanded="false" aria-haspopup="true" aria-controls="secondaryToolbar">
+                    <span data-l10n-id="pdfjs-tools-button-label">Tools</span>
+                  </button>
+                  <div id="secondaryToolbar" class="hidden doorHangerRight">
+                    <div id="secondaryToolbarButtonContainer" class="menuContainer">
+<!--#if GENERIC-->
+                      <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" title="Open File" tabindex="0" data-l10n-id="pdfjs-open-file-button">
+                        <span data-l10n-id="pdfjs-open-file-button-label">Open</span>
+                      </button>
+<!--#endif-->
+
+                      <div class="visibleMediumView">
+                        <button id="secondaryPrint" class="toolbarButton labeled" type="button" title="Print" tabindex="0" data-l10n-id="pdfjs-print-button">
+                          <span data-l10n-id="pdfjs-print-button-label">Print</span>
+                        </button>
+
+                        <button id="secondaryDownload" class="toolbarButton labeled" type="button" title="Save" tabindex="0" data-l10n-id="pdfjs-save-button">
+                          <span data-l10n-id="pdfjs-save-button-label">Save</span>
+                        </button>
+
+<!--#if !GENERIC-->
+<!--            <div class="horizontalToolbarSeparator"></div>-->
+<!--#endif-->
+                      </div>
+
+<!--#if GENERIC-->
+                      <div class="horizontalToolbarSeparator"></div>
+<!--#endif-->
+
+                      <button id="presentationMode" class="toolbarButton labeled" type="button" title="Switch to Presentation Mode" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button">
+                        <span data-l10n-id="pdfjs-presentation-mode-button-label">Presentation Mode</span>
+                      </button>
+
+                      <a href="#" id="viewBookmark" class="toolbarButton labeled" title="Current Page (View URL from Current Page)" tabindex="0" data-l10n-id="pdfjs-bookmark-button">
+                        <span data-l10n-id="pdfjs-bookmark-button-label">Current Page</span>
+                      </a>
+
+                      <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>
+
+                      <button id="firstPage" class="toolbarButton labeled" type="button" title="Go to First Page" tabindex="0" data-l10n-id="pdfjs-first-page-button">
+                        <span data-l10n-id="pdfjs-first-page-button-label">Go to First Page</span>
+                      </button>
+                      <button id="lastPage" class="toolbarButton labeled" type="button" title="Go to Last Page" tabindex="0" data-l10n-id="pdfjs-last-page-button">
+                        <span data-l10n-id="pdfjs-last-page-button-label">Go to Last Page</span>
+                      </button>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <button id="pageRotateCw" class="toolbarButton labeled" type="button" title="Rotate Clockwise" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button">
+                        <span data-l10n-id="pdfjs-page-rotate-cw-button-label">Rotate Clockwise</span>
+                      </button>
+                      <button id="pageRotateCcw" class="toolbarButton labeled" type="button" title="Rotate Counterclockwise" tabindex="0" data-l10n-id="pdfjs-page-rotate-ccw-button">
+                        <span data-l10n-id="pdfjs-page-rotate-ccw-button-label">Rotate Counterclockwise</span>
+                      </button>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <div id="cursorToolButtons" role="radiogroup">
+                        <button id="cursorSelectTool" class="toolbarButton labeled toggled" type="button" title="Enable Text Selection Tool" tabindex="0" data-l10n-id="pdfjs-cursor-text-select-tool-button" role="radio" aria-checked="true">
+                          <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label">Text Selection Tool</span>
+                        </button>
+                        <button id="cursorHandTool" class="toolbarButton labeled" type="button" title="Enable Hand Tool" tabindex="0" data-l10n-id="pdfjs-cursor-hand-tool-button" role="radio" aria-checked="false">
+                          <span data-l10n-id="pdfjs-cursor-hand-tool-button-label">Hand Tool</span>
+                        </button>
+                      </div>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <div id="scrollModeButtons" role="radiogroup">
+                        <button id="scrollPage" class="toolbarButton labeled" type="button" title="Use Page Scrolling" tabindex="0" data-l10n-id="pdfjs-scroll-page-button" role="radio" aria-checked="false">
+                          <span data-l10n-id="pdfjs-scroll-page-button-label">Page Scrolling</span>
+                        </button>
+                        <button id="scrollVertical" class="toolbarButton labeled toggled" type="button" title="Use Vertical Scrolling" tabindex="0" data-l10n-id="pdfjs-scroll-vertical-button" role="radio" aria-checked="true">
+                          <span data-l10n-id="pdfjs-scroll-vertical-button-label">Vertical Scrolling</span>
+                        </button>
+                        <button id="scrollHorizontal" class="toolbarButton labeled" type="button" title="Use Horizontal Scrolling" tabindex="0" data-l10n-id="pdfjs-scroll-horizontal-button" role="radio" aria-checked="false">
+                          <span data-l10n-id="pdfjs-scroll-horizontal-button-label">Horizontal Scrolling</span>
+                        </button>
+                        <button id="scrollWrapped" class="toolbarButton labeled" type="button" title="Use Wrapped Scrolling" tabindex="0" data-l10n-id="pdfjs-scroll-wrapped-button" role="radio" aria-checked="false">
+                          <span data-l10n-id="pdfjs-scroll-wrapped-button-label">Wrapped Scrolling</span>
+                        </button>
+                      </div>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <div id="spreadModeButtons" role="radiogroup">
+                        <button id="spreadNone" class="toolbarButton labeled toggled" type="button" title="Do not join page spreads" tabindex="0" data-l10n-id="pdfjs-spread-none-button" role="radio" aria-checked="true">
+                          <span data-l10n-id="pdfjs-spread-none-button-label">No Spreads</span>
+                        </button>
+                        <button id="spreadOdd" class="toolbarButton labeled" type="button" title="Join page spreads starting with odd-numbered pages" tabindex="0" data-l10n-id="pdfjs-spread-odd-button" role="radio" aria-checked="false">
+                          <span data-l10n-id="pdfjs-spread-odd-button-label">Odd Spreads</span>
+                        </button>
+                        <button id="spreadEven" class="toolbarButton labeled" type="button" title="Join page spreads starting with even-numbered pages" tabindex="0" data-l10n-id="pdfjs-spread-even-button" role="radio" aria-checked="false">
+                          <span data-l10n-id="pdfjs-spread-even-button-label">Even Spreads</span>
+                        </button>
+                      </div>
+
+                      <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
+                      <button id="imageAltTextSettings" type="button" class="toolbarButton labeled hidden" title="Image alt text settings" tabindex="0" data-l10n-id="pdfjs-image-alt-text-settings-button" aria-controls="altTextSettingsDialog">
+                        <span data-l10n-id="pdfjs-image-alt-text-settings-button-label">Image alt text settings</span>
+                      </button>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <button id="documentProperties" class="toolbarButton labeled" type="button" title="Document Properties…" tabindex="0" data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
+                        <span data-l10n-id="pdfjs-document-properties-button-label">Document Properties…</span>
+                      </button>
+                    </div>
+                  </div>  <!-- secondaryToolbar -->
+                </div>
               </div>
             </div>
             <div id="loadingBar">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -37,6 +37,7 @@ window.PDFViewerApplicationOptions = AppOptions;
 function getViewerConfiguration() {
   return {
     appContainer: document.body,
+    principalContainer: document.getElementById("mainContainer"),
     mainContainer: document.getElementById("viewerContainer"),
     viewerContainer: document.getElementById("viewer"),
     toolbar: {


### PR DESCRIPTION
The first goal of this patch was to remove the tabindex because it helps to improve overall a11y. That led to move some html elements associated with the buttons which helped to position these elements relatively to their buttons.
Consequently it was easy to change the toolbar height (configurable in Firefox with the pref browser.uidensity): it's the second goal of this patch. For a11y reasons we want to be able to change the height of the toolbar to make the buttons larger.