### PR TITLE
Remove the `globals` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-sort-exports": "^0.9.1",
         "eslint-plugin-unicorn": "^55.0.0",
-        "globals": "^15.8.0",
         "gulp": "^5.0.0",
         "gulp-cli": "^3.0.0",
         "gulp-postcss": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-sort-exports": "^0.9.1",
     "eslint-plugin-unicorn": "^55.0.0",
-    "globals": "^15.8.0",
     "gulp": "^5.0.0",
     "gulp-cli": "^3.0.0",
     "gulp-postcss": "^10.0.0",


### PR DESCRIPTION
This dependency got introduced in PR #10293, almost six years ago now, because `eslint-plugin-mozilla` didn't work without it but also didn't require it as a dependency itself.

However, nowadays `eslint-plugin-mozilla` works just fine without it, and other dependencies that need it correctly require it themselves. This can be seen using `npm ls globals`:

```
$ npm ls globals
pdf.js
├─┬ @babel/core@7.24.9
│ └─┬ @babel/traverse@7.25.0
│   └── globals@11.12.0
├─┬ @babel/preset-env@7.25.0
│ └─┬ @babel/plugin-transform-classes@7.25.0
│   └── globals@11.12.0
├─┬ eslint-plugin-unicorn@55.0.0
│ └── globals@15.8.0 deduped
├─┬ eslint@8.57.0
│ ├─┬ @eslint/eslintrc@2.1.4
│ │ └── globals@13.24.0
│ └── globals@13.24.0
└── globals@15.8.0
```

Further proof that `eslint-plugin-mozilla` (no longer) uses `globals` is from a source code search in
https://searchfox.org/mozilla-central/search?q=globals&path=&case=false&regexp=false. The only results for `eslint-plugin-mozilla` refer to a file named `globals.js`, but the `globals` NPM package is not actually imported anywhere.

Given this we should be able to safely get rid of this explicit dependency on our end now.

Fixes a part of #18354.