### PR TITLE
Disable link annotations during text selection

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -173,7 +173,7 @@ async function getSpanRectFromText(page, pageNumber, text) {
   return page.evaluate(
     (number, content) => {
       for (const el of document.querySelectorAll(
-        `.page[data-page-number="${number}"] > .textLayer > span`
+        `.page[data-page-number="${number}"] > .textLayer span:not(:has(> span))`
       )) {
         if (el.textContent === content) {
           const { x, y, width, height } = el.getBoundingClientRect();

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -126,6 +126,10 @@
     }
   }
 
+  .textLayer.selecting ~ & section {
+    pointer-events: none;
+  }
+
   :is(.linkAnnotation, .buttonWidgetAnnotation.pushButton) > a {
     position: absolute;
     font-size: 1em;

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -118,9 +118,9 @@
     z-index: 0;
     cursor: default;
     user-select: none;
+  }
 
-    &.active {
-      top: 0;
-    }
+  &.selecting .endOfContent {
+    top: 0;
   }
 }

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -150,8 +150,8 @@ class TextLayerBuilder {
   #bindMouse(end) {
     const { div } = this;
 
-    div.addEventListener("mousedown", evt => {
-      end.classList.add("active");
+    div.addEventListener("mousedown", () => {
+      div.classList.add("selecting");
     });
 
     div.addEventListener("copy", event => {
@@ -193,13 +193,39 @@ class TextLayerBuilder {
         end.style.width = "";
         end.style.height = "";
       }
-      end.classList.remove("active");
+      textLayer.classList.remove("selecting");
     };
 
+    let isPointerDown = false;
+    document.addEventListener(
+      "pointerdown",
+      () => {
+        isPointerDown = true;
+      },
+      { signal }
+    );
     document.addEventListener(
       "pointerup",
       () => {
+        isPointerDown = false;
         this.#textLayers.forEach(reset);
+      },
+      { signal }
+    );
+    window.addEventListener(
+      "blur",
+      () => {
+        isPointerDown = false;
+        this.#textLayers.forEach(reset);
+      },
+      { signal }
+    );
+    document.addEventListener(
+      "keyup",
+      () => {
+        if (!isPointerDown) {
+          this.#textLayers.forEach(reset);
+        }
       },
       { signal }
     );
@@ -237,7 +263,7 @@ class TextLayerBuilder {
 
         for (const [textLayerDiv, endDiv] of this.#textLayers) {
           if (activeTextLayers.has(textLayerDiv)) {
-            endDiv.classList.add("active");
+            textLayerDiv.classList.add("selecting");
           } else {
             reset(endDiv, textLayerDiv);
           }


### PR DESCRIPTION
Commit message:

> **Disable link annotations during text selection**
>
> When selecting text, hovering over an element causes all the text between (according the the dom order) the current selection and that element to be selected.
> 
> This means that when, while selecting, the cursor moves over a link, all the text in the page gets selected. Setting `user-select: none` on the link annotations would improve the situation, but it still makes it impossible to extend the selection within a link without using Shift+arrows keys on the keyboard.
> 
> This commit fixes the problem by setting `pointer-events: none` on the `<section>`s in the annotation layer while selecting some text. This way, they are ignored for hit-testing and do not affect selection.
> 
> It is still impossible to _start_ a selection inside a link, as the link text is covered by the link annotation.
> 
> Fixes #18266

A lot of changes are just indentation: the `selectionchange` event handler has a single changed line, and the pre-existing tests none. I recommend reviewing with whitespace diff disabled.