### PR TITLE
Inline single-line event handlers in the `web/app.js` file

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1886,10 +1886,9 @@ const PDFViewerApplication = {
   },
 
   triggerPrinting() {
-    if (!this.supportsPrinting) {
-      return;
+    if (this.supportsPrinting) {
+      window.print();
     }
-    window.print();
   },
 
   bindEvents() {
@@ -1900,6 +1899,10 @@ const PDFViewerApplication = {
 
     const {
       eventBus,
+      externalServices,
+      pdfDocumentProperties,
+      pdfViewer,
+      preferences,
       _eventBusAbortController: { signal },
     } = this;
 
@@ -1916,44 +1919,60 @@ const PDFViewerApplication = {
     eventBus._on("sidebarviewchanged", webViewerSidebarViewChanged, { signal });
     eventBus._on("pagemode", webViewerPageMode, { signal });
     eventBus._on("namedaction", webViewerNamedAction, { signal });
-    eventBus._on("presentationmodechanged", webViewerPresentationModeChanged, {
+    eventBus._on(
+      "presentationmodechanged",
+      evt => (pdfViewer.presentationModeState = evt.state),
+      { signal }
+    );
+    eventBus._on("presentationmode", this.requestPresentationMode.bind(this), {
       signal,
     });
-    eventBus._on("presentationmode", webViewerPresentationMode, { signal });
     eventBus._on(
       "switchannotationeditormode",
-      webViewerSwitchAnnotationEditorMode,
+      evt => (pdfViewer.annotationEditorMode = evt),
       { signal }
     );
     eventBus._on(
       "switchannotationeditorparams",
-      webViewerSwitchAnnotationEditorParams,
+      evt => (pdfViewer.annotationEditorParams = evt),
       { signal }
     );
-    eventBus._on("print", webViewerPrint, { signal });
-    eventBus._on("download", webViewerDownload, { signal });
-    eventBus._on("firstpage", webViewerFirstPage, { signal });
-    eventBus._on("lastpage", webViewerLastPage, { signal });
-    eventBus._on("nextpage", webViewerNextPage, { signal });
-    eventBus._on("previouspage", webViewerPreviousPage, { signal });
-    eventBus._on("zoomin", webViewerZoomIn, { signal });
-    eventBus._on("zoomout", webViewerZoomOut, { signal });
-    eventBus._on("zoomreset", webViewerZoomReset, { signal });
+    eventBus._on("print", this.triggerPrinting.bind(this), { signal });
+    eventBus._on("download", this.downloadOrSave.bind(this), { signal });
+    eventBus._on("firstpage", () => (this.page = 1), { signal });
+    eventBus._on("lastpage", () => (this.page = this.pagesCount), { signal });
+    eventBus._on("nextpage", () => pdfViewer.nextPage(), { signal });
+    eventBus._on("previouspage", () => pdfViewer.previousPage(), { signal });
+    eventBus._on("zoomin", this.zoomIn.bind(this), { signal });
+    eventBus._on("zoomout", this.zoomOut.bind(this), { signal });
+    eventBus._on("zoomreset", this.zoomReset.bind(this), { signal });
     eventBus._on("pagenumberchanged", webViewerPageNumberChanged, { signal });
-    eventBus._on("scalechanged", webViewerScaleChanged, { signal });
-    eventBus._on("rotatecw", webViewerRotateCw, { signal });
-    eventBus._on("rotateccw", webViewerRotateCcw, { signal });
-    eventBus._on("optionalcontentconfig", webViewerOptionalContentConfig, {
+    eventBus._on(
+      "scalechanged",
+      evt => (pdfViewer.currentScaleValue = evt.value),
+      { signal }
+    );
+    eventBus._on("rotatecw", this.rotatePages.bind(this, 90), { signal });
+    eventBus._on("rotateccw", this.rotatePages.bind(this, -90), { signal });
+    eventBus._on(
+      "optionalcontentconfig",
+      evt => (pdfViewer.optionalContentConfigPromise = evt.promise),
+      { signal }
+    );
+    eventBus._on("switchscrollmode", evt => (pdfViewer.scrollMode = evt.mode), {
       signal,
     });
-    eventBus._on("switchscrollmode", webViewerSwitchScrollMode, { signal });
     eventBus._on("scrollmodechanged", webViewerScrollModeChanged, { signal });
-    eventBus._on("switchspreadmode", webViewerSwitchSpreadMode, { signal });
+    eventBus._on("switchspreadmode", evt => (pdfViewer.spreadMode = evt.mode), {
+      signal,
+    });
     eventBus._on("spreadmodechanged", webViewerSpreadModeChanged, { signal });
     eventBus._on("imagealttextsettings", webViewerImageAltTextSettings, {
       signal,
     });
-    eventBus._on("documentproperties", webViewerDocumentProperties, { signal });
+    eventBus._on("documentproperties", () => pdfDocumentProperties?.open(), {
+      signal,
+    });
     eventBus._on("findfromurlhash", webViewerFindFromUrlHash, { signal });
     eventBus._on("updatefindmatchescount", webViewerUpdateFindMatchesCount, {
       signal,
@@ -1969,16 +1988,24 @@ const PDFViewerApplication = {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       eventBus._on(
         "annotationeditorstateschanged",
-        webViewerAnnotationEditorStatesChanged,
+        evt => externalServices.updateEditorStates(evt),
         { signal }
       );
-      eventBus._on("reporttelemetry", webViewerReportTelemetry, { signal });
+      eventBus._on(
+        "reporttelemetry",
+        evt => externalServices.reportTelemetry(evt.details),
+        { signal }
+      );
     }
     if (
       typeof PDFJSDev === "undefined" ||
       PDFJSDev.test("TESTING || MOZCENTRAL")
     ) {
-      eventBus._on("setpreference", webViewerSetPreference, { signal });
+      eventBus._on(
+        "setpreference",
+        evt => preferences.set(evt.name, evt.value),
+        { signal }
+      );
     }
   },
 
@@ -1991,12 +2018,13 @@ const PDFViewerApplication = {
     const {
       eventBus,
       appConfig: { mainContainer },
+      pdfViewer,
       _windowAbortController: { signal },
     } = this;
 
     function addWindowResolutionChange(evt = null) {
       if (evt) {
-        webViewerResolutionChange(evt);
+        pdfViewer.refresh();
       }
       const mediaQueryList = window.matchMedia(
         `(resolution: ${window.devicePixelRatio || 1}dppx)`
@@ -2029,9 +2057,7 @@ const PDFViewerApplication = {
     window.addEventListener("keyup", webViewerKeyUp, { signal });
     window.addEventListener(
       "resize",
-      () => {
-        eventBus.dispatch("resize", { source: window });
-      },
+      () => eventBus.dispatch("resize", { source: window }),
       { signal }
     );
     window.addEventListener(
@@ -2046,24 +2072,20 @@ const PDFViewerApplication = {
     );
     window.addEventListener(
       "beforeprint",
-      () => {
-        eventBus.dispatch("beforeprint", { source: window });
-      },
+      () => eventBus.dispatch("beforeprint", { source: window }),
       { signal }
     );
     window.addEventListener(
       "afterprint",
-      () => {
-        eventBus.dispatch("afterprint", { source: window });
-      },
+      () => eventBus.dispatch("afterprint", { source: window }),
       { signal }
     );
     window.addEventListener(
       "updatefromsandbox",
-      event => {
+      evt => {
         eventBus.dispatch("updatefromsandbox", {
           source: window,
-          detail: event.detail,
+          detail: evt.detail,
         });
       },
       { signal }
@@ -2317,10 +2339,6 @@ function webViewerNamedAction(evt) {
   }
 }
 
-function webViewerPresentationModeChanged(evt) {
-  PDFViewerApplication.pdfViewer.presentationModeState = evt.state;
-}
-
 function webViewerSidebarViewChanged({ view }) {
   PDFViewerApplication.pdfRenderingQueue.isThumbnailViewEnabled =
     view === SidebarView.THUMBS;
@@ -2436,42 +2454,6 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   };
 }
 
-function webViewerPresentationMode() {
-  PDFViewerApplication.requestPresentationMode();
-}
-function webViewerSwitchAnnotationEditorMode(evt) {
-  PDFViewerApplication.pdfViewer.annotationEditorMode = evt;
-}
-function webViewerSwitchAnnotationEditorParams(evt) {
-  PDFViewerApplication.pdfViewer.annotationEditorParams = evt;
-}
-function webViewerPrint() {
-  PDFViewerApplication.triggerPrinting();
-}
-function webViewerDownload() {
-  PDFViewerApplication.downloadOrSave();
-}
-function webViewerFirstPage() {
-  PDFViewerApplication.page = 1;
-}
-function webViewerLastPage() {
-  PDFViewerApplication.page = PDFViewerApplication.pagesCount;
-}
-function webViewerNextPage() {
-  PDFViewerApplication.pdfViewer.nextPage();
-}
-function webViewerPreviousPage() {
-  PDFViewerApplication.pdfViewer.previousPage();
-}
-function webViewerZoomIn() {
-  PDFViewerApplication.zoomIn();
-}
-function webViewerZoomOut() {
-  PDFViewerApplication.zoomOut();
-}
-function webViewerZoomReset() {
-  PDFViewerApplication.zoomReset();
-}
 function webViewerPageNumberChanged(evt) {
   const pdfViewer = PDFViewerApplication.pdfViewer;
   // Note that for `<input type="number">` HTML elements, an empty string will
@@ -2491,27 +2473,6 @@ function webViewerPageNumberChanged(evt) {
       pdfViewer.currentPageLabel
     );
   }
-}
-function webViewerScaleChanged(evt) {
-  PDFViewerApplication.pdfViewer.currentScaleValue = evt.value;
-}
-function webViewerRotateCw() {
-  PDFViewerApplication.rotatePages(90);
-}
-function webViewerRotateCcw() {
-  PDFViewerApplication.rotatePages(-90);
-}
-function webViewerOptionalContentConfig(evt) {
-  PDFViewerApplication.pdfViewer.optionalContentConfigPromise = evt.promise;
-}
-function webViewerSwitchScrollMode(evt) {
-  PDFViewerApplication.pdfViewer.scrollMode = evt.mode;
-}
-function webViewerSwitchSpreadMode(evt) {
-  PDFViewerApplication.pdfViewer.spreadMode = evt.mode;
-}
-function webViewerDocumentProperties() {
-  PDFViewerApplication.pdfDocumentProperties?.open();
 }
 
 function webViewerImageAltTextSettings() {
@@ -2597,10 +2558,6 @@ function webViewerPageChanging({ pageNumber, pageLabel }) {
   PDFViewerApplication.toolbar?.updateLoadingIndicatorState(
     currentPage?.renderingState === RenderingStates.RUNNING
   );
-}
-
-function webViewerResolutionChange(evt) {
-  PDFViewerApplication.pdfViewer.refresh();
 }
 
 function webViewerWheel(evt) {
@@ -3202,18 +3159,6 @@ function beforeUnload(evt) {
   evt.preventDefault();
   evt.returnValue = "";
   return false;
-}
-
-function webViewerAnnotationEditorStatesChanged(data) {
-  PDFViewerApplication.externalServices.updateEditorStates(data);
-}
-
-function webViewerReportTelemetry({ details }) {
-  PDFViewerApplication.externalServices.reportTelemetry(details);
-}
-
-function webViewerSetPreference({ name, value }) {
-  PDFViewerApplication.preferences.set(name, value);
 }
 
 export { PDFViewerApplication };


### PR DESCRIPTION
We have a fair number of (effectively) single-line event handlers in the  `web/app.js` file, which leads to unnecessarily verbose code. These can, without affecting readability too much, be replaced either by:
 - Using `bind` for the simplest cases.
 - Using arrow-functions for the remaining ones.

Note that this is possible since we started removing event listeners with `AbortSignal`, which means that we no longer need to keep a reference to the event handler functions to be able to remove them.

Given that the old event handler functions use fairly long function names, and the way that they access `PDFViewerApplication` (given their scope), they impact the overall code-size unnecessarily.
*Note:* This patch reduces the size of the `gulp mozcentral` output by `~3.7` kilo-bytes, which isn't a lot but still cannot hurt.