### PR TITLE
Link to the list of supported browsers in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,6 +15,7 @@ body:
   - type: input
     attributes:
       label: Web browser and its version
+      description: Please ensure that it's supported, refer to [the FAQ](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support)
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Given that users fairly often report issues with unsupported browsers/environments it cannot hurt to provide a link to the relevant section in the FAQ.