### PR TITLE
[DO-NOT-MERGE] Debug freetext scroll intermittent

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -3535,7 +3535,7 @@ describe("FreeText Editor", () => {
       await closePages(pages);
     });
 
-    it("must check that a freetext is still there after having updated it and scroll the doc", async () => {
+    fit("must check that a freetext is still there after having updated it and scroll the doc", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToFreeText(page);
@@ -3649,8 +3649,11 @@ describe("FreeText Editor", () => {
           editorPng = await page.screenshot({
             clip: editorRect,
             type: "png",
+            encoding: "base64",
           });
-          editorImage = PNG.sync.read(editorPng);
+          console.log("Base64 image: ", editorPng);
+
+          editorImage = PNG.sync.read(Buffer.from(editorPng, 'base64'));
           expect(editorImage.data.every(x => x === 0xff))
             .withContext(`In ${browserName}`)
             .toBeFalse();


### PR DESCRIPTION
I can't reproduce the issue for the `FreeText Editor Update a freetext and scroll must check that a freetext is still there after having updated it and scroll the doc` integration test locally, but it fails quite often on the Windows bot, so this patch should help us see what the bots see to figure out what goes wrong. The idea is to dump the screenshot, including one with a larger area, to a base64-encoded PNG so we can convert it back to an image locally to see if the annotation is even in the area or not. I did notice that the screenshot even locally is not entirely what I would have expected, but this patch aims to find out if that's an issue or not.