### PR TITLE
Check the relevant parameters inside of the `mustBeViewedWhenEditing` method

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -777,8 +777,8 @@ class Annotation {
     return this.printable;
   }
 
-  mustBeViewedWhenEditing() {
-    return !this.data.isEditable;
+  mustBeViewedWhenEditing(isEditing, modifiedIds = null) {
+    return isEditing ? !this.data.isEditable : !modifiedIds?.has(this.data.id);
   }
 
   /**

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -582,8 +582,7 @@ class Page {
           intentAny ||
           (intentDisplay &&
             annotation.mustBeViewed(annotationStorage, renderForms) &&
-            ((isEditing && annotation.mustBeViewedWhenEditing()) ||
-              (!isEditing && !modifiedIds?.has(annotation.data.id)))) ||
+            annotation.mustBeViewedWhenEditing(isEditing, modifiedIds)) ||
           (intentPrint && annotation.mustBePrinted(annotationStorage))
         ) {
           opListPromises.push(


### PR DESCRIPTION
Similar to the `mustBeViewed` method, we can check the relevant parameters within the `mustBeViewedWhenEditing` method itself since that (in my opinion) slightly helps readability of the code in the `src/core/document.js` file.