### PR TITLE
Upgrade Puppeteer to version 23.1.1

### DIFF
--- a/.puppeteerrc
+++ b/.puppeteerrc
@@ -1,0 +1,9 @@
+{
+  "chrome": {
+    "skipDownload": false
+  },
+  "firefox": {
+    "skipDownload": false,
+    "version": "nightly"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "pdf.js",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -21,7 +20,6 @@
         "caniuse-lite": "^1.0.30001653",
         "canvas": "^2.11.2",
         "core-js": "^3.38.1",
-        "cross-env": "^7.0.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-fetch-options": "^0.0.5",
@@ -54,7 +52,7 @@
         "postcss-discard-comments": "^7.0.2",
         "postcss-nesting": "^13.0.0",
         "prettier": "^3.3.3",
-        "puppeteer": "^22.15.0",
+        "puppeteer": "^23.1.1",
         "stylelint": "^16.8.2",
         "stylelint-prettier": "^5.0.2",
         "terser-webpack-plugin": "^5.3.10",
@@ -2649,13 +2647,13 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.1.tgz",
+      "integrity": "sha512-uK7o3hHkK+naEobMSJ+2ySYyXtQkBxIH8Gn4MK9ciePjNV+Pf+PgY/W7iPzn2MTjl3stcYB5AlcTmPYw7AXDwA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.4.0",
@@ -3958,9 +3956,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.4.tgz",
+      "integrity": "sha512-8zoq6ogmhQQkAKZVKO2ObFTl4uOkqoX1PlKQX3hZQ5E9cbUotcAb7h4pTNVAGGv8Z36PF3CtdOriEp/Rz82JqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4407,24 +4405,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -10622,36 +10602,39 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
-      "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
+      "version": "23.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.1.1.tgz",
+      "integrity": "sha512-giN4Ikwl5hkkouH/dVyxIPTPslWuqZ8fjALdSw5Cvt+r0LuDpLdfPxRADlB75YJ2UjPZhgok+xYBYk8ffzv4MA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.3.0",
+        "@puppeteer/browsers": "2.3.1",
+        "chromium-bidi": "0.6.4",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1312386",
-        "puppeteer-core": "22.15.0"
+        "puppeteer-core": "23.1.1",
+        "typed-query-selector": "^2.12.0"
       },
       "bin": {
-        "puppeteer": "lib/esm/puppeteer/node/cli.js"
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+      "version": "23.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.1.1.tgz",
+      "integrity": "sha512-OeTqNiYGF9qZtwZU4Yc88DDqFJs4TJ4rnK81jkillh6MwDeQodyisM9xe5lBmPhwiDy92s5J5DQtQLjCKHFQ3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.3.0",
-        "chromium-bidi": "0.6.3",
+        "@puppeteer/browsers": "2.3.1",
+        "chromium-bidi": "0.6.4",
         "debug": "^4.3.6",
         "devtools-protocol": "0.0.1312386",
+        "typed-query-selector": "^2.12.0",
         "ws": "^8.18.0"
       },
       "engines": {
@@ -12755,6 +12738,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.5.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "caniuse-lite": "^1.0.30001653",
     "canvas": "^2.11.2",
     "core-js": "^3.38.1",
-    "cross-env": "^7.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-fetch-options": "^0.0.5",
@@ -48,7 +47,7 @@
     "postcss-discard-comments": "^7.0.2",
     "postcss-nesting": "^13.0.0",
     "prettier": "^3.3.3",
-    "puppeteer": "^22.15.0",
+    "puppeteer": "^23.1.1",
     "stylelint": "^16.8.2",
     "stylelint-prettier": "^5.0.2",
     "terser-webpack-plugin": "^5.3.10",
@@ -59,9 +58,6 @@
     "webpack": "^5.94.0",
     "webpack-stream": "^7.0.0",
     "yargs": "^17.7.2"
-  },
-  "scripts": {
-    "postinstall": "cross-env PUPPETEER_PRODUCT=firefox node node_modules/puppeteer/install.mjs"
   },
   "repository": {
     "type": "git",

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -1675,7 +1675,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(editorPng);
+            const editorImage = PNG.sync.read(Buffer.from(editorPng));
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -1703,7 +1703,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(editorPng);
+            const editorImage = PNG.sync.read(Buffer.from(editorPng));
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -1836,7 +1836,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(editorPng);
+            const editorImage = PNG.sync.read(Buffer.from(editorPng));
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -1870,7 +1870,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(editorPng);
+            const editorImage = PNG.sync.read(Buffer.from(editorPng));
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -3589,7 +3589,7 @@ describe("FreeText Editor", () => {
             "[data-annotation-id='998R']",
             el => (el.hidden = false)
           );
-          let editorImage = PNG.sync.read(editorPng);
+          let editorImage = PNG.sync.read(Buffer.from(editorPng));
           expect(editorImage.data.every(x => x === 0xff))
             .withContext(`In ${browserName}`)
             .toBeTrue();
@@ -3636,7 +3636,7 @@ describe("FreeText Editor", () => {
             clip: editorRect,
             type: "png",
           });
-          editorImage = PNG.sync.read(editorPng);
+          editorImage = PNG.sync.read(Buffer.from(editorPng));
           expect(editorImage.data.every(x => x === 0xff))
             .withContext(`In ${browserName}`)
             .toBeFalse();

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -882,7 +882,7 @@ async function startBrowser({
   extraPrefsFirefox = {},
 }) {
   const options = {
-    product: browserName,
+    browser: browserName,
     protocol: "webDriverBiDi",
     headless,
     dumpio: true,


### PR DESCRIPTION
This major version contains three breaking changes that impact us:

- The `product` option has been renamed to the more suitable `browser`.
- The `page.screenshot()` API returns a `Uint8Array` instead of a `Buffer`, but since `pngjs` requires a `Buffer` object we need to do the conversion using `Buffer.from()` before passing data to `pngjs`.
- The browser configuration should be set using a configuration file instead of environment variables. Note that as a bonus this allows us to remove the `cross-env` dependency since that was only used to set the Puppeteer environment variable equally for all operating systems.

For more information about the changes between the old and new Puppeteer versions refer to https://github.com/puppeteer/puppeteer/releases.