### PR TITLE
Remove the `streamqueue` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "postcss-nesting": "^12.1.5",
         "prettier": "^3.3.3",
         "puppeteer": "^22.13.0",
-        "streamqueue": "^1.1.2",
         "stylelint": "^16.7.0",
         "stylelint-prettier": "^5.0.0",
         "terser-webpack-plugin": "^5.3.10",
@@ -8553,12 +8552,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -12402,19 +12395,6 @@
       "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/streamqueue": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-1.1.2.tgz",
-      "integrity": "sha512-CHUpqa+1BM99z7clQz9W6L9ZW4eXRRQCR0H+utVAGGvNo2ePlJAFjhdK0IjunaBbY/gWKJawk5kpJeyz0EXxRA==",
-      "dev": true,
-      "dependencies": {
-        "isstream": "^0.1.2",
-        "readable-stream": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=6.9.5"
-      }
     },
     "node_modules/streamx": {
       "version": "2.18.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "postcss-nesting": "^12.1.5",
     "prettier": "^3.3.3",
     "puppeteer": "^22.13.0",
-    "streamqueue": "^1.1.2",
     "stylelint": "^16.7.0",
     "stylelint-prettier": "^5.0.0",
     "terser-webpack-plugin": "^5.3.10",


### PR DESCRIPTION
The `streamqueue` dependency is only used for the test targets in the Gulpfile to make sure that the test types are run in series. This is done by modelling the test processes as readable streams and then having `streamqueue` combine them into a single readable stream for Gulp that processes the inner readable streams in series (in contrast to the `ordered-read-streams` dependency which is very similar but processes the inner streams in parallel).

However, modelling the test processes as readable streams is a bit odd because we're not actually streaming any data as one might expect. Instead, we only use them to signal test process completion/abortion.

Fortunately nowadays, with modern Gulp versions, we don't need readable streams and `streamqueue` anymore because we can achieve the same result with simple asynchronous functions that can be passed to e.g. `gulp.series()` calls. Note that we already do this in various places, and overall it should be a better fit for test process invocations.

_I have run all affected test targets locally to confirm that they still work and run the test types in series like before. Moreover, I have triggered the error paths to make sure those didn't change either._

Fixes #18474.