### PR TITLE
[Editor] Add an option to use the new 'add an image' flow (bug 1907207)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -55,6 +55,10 @@
       "type": "boolean",
       "default": false
     },
+    "enableUpdatedAddImage": {
+      "type": "boolean",
+      "default": false
+    },
     "cursorToolOnLoad": {
       "title": "Cursor tool on load",
       "description": "The cursor tool that is enabled upon load.\n 0 = Text selection tool.\n 1 = Hand tool.",

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -562,6 +562,8 @@ class AnnotationEditorUIManager {
 
   #enableHighlightFloatingButton = false;
 
+  #enableUpdatedAddImage = false;
+
   #filterFactory = null;
 
   #focusMainContainerTimeoutId = null;
@@ -779,6 +781,7 @@ class AnnotationEditorUIManager {
     pageColors,
     highlightColors,
     enableHighlightFloatingButton,
+    enableUpdatedAddImage,
     mlManager
   ) {
     this._signal = this.#abortController.signal;
@@ -798,6 +801,7 @@ class AnnotationEditorUIManager {
     this.#pageColors = pageColors;
     this.#highlightColors = highlightColors || null;
     this.#enableHighlightFloatingButton = enableHighlightFloatingButton;
+    this.#enableUpdatedAddImage = enableUpdatedAddImage;
     this.#mlManager = mlManager || null;
     this.viewParameters = {
       realScale: PixelsPerInch.PDF_TO_CSS_UNITS,
@@ -853,6 +857,10 @@ class AnnotationEditorUIManager {
 
   isMLEnabledFor(name) {
     return !!this.#mlManager?.isEnabledFor(name);
+  }
+
+  get useNewAltTextFlow() {
+    return this.#enableUpdatedAddImage;
   }
 
   get hcmFilter() {

--- a/web/app.js
+++ b/web/app.js
@@ -477,6 +477,7 @@ const PDFViewerApplication = {
       enableHighlightFloatingButton: AppOptions.get(
         "enableHighlightFloatingButton"
       ),
+      enableUpdatedAddImage: AppOptions.get("enableUpdatedAddImage"),
       imageResourcesPath: AppOptions.get("imageResourcesPath"),
       enablePrintAutoRotate: AppOptions.get("enablePrintAutoRotate"),
       maxCanvasPixels: AppOptions.get("maxCanvasPixels"),

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -178,6 +178,14 @@ const defaultOptions = {
     value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  enableUpdatedAddImage: {
+    // We'll probably want to make some experiments before enabling this
+    // in Firefox release, but it has to be temporary.
+    // TODO: remove it when unnecessary.
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   externalLinkRel: {
     /** @type {string} */
     value: "noopener noreferrer nofollow",

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -219,6 +219,8 @@ class PDFViewer {
 
   #enablePermissions = false;
 
+  #enableUpdatedAddImage = false;
+
   #eventAbortController = null;
 
   #mlManager = null;
@@ -291,6 +293,7 @@ class PDFViewer {
       options.annotationEditorHighlightColors || null;
     this.#enableHighlightFloatingButton =
       options.enableHighlightFloatingButton === true;
+    this.#enableUpdatedAddImage = options.enableUpdatedAddImage === true;
     this.imageResourcesPath = options.imageResourcesPath || "";
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
@@ -890,6 +893,7 @@ class PDFViewer {
               pageColors,
               this.#annotationEditorHighlightColors,
               this.#enableHighlightFloatingButton,
+              this.#enableUpdatedAddImage,
               this.#mlManager
             );
             eventBus.dispatch("annotationeditoruimanager", {


### PR DESCRIPTION
UX team designed in a new flow we'll implement soon and we want to be able to make an experiment to be able to compare current flow vs the new one.