### PR TITLE
Introduce a helper method for fetching l10n-data in `PDFDocumentProperties`

### DIFF
--- a/web/l10n.js
+++ b/web/l10n.js
@@ -66,7 +66,7 @@ class L10n {
         args,
       },
     ]);
-    return messages?.[0].value || fallback;
+    return messages[0]?.value || fallback;
   }
 
   /** @inheritdoc */

--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -235,13 +235,17 @@ class PDFDocumentProperties {
     }
   }
 
+  #getL10nStr(id, args = null) {
+    return this.l10n.get(`pdfjs-document-properties-${id}`, args);
+  }
+
   async #parseFileSize(fileSize = 0) {
     const kb = fileSize / 1024,
       mb = kb / 1024;
     if (!kb) {
       return undefined;
     }
-    return this.l10n.get(`pdfjs-document-properties-${mb >= 1 ? "mb" : "kb"}`, {
+    return this.#getL10nStr(mb >= 1 ? "mb" : "kb", {
       size_mb: mb >= 1 && (+mb.toPrecision(3)).toLocaleString(),
       size_kb: mb < 1 && (+kb.toPrecision(3)).toLocaleString(),
       size_b: fileSize.toLocaleString(),
@@ -314,24 +318,17 @@ class PDFDocumentProperties {
 
     const [{ width, height }, unit, name, orientation] = await Promise.all([
       this._isNonMetricLocale ? sizeInches : sizeMillimeters,
-      this.l10n.get(
-        `pdfjs-document-properties-page-size-unit-${
-          this._isNonMetricLocale ? "inches" : "millimeters"
-        }`
+      this.#getL10nStr(
+        `page-size-unit-${this._isNonMetricLocale ? "inches" : "millimeters"}`
       ),
-      rawName &&
-        this.l10n.get(`pdfjs-document-properties-page-size-name-${rawName}`),
-      this.l10n.get(
-        `pdfjs-document-properties-page-size-orientation-${
-          isPortrait ? "portrait" : "landscape"
-        }`
+      rawName && this.#getL10nStr(`page-size-name-${rawName}`),
+      this.#getL10nStr(
+        `page-size-orientation-${isPortrait ? "portrait" : "landscape"}`
       ),
     ]);
 
-    return this.l10n.get(
-      `pdfjs-document-properties-page-size-dimension-${
-        name ? "name-" : ""
-      }string`,
+    return this.#getL10nStr(
+      `page-size-dimension-${name ? "name-" : ""}string`,
       {
         width: width.toLocaleString(),
         height: height.toLocaleString(),
@@ -347,16 +344,14 @@ class PDFDocumentProperties {
     if (!dateObject) {
       return undefined;
     }
-    return this.l10n.get("pdfjs-document-properties-date-string", {
+    return this.#getL10nStr("date-string", {
       date: dateObject.toLocaleDateString(),
       time: dateObject.toLocaleTimeString(),
     });
   }
 
   #parseLinearization(isLinearized) {
-    return this.l10n.get(
-      `pdfjs-document-properties-linearized-${isLinearized ? "yes" : "no"}`
-    );
+    return this.#getL10nStr(`linearized-${isLinearized ? "yes" : "no"}`);
   }
 }
 


### PR DESCRIPTION
Given the length of the l10n-strings we can slightly reduce verbosity, and thus overall code-size, by introducing a helper method for fetching l10n-data.

While testing this I stumbled upon an issue in the `L10n`-class, where an optional chaining operator was placed incorrectly since the underlying method always return an Array; see https://github.com/projectfluent/fluent.js/blob/48e2a62ed45ff2a62a231b2e83cfd8b332d27acb/fluent-dom/src/localization.js#L38-L77