### PR TITLE
Re-factor how the "docBaseUrl" API-option is set in the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -854,7 +854,13 @@ const PDFViewerApplication = {
     }
     if (isDataScheme(url)) {
       this._hideViewBookmark();
+    } else if (
+      typeof PDFJSDev !== "undefined" &&
+      PDFJSDev.test("MOZCENTRAL || CHROME")
+    ) {
+      AppOptions.set("docBaseUrl", this.baseUrl);
     }
+
     let title = getPdfFilenameFromUrl(url, "");
     if (!title) {
       try {
@@ -995,13 +1001,6 @@ const PDFViewerApplication = {
         args.originalUrl || args.url,
         /* downloadUrl = */ args.url
       );
-    }
-    // Always set `docBaseUrl` in development mode, and in the (various)
-    // extension builds.
-    if (typeof PDFJSDev === "undefined") {
-      AppOptions.set("docBaseUrl", document.URL.split("#", 1)[0]);
-    } else if (PDFJSDev.test("MOZCENTRAL || CHROME")) {
-      AppOptions.set("docBaseUrl", this.baseUrl);
     }
 
     // Set the necessary API parameters, using all the available options.

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -345,7 +345,7 @@ const defaultOptions = {
   },
   docBaseUrl: {
     /** @type {string} */
-    value: "",
+    value: typeof PDFJSDev === "undefined" ? document.URL.split("#", 1)[0] : "",
     kind: OptionKind.API,
   },
   enableHWA: {


### PR DESCRIPTION
This option is old enough that it predates e.g. the introduction of AppOptions, so it probably cannot hurt to re-factor this a little bit now.

 - In development-mode we can just set this directly in AppOptions.

 - In the extension-builds we still need to set it dynamically, however by moving this code we get the benefit of being able to avoid storing a data-URL in that case; note how [the API ignores those anyway](https://github.com/mozilla/pdf.js/blob/98e772727e70dcad6433b5f02e027d6724b912f4/src/display/api.js#L256-L262).
