### PR TITLE
[Editor] Add a new dialog for alt-text settings (bug 1909604)

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -59,6 +59,14 @@
       "type": "boolean",
       "default": true
     },
+    "enableAltTextModelDownload": {
+      "type": "boolean",
+      "default": true
+    },
+    "enableNewAltTextWhenAddingImage": {
+      "type": "boolean",
+      "default": true
+    },
     "altTextLearnMoreUrl": {
       "type": "string",
       "default": ""

--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -446,7 +446,7 @@ pdfjs-editor-new-alt-text-error-close-button = Close
 #   $totalSize (Number) - the total size (in MB) of the AI model.
 #   $downloadedSize (Number) - the downloaded size (in MB) of the AI model.
 #   $percent (Number) - the percentage of the downloaded size.
-pdfjs-editor-new-alt-text-ai-model-downloading-progress =
+pdfjs-editor-new-alt-text-ai-model-downloading-progress = Downloading alt text AI model ({ $downloadedSize } of { $totalSize } MB)
     .aria-valuemin = 0
     .aria-valuemax = { $totalSize }
     .aria-valuenow = { $downloadedSize }
@@ -465,3 +465,28 @@ pdfjs-editor-new-alt-text-to-review-button-label = Review alt text
 # Variables:
 #   $generatedAltText (String) - the generated alt-text.
 pdfjs-editor-new-alt-text-generated-alt-text-with-disclaimer = Created automatically: { $generatedAltText }
+
+## Image alt-text settings
+
+pdfjs-image-alt-text-settings-button =
+    .title = Image alt text settings
+pdfjs-image-alt-text-settings-button-label = Image alt text settings
+
+pdfjs-editor-alt-text-settings-dialog-label = Image alt text settings
+pdfjs-editor-alt-text-settings-automatic-title = Automatic alt text
+pdfjs-editor-alt-text-settings-create-model-button-label = Create alt text automatically
+pdfjs-editor-alt-text-settings-create-model-description = Suggests descriptions to help people who can’t see the image or when the image doesn’t load.
+
+# Variables:
+#   $totalSize (Number) - the total size (in MB) of the AI model.
+pdfjs-editor-alt-text-settings-download-model-label = Alt text AI model ({ $totalSize } MB)
+
+pdfjs-editor-alt-text-settings-ai-model-description = Runs locally on your device so your data stays private. Required for automatic alt text.
+pdfjs-editor-alt-text-settings-delete-model-button = Delete
+pdfjs-editor-alt-text-settings-download-model-button = Download
+pdfjs-editor-alt-text-settings-downloading-model-button = Downloading…
+
+pdfjs-editor-alt-text-settings-editor-title = Alt text editor
+pdfjs-editor-alt-text-settings-show-dialog-button-label = Show alt text editor right away when adding an image
+pdfjs-editor-alt-text-settings-show-dialog-description = Helps you make sure all your images have alt text.
+pdfjs-editor-alt-text-settings-close-button = Close

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -126,7 +126,11 @@ class StampEditor extends AnnotationEditor {
     if (!this.#canvas) {
       return;
     }
-    if (this._uiManager.useNewAltTextFlow && this.#bitmap) {
+    if (
+      this._uiManager.useNewAltTextWhenAddingImage &&
+      this._uiManager.useNewAltTextFlow &&
+      this.#bitmap
+    ) {
       this._editToolbar.hide();
       this._uiManager.editAltText(this, /* firstTime = */ true);
     } else {
@@ -341,7 +345,10 @@ class StampEditor extends AnnotationEditor {
     this._uiManager.enableWaiting(false);
     const canvas = (this.#canvas = document.createElement("canvas"));
     div.append(canvas);
-    if (!this._uiManager.useNewAltTextFlow) {
+    if (
+      !this._uiManager.useNewAltTextWhenAddingImage ||
+      !this._uiManager.useNewAltTextFlow
+    ) {
       div.hidden = false;
     }
     this.#drawBitmap(width, height);

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -1349,3 +1349,63 @@
     }
   }
 }
+
+#altTextSettingsDialog {
+  padding: 16px;
+
+  #altTextSettingsContainer {
+    display: flex;
+    width: 573px;
+    flex-direction: column;
+    gap: 16px;
+
+    .mainContainer {
+      gap: 16px;
+    }
+
+    .description {
+      color: var(--text-secondary-color);
+    }
+
+    #aiModelSettings {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+
+      button {
+        width: fit-content;
+      }
+
+      &.download {
+        #deleteModelButton {
+          display: none;
+        }
+      }
+
+      &:not(.download) {
+        #downloadModelButton {
+          display: none;
+        }
+      }
+    }
+
+    #automaticAltText,
+    #altTextEditor {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    #createModelDescription,
+    #aiModelSettings,
+    #showAltTextDialogDescription {
+      padding-inline-start: 40px;
+    }
+
+    #automaticSettings {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+  }
+}

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -190,6 +190,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  enableAltTextModelDownload: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   enableGuessAltText: {
     /** @type {boolean} */
     value: true,
@@ -209,6 +214,11 @@ const defaultOptions = {
     // TODO: remove it when unnecessary.
     /** @type {boolean} */
     value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
+  enableNewAltTextWhenAddingImage: {
+    /** @type {boolean} */
+    value: true,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enablePermissions: {

--- a/web/dialog.css
+++ b/web/dialog.css
@@ -24,6 +24,7 @@
   --focus-ring-outline: 2px solid var(--focus-ring-color);
   --link-fg-color: #0060df;
   --link-hover-fg-color: #0250bb;
+  --separator-color: #f0f0f4;
 
   --textarea-border-color: #8f8f9d;
   --textarea-bg-color: white;
@@ -57,6 +58,7 @@
     --hover-filter: brightness(1.4);
     --link-fg-color: #0df;
     --link-hover-fg-color: #80ebff;
+    --separator-color: #52525e;
 
     --textarea-bg-color: #42414d;
 
@@ -79,6 +81,7 @@
     --focus-ring-color: ButtonBorder;
     --link-fg-color: LinkText;
     --link-hover-fg-color: LinkText;
+    --separator-color: CanvasText;
 
     --textarea-border-color: ButtonBorder;
     --textarea-bg-color: Field;
@@ -132,6 +135,13 @@
         font-weight: 590;
         line-height: 150%; /* 19.5px */
       }
+    }
+
+    .dialogSeparator {
+      width: 100%;
+      height: 1px;
+      margin-block: 4px;
+      background-color: var(--separator-color);
     }
 
     .dialogButtonsGroup {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -221,6 +221,8 @@ class PDFViewer {
 
   #enableUpdatedAddImage = false;
 
+  #enableNewAltTextWhenAddingImage = false;
+
   #eventAbortController = null;
 
   #mlManager = null;
@@ -294,6 +296,8 @@ class PDFViewer {
     this.#enableHighlightFloatingButton =
       options.enableHighlightFloatingButton === true;
     this.#enableUpdatedAddImage = options.enableUpdatedAddImage === true;
+    this.#enableNewAltTextWhenAddingImage =
+      options.enableNewAltTextWhenAddingImage === true;
     this.imageResourcesPath = options.imageResourcesPath || "";
     this.enablePrintAutoRotate = options.enablePrintAutoRotate || false;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
@@ -894,6 +898,7 @@ class PDFViewer {
               this.#annotationEditorHighlightColors,
               this.#enableHighlightFloatingButton,
               this.#enableUpdatedAddImage,
+              this.#enableNewAltTextWhenAddingImage,
               this.#mlManager
             );
             eventBus.dispatch("annotationeditoruimanager", {

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -49,6 +49,8 @@ import { PagesCountLimit } from "./pdf_viewer.js";
  *   select tool.
  * @property {HTMLButtonElement} cursorHandToolButton - Button to enable the
  *   hand tool.
+ * @property {HTMLButtonElement} imageAltTextSettingsButton - Button for opening
+ *   the image alt-text settings dialog.
  * @property {HTMLButtonElement} documentPropertiesButton - Button for opening
  *   the document properties dialog.
  */
@@ -135,6 +137,11 @@ class SecondaryToolbar {
         element: options.spreadEvenButton,
         eventName: "switchspreadmode",
         eventDetails: { mode: SpreadMode.EVEN },
+        close: true,
+      },
+      {
+        element: options.imageAltTextSettingsButton,
+        eventName: "imagealttextsettings",
         close: true,
       },
       {

--- a/web/stubs-geckoview.js
+++ b/web/stubs-geckoview.js
@@ -15,6 +15,7 @@
 
 const AltTextManager = null;
 const AnnotationEditorParams = null;
+const ImageAltTextSettings = null;
 const NewAltTextManager = null;
 const PDFAttachmentViewer = null;
 const PDFCursorTools = null;
@@ -30,6 +31,7 @@ const SecondaryToolbar = null;
 export {
   AltTextManager,
   AnnotationEditorParams,
+  ImageAltTextSettings,
   NewAltTextManager,
   PDFAttachmentViewer,
   PDFCursorTools,

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -120,6 +120,9 @@
   --secondaryToolbarButton-spreadNone-icon: url(images/secondaryToolbarButton-spreadNone.svg);
   --secondaryToolbarButton-spreadOdd-icon: url(images/secondaryToolbarButton-spreadOdd.svg);
   --secondaryToolbarButton-spreadEven-icon: url(images/secondaryToolbarButton-spreadEven.svg);
+  --secondaryToolbarButton-imageAltTextSettings-icon: var(
+    --toolbarButton-editorStamp-icon
+  );
   --secondaryToolbarButton-documentProperties-icon: url(images/secondaryToolbarButton-documentProperties.svg);
   --editorParams-stampAddImage-icon: url(images/toolbarButton-zoomIn.svg);
 }
@@ -1075,6 +1078,10 @@ a:is(.toolbarButton, .secondaryToolbarButton)[href="#"] {
 
 #documentProperties::before {
   mask-image: var(--secondaryToolbarButton-documentProperties-icon);
+}
+
+#imageAltTextSettings::before {
+  mask-image: var(--secondaryToolbarButton-imageAltTextSettings-icon);
 }
 
 .verticalToolbarSeparator {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -323,9 +323,14 @@ See https://github.com/adobe-type-tools/cmap-resources
               </button>
             </div>
 
+            <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
+            <button id="imageAltTextSettings" type="button" class="secondaryToolbarButton hidden" title="Image alt text settings" tabindex="69" data-l10n-id="pdfjs-image-alt-text-settings-button" aria-controls="altTextSettingsDialog">
+              <span data-l10n-id="pdfjs-image-alt-text-settings-button-label">Image alt text settings</span>
+            </button>
+
             <div class="horizontalToolbarSeparator"></div>
 
-            <button id="documentProperties" class="secondaryToolbarButton" type="button" title="Document Properties…" tabindex="69" data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
+            <button id="documentProperties" class="secondaryToolbarButton" type="button" title="Document Properties…" tabindex="70" data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
               <span data-l10n-id="pdfjs-document-properties-button-label">Document Properties…</span>
             </button>
           </div>
@@ -593,6 +598,53 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </dialog>
 
+        <dialog class="dialog" id="altTextSettingsDialog" aria-labelledby="altTextSettingsTitle">
+          <div id="altTextSettingsContainer" class="mainContainer">
+            <div class="title">
+              <span id="altTextSettingsTitle" data-l10n-id="pdfjs-editor-alt-text-settings-dialog-label" role="sectionhead" tabindex="0" class="title">Image alt text settings</span>
+            </div>
+            <div id="automaticAltText">
+              <span data-l10n-id="pdfjs-editor-alt-text-settings-automatic-title">Automatic alt text</span>
+              <div id="automaticSettings">
+                <div id="createModelSetting">
+                  <div class="toggler">
+                    <button id="createModelButton" type="button" class="toggle-button" aria-pressed="true" tabindex="0"></button>
+                    <label for="createModelButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-create-model-button-label">Create alt text automatically</label>
+                  </div>
+                  <div id="createModelDescription" class="description">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description">Suggests descriptions to help people who can’t see the image or when the image doesn’t load.</span> <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank" rel="noopener noreferrer" id="altTextSettingsLearnMore" data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url" tabindex="0">Learn more</a>
+                  </div>
+                </div>
+                <div id="aiModelSettings">
+                  <div>
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-label" data-l10n-args='{ "totalSize": 180 }'>Alt text AI model (180MB)</span>
+                    <div id="aiModelDescription" class="description">
+                      <span data-l10n-id="pdfjs-editor-alt-text-settings-ai-model-description">Runs locally on your device so your data stays private. Required for automatic alt text.</span>
+                    </div>
+                  </div>
+                  <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button">Delete</span></button>
+                  <button id="downloadModelButton"type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button">Download</span></button>
+                </div>
+              </div>
+            </div>
+            <div class="dialogSeparator"></div>
+            <div id="altTextEditor">
+              <span data-l10n-id="pdfjs-editor-alt-text-settings-editor-title">Alt text editor</span>
+              <div id="showAltTextEditor">
+                <div class="toggler">
+                  <button id="showAltTextDialogButton" type="button" class="toggle-button" aria-pressed="true" tabindex="0"></button>
+                  <label for="showAltTextDialogButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-button-label">Show alt text editor right away when adding an image</label>
+                </div>
+                <div id="showAltTextDialogDescription" class="description">
+                  <span data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-description">Helps you make sure all your images have alt text.</span>
+                </div>
+              </div>
+            </div>
+            <div id="buttons" class="dialogButtonsGroup">
+              <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-settings-close-button">Close</span></button>
+            </div>
+          </div>
+        </dialog>
 <!--#if !MOZCENTRAL-->
         <dialog id="printServiceDialog" style="min-width: 200px;">
           <div class="row">

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -93,6 +93,12 @@ function getViewerConfiguration() {
       spreadNoneButton: document.getElementById("spreadNone"),
       spreadOddButton: document.getElementById("spreadOdd"),
       spreadEvenButton: document.getElementById("spreadEven"),
+      imageAltTextSettingsButton: document.getElementById(
+        "imageAltTextSettings"
+      ),
+      imageAltTextSettingsSeparator: document.getElementById(
+        "imageAltTextSettingsSeparator"
+      ),
       documentPropertiesButton: document.getElementById("documentProperties"),
     },
     sidebar: {
@@ -187,6 +193,21 @@ function getViewerConfiguration() {
       cancelButton: document.getElementById("newAltTextCancel"),
       notNowButton: document.getElementById("newAltTextNotNow"),
       saveButton: document.getElementById("newAltTextSave"),
+    },
+    altTextSettingsDialog: {
+      dialog: document.getElementById("altTextSettingsDialog"),
+      createModelButton: document.getElementById("createModelButton"),
+      aiModelSettings: document.getElementById("aiModelSettings"),
+      learnMore: document.getElementById("altTextSettingsLearnMore"),
+      deleteModelButton: document.getElementById("deleteModelButton"),
+      downloadModelButton: document.getElementById("downloadModelButton"),
+      showAltTextDialogButton: document.getElementById(
+        "showAltTextDialogButton"
+      ),
+      altTextSettingsCloseButton: document.getElementById(
+        "altTextSettingsCloseButton"
+      ),
+      closeButton: document.getElementById("altTextSettingsCloseButton"),
     },
     annotationEditorParams: {
       editorFreeTextFontSize: document.getElementById("editorFreeTextFontSize"),


### PR DESCRIPTION
This patch adds a new entry in the secondary menu in order to open a dialog to let the user:
 - disables the alt-text generation thanks to a ML model;
 - deletes the alt-text model downloaded in Firefox;
 - disabled the new alt-text flow.