### PR TITLE
Invoke the "download" event handler correctly (PR 18527 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1943,7 +1943,7 @@ const PDFViewerApplication = {
       { signal }
     );
     eventBus._on("print", this.triggerPrinting.bind(this), { signal });
-    eventBus._on("download", this.downloadOrSave.bind(this), { signal });
+    eventBus._on("download", () => this.downloadOrSave(), { signal });
     eventBus._on("firstpage", () => (this.page = 1), { signal });
     eventBus._on("lastpage", () => (this.page = this.pagesCount), { signal });
     eventBus._on("nextpage", () => pdfViewer.nextPage(), { signal });


### PR DESCRIPTION
Since the `PDFViewerApplication.downloadOrSave` method accepts an optional argument we cannot use `bind` but instead need to invoke it explicitly when handling the "download" event; currently this leads to failing tests in mozilla-central.