### PR TITLE
Reduce a tiny bit of duplication in `PDFViewerApplication.setTitleUsingUrl`

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -859,14 +859,12 @@ const PDFViewerApplication = {
     let title = getPdfFilenameFromUrl(url, "");
     if (!title) {
       try {
-        title = decodeURIComponent(getFilenameFromUrl(url)) || url;
+        title = decodeURIComponent(getFilenameFromUrl(url));
       } catch {
-        // decodeURIComponent may throw URIError,
-        // fall back to using the unprocessed url in that case
-        title = url;
+        // decodeURIComponent may throw URIError.
       }
     }
-    this.setTitle(title);
+    this.setTitle(title || url); // Always fallback to the raw URL.
   },
 
   setTitle(title = this._title) {


### PR DESCRIPTION
Rather than repeating code, we can always fallback to the raw URL instead.