### PR TITLE
[Editor] Move setting `window.uiManager` back to the test code

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -806,7 +806,6 @@ class AnnotationEditorUIManager {
     this.isShiftKeyDown = false;
 
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) {
-      window.uiManager = this;
       Object.defineProperty(this, "reset", {
         value: () => {
           this.selectAll();

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -990,7 +990,13 @@ describe("Highlight Editor", () => {
         "tracemonkey.pdf",
         ".annotationEditorLayer",
         null,
-        null,
+        {
+          eventBusSetup: eventBus => {
+            eventBus.on("annotationeditoruimanager", ({ uiManager }) => {
+              window.uiManager = uiManager;
+            });
+          },
+        },
         {
           highlightEditorColors: "red=#AB0000",
           supportsCaretBrowsingMode: true,

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -832,7 +832,13 @@ describe("Stamp Editor", () => {
         "empty.pdf",
         ".annotationEditorLayer",
         null,
-        null,
+        {
+          eventBusSetup: eventBus => {
+            eventBus.on("annotationeditoruimanager", ({ uiManager }) => {
+              window.uiManager = uiManager;
+            });
+          },
+        },
         {
           enableAltText: true,
           enableUpdatedAddImage: true,


### PR DESCRIPTION
In PR #18574 setting `window.uiManager` was moved into the `src` folder to avoid intermittent integration test failures because at the time we lacked a way to register event listeners early (before PDF.js loads). However, in PR #18617 this functionality got introduced, so we can now use the new way of setting up the event bus in the tests to move this back to the `test` folder again and to reduce the amount of test-only code in the main codebase as discussed in PR #18574.

Partially reverts e037c5711d3d2413669e9b6c275986adf24a295b.