### PR TITLE
Improve the larger event listeners in the `web/app.js` file

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1969,15 +1969,19 @@ const PDFViewerApplication = {
     eventBus._on("switchscrollmode", evt => (pdfViewer.scrollMode = evt.mode), {
       signal,
     });
-    eventBus._on("scrollmodechanged", onScrollModeChanged.bind(this), {
-      signal,
-    });
+    eventBus._on(
+      "scrollmodechanged",
+      onViewerModesChanged.bind(this, "scrollMode"),
+      { signal }
+    );
     eventBus._on("switchspreadmode", evt => (pdfViewer.spreadMode = evt.mode), {
       signal,
     });
-    eventBus._on("spreadmodechanged", onSpreadModeChanged.bind(this), {
-      signal,
-    });
+    eventBus._on(
+      "spreadmodechanged",
+      onViewerModesChanged.bind(this, "spreadMode"),
+      { signal }
+    );
     eventBus._on("imagealttextsettings", onImageAltTextSettings.bind(this), {
       signal,
     });
@@ -2402,19 +2406,10 @@ function onUpdateViewarea({ location }) {
   }
 }
 
-function onScrollModeChanged(evt) {
+function onViewerModesChanged(name, evt) {
   if (this.isInitialViewSet && !this.pdfViewer.isInPresentationMode) {
     // Only update the storage when the document has been loaded *and* rendered.
-    this.store?.set("scrollMode", evt.mode).catch(() => {
-      // Unable to write to storage.
-    });
-  }
-}
-
-function onSpreadModeChanged(evt) {
-  if (this.isInitialViewSet && !this.pdfViewer.isInPresentationMode) {
-    // Only update the storage when the document has been loaded *and* rendered.
-    this.store?.set("spreadMode", evt.mode).catch(() => {
+    this.store?.set(name, evt.mode).catch(() => {
       // Unable to write to storage.
     });
   }

--- a/web/app.js
+++ b/web/app.js
@@ -1909,19 +1909,21 @@ const PDFViewerApplication = {
       _eventBusAbortController: { signal },
     } = this;
 
-    eventBus._on("resize", webViewerResize, { signal });
-    eventBus._on("hashchange", webViewerHashchange, { signal });
+    eventBus._on("resize", onResize.bind(this), { signal });
+    eventBus._on("hashchange", onHashchange.bind(this), { signal });
     eventBus._on("beforeprint", this.beforePrint.bind(this), { signal });
     eventBus._on("afterprint", this.afterPrint.bind(this), { signal });
-    eventBus._on("pagerender", webViewerPageRender, { signal });
-    eventBus._on("pagerendered", webViewerPageRendered, { signal });
-    eventBus._on("updateviewarea", webViewerUpdateViewarea, { signal });
-    eventBus._on("pagechanging", webViewerPageChanging, { signal });
-    eventBus._on("scalechanging", webViewerScaleChanging, { signal });
-    eventBus._on("rotationchanging", webViewerRotationChanging, { signal });
-    eventBus._on("sidebarviewchanged", webViewerSidebarViewChanged, { signal });
-    eventBus._on("pagemode", webViewerPageMode, { signal });
-    eventBus._on("namedaction", webViewerNamedAction, { signal });
+    eventBus._on("pagerender", onPageRender.bind(this), { signal });
+    eventBus._on("pagerendered", onPageRendered.bind(this), { signal });
+    eventBus._on("updateviewarea", onUpdateViewarea.bind(this), { signal });
+    eventBus._on("pagechanging", onPageChanging.bind(this), { signal });
+    eventBus._on("scalechanging", onScaleChanging.bind(this), { signal });
+    eventBus._on("rotationchanging", onRotationChanging.bind(this), { signal });
+    eventBus._on("sidebarviewchanged", onSidebarViewChanged.bind(this), {
+      signal,
+    });
+    eventBus._on("pagemode", onPageMode.bind(this), { signal });
+    eventBus._on("namedaction", onNamedAction.bind(this), { signal });
     eventBus._on(
       "presentationmodechanged",
       evt => (pdfViewer.presentationModeState = evt.state),
@@ -1949,7 +1951,9 @@ const PDFViewerApplication = {
     eventBus._on("zoomin", this.zoomIn.bind(this), { signal });
     eventBus._on("zoomout", this.zoomOut.bind(this), { signal });
     eventBus._on("zoomreset", this.zoomReset.bind(this), { signal });
-    eventBus._on("pagenumberchanged", webViewerPageNumberChanged, { signal });
+    eventBus._on("pagenumberchanged", onPageNumberChanged.bind(this), {
+      signal,
+    });
     eventBus._on(
       "scalechanged",
       evt => (pdfViewer.currentScaleValue = evt.value),
@@ -1965,28 +1969,36 @@ const PDFViewerApplication = {
     eventBus._on("switchscrollmode", evt => (pdfViewer.scrollMode = evt.mode), {
       signal,
     });
-    eventBus._on("scrollmodechanged", webViewerScrollModeChanged, { signal });
+    eventBus._on("scrollmodechanged", onScrollModeChanged.bind(this), {
+      signal,
+    });
     eventBus._on("switchspreadmode", evt => (pdfViewer.spreadMode = evt.mode), {
       signal,
     });
-    eventBus._on("spreadmodechanged", webViewerSpreadModeChanged, { signal });
-    eventBus._on("imagealttextsettings", webViewerImageAltTextSettings, {
+    eventBus._on("spreadmodechanged", onSpreadModeChanged.bind(this), {
+      signal,
+    });
+    eventBus._on("imagealttextsettings", onImageAltTextSettings.bind(this), {
       signal,
     });
     eventBus._on("documentproperties", () => pdfDocumentProperties?.open(), {
       signal,
     });
-    eventBus._on("findfromurlhash", webViewerFindFromUrlHash, { signal });
-    eventBus._on("updatefindmatchescount", webViewerUpdateFindMatchesCount, {
-      signal,
-    });
-    eventBus._on("updatefindcontrolstate", webViewerUpdateFindControlState, {
-      signal,
-    });
+    eventBus._on("findfromurlhash", onFindFromUrlHash.bind(this), { signal });
+    eventBus._on(
+      "updatefindmatchescount",
+      onUpdateFindMatchesCount.bind(this),
+      { signal }
+    );
+    eventBus._on(
+      "updatefindcontrolstate",
+      onUpdateFindControlState.bind(this),
+      { signal }
+    );
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      eventBus._on("fileinputchange", webViewerFileInputChange, { signal });
-      eventBus._on("openfile", webViewerOpenFile, { signal });
+      eventBus._on("fileinputchange", onFileInputChange.bind(this), { signal });
+      eventBus._on("openfile", onOpenFile.bind(this), { signal });
     }
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
       eventBus._on(
@@ -2039,25 +2051,25 @@ const PDFViewerApplication = {
     }
     addWindowResolutionChange();
 
-    window.addEventListener("wheel", webViewerWheel, {
+    window.addEventListener("wheel", onWheel.bind(this), {
       passive: false,
       signal,
     });
-    window.addEventListener("touchstart", webViewerTouchStart, {
+    window.addEventListener("touchstart", onTouchStart.bind(this), {
       passive: false,
       signal,
     });
-    window.addEventListener("touchmove", webViewerTouchMove, {
+    window.addEventListener("touchmove", onTouchMove.bind(this), {
       passive: false,
       signal,
     });
-    window.addEventListener("touchend", webViewerTouchEnd, {
+    window.addEventListener("touchend", onTouchEnd.bind(this), {
       passive: false,
       signal,
     });
-    window.addEventListener("click", webViewerClick, { signal });
-    window.addEventListener("keydown", webViewerKeyDown, { signal });
-    window.addEventListener("keyup", webViewerKeyUp, { signal });
+    window.addEventListener("click", onClick.bind(this), { signal });
+    window.addEventListener("keydown", onKeyDown.bind(this), { signal });
+    window.addEventListener("keyup", onKeyUp.bind(this), { signal });
     window.addEventListener(
       "resize",
       () => eventBus.dispatch("resize", { source: window }),
@@ -2256,29 +2268,45 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       throw ex;
     }
   };
+
+  // eslint-disable-next-line no-var
+  var onFileInputChange = function (evt) {
+    if (this.pdfViewer?.isInPresentationMode) {
+      return; // Opening a new PDF file isn't supported in Presentation Mode.
+    }
+    const file = evt.fileInput.files[0];
+
+    this.open({
+      url: URL.createObjectURL(file),
+      originalUrl: file.name,
+    });
+  };
+
+  // eslint-disable-next-line no-var
+  var onOpenFile = function (evt) {
+    this._openFileInput?.click();
+  };
 }
 
-function webViewerPageRender({ pageNumber }) {
+function onPageRender({ pageNumber }) {
   // If the page is (the most) visible when it starts rendering,
   // ensure that the page number input loading indicator is displayed.
-  if (pageNumber === PDFViewerApplication.page) {
-    PDFViewerApplication.toolbar?.updateLoadingIndicatorState(true);
+  if (pageNumber === this.page) {
+    this.toolbar?.updateLoadingIndicatorState(true);
   }
 }
 
-function webViewerPageRendered({ pageNumber, error }) {
+function onPageRendered({ pageNumber, error }) {
   // If the page is still visible when it has finished rendering,
   // ensure that the page number input loading indicator is hidden.
-  if (pageNumber === PDFViewerApplication.page) {
-    PDFViewerApplication.toolbar?.updateLoadingIndicatorState(false);
+  if (pageNumber === this.page) {
+    this.toolbar?.updateLoadingIndicatorState(false);
   }
 
   // Use the rendered page to set the corresponding thumbnail image.
-  if (PDFViewerApplication.pdfSidebar?.visibleView === SidebarView.THUMBS) {
-    const pageView = PDFViewerApplication.pdfViewer.getPageView(
-      /* index = */ pageNumber - 1
-    );
-    const thumbnailView = PDFViewerApplication.pdfThumbnailViewer?.getThumbnail(
+  if (this.pdfSidebar?.visibleView === SidebarView.THUMBS) {
+    const pageView = this.pdfViewer.getPageView(/* index = */ pageNumber - 1);
+    const thumbnailView = this.pdfThumbnailViewer?.getThumbnail(
       /* index = */ pageNumber - 1
     );
     if (pageView) {
@@ -2287,11 +2315,11 @@ function webViewerPageRendered({ pageNumber, error }) {
   }
 
   if (error) {
-    PDFViewerApplication._otherError("pdfjs-rendering-error", error);
+    this._otherError("pdfjs-rendering-error", error);
   }
 }
 
-function webViewerPageMode({ mode }) {
+function onPageMode({ mode }) {
   // Handle the 'pagemode' hash parameter, see also `PDFLinkService_setHash`.
   let view;
   switch (mode) {
@@ -2315,49 +2343,48 @@ function webViewerPageMode({ mode }) {
       console.error('Invalid "pagemode" hash parameter: ' + mode);
       return;
   }
-  PDFViewerApplication.pdfSidebar?.switchView(view, /* forceOpen = */ true);
+  this.pdfSidebar?.switchView(view, /* forceOpen = */ true);
 }
 
-function webViewerNamedAction(evt) {
+function onNamedAction(evt) {
   // Processing a couple of named actions that might be useful, see also
   // `PDFLinkService.executeNamedAction`.
   switch (evt.action) {
     case "GoToPage":
-      PDFViewerApplication.appConfig.toolbar?.pageNumber.select();
+      this.appConfig.toolbar?.pageNumber.select();
       break;
 
     case "Find":
-      if (!PDFViewerApplication.supportsIntegratedFind) {
-        PDFViewerApplication.findBar?.toggle();
+      if (!this.supportsIntegratedFind) {
+        this.findBar?.toggle();
       }
       break;
 
     case "Print":
-      PDFViewerApplication.triggerPrinting();
+      this.triggerPrinting();
       break;
 
     case "SaveAs":
-      PDFViewerApplication.downloadOrSave();
+      this.downloadOrSave();
       break;
   }
 }
 
-function webViewerSidebarViewChanged({ view }) {
-  PDFViewerApplication.pdfRenderingQueue.isThumbnailViewEnabled =
-    view === SidebarView.THUMBS;
+function onSidebarViewChanged({ view }) {
+  this.pdfRenderingQueue.isThumbnailViewEnabled = view === SidebarView.THUMBS;
 
-  if (PDFViewerApplication.isInitialViewSet) {
+  if (this.isInitialViewSet) {
     // Only update the storage when the document has been loaded *and* rendered.
-    PDFViewerApplication.store?.set("sidebarView", view).catch(() => {
+    this.store?.set("sidebarView", view).catch(() => {
       // Unable to write to storage.
     });
   }
 }
 
-function webViewerUpdateViewarea({ location }) {
-  if (PDFViewerApplication.isInitialViewSet) {
+function onUpdateViewarea({ location }) {
+  if (this.isInitialViewSet) {
     // Only update the storage when the document has been loaded *and* rendered.
-    PDFViewerApplication.store
+    this.store
       ?.setMultiple({
         page: location.pageNumber,
         zoom: location.scale,
@@ -2369,41 +2396,32 @@ function webViewerUpdateViewarea({ location }) {
         // Unable to write to storage.
       });
   }
-  if (PDFViewerApplication.appConfig.secondaryToolbar) {
-    const href = PDFViewerApplication.pdfLinkService.getAnchorUrl(
-      location.pdfOpenParams
-    );
-    PDFViewerApplication.appConfig.secondaryToolbar.viewBookmarkButton.href =
-      href;
+  if (this.appConfig.secondaryToolbar) {
+    this.appConfig.secondaryToolbar.viewBookmarkButton.href =
+      this.pdfLinkService.getAnchorUrl(location.pdfOpenParams);
   }
 }
 
-function webViewerScrollModeChanged(evt) {
-  if (
-    PDFViewerApplication.isInitialViewSet &&
-    !PDFViewerApplication.pdfViewer.isInPresentationMode
-  ) {
+function onScrollModeChanged(evt) {
+  if (this.isInitialViewSet && !this.pdfViewer.isInPresentationMode) {
     // Only update the storage when the document has been loaded *and* rendered.
-    PDFViewerApplication.store?.set("scrollMode", evt.mode).catch(() => {
+    this.store?.set("scrollMode", evt.mode).catch(() => {
       // Unable to write to storage.
     });
   }
 }
 
-function webViewerSpreadModeChanged(evt) {
-  if (
-    PDFViewerApplication.isInitialViewSet &&
-    !PDFViewerApplication.pdfViewer.isInPresentationMode
-  ) {
+function onSpreadModeChanged(evt) {
+  if (this.isInitialViewSet && !this.pdfViewer.isInPresentationMode) {
     // Only update the storage when the document has been loaded *and* rendered.
-    PDFViewerApplication.store?.set("spreadMode", evt.mode).catch(() => {
+    this.store?.set("spreadMode", evt.mode).catch(() => {
       // Unable to write to storage.
     });
   }
 }
 
-function webViewerResize() {
-  const { pdfDocument, pdfViewer, pdfRenderingQueue } = PDFViewerApplication;
+function onResize() {
+  const { pdfDocument, pdfViewer, pdfRenderingQueue } = this;
 
   if (pdfRenderingQueue.printing && window.matchMedia("print").matches) {
     // Work-around issue 15324 by ignoring "resize" events during printing.
@@ -2425,44 +2443,24 @@ function webViewerResize() {
   pdfViewer.update();
 }
 
-function webViewerHashchange(evt) {
+function onHashchange(evt) {
   const hash = evt.hash;
   if (!hash) {
     return;
   }
-  if (!PDFViewerApplication.isInitialViewSet) {
-    PDFViewerApplication.initialBookmark = hash;
-  } else if (!PDFViewerApplication.pdfHistory?.popStateInProgress) {
-    PDFViewerApplication.pdfLinkService.setHash(hash);
+  if (!this.isInitialViewSet) {
+    this.initialBookmark = hash;
+  } else if (!this.pdfHistory?.popStateInProgress) {
+    this.pdfLinkService.setHash(hash);
   }
 }
 
-if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  // eslint-disable-next-line no-var
-  var webViewerFileInputChange = function (evt) {
-    if (PDFViewerApplication.pdfViewer?.isInPresentationMode) {
-      return; // Opening a new PDF file isn't supported in Presentation Mode.
-    }
-    const file = evt.fileInput.files[0];
-
-    PDFViewerApplication.open({
-      url: URL.createObjectURL(file),
-      originalUrl: file.name,
-    });
-  };
-
-  // eslint-disable-next-line no-var
-  var webViewerOpenFile = function (evt) {
-    PDFViewerApplication._openFileInput?.click();
-  };
-}
-
-function webViewerPageNumberChanged(evt) {
-  const pdfViewer = PDFViewerApplication.pdfViewer;
+function onPageNumberChanged(evt) {
+  const { pdfViewer } = this;
   // Note that for `<input type="number">` HTML elements, an empty string will
   // be returned for non-number inputs; hence we simply do nothing in that case.
   if (evt.value !== "") {
-    PDFViewerApplication.pdfLinkService.goToPage(evt.value);
+    this.pdfLinkService.goToPage(evt.value);
   }
 
   // Ensure that the page number input displays the correct value, even if the
@@ -2471,15 +2469,15 @@ function webViewerPageNumberChanged(evt) {
     evt.value !== pdfViewer.currentPageNumber.toString() &&
     evt.value !== pdfViewer.currentPageLabel
   ) {
-    PDFViewerApplication.toolbar?.setPageNumber(
+    this.toolbar?.setPageNumber(
       pdfViewer.currentPageNumber,
       pdfViewer.currentPageLabel
     );
   }
 }
 
-function webViewerImageAltTextSettings() {
-  PDFViewerApplication.imageAltTextSettings?.open({
+function onImageAltTextSettings() {
+  this.imageAltTextSettings?.open({
     enableGuessAltText: AppOptions.get("enableGuessAltText"),
     enableNewAltTextWhenAddingImage: AppOptions.get(
       "enableNewAltTextWhenAddingImage"
@@ -2487,8 +2485,8 @@ function webViewerImageAltTextSettings() {
   });
 }
 
-function webViewerFindFromUrlHash(evt) {
-  PDFViewerApplication.eventBus.dispatch("find", {
+function onFindFromUrlHash(evt) {
+  this.eventBus.dispatch("find", {
     source: evt.source,
     type: "",
     query: evt.query,
@@ -2500,23 +2498,23 @@ function webViewerFindFromUrlHash(evt) {
   });
 }
 
-function webViewerUpdateFindMatchesCount({ matchesCount }) {
-  if (PDFViewerApplication.supportsIntegratedFind) {
-    PDFViewerApplication.externalServices.updateFindMatchesCount(matchesCount);
+function onUpdateFindMatchesCount({ matchesCount }) {
+  if (this.supportsIntegratedFind) {
+    this.externalServices.updateFindMatchesCount(matchesCount);
   } else {
-    PDFViewerApplication.findBar?.updateResultsCount(matchesCount);
+    this.findBar?.updateResultsCount(matchesCount);
   }
 }
 
-function webViewerUpdateFindControlState({
+function onUpdateFindControlState({
   state,
   previous,
   entireWord,
   matchesCount,
   rawQuery,
 }) {
-  if (PDFViewerApplication.supportsIntegratedFind) {
-    PDFViewerApplication.externalServices.updateFindControlState({
+  if (this.supportsIntegratedFind) {
+    this.externalServices.updateFindControlState({
       result: state,
       findPrevious: previous,
       entireWord,
@@ -2524,52 +2522,48 @@ function webViewerUpdateFindControlState({
       rawQuery,
     });
   } else {
-    PDFViewerApplication.findBar?.updateUIState(state, previous, matchesCount);
+    this.findBar?.updateUIState(state, previous, matchesCount);
   }
 }
 
-function webViewerScaleChanging(evt) {
-  PDFViewerApplication.toolbar?.setPageScale(evt.presetValue, evt.scale);
+function onScaleChanging(evt) {
+  this.toolbar?.setPageScale(evt.presetValue, evt.scale);
 
-  PDFViewerApplication.pdfViewer.update();
+  this.pdfViewer.update();
 }
 
-function webViewerRotationChanging(evt) {
-  if (PDFViewerApplication.pdfThumbnailViewer) {
-    PDFViewerApplication.pdfThumbnailViewer.pagesRotation = evt.pagesRotation;
+function onRotationChanging(evt) {
+  if (this.pdfThumbnailViewer) {
+    this.pdfThumbnailViewer.pagesRotation = evt.pagesRotation;
   }
 
-  PDFViewerApplication.forceRendering();
+  this.forceRendering();
   // Ensure that the active page doesn't change during rotation.
-  PDFViewerApplication.pdfViewer.currentPageNumber = evt.pageNumber;
+  this.pdfViewer.currentPageNumber = evt.pageNumber;
 }
 
-function webViewerPageChanging({ pageNumber, pageLabel }) {
-  PDFViewerApplication.toolbar?.setPageNumber(pageNumber, pageLabel);
-  PDFViewerApplication.secondaryToolbar?.setPageNumber(pageNumber);
+function onPageChanging({ pageNumber, pageLabel }) {
+  this.toolbar?.setPageNumber(pageNumber, pageLabel);
+  this.secondaryToolbar?.setPageNumber(pageNumber);
 
-  if (PDFViewerApplication.pdfSidebar?.visibleView === SidebarView.THUMBS) {
-    PDFViewerApplication.pdfThumbnailViewer?.scrollThumbnailIntoView(
-      pageNumber
-    );
+  if (this.pdfSidebar?.visibleView === SidebarView.THUMBS) {
+    this.pdfThumbnailViewer?.scrollThumbnailIntoView(pageNumber);
   }
 
   // Show/hide the loading indicator in the page number input element.
-  const currentPage = PDFViewerApplication.pdfViewer.getPageView(
-    /* index = */ pageNumber - 1
-  );
-  PDFViewerApplication.toolbar?.updateLoadingIndicatorState(
+  const currentPage = this.pdfViewer.getPageView(/* index = */ pageNumber - 1);
+  this.toolbar?.updateLoadingIndicatorState(
     currentPage?.renderingState === RenderingStates.RUNNING
   );
 }
 
-function webViewerWheel(evt) {
+function onWheel(evt) {
   const {
     pdfViewer,
     supportsMouseWheelZoomCtrlKey,
     supportsMouseWheelZoomMetaKey,
     supportsPinchToZoom,
-  } = PDFViewerApplication;
+  } = this;
 
   if (pdfViewer.isInPresentationMode) {
     return;
@@ -2598,7 +2592,7 @@ function webViewerWheel(evt) {
     FeatureTest.platform.isMac;
   const isPinchToZoom =
     evt.ctrlKey &&
-    !PDFViewerApplication._isCtrlKeyDown &&
+    !this._isCtrlKeyDown &&
     deltaMode === WheelEvent.DOM_DELTA_PIXEL &&
     evt.deltaX === 0 &&
     (Math.abs(scaleFactor - 1) < 0.05 || isBuiltInMac) &&
@@ -2614,20 +2608,20 @@ function webViewerWheel(evt) {
     evt.preventDefault();
     // NOTE: this check must be placed *after* preventDefault.
     if (
-      PDFViewerApplication._isScrolling ||
+      this._isScrolling ||
       document.visibilityState === "hidden" ||
-      PDFViewerApplication.overlayManager.active
+      this.overlayManager.active
     ) {
       return;
     }
 
     if (isPinchToZoom && supportsPinchToZoom) {
-      scaleFactor = PDFViewerApplication._accumulateFactor(
+      scaleFactor = this._accumulateFactor(
         pdfViewer.currentScale,
         scaleFactor,
         "_wheelUnusedFactor"
       );
-      PDFViewerApplication.updateZoom(null, scaleFactor, origin);
+      this.updateZoom(null, scaleFactor, origin);
     } else {
       const delta = normalizeWheelEventDirection(evt);
 
@@ -2640,41 +2634,35 @@ function webViewerWheel(evt) {
         // OSs have different defaults for the number lines. But we generally
         // want one "clicky" roll of the wheel (which produces one event) to
         // adjust the zoom by one step.
-        if (Math.abs(delta) >= 1) {
-          ticks = Math.sign(delta);
-        } else {
-          // If we're getting fractional lines (I can't think of a scenario
-          // this might actually happen), be safe and use the accumulator.
-          ticks = PDFViewerApplication._accumulateTicks(
-            delta,
-            "_wheelUnusedTicks"
-          );
-        }
+        //
+        // If we're getting fractional lines (I can't think of a scenario
+        // this might actually happen), be safe and use the accumulator.
+        ticks =
+          Math.abs(delta) >= 1
+            ? Math.sign(delta)
+            : this._accumulateTicks(delta, "_wheelUnusedTicks");
       } else {
         // pixel-based devices
         const PIXELS_PER_LINE_SCALE = 30;
-        ticks = PDFViewerApplication._accumulateTicks(
+        ticks = this._accumulateTicks(
           delta / PIXELS_PER_LINE_SCALE,
           "_wheelUnusedTicks"
         );
       }
 
-      PDFViewerApplication.updateZoom(ticks, null, origin);
+      this.updateZoom(ticks, null, origin);
     }
   }
 }
 
-function webViewerTouchStart(evt) {
-  if (
-    PDFViewerApplication.pdfViewer.isInPresentationMode ||
-    evt.touches.length < 2
-  ) {
+function onTouchStart(evt) {
+  if (this.pdfViewer.isInPresentationMode || evt.touches.length < 2) {
     return;
   }
   evt.preventDefault();
 
-  if (evt.touches.length !== 2 || PDFViewerApplication.overlayManager.active) {
-    PDFViewerApplication._touchInfo = null;
+  if (evt.touches.length !== 2 || this.overlayManager.active) {
+    this._touchInfo = null;
     return;
   }
 
@@ -2682,7 +2670,7 @@ function webViewerTouchStart(evt) {
   if (touch0.identifier > touch1.identifier) {
     [touch0, touch1] = [touch1, touch0];
   }
-  PDFViewerApplication._touchInfo = {
+  this._touchInfo = {
     touch0X: touch0.pageX,
     touch0Y: touch0.pageY,
     touch1X: touch1.pageX,
@@ -2690,12 +2678,12 @@ function webViewerTouchStart(evt) {
   };
 }
 
-function webViewerTouchMove(evt) {
-  if (!PDFViewerApplication._touchInfo || evt.touches.length !== 2) {
+function onTouchMove(evt) {
+  if (!this._touchInfo || evt.touches.length !== 2) {
     return;
   }
 
-  const { pdfViewer, _touchInfo, supportsPinchToZoom } = PDFViewerApplication;
+  const { pdfViewer, _touchInfo, supportsPinchToZoom } = this;
   let [touch0, touch1] = evt.touches;
   if (touch0.identifier > touch1.identifier) {
     [touch0, touch1] = [touch1, touch0];
@@ -2764,61 +2752,61 @@ function webViewerTouchMove(evt) {
   const distance = Math.hypot(page0X - page1X, page0Y - page1Y) || 1;
   const pDistance = Math.hypot(pTouch0X - pTouch1X, pTouch0Y - pTouch1Y) || 1;
   if (supportsPinchToZoom) {
-    const newScaleFactor = PDFViewerApplication._accumulateFactor(
+    const newScaleFactor = this._accumulateFactor(
       pdfViewer.currentScale,
       distance / pDistance,
       "_touchUnusedFactor"
     );
-    PDFViewerApplication.updateZoom(null, newScaleFactor, origin);
+    this.updateZoom(null, newScaleFactor, origin);
   } else {
     const PIXELS_PER_LINE_SCALE = 30;
-    const ticks = PDFViewerApplication._accumulateTicks(
+    const ticks = this._accumulateTicks(
       (distance - pDistance) / PIXELS_PER_LINE_SCALE,
       "_touchUnusedTicks"
     );
-    PDFViewerApplication.updateZoom(ticks, null, origin);
+    this.updateZoom(ticks, null, origin);
   }
 }
 
-function webViewerTouchEnd(evt) {
-  if (!PDFViewerApplication._touchInfo) {
+function onTouchEnd(evt) {
+  if (!this._touchInfo) {
     return;
   }
 
   evt.preventDefault();
-  PDFViewerApplication._touchInfo = null;
-  PDFViewerApplication._touchUnusedTicks = 0;
-  PDFViewerApplication._touchUnusedFactor = 1;
+  this._touchInfo = null;
+  this._touchUnusedTicks = 0;
+  this._touchUnusedFactor = 1;
 }
 
-function webViewerClick(evt) {
-  if (!PDFViewerApplication.secondaryToolbar?.isOpen) {
+function onClick(evt) {
+  if (!this.secondaryToolbar?.isOpen) {
     return;
   }
-  const appConfig = PDFViewerApplication.appConfig;
+  const appConfig = this.appConfig;
   if (
-    PDFViewerApplication.pdfViewer.containsElement(evt.target) ||
+    this.pdfViewer.containsElement(evt.target) ||
     (appConfig.toolbar?.container.contains(evt.target) &&
       evt.target !== appConfig.secondaryToolbar?.toggleButton)
   ) {
-    PDFViewerApplication.secondaryToolbar.close();
+    this.secondaryToolbar.close();
   }
 }
 
-function webViewerKeyUp(evt) {
+function onKeyUp(evt) {
   // evt.ctrlKey is false hence we use evt.key.
   if (evt.key === "Control") {
-    PDFViewerApplication._isCtrlKeyDown = false;
+    this._isCtrlKeyDown = false;
   }
 }
 
-function webViewerKeyDown(evt) {
-  PDFViewerApplication._isCtrlKeyDown = evt.key === "Control";
+function onKeyDown(evt) {
+  this._isCtrlKeyDown = evt.key === "Control";
 
-  if (PDFViewerApplication.overlayManager.active) {
+  if (this.overlayManager.active) {
     return;
   }
-  const { eventBus, pdfViewer } = PDFViewerApplication;
+  const { eventBus, pdfViewer } = this;
   const isViewerInPresentationMode = pdfViewer.isInPresentationMode;
 
   let handled = false,
@@ -2835,14 +2823,14 @@ function webViewerKeyDown(evt) {
     // either CTRL or META key with optional SHIFT.
     switch (evt.keyCode) {
       case 70: // f
-        if (!PDFViewerApplication.supportsIntegratedFind && !evt.shiftKey) {
-          PDFViewerApplication.findBar?.open();
+        if (!this.supportsIntegratedFind && !evt.shiftKey) {
+          this.findBar?.open();
           handled = true;
         }
         break;
       case 71: // g
-        if (!PDFViewerApplication.supportsIntegratedFind) {
-          const { state } = PDFViewerApplication.findController;
+        if (!this.supportsIntegratedFind) {
+          const { state } = this.findController;
           if (state) {
             const newState = {
               source: window,
@@ -2858,40 +2846,37 @@ function webViewerKeyDown(evt) {
       case 107: // FF '+' and '='
       case 187: // Chrome '+'
       case 171: // FF with German keyboard
-        PDFViewerApplication.zoomIn();
+        this.zoomIn();
         handled = true;
         break;
       case 173: // FF/Mac '-'
       case 109: // FF '-'
       case 189: // Chrome '-'
-        PDFViewerApplication.zoomOut();
+        this.zoomOut();
         handled = true;
         break;
       case 48: // '0'
       case 96: // '0' on Numpad of Swedish keyboard
         if (!isViewerInPresentationMode) {
           // keeping it unhandled (to restore page zoom to 100%)
-          setTimeout(function () {
+          setTimeout(() => {
             // ... and resetting the scale after browser adjusts its scale
-            PDFViewerApplication.zoomReset();
+            this.zoomReset();
           });
           handled = false;
         }
         break;
 
       case 38: // up arrow
-        if (isViewerInPresentationMode || PDFViewerApplication.page > 1) {
-          PDFViewerApplication.page = 1;
+        if (isViewerInPresentationMode || this.page > 1) {
+          this.page = 1;
           handled = true;
           ensureViewerFocused = true;
         }
         break;
       case 40: // down arrow
-        if (
-          isViewerInPresentationMode ||
-          PDFViewerApplication.page < PDFViewerApplication.pagesCount
-        ) {
-          PDFViewerApplication.page = PDFViewerApplication.pagesCount;
+        if (isViewerInPresentationMode || this.page < this.pagesCount) {
+          this.page = this.pagesCount;
           handled = true;
           ensureViewerFocused = true;
         }
@@ -2922,17 +2907,17 @@ function webViewerKeyDown(evt) {
   if (cmd === 3 || cmd === 10) {
     switch (evt.keyCode) {
       case 80: // p
-        PDFViewerApplication.requestPresentationMode();
+        this.requestPresentationMode();
         handled = true;
-        PDFViewerApplication.externalServices.reportTelemetry({
+        this.externalServices.reportTelemetry({
           type: "buttons",
           data: { id: "presentationModeKeyboard" },
         });
         break;
       case 71: // g
         // focuses input#pageNumber field
-        if (PDFViewerApplication.appConfig.toolbar) {
-          PDFViewerApplication.appConfig.toolbar.pageNumber.select();
+        if (this.appConfig.toolbar) {
+          this.appConfig.toolbar.pageNumber.select();
           handled = true;
         }
         break;
@@ -2971,11 +2956,8 @@ function webViewerKeyDown(evt) {
       turnOnlyIfPageFit = false;
     switch (evt.keyCode) {
       case 38: // up arrow
-        if (PDFViewerApplication.supportsCaretBrowsingMode) {
-          PDFViewerApplication.moveCaret(
-            /* isUp = */ true,
-            /* select = */ false
-          );
+        if (this.supportsCaretBrowsingMode) {
+          this.moveCaret(/* isUp = */ true, /* select = */ false);
           handled = true;
           break;
         }
@@ -2994,7 +2976,7 @@ function webViewerKeyDown(evt) {
         turnPage = -1;
         break;
       case 37: // left arrow
-        if (PDFViewerApplication.supportsCaretBrowsingMode) {
+        if (this.supportsCaretBrowsingMode) {
           return;
         }
         // horizontal scrolling using arrow keys
@@ -3007,24 +2989,18 @@ function webViewerKeyDown(evt) {
         turnPage = -1;
         break;
       case 27: // esc key
-        if (PDFViewerApplication.secondaryToolbar?.isOpen) {
-          PDFViewerApplication.secondaryToolbar.close();
+        if (this.secondaryToolbar?.isOpen) {
+          this.secondaryToolbar.close();
           handled = true;
         }
-        if (
-          !PDFViewerApplication.supportsIntegratedFind &&
-          PDFViewerApplication.findBar?.opened
-        ) {
-          PDFViewerApplication.findBar.close();
+        if (!this.supportsIntegratedFind && this.findBar?.opened) {
+          this.findBar.close();
           handled = true;
         }
         break;
       case 40: // down arrow
-        if (PDFViewerApplication.supportsCaretBrowsingMode) {
-          PDFViewerApplication.moveCaret(
-            /* isUp = */ false,
-            /* select = */ false
-          );
+        if (this.supportsCaretBrowsingMode) {
+          this.moveCaret(/* isUp = */ false, /* select = */ false);
           handled = true;
           break;
         }
@@ -3044,7 +3020,7 @@ function webViewerKeyDown(evt) {
         turnPage = 1;
         break;
       case 39: // right arrow
-        if (PDFViewerApplication.supportsCaretBrowsingMode) {
+        if (this.supportsCaretBrowsingMode) {
           return;
         }
         // horizontal scrolling using arrow keys
@@ -3058,36 +3034,33 @@ function webViewerKeyDown(evt) {
         break;
 
       case 36: // home
-        if (isViewerInPresentationMode || PDFViewerApplication.page > 1) {
-          PDFViewerApplication.page = 1;
+        if (isViewerInPresentationMode || this.page > 1) {
+          this.page = 1;
           handled = true;
           ensureViewerFocused = true;
         }
         break;
       case 35: // end
-        if (
-          isViewerInPresentationMode ||
-          PDFViewerApplication.page < PDFViewerApplication.pagesCount
-        ) {
-          PDFViewerApplication.page = PDFViewerApplication.pagesCount;
+        if (isViewerInPresentationMode || this.page < this.pagesCount) {
+          this.page = this.pagesCount;
           handled = true;
           ensureViewerFocused = true;
         }
         break;
 
       case 83: // 's'
-        PDFViewerApplication.pdfCursorTools?.switchTool(CursorTool.SELECT);
+        this.pdfCursorTools?.switchTool(CursorTool.SELECT);
         break;
       case 72: // 'h'
-        PDFViewerApplication.pdfCursorTools?.switchTool(CursorTool.HAND);
+        this.pdfCursorTools?.switchTool(CursorTool.HAND);
         break;
 
       case 82: // 'r'
-        PDFViewerApplication.rotatePages(90);
+        this.rotatePages(90);
         break;
 
       case 115: // F4
-        PDFViewerApplication.pdfSidebar?.toggle();
+        this.pdfSidebar?.toggle();
         break;
     }
 
@@ -3121,15 +3094,15 @@ function webViewerKeyDown(evt) {
         break;
 
       case 38: // up arrow
-        PDFViewerApplication.moveCaret(/* isUp = */ true, /* select = */ true);
+        this.moveCaret(/* isUp = */ true, /* select = */ true);
         handled = true;
         break;
       case 40: // down arrow
-        PDFViewerApplication.moveCaret(/* isUp = */ false, /* select = */ true);
+        this.moveCaret(/* isUp = */ false, /* select = */ true);
         handled = true;
         break;
       case 82: // 'r'
-        PDFViewerApplication.rotatePages(-90);
+        this.rotatePages(-90);
         break;
     }
   }


### PR DESCRIPTION
 - Shorten the names of the event listeners.

 - Use `bind` to pass in the `PDFViewerApplication`-scope to the event handlers.
   This makes the event handler code (a lot) less verbose, and this change is possible now that we're removing event listeners with `AbortSignal`.

 - Move the GENERIC-only event listeners into the same pre-processor block.

*Note:* This patch reduces the size of the `gulp mozcentral` output by `~4.3` kilo-bytes, which isn't a lot but still cannot hurt.