### PR TITLE
Re-factor the code to remove all uses of `PDFViewerApplication.downloadComplete`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1188,17 +1188,12 @@ const PDFViewerApplication = {
   },
 
   progress(level) {
-    if (!this.loadingBar || this.downloadComplete) {
-      // Don't accidentally show the loading bar again when the entire file has
-      // already been fetched (only an issue when disableAutoFetch is enabled).
-      return;
-    }
     const percent = Math.round(level * 100);
     // When we transition from full request to range requests, it's possible
     // that we discard some of the loaded data. This can cause the loading
     // bar to move backwards. So prevent this by only updating the bar if it
     // increases.
-    if (percent <= this.loadingBar.percent) {
+    if (!this.loadingBar || percent <= this.loadingBar.percent) {
       return;
     }
     this.loadingBar.percent = percent;

--- a/web/app.js
+++ b/web/app.js
@@ -151,7 +151,6 @@ const PDFViewerApplication = {
   /** @type {AnnotationEditorParams} */
   annotationEditorParams: null,
   isInitialViewSet: false,
-  downloadComplete: false,
   isViewerEmbedded: window.parent !== window,
   url: "",
   baseUrl: "",
@@ -942,7 +941,6 @@ const PDFViewerApplication = {
     this.pdfLinkService.externalLinkEnabled = true;
     this.store = null;
     this.isInitialViewSet = false;
-    this.downloadComplete = false;
     this.url = "";
     this.baseUrl = "";
     this._downloadUrl = "";
@@ -1072,12 +1070,9 @@ const PDFViewerApplication = {
   async download(options = {}) {
     let data;
     try {
-      if (this.downloadComplete) {
-        data = await this.pdfDocument.getData();
-      }
+      data = await this.pdfDocument.getData();
     } catch {
-      // When the PDF document isn't ready, or the PDF file is still
-      // downloading, simply download using the URL.
+      // When the PDF document isn't ready, simply download using the URL.
     }
     this.downloadManager.download(
       data,
@@ -1216,7 +1211,6 @@ const PDFViewerApplication = {
 
     pdfDocument.getDownloadInfo().then(({ length }) => {
       this._contentLength = length; // Ensure that the correct length is used.
-      this.downloadComplete = true;
       this.loadingBar?.hide();
 
       firstPagePromise.then(() => {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -740,7 +740,7 @@ class ProgressBar {
   }
 
   setDisableAutoFetch(delay = /* ms = */ 5000) {
-    if (isNaN(this.#percent)) {
+    if (this.#percent === 100 || isNaN(this.#percent)) {
       return;
     }
     if (this.#disableAutoFetchTimeout) {


### PR DESCRIPTION
 - **Stop using `downloadComplete` in `PDFViewerApplication.progress`**
   
   This was only necessary to prevent (unlikely) visual glitches when `disableAutoFetch = true` is being used.
   However, it turns out that we can move this functionality into the `ProgressBar` class instead by checking if the entire PDF document has loaded. This works since the API is always reporting 100% loading progress regardless of how the document was loaded; see [this code](https://github.com/mozilla/pdf.js/blob/ed83d7c5e16798a56c493d56aaa8200dd280bb17/src/display/api.js#L2735-L2740).

 - **Avoid downloading the document twice in `PDFViewerApplication.download`**
   
   The old implementation in `PDFViewerApplication.download` means that if the `getDocument`-call hasn't yet downloaded the *entire* PDF document it will be re-downloaded. This seems generally undesirable since:
    - In some (probably rare) cases a URL may not be valid an arbitrary number of times, which means that the download may fail.
    - It will lead to wasted resources, since we'll end up fetching the same PDF document *twice* in that case (once via the `getDocument`-call and once to allow the user to save it).

   Hence this patch suggests that we change this very old code to instead always call the `PDFDocumentProxy.getData` method, since that'll trigger immediate downloading of the remaining document via the existing `getDocument`-call.

   Finally, the patch removes the `PDFViewerApplication.downloadComplete` property since it's now unused.
