### PR TITLE
Fix the "must check that a value is correctly updated on a field and its siblings" scripting integration test

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -1494,7 +1494,7 @@ describe("Interaction", () => {
       await closePages(pages);
     });
 
-    it("must check that a values is correctly updated on a field and its siblings", async () => {
+    it("must check that a value is correctly updated on a field and its siblings", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await waitForScripting(page);
@@ -1502,28 +1502,17 @@ describe("Interaction", () => {
           await clearInput(page, getSelector("39R"));
           await page.type(getSelector("39R"), "123", { delay: 10 });
 
-          const prevTotal = await page.$eval(
-            getSelector("43R"),
-            el => el.value
-          );
-
           await clearInput(page, getSelector("42R"));
           await page.type(getSelector("42R"), "456", { delay: 10 });
 
           await page.click(getSelector("45R"));
 
           await page.waitForFunction(
-            `${getQuerySelector("43R")}.value !== "${prevTotal}"`
+            `${getQuerySelector("43R")}.value === "579.00"`
           );
           await page.waitForFunction(
-            `${getQuerySelector("46R")}.value !== "${prevTotal}"`
+            `${getQuerySelector("46R")}.value === "579.00"`
           );
-
-          let total = await page.$eval(getSelector("43R"), el => el.value);
-          expect(total).withContext(`In ${browserName}`).toEqual("579.00");
-
-          total = await page.$eval(getSelector("46R"), el => el.value);
-          expect(total).withContext(`In ${browserName}`).toEqual("579.00");
         })
       );
     });


### PR DESCRIPTION
This integration test fails intermittently because we cache the initial total value to be able to compare it to the new total value at the end of the test to check that it's different before doing the assertions. However, this doesn't work as expected because the second `clearInput` call triggers an intermediate total value calculation because it clicks on another input field and that triggers a sandbox event.

This results in the `waitForFunction` calls always resolving immediately and since we don't use other means of waiting until the calculation is done (using e.g. `waitForSandboxTrip`) we basically rely on the time between the final click and the assertions to be enough for the sandbox to do its work. If it's is not done in that time, we do the assertions with older values and that makes the test fail.

This commit fixes the issue by simply waiting for the total value to be what we expect it to be. This requires less code, is more consistent with the other integration tests and removes the possibility of doing assertions against older values.

Fixes a part of #18396.