### PR TITLE
Stop sending the unused `options` parameter to various download-methods in the viewer

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1109,22 +1109,17 @@ const PDFViewerApplication = {
     );
   },
 
-  async download(options = {}) {
+  async download() {
     let data;
     try {
       data = await this.pdfDocument.getData();
     } catch {
       // When the PDF document isn't ready, simply download using the URL.
     }
-    this.downloadManager.download(
-      data,
-      this._downloadUrl,
-      this._docFilename,
-      options
-    );
+    this.downloadManager.download(data, this._downloadUrl, this._docFilename);
   },
 
-  async save(options = {}) {
+  async save() {
     if (this._saveInProgress) {
       return;
     }
@@ -1133,16 +1128,11 @@ const PDFViewerApplication = {
 
     try {
       const data = await this.pdfDocument.saveDocument();
-      this.downloadManager.download(
-        data,
-        this._downloadUrl,
-        this._docFilename,
-        options
-      );
+      this.downloadManager.download(data, this._downloadUrl, this._docFilename);
     } catch (reason) {
       // When the PDF document isn't ready, fallback to a "regular" download.
       console.error(`Error when saving the document: ${reason.message}`);
-      await this.download(options);
+      await this.download();
     } finally {
       await this.pdfScriptingManager.dispatchDidSave();
       this._saveInProgress = false;
@@ -1159,7 +1149,7 @@ const PDFViewerApplication = {
     }
   },
 
-  async downloadOrSave(options = {}) {
+  async downloadOrSave() {
     // In the Firefox case, this method MUST always trigger a download.
     // When the user is closing a modified and unsaved document, we display a
     // prompt asking for saving or not. In case they save, we must wait for
@@ -1169,8 +1159,8 @@ const PDFViewerApplication = {
     const { classList } = this.appConfig.appContainer;
     classList.add("wait");
     await (this.pdfDocument?.annotationStorage.size > 0
-      ? this.save(options)
-      : this.download(options));
+      ? this.save()
+      : this.download());
     classList.remove("wait");
   },
 

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -105,7 +105,7 @@ class DownloadManager {
     return false;
   }
 
-  download(data, url, filename, _options) {
+  download(data, url, filename) {
     let blobUrl;
     if (data) {
       blobUrl = URL.createObjectURL(

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -133,7 +133,7 @@ class DownloadManager {
     return false;
   }
 
-  download(data, url, filename, options = {}) {
+  download(data, url, filename) {
     const blobUrl = data
       ? URL.createObjectURL(new Blob([data], { type: "application/pdf" }))
       : null;
@@ -142,7 +142,6 @@ class DownloadManager {
       blobUrl,
       originalUrl: url,
       filename,
-      options,
     });
   }
 }

--- a/web/interfaces.js
+++ b/web/interfaces.js
@@ -156,9 +156,8 @@ class IDownloadManager {
    * @param {Uint8Array} data
    * @param {string} url
    * @param {string} filename
-   * @param {Object} [options]
    */
-  download(data, url, filename, options) {}
+  download(data, url, filename) {}
 }
 
 /**


### PR DESCRIPTION
The `options` handling, for the download-methods, was originally added in PR #16391 and became obsolete in PR #17771.

This fixes failures, in mozilla-central tests, which appeared after landing PR #18527.

----

***Edit:*** _This replaces PR #18550._