### PR TITLE
Limit base-class initialization checks to development and TESTING modes

### DIFF
--- a/src/core/base_stream.js
+++ b/src/core/base_stream.js
@@ -17,7 +17,10 @@ import { bytesToString, shadow, unreachable } from "../shared/util.js";
 
 class BaseStream {
   constructor() {
-    if (this.constructor === BaseStream) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseStream
+    ) {
       unreachable("Cannot initialize BaseStream.");
     }
   }

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -62,7 +62,10 @@ function resizeRgbImage(src, dest, w1, h1, w2, h2, alpha01) {
 
 class ColorSpace {
   constructor(name, numComps) {
-    if (this.constructor === ColorSpace) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === ColorSpace
+    ) {
       unreachable("Cannot initialize ColorSpace.");
     }
     this.name = name;

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -693,7 +693,10 @@ class NullCipher {
 
 class AESBaseCipher {
   constructor() {
-    if (this.constructor === AESBaseCipher) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === AESBaseCipher
+    ) {
       unreachable("Cannot initialize AESBaseCipher.");
     }
 

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -769,7 +769,10 @@ class Commands {
 
 class CompiledFont {
   constructor(fontMatrix) {
-    if (this.constructor === CompiledFont) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === CompiledFont
+    ) {
       unreachable("Cannot initialize CompiledFont.");
     }
     this.fontMatrix = fontMatrix;

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -23,7 +23,10 @@ import { RefSet, RefSetCache } from "./primitives.js";
 
 class BaseLocalCache {
   constructor(options) {
-    if (this.constructor === BaseLocalCache) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseLocalCache
+    ) {
       unreachable("Cannot initialize BaseLocalCache.");
     }
     this._onlyRefs = options?.onlyRefs === true;

--- a/src/core/name_number_tree.js
+++ b/src/core/name_number_tree.js
@@ -23,7 +23,10 @@ import { FormatError, unreachable, warn } from "../shared/util.js";
  */
 class NameOrNumberTree {
   constructor(root, xref, type) {
-    if (this.constructor === NameOrNumberTree) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === NameOrNumberTree
+    ) {
       unreachable("Cannot initialize NameOrNumberTree.");
     }
     this.root = root;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -98,7 +98,10 @@ class BaseShading {
   static SMALL_NUMBER = 1e-6;
 
   constructor() {
-    if (this.constructor === BaseShading) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseShading
+    ) {
       unreachable("Cannot initialize BaseShading.");
     }
   }

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -37,7 +37,10 @@ function parseDocBaseUrl(url) {
 
 class BasePdfManager {
   constructor(args) {
-    if (this.constructor === BasePdfManager) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BasePdfManager
+    ) {
       unreachable("Cannot initialize BasePdfManager.");
     }
     this._docBaseUrl = parseDocBaseUrl(args.docBaseUrl);

--- a/src/display/base_factory.js
+++ b/src/display/base_factory.js
@@ -17,7 +17,10 @@ import { CMapCompressionType, unreachable } from "../shared/util.js";
 
 class BaseFilterFactory {
   constructor() {
-    if (this.constructor === BaseFilterFactory) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseFilterFactory
+    ) {
       unreachable("Cannot initialize BaseFilterFactory.");
     }
   }
@@ -49,7 +52,10 @@ class BaseCanvasFactory {
   #enableHWA = false;
 
   constructor({ enableHWA = false } = {}) {
-    if (this.constructor === BaseCanvasFactory) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseCanvasFactory
+    ) {
       unreachable("Cannot initialize BaseCanvasFactory.");
     }
     this.#enableHWA = enableHWA;
@@ -101,7 +107,10 @@ class BaseCanvasFactory {
 
 class BaseCMapReaderFactory {
   constructor({ baseUrl = null, isCompressed = true }) {
-    if (this.constructor === BaseCMapReaderFactory) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseCMapReaderFactory
+    ) {
       unreachable("Cannot initialize BaseCMapReaderFactory.");
     }
     this.baseUrl = baseUrl;
@@ -139,7 +148,10 @@ class BaseCMapReaderFactory {
 
 class BaseStandardFontDataFactory {
   constructor({ baseUrl = null }) {
-    if (this.constructor === BaseStandardFontDataFactory) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseStandardFontDataFactory
+    ) {
       unreachable("Cannot initialize BaseStandardFontDataFactory.");
     }
     this.baseUrl = baseUrl;
@@ -171,7 +183,10 @@ class BaseStandardFontDataFactory {
 
 class BaseSVGFactory {
   constructor() {
-    if (this.constructor === BaseSVGFactory) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseSVGFactory
+    ) {
       unreachable("Cannot initialize BaseSVGFactory.");
     }
   }

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -140,7 +140,10 @@ class AnnotationEditor {
    * @param {AnnotationEditorParameters} parameters
    */
   constructor(parameters) {
-    if (this.constructor === AnnotationEditor) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === AnnotationEditor
+    ) {
       unreachable("Cannot initialize AnnotationEditor.");
     }
 

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -35,7 +35,10 @@ function applyBoundingBox(ctx, bbox) {
 
 class BaseShadingPattern {
   constructor() {
-    if (this.constructor === BaseShadingPattern) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseShadingPattern
+    ) {
       unreachable("Cannot initialize BaseShadingPattern.");
     }
   }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -468,7 +468,10 @@ function shadow(obj, prop, value, nonSerializable = false) {
 const BaseException = (function BaseExceptionClosure() {
   // eslint-disable-next-line no-shadow
   function BaseException(message, name) {
-    if (this.constructor === BaseException) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseException
+    ) {
       unreachable("Cannot initialize BaseException.");
     }
     this.message = message;

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -583,7 +583,9 @@ class AppOptions {
   }
 
   constructor() {
-    throw new Error("Cannot initialize AppOptions.");
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+      throw new Error("Cannot initialize AppOptions.");
+    }
   }
 
   static get(name) {

--- a/web/base_tree_viewer.js
+++ b/web/base_tree_viewer.js
@@ -20,7 +20,10 @@ const TREEITEM_SELECTED_CLASS = "selected";
 
 class BaseTreeViewer {
   constructor(options) {
-    if (this.constructor === BaseTreeViewer) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseTreeViewer
+    ) {
       throw new Error("Cannot initialize BaseTreeViewer.");
     }
     this.container = options.container;

--- a/web/external_services.js
+++ b/web/external_services.js
@@ -17,7 +17,10 @@
 
 class BaseExternalServices {
   constructor() {
-    if (this.constructor === BaseExternalServices) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BaseExternalServices
+    ) {
       throw new Error("Cannot initialize BaseExternalServices.");
     }
   }

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -30,7 +30,10 @@ class BasePreferences {
   #initializedPromise = null;
 
   constructor() {
-    if (this.constructor === BasePreferences) {
+    if (
+      (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
+      this.constructor === BasePreferences
+    ) {
       throw new Error("Cannot initialize BasePreferences.");
     }
 


### PR DESCRIPTION
We have a number of base-classes that are only intended to be extended, but never to be used directly. To help enforce this during development these base-class constructors will check for direct usage, however that code is obviously not needed in the actual builds.

*Note:* This patch reduces the size of the `gulp mozcentral` output by `~2.7` kilo-bytes, which isn't a lot but still cannot hurt.