### PR TITLE
Shorten the errors mentioning API parameters in `BaseCMapReaderFactory` and `BaseStandardFontDataFactory`

### DIFF
--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -111,8 +111,7 @@ class BaseCMapReaderFactory {
   async fetch({ name }) {
     if (!this.baseUrl) {
       throw new Error(
-        'The CMap "baseUrl" parameter must be specified, ensure that ' +
-          'the "cMapUrl" and "cMapPacked" API parameters are provided.'
+        "Ensure that the `cMapUrl` and `cMapPacked` API parameters are provided."
       );
     }
     if (!name) {
@@ -149,8 +148,7 @@ class BaseStandardFontDataFactory {
   async fetch({ filename }) {
     if (!this.baseUrl) {
       throw new Error(
-        'The standard font "baseUrl" parameter must be specified, ensure that ' +
-          'the "standardFontDataUrl" API parameter is provided.'
+        "Ensure that the `standardFontDataUrl` API parameter is provided."
       );
     }
     if (!filename) {

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -222,8 +222,7 @@ describe("cmap", function () {
     } catch (reason) {
       expect(reason instanceof Error).toEqual(true);
       expect(reason.message).toEqual(
-        'The CMap "baseUrl" parameter must be specified, ensure that ' +
-          'the "cMapUrl" and "cMapPacked" API parameters are provided.'
+        "Ensure that the `cMapUrl` and `cMapPacked` API parameters are provided."
       );
     }
   });


### PR DESCRIPTION
The current error-messages also mention internal parameters, which an end-user obviously don't have to care about. So, let's try to avoid confusion here by only including the API parameters.