### PR TITLE
Move the `Preferences` initialization as early as possible

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -139,7 +139,7 @@ const PDFViewerApplication = {
   /** @type {OverlayManager} */
   overlayManager: null,
   /** @type {Preferences} */
-  preferences: null,
+  preferences: new Preferences(),
   /** @type {Toolbar} */
   toolbar: null,
   /** @type {SecondaryToolbar} */
@@ -638,7 +638,6 @@ const PDFViewerApplication = {
   },
 
   async run(config) {
-    this.preferences = new Preferences();
     await this.initialize(config);
 
     const { appConfig, eventBus } = this;


### PR DESCRIPTION
Given that the entire default viewer initialization depends on the preferences being available, try to do this as early as possible.