### PR TITLE
Disable network connections to Contile for the tests

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -944,6 +944,8 @@ async function startBrowser({
       "accessibility.browsewithcaret": true,
       // Disable the newtabpage stuff.
       "browser.newtabpage.enabled": false,
+      // Disable network connections to Contile.
+      "browser.topsites.contile.enabled": false,
       ...extraPrefsFirefox,
     };
   }


### PR DESCRIPTION
In PR #18356 the new tab page logic was disabled to prevent Firefox from logging failed network connections to Contile, the Mozilla Tiles service that is used for the new tab page [1]. However, recently this log reappeared locally and on the bots:

```
console.warn: TopSitesFeed: Failed to fetch data from Contile server:
NetworkError when attempting to fetch resource.
```

It looks like Contile communication is also triggered from other places in Firefox such as the URL bar [2], so this commit fixes the issue by disabling network connections to Contile [3] altogether regardless of their origin within Firefox. Note that we don't revert the change from PR #18356 because as noted in [4] it can't hurt to keep that disabled too to avoid overhead for a feature we don't use in the tests.

[1] https://github.com/mozilla-services/contile
[2] https://github.com/mozilla/gecko-dev/blob/196ef8360e4d3b5c334f1f8f91b3b1fdb434eb63/browser/components/urlbar/UrlbarProviderTopSites.sys.mjs#L38
[3] https://github.com/mozilla/gecko-dev/blob/196ef8360e4d3b5c334f1f8f91b3b1fdb434eb63/browser/components/newtab/lib/TopSitesFeed.sys.mjs#L111
[4] https://github.com/mozilla/pdf.js/pull/18356#issuecomment-2200354730