### PR TITLE
Define a few editor event handler functions inline

### DIFF
--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -53,8 +53,6 @@ class HighlightEditor extends AnnotationEditor {
 
   #isFreeHighlight = false;
 
-  #boundKeydown = this.#keydown.bind(this);
-
   #lastPoint = null;
 
   #opacity;
@@ -568,7 +566,7 @@ class HighlightEditor extends AnnotationEditor {
     if (this.#isFreeHighlight) {
       div.classList.add("free");
     } else {
-      this.div.addEventListener("keydown", this.#boundKeydown, {
+      this.div.addEventListener("keydown", this.#keydown.bind(this), {
         signal: this._uiManager._signal,
       });
     }

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -612,16 +612,6 @@ class AnnotationEditorUIManager {
 
   #boundKeyup = this.keyup.bind(this);
 
-  #boundOnEditingAction = this.onEditingAction.bind(this);
-
-  #boundOnPageChanging = this.onPageChanging.bind(this);
-
-  #boundOnScaleChanging = this.onScaleChanging.bind(this);
-
-  #boundOnSetPreference = this.onSetPreference.bind(this);
-
-  #boundOnRotationChanging = this.onRotationChanging.bind(this);
-
   #previousStates = {
     isEditing: false,
     isEmpty: true,
@@ -794,13 +784,21 @@ class AnnotationEditorUIManager {
     this.#viewer = viewer;
     this.#altTextManager = altTextManager;
     this._eventBus = eventBus;
-    this._eventBus._on("editingaction", this.#boundOnEditingAction, { signal });
-    this._eventBus._on("pagechanging", this.#boundOnPageChanging, { signal });
-    this._eventBus._on("scalechanging", this.#boundOnScaleChanging, { signal });
-    this._eventBus._on("rotationchanging", this.#boundOnRotationChanging, {
+    this._eventBus._on("editingaction", this.onEditingAction.bind(this), {
       signal,
     });
-    this._eventBus._on("setpreference", this.#boundOnSetPreference, { signal });
+    this._eventBus._on("pagechanging", this.onPageChanging.bind(this), {
+      signal,
+    });
+    this._eventBus._on("scalechanging", this.onScaleChanging.bind(this), {
+      signal,
+    });
+    this._eventBus._on("rotationchanging", this.onRotationChanging.bind(this), {
+      signal,
+    });
+    this._eventBus._on("setpreference", this.onSetPreference.bind(this), {
+      signal,
+    });
     this.#addSelectionListener();
     this.#addDragAndDropListeners();
     this.#addKeyboardManager();


### PR DESCRIPTION
Given that we're removing event listeners with `AbortSignal` it's no longer necessary to keep a reference to a few of the event handler functions in order to remove them.
Hence we can simply inline the relevant `bind`-calls instead, which reduces the code-size a tiny bit.