### PR TITLE
Replace the GENERIC-only "locale" with "localeProperties" in AppOptions

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -336,7 +336,7 @@ const PDFViewerApplication = {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
       params.has("locale")
     ) {
-      AppOptions.set("locale", params.get("locale"));
+      AppOptions.set("localeProperties", { lang: params.get("locale") });
     }
 
     // Set some specific preferences for tests.

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -90,7 +90,10 @@ const defaultOptions = {
   },
   localeProperties: {
     /** @type {Object} */
-    value: null,
+    value:
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
+        ? { lang: navigator.language || "en-US" }
+        : null,
     kind: OptionKind.BROWSER,
   },
   nimbusDataStr: {
@@ -466,11 +469,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   defaultOptions.disablePreferences = {
     /** @type {boolean} */
     value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER,
-  };
-  defaultOptions.locale = {
-    /** @type {string} */
-    value: navigator.language || "en-US",
     kind: OptionKind.VIEWER,
   };
 } else if (PDFJSDev.test("CHROME")) {

--- a/web/genericcom.js
+++ b/web/genericcom.js
@@ -39,7 +39,7 @@ class Preferences extends BasePreferences {
 
 class ExternalServices extends BaseExternalServices {
   async createL10n() {
-    return new GenericL10n(AppOptions.get("locale"));
+    return new GenericL10n(AppOptions.get("localeProperties")?.lang);
   }
 
   createScripting() {


### PR DESCRIPTION
Since "localeProperties" is needed in Firefox, let's remove a tiny bit of option duplication by using it in the GENERIC builds as well.
For convenience, the old debug-only "locale" hash-parameter is kept intact.