### PR TITLE
Stop testing in Node.js 21 since it's reached end-of-life

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, lts/*, 21]
+        node-version: [18, lts/*]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
According to https://github.com/nodejs/release?tab=readme-ov-file#end-of-life-releases Node.js 21 stopped being supported on 2024-06-01, which is almost two months ago now, hence it seems pointless to keep testing in that environment.