### PR TITLE
[Editor] Allow Float32Array for quadpoints in annotations (bug 1907958)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -242,10 +242,19 @@ function isBooleanArray(arr, len) {
  * @returns {boolean}
  */
 function isNumberArray(arr, len) {
+  if (Array.isArray(arr)) {
+    return (
+      (len === null || arr.length === len) &&
+      arr.every(x => typeof x === "number")
+    );
+  }
+
+  // This check allows us to have typed arrays but not the
+  // BigInt64Array/BigUint64Array types (their elements aren't "number").
   return (
-    Array.isArray(arr) &&
-    (len === null || arr.length === len) &&
-    arr.every(x => typeof x === "number")
+    ArrayBuffer.isView(arr) &&
+    (arr.length === 0 || typeof arr[0] === "number") &&
+    (len === null || arr.length === len)
   );
 }
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -610,7 +610,7 @@ class Driver {
 
         if (task.annotationStorage) {
           for (const annotation of Object.values(task.annotationStorage)) {
-            const { bitmapName } = annotation;
+            const { bitmapName, quadPoints } = annotation;
             if (bitmapName) {
               promise = promise.then(async doc => {
                 const response = await fetch(
@@ -642,6 +642,11 @@ class Driver {
 
                 return doc;
               });
+            }
+            if (quadPoints) {
+              // Just to ensure that the quadPoints are always a Float32Array
+              // like IRL (in order to avoid bugs like bug 1907958).
+              annotation.quadPoints = new Float32Array(quadPoints);
             }
           }
         }


### PR DESCRIPTION
Added annotations could have some quadpoints (highlight, ink). The isNumberArray check was returning false and consequently the annotation wasn't printable.
The tests didn't catch this issue because the quadpoints were passed as Array.
So driver.js has been updated in order to pass them as Float32Array in order to be in a situation similar to the real life one.