### PR TITLE
[Editor] Avoid error when an editor is unselected during the pdf.js closing

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -1581,7 +1581,7 @@ class AnnotationEditor {
     if (this.div?.contains(document.activeElement)) {
       // Don't use this.div.blur() because we don't know where the focus will
       // go.
-      this._uiManager.currentLayer.div.focus({
+      this.currentLayer?.div.focus({
         preventScroll: true,
       });
     }


### PR DESCRIPTION
It aims to fix an error I noticed in the logs:
JavaScript error: http://127.0.0.1:65159/build/generic/build/pdf.mjs, line 15847: TypeError: can't access property "div", currentLayer is undefined