### PR TITLE
Include additional data when fetching browser preferences in the PDF Viewer (bug 1908401)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -155,7 +155,6 @@ const PDFViewerApplication = {
   isViewerEmbedded: window.parent !== window,
   url: "",
   baseUrl: "",
-  _allowedGlobalEventsPromise: null,
   _downloadUrl: "",
   _eventBusAbortController: null,
   _windowAbortController: null,
@@ -175,31 +174,12 @@ const PDFViewerApplication = {
   _printAnnotationStoragePromise: null,
   _touchInfo: null,
   _isCtrlKeyDown: false,
-  _nimbusDataPromise: null,
   _caretBrowsing: null,
   _isScrolling: false,
 
   // Called once when the document is loaded.
   async initialize(appConfig) {
-    let l10nPromise;
-    // In the (various) extension builds, where the locale is set automatically,
-    // initialize the `L10n`-instance as soon as possible.
-    if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("GENERIC")) {
-      l10nPromise = this.externalServices.createL10n();
-      if (PDFJSDev.test("MOZCENTRAL")) {
-        this._allowedGlobalEventsPromise =
-          this.externalServices.getGlobalEventNames();
-      }
-    }
     this.appConfig = appConfig;
-
-    if (
-      typeof PDFJSDev === "undefined"
-        ? window.isGECKOVIEW
-        : PDFJSDev.test("GECKOVIEW")
-    ) {
-      this._nimbusDataPromise = this.externalServices.getNimbusExperimentData();
-    }
 
     // Ensure that `Preferences`, and indirectly `AppOptions`, have initialized
     // before creating e.g. the various viewer components.
@@ -229,10 +209,7 @@ const PDFViewerApplication = {
 
     // Ensure that the `L10n`-instance has been initialized before creating
     // e.g. the various viewer components.
-    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      l10nPromise = this.externalServices.createL10n();
-    }
-    this.l10n = await l10nPromise;
+    this.l10n = await this.externalServices.createL10n();
     document.getElementsByTagName("html")[0].dir = this.l10n.getDirection();
     // Connect Fluent, when necessary, and translate what we already have.
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
@@ -394,11 +371,10 @@ const PDFViewerApplication = {
     let eventBus;
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       eventBus = AppOptions.eventBus = new FirefoxEventBus(
-        await this._allowedGlobalEventsPromise,
+        AppOptions.get("allowedGlobalEvents"),
         externalServices,
         AppOptions.get("isInAutomation")
       );
-      this._allowedGlobalEventsPromise = null;
     } else {
       eventBus = new EventBus();
     }
@@ -564,11 +540,10 @@ const PDFViewerApplication = {
           ? window.isGECKOVIEW
           : PDFJSDev.test("GECKOVIEW")
       ) {
-        this.toolbar = new Toolbar(
-          appConfig.toolbar,
-          eventBus,
-          await this._nimbusDataPromise
+        const nimbusData = JSON.parse(
+          AppOptions.get("nimbusDataStr") || "null"
         );
+        this.toolbar = new Toolbar(appConfig.toolbar, eventBus, nimbusData);
       } else {
         this.toolbar = new Toolbar(
           appConfig.toolbar,

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -56,6 +56,11 @@ const OptionKind = {
  *       primitive types and cannot rely on any imported types.
  */
 const defaultOptions = {
+  allowedGlobalEvents: {
+    /** @type {Object} */
+    value: null,
+    kind: OptionKind.BROWSER,
+  },
   canvasMaxAreaInBytes: {
     /** @type {number} */
     value: -1,
@@ -64,6 +69,16 @@ const defaultOptions = {
   isInAutomation: {
     /** @type {boolean} */
     value: false,
+    kind: OptionKind.BROWSER,
+  },
+  localeProperties: {
+    /** @type {Object} */
+    value: null,
+    kind: OptionKind.BROWSER,
+  },
+  nimbusDataStr: {
+    /** @type {string} */
+    value: "",
     kind: OptionKind.BROWSER,
   },
   supportsCaretBrowsingMode: {

--- a/web/external_services.js
+++ b/web/external_services.js
@@ -45,12 +45,6 @@ class BaseExternalServices {
     throw new Error("Not implemented: updateEditorStates");
   }
 
-  async getNimbusExperimentData() {}
-
-  async getGlobalEventNames() {
-    return null;
-  }
-
   dispatchGlobalEvent(_event) {}
 }
 

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -14,6 +14,7 @@
  */
 
 import { isPdfFile, PDFDataRangeTransport } from "pdfjs-lib";
+import { AppOptions } from "./app_options.js";
 import { BaseExternalServices } from "./external_services.js";
 import { BasePreferences } from "./preferences.js";
 import { DEFAULT_SCALE_VALUE } from "./ui_utils.js";
@@ -396,30 +397,12 @@ class ExternalServices extends BaseExternalServices {
   }
 
   async createL10n() {
-    const [localeProperties] = await Promise.all([
-      FirefoxCom.requestAsync("getLocaleProperties", null),
-      document.l10n.ready,
-    ]);
-    return new L10n(localeProperties, document.l10n);
+    await document.l10n.ready;
+    return new L10n(AppOptions.get("localeProperties"), document.l10n);
   }
 
   createScripting() {
     return FirefoxScripting;
-  }
-
-  async getNimbusExperimentData() {
-    if (!PDFJSDev.test("GECKOVIEW")) {
-      return null;
-    }
-    const nimbusData = await FirefoxCom.requestAsync(
-      "getNimbusExperimentData",
-      null
-    );
-    return nimbusData && JSON.parse(nimbusData);
-  }
-
-  async getGlobalEventNames() {
-    return FirefoxCom.requestAsync("getGlobalEventNames", null);
   }
 
   dispatchGlobalEvent(event) {


### PR DESCRIPTION
To avoid having to request and await various browser data early during the PDF Viewer initialization, we can include that data in the existing preference fetching instead. With other planned changes to the PDF Viewer, the current situation would only become worse over time.

*Note:* Technically this data aren't preference-values, however we're already including other non-prefs in this list (e.g. `isInAutomation`) and doing it this way simplifies the overall implementation.