### PR TITLE
Use standard glyph mapping for non-embedded and non-composite Calibri fonts (issue 18208)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1244,7 +1244,7 @@ class Font {
         getDingbatsGlyphsUnicode(),
         this.differences
       );
-    } else if (isStandardFont) {
+    } else if (isStandardFont || isMappedToStandardFont) {
       const map = buildToFontChar(
         this.defaultEncoding,
         getGlyphsUnicode(),

--- a/test/pdfs/issue18208.pdf.link
+++ b/test/pdfs/issue18208.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/15587595/d403d5d5-f3e1-411d-b289-9b497069b80e.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3013,6 +3013,15 @@
     "type": "text"
   },
   {
+    "id": "issue18208",
+    "file": "pdfs/issue18208.pdf",
+    "md5": "d07311117b5cc970159b09977898996b",
+    "link": true,
+    "rounds": 1,
+    "lastPage": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue11139",
     "file": "pdfs/issue11139.pdf",
     "md5": "006dd4f4bb1878bc14a12072d81a4524",


### PR DESCRIPTION
Given that we handle non-embedded Calibri fonts as "mapped to standard font", we really ought to be able to use the same glyph mapping as for an actual standard font.
Note that this actually improves consistency in the code, given how we already handle such fonts if they happen to be of the `CIDFontType2` type; see https://github.com/mozilla/pdf.js/blob/b47c7eca83c35b8f9ea170aa3742fc70359726c2/src/core/fonts.js#L1186-L1190

---

*Please note:* I'm well aware that someone else expressed interest in working on this issue, however that was over a month ago and there's not been *any* updates since. Hence it's hopefully OK to "steal" the issue now.
Also, given just how complicated the topic of fonts in PDFs usually are that issue was probably never going to be a good beginner bug unfortunately.