### PR TITLE
Handle the "switchannotationeditorparams" event in the editor-code (issue 18196)

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -783,6 +783,11 @@ class AnnotationEditorUIManager {
       signal,
     });
     eventBus._on("setpreference", this.onSetPreference.bind(this), { signal });
+    eventBus._on(
+      "switchannotationeditorparams",
+      evt => this.updateParams(evt.type, evt.value),
+      { signal }
+    );
     this.#addSelectionListener();
     this.#addDragAndDropListeners();
     this.#addKeyboardManager();

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -776,21 +776,13 @@ class AnnotationEditorUIManager {
     this.#viewer = viewer;
     this.#altTextManager = altTextManager;
     this._eventBus = eventBus;
-    this._eventBus._on("editingaction", this.onEditingAction.bind(this), {
+    eventBus._on("editingaction", this.onEditingAction.bind(this), { signal });
+    eventBus._on("pagechanging", this.onPageChanging.bind(this), { signal });
+    eventBus._on("scalechanging", this.onScaleChanging.bind(this), { signal });
+    eventBus._on("rotationchanging", this.onRotationChanging.bind(this), {
       signal,
     });
-    this._eventBus._on("pagechanging", this.onPageChanging.bind(this), {
-      signal,
-    });
-    this._eventBus._on("scalechanging", this.onScaleChanging.bind(this), {
-      signal,
-    });
-    this._eventBus._on("rotationchanging", this.onRotationChanging.bind(this), {
-      signal,
-    });
-    this._eventBus._on("setpreference", this.onSetPreference.bind(this), {
-      signal,
-    });
+    eventBus._on("setpreference", this.onSetPreference.bind(this), { signal });
     this.#addSelectionListener();
     this.#addDragAndDropListeners();
     this.#addKeyboardManager();

--- a/web/app.js
+++ b/web/app.js
@@ -1939,11 +1939,6 @@ const PDFViewerApplication = {
       evt => (pdfViewer.annotationEditorMode = evt),
       { signal }
     );
-    eventBus._on(
-      "switchannotationeditorparams",
-      evt => (pdfViewer.annotationEditorParams = evt),
-      { signal }
-    );
     eventBus._on("print", this.triggerPrinting.bind(this), { signal });
     eventBus._on("download", this.downloadOrSave.bind(this), { signal });
     eventBus._on("firstpage", () => (this.page = 1), { signal });

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2363,14 +2363,6 @@ class PDFViewer {
     updater();
   }
 
-  // eslint-disable-next-line accessor-pairs
-  set annotationEditorParams({ type, value }) {
-    if (!this.#annotationEditorUIManager) {
-      throw new Error(`The AnnotationEditor is not enabled.`);
-    }
-    this.#annotationEditorUIManager.updateParams(type, value);
-  }
-
   refresh(noUpdate = false, updateArgs = Object.create(null)) {
     if (!this.pdfDocument) {
       return;


### PR DESCRIPTION
The problem seems to be caused by the browser trying to "restore" editor input-elements, in the various toolbars, to their previous values when the tab is re-opened.

Hence the simplest solution appears to be to move the event handling into the editor-code, which is also less code overall, since the listener thus won't be registered early enough for the problem to appear.