### PR TITLE
Introduce a `L10n`-method to translate an element once, and use that in `PDFLayerViewer`

### DIFF
--- a/web/l10n.js
+++ b/web/l10n.js
@@ -81,6 +81,15 @@ class L10n {
   }
 
   /** @inheritdoc */
+  async translateOnce(element) {
+    try {
+      await this.#l10n.translateElements([element]);
+    } catch (ex) {
+      console.error(`translateOnce: "${ex}".`);
+    }
+  }
+
+  /** @inheritdoc */
   async destroy() {
     for (const element of this.#elements) {
       this.#l10n.disconnectRoot(element);

--- a/web/pdf_layer_viewer.js
+++ b/web/pdf_layer_viewer.js
@@ -93,13 +93,16 @@ class PDFLayerViewer extends BaseTreeViewer {
   /**
    * @private
    */
-  async _setNestedName(element, { name = null }) {
+  _setNestedName(element, { name = null }) {
     if (typeof name === "string") {
       element.textContent = this._normalizeTextContent(name);
       return;
     }
-    element.textContent = await this._l10n.get("pdfjs-additional-layers");
+    element.setAttribute("data-l10n-id", "pdfjs-additional-layers");
     element.style.fontStyle = "italic";
+    // Trigger translation manually, since translation is paused when
+    // the final layer-tree is appended to the DOM.
+    this._l10n.translateOnce(element);
   }
 
   /**


### PR DESCRIPTION
Currently we *manually* fetch the "pdfjs-additional-layers" string and update the DOM-element, which was needed since we want to avoid triggering a bunch of otherwise unnecessary translation when appending the entire layer-tree to the DOM.
By introducing a new helper method in the `L10n`-class we can avoid this, and instead use a "data-l10n-id" attribute on the element (as most other viewer code does nowadays).