### PR TITLE
Fix `ensureMinFontSizeComputed` calculation if `<body>` is a flex container

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -480,6 +480,7 @@ class TextLayer {
     div.style.opacity = 0;
     div.style.lineHeight = 1;
     div.style.fontSize = "1px";
+    div.style.position = "absolute";
     div.textContent = "X";
     document.body.append(div);
     // In `display:block` elements contain a single line of text,


### PR DESCRIPTION
Given:

```css
html,
body {
  height: 100%;
}

body {
  display: flex;
}
```

The `<div>` appended to the `<body>` will take up the full height of the
viewport due to the implicit `align-items: stretch` of flex containers.

This results in an incorrect computed `minFontSize` value.

---

## Reproduction

I isolated the calculation to demonstrate the issue:

```js
function calculateMinFontSize() {
  const div = document.createElement("div");
  div.style.opacity = 0;
  div.style.lineHeight = 1;
  div.style.fontSize = "1px";
  div.textContent = "X";
  document.body.append(div);
  const height = div.getBoundingClientRect().height;
  div.remove();

  document.body.textContent = height + "px";
}

calculateMinFontSize();
window.addEventListener("resize", calculateMinFontSize);
```

https://codepen.io/razh/pen/OJePRMd/c9d3a97fb8c2f7df89f193808a3f3a02?editors=1111

This can also be reproduced at:

https://mozilla.github.io/pdf.js/web/viewer.html

By applying `display: flex` to the `<body>` tag (`opacity: 0` removed from `.textLayer` for visibility):

Without `display: flex`|With `display: flex`
:-|:-
![CleanShot 2024-07-10 at 03 03 35@2x (Before)](https://github.com/mozilla/pdf.js/assets/240770/5a356c37-ece6-4415-ab0f-74cabec55afc)|![CleanShot 2024-07-10 at 03 03 26@2x (After)](https://github.com/mozilla/pdf.js/assets/240770/91861903-cde9-451a-aaa7-39c2d04a9994)
