### PR TITLE
[api-minor] Allow specifying custom match logic in PDFFindController

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -670,37 +670,6 @@ class PDFFindController {
     return true;
   }
 
-  #calculateRegExpMatch(query, entireWord, pageIndex, pageContent) {
-    const matches = (this._pageMatches[pageIndex] = []);
-    const matchesLength = (this._pageMatchesLength[pageIndex] = []);
-    if (!query) {
-      // The query can be empty because some chars like diacritics could have
-      // been stripped out.
-      return;
-    }
-    const diffs = this._pageDiffs[pageIndex];
-    let match;
-    while ((match = query.exec(pageContent)) !== null) {
-      if (
-        entireWord &&
-        !this.#isEntireWord(pageContent, match.index, match[0].length)
-      ) {
-        continue;
-      }
-
-      const [matchPos, matchLen] = getOriginalIndex(
-        diffs,
-        match.index,
-        match[0].length
-      );
-
-      if (matchLen) {
-        matches.push(matchPos);
-        matchesLength.push(matchLen);
-      }
-    }
-  }
-
   #convertToRegExpString(query, hasDiacritics) {
     const { matchDiacritics } = this.#state;
     let isUnicode = false;
@@ -772,12 +741,64 @@ class PDFFindController {
   }
 
   #calculateMatch(pageIndex) {
-    let query = this.#query;
+    const query = this.#query;
     if (query.length === 0) {
       return; // Do nothing: the matches should be wiped out already.
     }
-    const { caseSensitive, entireWord } = this.#state;
     const pageContent = this._pageContents[pageIndex];
+    const matcherResult = this.match(query, pageContent, pageIndex);
+
+    const matches = (this._pageMatches[pageIndex] = []);
+    const matchesLength = (this._pageMatchesLength[pageIndex] = []);
+    const diffs = this._pageDiffs[pageIndex];
+
+    matcherResult?.forEach(({ index, length }) => {
+      const [matchPos, matchLen] = getOriginalIndex(diffs, index, length);
+      if (matchLen) {
+        matches.push(matchPos);
+        matchesLength.push(matchLen);
+      }
+    });
+
+    // When `highlightAll` is set, ensure that the matches on previously
+    // rendered (and still active) pages are correctly highlighted.
+    if (this.#state.highlightAll) {
+      this.#updatePage(pageIndex);
+    }
+    if (this._resumePageIdx === pageIndex) {
+      this._resumePageIdx = null;
+      this.#nextPageMatch();
+    }
+
+    // Update the match count.
+    const pageMatchesCount = matches.length;
+    this._matchesCountTotal += pageMatchesCount;
+    if (this.#updateMatchesCountOnProgress) {
+      if (pageMatchesCount > 0) {
+        this.#updateUIResultsCount();
+      }
+    } else if (++this.#visitedPagesCount === this._linkService.pagesCount) {
+      // For example, in GeckoView we want to have only the final update because
+      // the Java side provides only one object to update the counts.
+      this.#updateUIResultsCount();
+    }
+  }
+
+  /**
+   * @typedef {Object} FindMatch
+   * @property {number} index - The start of the matched text in the page's
+   *   string contents.
+   * @property {number} length - The length of the matched text.
+   */
+
+  /**
+   * @param {string | string[]} query - The search query.
+   * @param {string} pageContent - The text content of the page to search in.
+   * @param {number} pageIndex - The index of the page that is being processed.
+   * @returns {FindMatch[] | undefined} An array of matches in the provided
+   *   page.
+   */
+  match(query, pageContent, pageIndex) {
     const hasDiacritics = this._hasDiacritics[pageIndex];
 
     let isUnicode = false;
@@ -799,34 +820,28 @@ class PDFFindController {
         })
         .join("|");
     }
+    if (!query) {
+      // The query can be empty because some chars like diacritics could have
+      // been stripped out.
+      return undefined;
+    }
 
+    const { caseSensitive, entireWord } = this.#state;
     const flags = `g${isUnicode ? "u" : ""}${caseSensitive ? "" : "i"}`;
-    query = query ? new RegExp(query, flags) : null;
+    query = new RegExp(query, flags);
 
