### PR TITLE
Remove the `renderForms` parameter from the Annotation `getOperatorList` methods

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1105,13 +1105,7 @@ class Annotation {
     });
   }
 
-  async getOperatorList(
-    evaluator,
-    task,
-    intent,
-    renderForms,
-    annotationStorage
-  ) {
+  async getOperatorList(evaluator, task, intent, annotationStorage) {
     const { hasOwnCanvas, id, rect } = this.data;
     let appearance = this.appearance;
     const isUsingOwnCanvas = !!(
@@ -1959,17 +1953,11 @@ class WidgetAnnotation extends Annotation {
     return str;
   }
 
-  async getOperatorList(
-    evaluator,
-    task,
-    intent,
-    renderForms,
-    annotationStorage
-  ) {
+  async getOperatorList(evaluator, task, intent, annotationStorage) {
     // Do not render form elements on the canvas when interactive forms are
     // enabled. The display layer is responsible for rendering them instead.
     if (
-      renderForms &&
+      intent & RenderingIntentFlag.ANNOTATIONS_FORMS &&
       !(this instanceof SignatureWidgetAnnotation) &&
       !this.data.noHTML &&
       !this.data.hasOwnCanvas
@@ -1982,13 +1970,7 @@ class WidgetAnnotation extends Annotation {
     }
 
     if (!this._hasText) {
-      return super.getOperatorList(
-        evaluator,
-        task,
-        intent,
-        renderForms,
-        annotationStorage
-      );
+      return super.getOperatorList(evaluator, task, intent, annotationStorage);
     }
 
     const content = await this._getAppearance(
@@ -1998,13 +1980,7 @@ class WidgetAnnotation extends Annotation {
       annotationStorage
     );
     if (this.appearance && content === null) {
-      return super.getOperatorList(
-        evaluator,
-        task,
-        intent,
-        renderForms,
-        annotationStorage
-      );
+      return super.getOperatorList(evaluator, task, intent, annotationStorage);
     }
 
     const opList = new OperatorList();
@@ -2934,13 +2910,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
     }
   }
 
-  async getOperatorList(
-    evaluator,
-    task,
-    intent,
-    renderForms,
-    annotationStorage
-  ) {
+  async getOperatorList(evaluator, task, intent, annotationStorage) {
     if (this.data.pushButton) {
       return super.getOperatorList(
         evaluator,
@@ -2962,13 +2932,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
     if (value === null && this.appearance) {
       // Nothing in the annotationStorage.
       // But we've a default appearance so use it.
-      return super.getOperatorList(
-        evaluator,
-        task,
-        intent,
-        renderForms,
-        annotationStorage
-      );
+      return super.getOperatorList(evaluator, task, intent, annotationStorage);
     }
 
     if (value === null || value === undefined) {
@@ -3001,7 +2965,6 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
         evaluator,
         task,
         intent,
-        renderForms,
         annotationStorage
       );
       this.appearance = savedAppearance;

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -592,7 +592,6 @@ class Page {
                 partialEvaluator,
                 task,
                 intent,
-                renderForms,
                 annotationStorage
               )
               .catch(function (reason) {

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1768,7 +1768,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList.argsArray.length).toEqual(3);
@@ -2523,7 +2522,6 @@ describe("annotation", function () {
         checkboxEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList.argsArray.length).toEqual(5);
@@ -2584,7 +2582,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList1.argsArray.length).toEqual(3);
@@ -2608,7 +2605,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList2.argsArray.length).toEqual(3);
@@ -2670,7 +2666,6 @@ describe("annotation", function () {
           partialEvaluator,
           task,
           RenderingIntentFlag.PRINT,
-          false,
           annotationStorage
         );
         expect(opList.argsArray.length).toEqual(3);
@@ -2732,7 +2727,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList.argsArray.length).toEqual(3);
@@ -2986,7 +2980,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList1.argsArray.length).toEqual(3);
@@ -3010,7 +3003,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList2.argsArray.length).toEqual(3);
@@ -3070,7 +3062,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         annotationStorage
       );
       expect(opList.argsArray.length).toEqual(3);
@@ -4242,7 +4233,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         null
       );
 
@@ -4503,7 +4493,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         null
       );
 
@@ -4672,7 +4661,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         null
       );
 
@@ -4791,7 +4779,6 @@ describe("annotation", function () {
         partialEvaluator,
         task,
         RenderingIntentFlag.PRINT,
-        false,
         null
       );
 


### PR DESCRIPTION
The `renderForms` parameter pre-dates the introduction of the general `intent` parameter, which means that we're now effectively passing the same state twice to these `getOperatorList` methods.