### PR TITLE
Further emphasize the importance of `Attach (recommended) or Link to PDF file` in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,6 +5,7 @@ body:
   - type: textarea
     attributes:
       label: Attach (recommended) or Link to PDF file
+      description: Without this information the issue may be closed without comment
     validations:
       required: true
 


### PR DESCRIPTION
Unfortunately it turns out (perhaps unsurprisingly) that even the new bug report template isn't stopping users from leaving out the single most important part, i.e. `Attach (recommended) or Link to PDF file`, despite it now being marked as a required field.