### PR TITLE
Draw tool should warn users that it shouldn't be used for redaction #18203

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1422,6 +1422,23 @@ dialog :link {
   z-index: 50000; /* should be higher than anything else in PDF.js! */
 }
 
+.note-section {
+  margin-top: 10px;
+  padding: 10px;
+  border-top: 1px solid #ccc;
+}
+
+.note-title {
+  font-weight: bold;
+  margin-bottom: 5px;
+  color: #d9534f;
+}
+
+.note-text {
+  font-size: 12px;
+  color: #555;
+}
+
 @page {
   margin: 0;
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -550,8 +550,6 @@ See https://github.com/adobe-type-tools/cmap-resources
                 </div>
               </div>
             </div>
-            <button id="editButton">Edit</button>
-            <button id="saveButton">Save</button>
             <div id="buttons">
               <button id="altTextCancel" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-cancel-button">Cancel</span></button>
               <button id="altTextSave" class="primaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button">Save</span></button>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -221,6 +221,12 @@ See https://github.com/adobe-type-tools/cmap-resources
               <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input">Opacity</label>
               <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="100" min="1" max="100" step="1" tabindex="107">
             </div>
+            <div class="note-section">
+              <p class="note-title">Note:</p>
+              <p class="note-text">
+                Drawings created with the draw tool can easily be removed. You should not use the draw tool to obscure or redact content.
+              </p>
+            </div>
           </div>
         </div>
 
@@ -544,6 +550,8 @@ See https://github.com/adobe-type-tools/cmap-resources
                 </div>
               </div>
             </div>
+            <button id="editButton">Edit</button>
+            <button id="saveButton">Save</button>
             <div id="buttons">
               <button id="altTextCancel" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-cancel-button">Cancel</span></button>
               <button id="altTextSave" class="primaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button">Save</span></button>


### PR DESCRIPTION
Changes:
![moziallapdf](https://github.com/user-attachments/assets/b1593063-d562-4069-8206-e024f39f10af)

Added a notice to the draw tool UI: "Drawings created with the draw tool can easily be removed. You should not use the draw tool to obscure or redact content."

Reason for Change:
Some users may mistakenly believe that the draw tool permanently removes content, potentially exposing sensitive information. This notice aims to prevent such misunderstandings and ensure that users are fully aware of the limitations of the draw tool in terms of content removal