### PR TITLE
Improve how the findbar's toggle button is referenced in the viewer code

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -717,7 +717,7 @@ const PDFViewerApplication = {
     }
 
     if (this.supportsIntegratedFind) {
-      appConfig.toolbar?.viewFind?.classList.add("hidden");
+      appConfig.findBar?.toggleButton?.classList.add("hidden");
     }
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -38,7 +38,6 @@ import {
  * @property {HTMLButtonElement} next - Button to go to the next page.
  * @property {HTMLButtonElement} zoomIn - Button to zoom in the pages.
  * @property {HTMLButtonElement} zoomOut - Button to zoom out the pages.
- * @property {HTMLButtonElement} viewFind - Button to open find bar.
  * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
  *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -49,7 +49,6 @@ function getViewerConfiguration() {
       next: document.getElementById("next"),
       zoomIn: document.getElementById("zoomIn"),
       zoomOut: document.getElementById("zoomOut"),
-      viewFind: document.getElementById("viewFind"),
       print: document.getElementById("print"),
       editorFreeTextButton: document.getElementById("editorFreeText"),
       editorFreeTextParamsToolbar: document.getElementById(


### PR DESCRIPTION
The sidebar and secondary toolbar both have a reference to their toggle buttons in their own sections in `getViewerConfiguration`, so it makes sense for the findbar to do the same.

While we actually have a findbar-specific reference to the toggle button, I noticed that we don't use it consistently because the toolbar also has a reference to the exact same toggle button and we use both in the code. This is probably for historical reasons: the docstring in the toolbar file indicates that the `viewFind` element is an input to the component, but that option is never actually used in the code itself.

This commit fixes the issue by removing the toolbar-specific reference, since it's not actually used (anymore) in the toolbar code, so that we consistently use the findbar-specific reference everywhere.