### PR TITLE
Fix the "caches image resources at the document/page level as expected (issue 11878)" unit test

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4155,7 +4155,7 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
             checkedCopyLocalImage = true;
             // Ensure that the image was copied in the main-thread, rather
             // than being re-parsed in the worker-thread (which is slower).
-            expect(statsOverall).toBeLessThan(firstStatsOverall / 4);
+            expect(statsOverall).toBeLessThan(firstStatsOverall / 2);
           }
         }
       }


### PR DESCRIPTION
This unit test fails occasionally (albeit much less than before thanks to PR #17663), so we change the parsing time check's divisor to prevent it from happening again. If the last page's rendering time is less than or equal to 50% of the first page's rendering time that should be enough proof that no worker thread re-parsing occurred while also providing a wide enough range to avoid intermittents.

Note that the assertion is now equal to the one we already have in the "caches image resources at the document/page level, with main-thread copying of complex images (issue 11518)" unit test which seems to work reliably so far.

Fixes #18403.