### PR TITLE
Remove obsolete `otherPages` variable from the scripting integration tests

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -2198,20 +2198,13 @@ describe("Interaction", () => {
 
   describe("Textfield with a Blur callback", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("bug1863910.pdf", getSelector("25R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check that blur callback is called", async () => {
@@ -2237,20 +2230,13 @@ describe("Interaction", () => {
 
   describe("Radio button without T value", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("bug1860602.pdf", getSelector("22R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check that only one radio is selected", async () => {
@@ -2301,20 +2287,13 @@ describe("Interaction", () => {
 
   describe("Textfield with a number and some decimals", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("issue17540.pdf", getSelector("15R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check the number has the correct number of decimals", async () => {
@@ -2341,20 +2320,13 @@ describe("Interaction", () => {
 
   describe("Textfield with a zip code starting with 0", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("bug1889122.pdf", getSelector("24R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check the zip code is correctly formatted", async () => {
@@ -2376,20 +2348,13 @@ describe("Interaction", () => {
 
   describe("Value of event.change when a choice list is modified", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("issue17998.pdf", getSelector("7R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check the properties of the event", async () => {
@@ -2417,20 +2382,13 @@ describe("Interaction", () => {
 
   describe("PageOpen and PageClose actions in fields", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("issue18305.pdf", getSelector("7R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check that PageOpen/PageClose actions are correctly executed", async () => {
@@ -2469,20 +2427,13 @@ describe("Interaction", () => {
 
   describe("Compute product of different fields", () => {
     let pages;
-    let otherPages;
 
     beforeAll(async () => {
-      otherPages = await Promise.all(
-        global.integrationSessions.map(async session =>
-          session.browser.newPage()
-        )
-      );
       pages = await loadAndWait("issue18536.pdf", getSelector("34R"));
     });
 
     afterAll(async () => {
       await closePages(pages);
-      await Promise.all(otherPages.map(page => page.close()));
     });
 
     it("must check that the product are null", async () => {


### PR DESCRIPTION
It looks like this has accidentally been copy/pasted from the `Textfields and focus` block, which is the only one in which a test actually uses it. We can therefore safely remove it from all other blocks where no test uses it.