### PR TITLE
Revert "[Editor] Pass a buffer instead of a typed array when passing image data to the model"

### DIFF
--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -169,9 +169,7 @@ class StampEditor extends AnnotationEditor {
     const response = await mlManager.guess({
       name: "altText",
       request: {
-        // Pass a buffer to avoid copy, see "run" method in:
-        //  https://searchfox.org/mozilla-central/source/toolkit/components/ml/actors/MLEngineParent.sys.mjs
-        data: data.buffer,
+        data,
         width,
         height,
         channels: data.length / (width * height),


### PR DESCRIPTION
Reverts mozilla/pdf.js#18580

It was a bad idea: all the images have almost the same generated description.
I'll investigate later why it's wrong.