### PR TITLE
Move the internal API/Worker `isEditing`-state into `RenderingIntentFlag`

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -411,7 +411,6 @@ class Page {
     intent,
     cacheKey,
     annotationStorage = null,
-    isEditing = false,
     modifiedIds = null,
   }) {
     const contentStreamPromise = this.getContentStream();
@@ -570,6 +569,7 @@ class Page {
         return { length: pageOpList.totalLength };
       }
       const renderForms = !!(intent & RenderingIntentFlag.ANNOTATIONS_FORMS),
+        isEditing = !!(intent & RenderingIntentFlag.IS_EDITING),
         intentAny = !!(intent & RenderingIntentFlag.ANY),
         intentDisplay = !!(intent & RenderingIntentFlag.DISPLAY),
         intentPrint = !!(intent & RenderingIntentFlag.PRINT);

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -752,7 +752,6 @@ class WorkerMessageHandler {
             intent: data.intent,
             cacheKey: data.cacheKey,
             annotationStorage: data.annotationStorage,
-            isEditing: data.isEditing,
             modifiedIds: data.modifiedIds,
           })
           .then(

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1818,7 +1818,6 @@ class PDFPageProxy {
     renderingIntent,
     cacheKey,
     annotationStorageSerializable,
-    isEditing,
     modifiedIds,
   }) {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
@@ -1836,7 +1835,6 @@ class PDFPageProxy {
         intent: renderingIntent,
         cacheKey,
         annotationStorage: map,
-        isEditing,
         modifiedIds,
       },
       transfer
@@ -2473,6 +2471,9 @@ class WorkerTransport {
         warn(`getRenderingIntent - invalid annotationMode: ${annotationMode}`);
     }
 
+    if (isEditing) {
+      renderingIntent += RenderingIntentFlag.IS_EDITING;
+    }
     if (isOpList) {
       renderingIntent += RenderingIntentFlag.OPLIST;
     }
@@ -2483,7 +2484,6 @@ class WorkerTransport {
     const cacheKeyBuf = [
       renderingIntent,
       annotationStorageSerializable.hash,
-      isEditing ? 1 : 0,
       modifiedIdsHash,
     ];
 
@@ -2491,7 +2491,6 @@ class WorkerTransport {
       renderingIntent,
       cacheKey: cacheKeyBuf.join("_"),
       annotationStorageSerializable,
-      isEditing,
       modifiedIds,
     };
   }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -41,10 +41,12 @@ const BASELINE_FACTOR = LINE_DESCENT_FACTOR / LINE_FACTOR;
  * how these flags are being used:
  *  - ANY, DISPLAY, and PRINT are the normal rendering intents, note the
  *    `PDFPageProxy.{render, getOperatorList, getAnnotations}`-methods.
+ *  - SAVE is used, on the worker-thread, when saving modified annotations.
  *  - ANNOTATIONS_FORMS, ANNOTATIONS_STORAGE, ANNOTATIONS_DISABLE control which
  *    annotations are rendered onto the canvas (i.e. by being included in the
  *    operatorList), note the `PDFPageProxy.{render, getOperatorList}`-methods
  *    and their `annotationMode`-option.
+ *  - IS_EDITING is used when editing is active in the viewer.
  *  - OPLIST is used with the `PDFPageProxy.getOperatorList`-method, note the
  *    `OperatorList`-constructor (on the worker-thread).
  */
@@ -56,6 +58,7 @@ const RenderingIntentFlag = {
   ANNOTATIONS_FORMS: 0x10,
   ANNOTATIONS_STORAGE: 0x20,
   ANNOTATIONS_DISABLE: 0x40,
+  IS_EDITING: 0x80,
   OPLIST: 0x100,
 };
 


### PR DESCRIPTION
In *hindsight* this seems like a better idea, since it avoids the need to manually pass `isEditing` around as a boolean value.
Note that `RenderingIntentFlag` is *internal* functionality, not exposed in the official API, which means that it can be extended and modified as necessary.