### PR TITLE
Disable system fonts on Android (issue 18210)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1003,16 +1003,6 @@ const PDFViewerApplication = {
       AppOptions.set("docBaseUrl", this.baseUrl);
     }
 
-    // On Android, there is almost no chance to have the font we want so we
-    // don't use the system fonts in this case.
-    if (
-      typeof PDFJSDev === "undefined"
-        ? window.isGECKOVIEW
-        : PDFJSDev.test("GECKOVIEW")
-    ) {
-      args.useSystemFonts = false;
-    }
-
     // Set the necessary API parameters, using all the available options.
     const apiParams = AppOptions.getAll(OptionKind.API);
     const loadingTask = getDocument({

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -506,23 +506,23 @@ class AppOptions {
   static getAll(kind = null, defaultOnly = false) {
     const options = Object.create(null);
     for (const name in defaultOptions) {
-      const defaultOption = defaultOptions[name];
+      const defaultOpt = defaultOptions[name];
 
-      if (kind && !(kind & defaultOption.kind)) {
+      if (kind && !(kind & defaultOpt.kind)) {
         continue;
       }
       options[name] =
         !defaultOnly && userOptions.has(name)
           ? userOptions.get(name)
-          : defaultOption.value;
+          : defaultOpt.value;
     }
     return options;
   }
 
   static set(name, value) {
-    const defaultOption = defaultOptions[name];
+    const defaultOpt = defaultOptions[name];
 
-    if (!defaultOption || typeof value !== typeof defaultOption.value) {
+    if (!defaultOpt || typeof value !== typeof defaultOpt.value) {
       return;
     }
     userOptions.set(name, value);
@@ -532,23 +532,23 @@ class AppOptions {
     let events;
 
     for (const name in options) {
-      const defaultOption = defaultOptions[name],
-        userOption = options[name];
+      const defaultOpt = defaultOptions[name],
+        userOpt = options[name];
 
-      if (!defaultOption || typeof userOption !== typeof defaultOption.value) {
+      if (!defaultOpt || typeof userOpt !== typeof defaultOpt.value) {
         continue;
       }
       if (prefs) {
-        const { kind } = defaultOption;
+        const { kind } = defaultOpt;
 
         if (!(kind & OptionKind.BROWSER || kind & OptionKind.PREFERENCE)) {
           continue;
         }
         if (this.eventBus && kind & OptionKind.EVENT_DISPATCH) {
-          (events ||= new Map()).set(name, userOption);
+          (events ||= new Map()).set(name, userOpt);
         }
       }
-      userOptions.set(name, userOption);
+      userOptions.set(name, userOpt);
     }
 
     if (events) {

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -42,6 +42,12 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 
 <!--#if !MOZCENTRAL-->
+    <script>
+      if (typeof PDFJSDev === "undefined") {
+        window.isGECKOVIEW = true;
+      }
+    </script>
+
     <script type="importmap">
       {
         "imports": {

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -60,9 +60,6 @@ function getViewerConfiguration() {
 function webViewerLoad() {
   const config = getViewerConfiguration();
 
-  if (typeof PDFJSDev === "undefined") {
-    window.isGECKOVIEW = true;
-  }
   PDFViewerApplication.run(config);
 }
 


### PR DESCRIPTION
To avoid introducing any inline "hacks" in the viewer-code this meant adding `useSystemFonts` to the AppOptions, which thus required some new functionality since the default value should be `undefined` given how the option is handled in the API; note [this code](https://github.com/mozilla/pdf.js/blob/ed83d7c5e16798a56c493d56aaa8200dd280bb17/src/display/api.js#L298-L301).

Finally, also moves the definition of the development-mode `window.isGECKOVIEW` property to the HTML file such that it's guaranteed to be set regardless of how and when it's accessed.