### PR TITLE
Fix `DOMFilterFactory.#createUrl` in MOZCENTRAL builds (18417 PR follow-up)

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -124,22 +124,20 @@ class DOMFilterFactory extends BaseFilterFactory {
   }
 
   #createUrl(id) {
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      if (this.#baseUrl === undefined) {
-        const url = this.#document.URL;
-        if (url === this.#document.baseURI) {
-          // No `<base>`-element present, hence a relative URL should work.
-          this.#baseUrl = "";
-        } else if (isDataScheme(url)) {
+    if (this.#baseUrl === undefined) {
+      // Unless a `<base>`-element is present a relative URL should work.
+      this.#baseUrl = "";
+
+      const url = this.#document.URL;
+      if (url !== this.#document.baseURI) {
+        if (isDataScheme(url)) {
           warn('#createUrl: ignore "data:"-URL for performance reasons.');
-          this.#baseUrl = "";
         } else {
           this.#baseUrl = url.split("#", 1)[0];
         }
       }
-      return `url(${this.#baseUrl}#${id})`;
     }
-    return `url(${id})`;
+    return `url(${this.#baseUrl}#${id})`;
   }
 
   addFilter(maps) {


### PR DESCRIPTION
Somehow I managed to mess up the URL creation relevant to e.g. MOZCENTRAL builds, which is breaking the pending PDF.js update in mozilla-central; sorry about that!