### PR TITLE
Attempt to improve support for using the PDF.js builds with Vite

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,7 @@
 
   "globals": {
     "PDFJSDev": "readonly",
-    "__non_webpack_import__": "readonly",
+    "__raw_import__": "readonly",
   },
 
   "rules": {

--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -168,17 +168,21 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
           path.replaceWith(t.inherits(t.valueToNode(result), path.node));
         }
 
-        if (t.isIdentifier(node.callee, { name: "__non_webpack_import__" })) {
+        if (t.isIdentifier(node.callee, { name: "__raw_import__" })) {
           if (node.arguments.length !== 1) {
-            throw new Error("Invalid `__non_webpack_import__` usage.");
+            throw new Error("Invalid `__raw_import__` usage.");
           }
-          // Replace it with a standard `import`-call and
-          // ensure that Webpack will leave it alone.
+          // Replace it with a standard `import`-call and attempt to ensure
+          // that various bundlers will leave it alone.
           const source = node.arguments[0];
           source.leadingComments = [
             {
               type: "CommentBlock",
               value: "webpackIgnore: true",
+            },
+            {
+              type: "CommentBlock",
+              value: "@vite-ignore",
             },
           ];
           path.replaceWith(t.importExpression(source));

--- a/external/builder/fixtures_babel/importalias-expected.js
+++ b/external/builder/fixtures_babel/importalias-expected.js
@@ -1,4 +1,7 @@
 import { Test } from "import-name";
 import { Test2 } from './non-alias';
 export { Test3 } from "import-name";
-await import( /*webpackIgnore: true*/"./non-alias");
+await import(
+/*webpackIgnore: true*/
+/*@vite-ignore*/
+"./non-alias");

--- a/external/builder/fixtures_babel/importalias.js
+++ b/external/builder/fixtures_babel/importalias.js
@@ -1,4 +1,4 @@
 import { Test } from 'import-alias';
 import { Test2 } from './non-alias';
 export { Test3 } from 'import-alias';
-await __non_webpack_import__("./non-alias");
+await __raw_import__("./non-alias");

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2336,7 +2336,7 @@ class PDFWorker {
       const worker =
         typeof PDFJSDev === "undefined"
           ? await import("pdfjs/pdf.worker.js")
-          : await __non_webpack_import__(this.workerSrc);
+          : await __raw_import__(this.workerSrc);
       return worker.WorkerMessageHandler;
     };
 

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -35,19 +35,19 @@ if (isNodeJS) {
 
   const loadPackages = async () => {
     // Native packages.
-    const fs = await __non_webpack_import__("fs"),
-      http = await __non_webpack_import__("http"),
-      https = await __non_webpack_import__("https"),
-      url = await __non_webpack_import__("url");
+    const fs = await __raw_import__("fs"),
+      http = await __raw_import__("http"),
+      https = await __raw_import__("https"),
+      url = await __raw_import__("url");
 
     // Optional, third-party, packages.
     let canvas, path2d;
     if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("SKIP_BABEL")) {
       try {
-        canvas = await __non_webpack_import__("canvas");
+        canvas = await __raw_import__("canvas");
       } catch {}
       try {
-        path2d = await __non_webpack_import__("path2d");
+        path2d = await __raw_import__("path2d");
       } catch {}
     }
 

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -24,8 +24,8 @@ if (!isNodeJS) {
   );
 }
 
-const path = await __non_webpack_import__("path");
-const url = await __non_webpack_import__("url");
+const path = await __raw_import__("path");
+const url = await __raw_import__("url");
 
 describe("node_stream", function () {
   let tempServer = null;

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -21,8 +21,8 @@ import { Ref } from "../../src/core/primitives.js";
 let fs, http;
 if (isNodeJS) {
   // Native packages.
-  fs = await __non_webpack_import__("fs");
-  http = await __non_webpack_import__("http");
+  fs = await __raw_import__("fs");
+  http = await __raw_import__("http");
 }
 
 const TEST_PDFS_PATH = isNodeJS ? "./test/pdfs/" : "../pdfs/";

--- a/web/app.js
+++ b/web/app.js
@@ -278,7 +278,7 @@ const PDFViewerApplication = {
       const { PDFBug } =
         typeof PDFJSDev === "undefined"
           ? await import(AppOptions.get("debuggerSrc")) // eslint-disable-line no-unsanitized/method
-          : await __non_webpack_import__(AppOptions.get("debuggerSrc"));
+          : await __raw_import__(AppOptions.get("debuggerSrc"));
 
       this._PDFBug = PDFBug;
     };
@@ -290,7 +290,7 @@ const PDFViewerApplication = {
         if (typeof PDFJSDev === "undefined") {
           globalThis.pdfjsWorker = await import("pdfjs/pdf.worker.js");
         } else {
-          await __non_webpack_import__(PDFWorker.workerSrc);
+          await __raw_import__(PDFWorker.workerSrc);
         }
       } catch (ex) {
         console.error(`_parseHashParams: "${ex.message}".`);

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -45,7 +45,7 @@ class GenericScripting {
       const sandbox =
         typeof PDFJSDev === "undefined"
           ? import(sandboxBundleSrc) // eslint-disable-line no-unsanitized/method
-          : __non_webpack_import__(sandboxBundleSrc);
+          : __raw_import__(sandboxBundleSrc);
       sandbox
         .then(pdfjsSandbox => {
           resolve(pdfjsSandbox.QuickJSSandbox());


### PR DESCRIPTION
Similar to Webpack there's apparently other bundlers that will not leave `import`-calls alone unless magic comments are used. Hence we extend the builder to also append `/* @vite-ignore */` comments to `import`-calls, in order to attempt to improve support for using the PDF.js builds together with Vite.

This patch also renames `__non_webpack_import__` to `__raw_import__` since the functionality is no longer bundle-specific.

Fixes https://github.com/mozilla/pdf.js/issues/17245#issuecomment-2165766280

---

***Please note:*** This will further increase the maintenance/support burden of the general PDF.js library, for a feature that's completely unused within the project itself.
Hence, if you'd like to see this patch landed, please contact me privately to discuss sponsoring this work (email address can be found in my GitHub profile).