### PR TITLE
[Editor] Avoid to have the create alt-text button without a click listener

### DIFF
--- a/web/new_alt_text_manager.js
+++ b/web/new_alt_text_manager.js
@@ -468,8 +468,6 @@ class NewAltTextManager {
 class ImageAltTextSettings {
   #aiModelSettings;
 
-  #boundOnClickCreateModel;
-
   #createModelButton;
 
   #dialog;
@@ -504,17 +502,12 @@ class ImageAltTextSettings {
     this.#overlayManager = overlayManager;
     this.#eventBus = eventBus;
     this.#mlManager = mlManager;
-    this.#boundOnClickCreateModel = this.#togglePref.bind(
-      this,
-      "enableGuessAltText"
-    );
 
     const { altTextLearnMoreUrl } = mlManager;
     if (altTextLearnMoreUrl) {
       learnMore.href = altTextLearnMoreUrl;
     }
 
-    dialog.addEventListener("close", this.#close.bind(this));
     dialog.addEventListener("contextmenu", noContextMenu);
 
     createModelButton.addEventListener("click", async e => {
@@ -531,10 +524,7 @@ class ImageAltTextSettings {
       await mlManager.deleteModel("altText");
 
       aiModelSettings.classList.toggle("download", true);
-      createModelButton.removeEventListener(
-        "click",
-        this.#boundOnClickCreateModel
-      );
+      createModelButton.disabled = true;
       createModelButton.setAttribute("aria-pressed", false);
       this.#setPref("enableGuessAltText", false);
       this.#setPref("enableAltTextModelDownload", false);
@@ -554,10 +544,7 @@ class ImageAltTextSettings {
         "data-l10n-id",
         "pdfjs-editor-alt-text-settings-download-model-button"
       );
-      createModelButton.addEventListener(
-        "click",
-        this.#boundOnClickCreateModel
-      );
+      createModelButton.disabled = false;
       createModelButton.setAttribute("aria-pressed", true);
       this.#setPref("enableGuessAltText", true);
       mlManager.toggleService("altText", true);
@@ -585,12 +572,7 @@ class ImageAltTextSettings {
       !enableAltTextModelDownload
     );
 
-    try {
-      await this.#overlayManager.open(this.#dialog);
-    } catch (ex) {
-      this.#close();
-      throw ex;
-    }
+    await this.#overlayManager.open(this.#dialog);
   }
 
   #togglePref(name, { target }) {
@@ -612,13 +594,6 @@ class ImageAltTextSettings {
     if (this.#overlayManager.active === this.#dialog) {
       this.#overlayManager.close(this.#dialog);
     }
-  }
-
-  #close() {
-    this.#createModelButton.removeEventListener(
-      "click",
-      this.#boundOnClickCreateModel
-    );
   }
 }
 


### PR DESCRIPTION
The toggle button hasn't a click listener after we deleted and downloaded the model.