### PR TITLE
Group and scope the secondary toolbar rules using CSS nesting

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -334,8 +334,7 @@ body {
 }
 
 :is(.toolbar, .editorParamsToolbar, #sidebarContainer)
-  :is(input, button, select),
-.secondaryToolbar :is(input, button, a, select) {
+  :is(input, button, select) {
   outline: none;
   font: message-box;
 }
@@ -362,7 +361,6 @@ body {
 }
 
 #toolbarContainer,
-.secondaryToolbar,
 .editorParamsToolbar {
   position: relative;
   height: var(--toolbar-height);
@@ -447,7 +445,6 @@ body {
   transition-duration: 0s;
 }
 
-.secondaryToolbar,
 .editorParamsToolbar {
   top: var(--toolbar-height);
   position: absolute;
@@ -462,7 +459,6 @@ body {
   cursor: default;
 }
 
-.secondaryToolbar,
 .editorParamsToolbar {
   padding: 6px 0 10px;
   inset-inline-end: 4px;
@@ -1223,6 +1219,25 @@ dialog :link {
 }
 
 #secondaryToolbar {
+  background-color: var(--doorhanger-bg-color);
+  cursor: default;
+  font: message-box;
+  font-size: 12px;
+  height: auto;
+  inset-inline-end: 4px;
+  line-height: 14px;
+  margin: 4px 2px;
+  padding: 6px 0 10px;
+  position: absolute;
+  text-align: left;
+  top: var(--toolbar-height);
+  z-index: 30000;
+
+  :is(button, a) {
+    font: message-box;
+    outline: none;
+  }
+
   .toolbarButton {
     border-radius: 0;
     display: inline-block;


### PR DESCRIPTION
The secondary toolbar CSS rules predate the general availability of CSS nesting, which makes them more difficult to understand and change safely. The primary issues are that the rules are spread over the `viewer.css` file, they share blocks with other elements and the scope of the rules is sometimes bigger than necessary.

This refactoring groups all remaining secondary toolbar rules together, scoped to the top-level `#secondaryToolbar` element, for improved overview and isolation. Note that this patch only intends to move the existing rules around and not change any behavior.

Notes for the reviewer:

- This is the final part for the secondary toolbar isolation/refactoring. The changes here are very similar to those from #18568.
- The rules at https://github.com/mozilla/pdf.js/pull/18597/files#diff-d1047e1376717fbe7c554bb385cd48b2dcbbb135e02884be3db97ad072ba741eL365 were all overridden by either https://github.com/mozilla/pdf.js/pull/18597/files#diff-d1047e1376717fbe7c554bb385cd48b2dcbbb135e02884be3db97ad072ba741eL450, https://github.com/mozilla/pdf.js/pull/18597/files#diff-d1047e1376717fbe7c554bb385cd48b2dcbbb135e02884be3db97ad072ba741eL465 or the doorhanger class, and as such could simply be removed. This can be confirmed by opening the default viewer, inspecting the `#secondaryToolbar` element and noticing that the rules in this block are already inactive:

![afbeelding](https://github.com/user-attachments/assets/414a9481-5c0f-437d-847c-6ca1341da031)

Extracts a part of #18385.