### PR TITLE
Move all event listeners into `Toolbar.prototype.#bindListeners`

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -118,31 +118,7 @@ class Toolbar {
     // Bind the event listeners for click and various other actions.
     this.#bindListeners(buttons);
 
-    if (options.editorHighlightColorPicker) {
-      eventBus._on(
-        "annotationeditoruimanager",
-        ({ uiManager }) => {
-          this.#setAnnotationEditorUIManager(
-            uiManager,
-            options.editorHighlightColorPicker
-          );
-        },
-        // Once the color picker has been added, we don't want to add it again.
-        { once: true }
-      );
-    }
-
-    eventBus._on("showannotationeditorui", ({ mode }) => {
-      switch (mode) {
-        case AnnotationEditorType.HIGHLIGHT:
-          options.editorHighlightButton.click();
-          break;
-      }
-    });
-
-    eventBus._on("toolbardensity", this.#updateToolbarDensity.bind(this));
     this.#updateToolbarDensity({ value: toolbarDensity });
-
     this.reset();
   }
 
@@ -188,7 +164,12 @@ class Toolbar {
 
   #bindListeners(buttons) {
     const { eventBus } = this;
-    const { pageNumber, scaleSelect } = this.#opts;
+    const {
+      editorHighlightColorPicker,
+      editorHighlightButton,
+      pageNumber,
+      scaleSelect,
+    } = this.#opts;
     const self = this;
 
     // The buttons within the toolbar.
@@ -243,6 +224,28 @@ class Toolbar {
       "annotationeditormodechanged",
       this.#editorModeChanged.bind(this)
     );
+    eventBus._on("showannotationeditorui", ({ mode }) => {
+      switch (mode) {
+        case AnnotationEditorType.HIGHLIGHT:
+          editorHighlightButton.click();
+          break;
+      }
+    });
+    eventBus._on("toolbardensity", this.#updateToolbarDensity.bind(this));
+
+    if (editorHighlightColorPicker) {
+      eventBus._on(
+        "annotationeditoruimanager",
+        ({ uiManager }) => {
+          this.#setAnnotationEditorUIManager(
+            uiManager,
+            editorHighlightColorPicker
+          );
+        },
+        // Once the color picker has been added, we don't want to add it again.
+        { once: true }
+      );
+    }
   }
 
   #editorModeChanged({ mode }) {


### PR DESCRIPTION
Over time a couple of event listeners have been placed in the constructor, despite there being an existing helper method for that purpose. To improve the code organization, let's move these to the intended method instead.