-    this.#calculateRegExpMatch(query, entireWord, pageIndex, pageContent);
-
-    // When `highlightAll` is set, ensure that the matches on previously
-    // rendered (and still active) pages are correctly highlighted.
-    if (this.#state.highlightAll) {
-      this.#updatePage(pageIndex);
-    }
-    if (this._resumePageIdx === pageIndex) {
-      this._resumePageIdx = null;
-      this.#nextPageMatch();
-    }
-
-    // Update the match count.
-    const pageMatchesCount = this._pageMatches[pageIndex].length;
-    this._matchesCountTotal += pageMatchesCount;
-    if (this.#updateMatchesCountOnProgress) {
-      if (pageMatchesCount > 0) {
-        this.#updateUIResultsCount();
+    const matches = [];
+    let match;
+    while ((match = query.exec(pageContent)) !== null) {
+      if (
+        entireWord &&
+        !this.#isEntireWord(pageContent, match.index, match[0].length)
+      ) {
+        continue;
       }
-    } else if (++this.#visitedPagesCount === this._linkService.pagesCount) {
-      // For example, in GeckoView we want to have only the final update because
-      // the Java side provides only one object to update the counts.
-      this.#updateUIResultsCount();
+      matches.push({ index: match.index, length: match[0].length });
     }
+    return matches;
   }
 
   #extractText() {
@@ -1103,7 +1118,7 @@ class PDFFindController {
       current += matchIdx + 1;
     }
     // When searching starts, this method may be called before the `pageMatches`
-    // have been counted (in `_calculateMatch`). Ensure that the UI won't show
+    // have been counted (in `#calculateMatch`). Ensure that the UI won't show
     // temporarily broken state when the active find result doesn't make sense.
     if (current < 1 || current > total) {
       current = total = 0;


### PR DESCRIPTION
> **Allow specifying custom match logic in PDFFindController**
>
> This patch allows embedders of PDF.js to provide custom match logic for seaching in PDFs. This is done by subclassing the PDFFindController class and overriding the `match` method.
>
> `match` is called once per PDF page, receives as parameters the search query, the page contents, and the page index, and returns an array of `{ index, length }` objects representing the search results.

This is my proposed API for https://github.com/mozilla/pdf.js/issues/18482. It is mostly moving code around, to carve out a (public) method with the minimum possible API that non-Firefox embedders can use to provide their own custom search. More specifically:
- the logic in `#calculateMatch` that builds the RegExp has been moved to `#calculateRegExpMatch`, so that `#calculateMatch` is agnostic to the matching logic and only takes care of running the matcher and updating the state based on the match result
- `#calculateRegExpMatch` has been renamed to `match(...)`, that subclasses can override
- ~`#calculateMatch` supports calling `match` even when it's an async function. This does not affect PDF.js itself (since `#calculateMatch()` is already called in a non-awaited `.then(() => ...)`), but makes it possible for consumers to have async match logic.~

I believe that this API is minimal enough that it won't cause problems if in the future PDFFindController needs to be refactored, as @calixteman mentioned in https://github.com/mozilla/pdf.js/issues/18482#issuecomment-2248020959.

Some examples of how it can be used:


<details>
<summary><em>External search provider</em></summary>

```js
import fuzzySearch from "some-fuzzy-search-library";

class FuzzyFindController extends PDFFindController {
  // "query" is a string
  match(query, text) {
    const results = fuzzySearch(query, text);
    return results.map(({ index, value }) => ({ index, length: value.length }));
  }
}
```

</details>

<details>
<summary><em>Multi-word search</em></summary>

This is already supported by PDF.js, but as far as I can tell it cannot be used through the Firefox UI. This example is how it would be implemented in an alternative timeline where this PR would have happened before adding support for multi-word search.

This example assumes that in that alternative universe `convertToRegExpString` is not private, and it accepts `pageIndex` instead of `this._hasDiacritics[pageIndex]`.

```js
class MultiWordFindController extends PDFFindController {
  // "query" is an array of strings
  match(query, text, pageIndex) {
    let isUnicode = false;
    // Words are sorted in reverse order to be sure that "foobar" is matched
    // before "foo" in case the query is "foobar foo".
    const queryStr = query
      .sort()
      .reverse()
      .map(q => {
        const [isUnicodePart, queryPart] = this.convertToRegExpString(
          q,
          pageIndex
        );
        isUnicode ||= isUnicodePart;
        return `(${queryPart})`;
      })
      .join("|");

    const flags = `g${isUnicode ? "u" : ""}${this.state.caseSensitive ? "" : "i"}`;
    query = new RegExp(queryStr, flags);

    const matches = [];
    for (const { index, 0: match } of pageContent.matchAll(query)) {
      matches.push({ index, length: match.length });
    }
    return matches;
  }
}
```

</details>

<details>
<summary><em>Simple multi-page search</em></summary>

**EDIT**: This example does not apply anymore now that we only support sync `.match`. See https://github.com/mozilla/pdf.js/pull/18549#issuecomment-2268954354 for an async matcher example.

This implementation uses some `_`-prefixed properties of `PDFFindController`. Assuming that they are meant to be private (I can open a PR to replace `_` with `#` if needed, after that this PR lands), there is also a second implementation that only uses the real public API.

```js
class MultiPageFindController extends PDFFindController {
  // "query" is a string
  async match(query, text, pageIndex) {
    let prefix = "", suffix = "";
    if (pageIndex > 0) {
      await this._extractTextPromises[pageIndex - 1];
      prefix = this._pageContents[pageIndex - 1].slice(1 - query.length) + " ";
    }
    if (pageIndex + 1 < this._linkService.pagesCount) {
      await this._extractTextPromises[pageIndex + 1];
      suffix = " " + this._pageContents[pageIndex + 1].slice(0, query.length - 1);
    }
    text = prefix + text + suffix;

    const matches = [];
    let index = -1;
    while ((index = text.indexOf(query, index + 1)) !== -1) {
      let start = Math.max(prefix.length, index);
      let end = Math.min(index + query.length, prefix.length + text.length);
      matches.push({ index: start - prefix.length, length: end - start });
    }
    return matches;
  }
}
```

```js
class MultiPageFindController extends PDFFindController {
  #linkService;
  #pageContents;
  #pageContentsPromises = [];

  constructor(opts) {
    super(opts);
    this.#linkService = opts.linkService;
  }

  async #getPageContent(index) {
    if (this.#pageContents[index] == null) {
      this.#pageContentsPromises[pageIndex - 1] ??= Promise.withResolvers();
      await this.#pageContentsPromises[pageIndex - 1].promise;
    }
    return this.#pageContents[index];
  }

  // "query" is a string
  async match(query, text, pageIndex) {
    if (this.#pageContents[pageIndex] == null) {
    	this.#pageContents[pageIndex] = text;
    	this.#pageContentsPromises[pageIndex]?.resolve();
    }

    const [prevPage, nextPage] = await Promise.all([
      pageIndex > 0 ? this.#getPageContent(pageIndex - 1) : "",
      pageIndex + 1 < this.#linkService.pagesCount ? this.#getPageContent(pageIndex + 1) : "",
    ]);
    const prefix = prevPage.slice(1 - query.length) + " ";
    const suffix = " " + nextPage.slice(0, query.length - 1);
    text = prefix + text + suffix;

    const matches = [];
    let index = -1;
    while ((index = text.indexOf(query, index + 1)) !== -1) {
      let start = Math.max(prefix.length, index);
      let end = Math.min(index + query.length, prefix.length + text.length);
      matches.push({ index: start - prefix.length, length: end - start });
    }
    return matches;
  }
}
```

</details>

There are two questions that for which I keep swinging back and forth:
- Should the API be subclass-based, or parameter-based?
  ```js
  class CustomFindController extends PDFFindController {
    match(...) {}
  }
  ```
  vs
  ```js
  new PDFFindController({
    /* ... various other options... ,*/
    matcher(...) {}
  }
  ```
  `PDFFindController` already accepts multiple parameters to control its behavior, but having it as a subclass extension point leads to a cleaner implementation.
- Should the `isEntireWord` word check apply after running the matcher, or as part of the default matcher? Running after means that it would easily be available to custom matching logic (simply by setting `eintireWord: true` on the dispatched `"find"` event), but on the other hand it feels like its part of the match logic itself.

Please let me know what you think about this :)

PS. If this feature gets accepted and it will need any maintenance in the future feel free to ping me, similarly to how I have been keeping an eye on the various bugs related to text selection.