### PR TITLE
Check that `AbortSignal.any()` is supported in `PDFViewer` too (PR 18586 follow-up)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -880,7 +880,11 @@ class PDFViewer {
           viewer.before(element);
         }
 
-        if (annotationEditorMode !== AnnotationEditorType.DISABLE) {
+        if (
+          ((typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+            typeof AbortSignal.any === "function") &&
+          annotationEditorMode !== AnnotationEditorType.DISABLE
+        ) {
           const mode = annotationEditorMode;
 
           if (pdfDocument.isPureXfa) {


### PR DESCRIPTION
Without this patch the viewer may break on load, since the check added in PR #18586 only applies to the toolbar.