### PR TITLE
Fix the unable to select highlighted text issue

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -115,7 +115,7 @@
   section {
     position: absolute;
     text-align: initial;
-    pointer-events: auto;
+    pointer-events: none;
     box-sizing: border-box;
     transform-origin: 0 0;
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/issues/18190
The "burnt in" highlighted text couldn't be selected earlier, setting `pointer-events: none` fixes this.