### PR TITLE
Update the Babel plugin to remove empty static blocks

### DIFF
--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -184,7 +184,7 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
           path.replaceWith(t.importExpression(source));
         }
       },
-      BlockStatement: {
+      "BlockStatement|StaticBlock": {
         // Visit node in post-order so that recursive flattening
         // of blocks works correctly.
         exit(path) {
@@ -214,6 +214,10 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
                 break;
             }
             subExpressionIndex++;
+          }
+
+          if (node.type === "StaticBlock" && node.body.length === 0) {
+            path.remove();
           }
         },
       },

--- a/external/builder/fixtures_babel/staticblock-expected.js
+++ b/external/builder/fixtures_babel/staticblock-expected.js
@@ -1,0 +1,8 @@
+class A {
+  static {
+    foo();
+  }
+  static {
+    var a = 0;
+  }
+}

--- a/external/builder/fixtures_babel/staticblock.js
+++ b/external/builder/fixtures_babel/staticblock.js
@@ -1,0 +1,20 @@
+class A {
+  static {}
+  static {
+    { foo() }
+  }
+  static {
+    {;}
+  }
+  static {
+    if (PDFJSDev.test('TRUE')) {
+      var a = 0;
+    }
+  }
+
+  static {
+    if (PDFJSDev.test('FALSE')) {
+      var a = 1;
+    }
+  }
+}


### PR DESCRIPTION
> **Update the Babel plugin to remove empty static blocks**
> 
> This commit updates the Babel plugin to:
> - apply the same flattening logic that we already have for blocks, to flatten blocks nested inside class static blocks
> - remove class static blocks when, after flattening all the blocks they contain, they are empty.
> 
> Before this commit, the transform output was the same as the input.

Closes https://github.com/mozilla/pdf.js/issues/18559