### PR TITLE
Set the event handlers in the integration tests before any event is triggered

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -2171,20 +2171,13 @@ describe("FreeText Editor", () => {
         "tracemonkey.pdf",
         ".annotationEditorLayer",
         100,
-        async page => {
-          await page.waitForFunction(async () => {
-            await window.PDFViewerApplication.initializedPromise;
-            return true;
-          });
-          await page.evaluate(() => {
+        {
+          eventBusSetup: eventBus => {
             window.visitedPages = [];
-            window.PDFViewerApplication.eventBus.on(
-              "pagechanging",
-              ({ pageNumber }) => {
-                window.visitedPages.push(pageNumber);
-              }
-            );
-          });
+            eventBus.on("pagechanging", ({ pageNumber }) => {
+              window.visitedPages.push(pageNumber);
+            });
+          },
         }
       );
     });
@@ -2403,19 +2396,12 @@ describe("FreeText Editor", () => {
         "tracemonkey.pdf",
         ".annotationEditorLayer",
         100,
-        async page => {
-          await page.waitForFunction(async () => {
-            await window.PDFViewerApplication.initializedPromise;
-            return true;
-          });
-          await page.evaluate(() => {
-            window.PDFViewerApplication.eventBus.on(
-              "annotationeditorstateschanged",
-              ({ details }) => {
-                window.editingEvents?.push(details);
-              }
-            );
-          });
+        {
+          eventBusSetup: eventBus => {
+            eventBus.on("annotationeditorstateschanged", ({ details }) => {
+              window.editingEvents?.push(details);
+            });
+          },
         }
       );
     });

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -910,20 +910,13 @@ describe("Highlight Editor", () => {
         "tracemonkey.pdf",
         `.page[data-page-number = "1"] .endOfContent`,
         null,
-        async page => {
-          await page.waitForFunction(async () => {
-            await window.PDFViewerApplication.initializedPromise;
-            return true;
-          });
-          await page.evaluate(() => {
+        {
+          eventBusSetup: eventBus => {
             window.editingEvents = [];
-            window.PDFViewerApplication.eventBus.on(
-              "annotationeditorstateschanged",
-              ({ details }) => {
-                window.editingEvents.push(details);
-              }
-            );
-          });
+            eventBus.on("annotationeditorstateschanged", ({ details }) => {
+              window.editingEvents.push(details);
+            });
+          },
         },
         { highlightEditorColors: "red=#AB0000" }
       );


### PR DESCRIPTION
The function evaluateOnNewDocument in Puppeteer allow us to execute some js before the pdf.js one is loaded.
It allows us to stub some setters before there are used and then set some event handlers very soon.