### PR TITLE
Use `HTMLCanvasElement.toBlob()` unconditionally in `PDFPrintService`

### DIFF
--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -199,10 +199,18 @@ class PDFPrintService {
     wrapper.append(img);
     this.printContainer.append(wrapper);
 
-    return new Promise(function (resolve, reject) {
-      img.onload = resolve;
-      img.onerror = reject;
-    });
+    const { promise, resolve, reject } = Promise.withResolvers();
+    img.onload = resolve;
+    img.onerror = reject;
+
+    promise
+      .catch(() => {
+        // Avoid "Uncaught promise" messages in the console.
+      })
+      .then(() => {
+        URL.revokeObjectURL(img.src);
+      });
+    return promise;
   }
 
   performPrint() {

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -190,14 +190,9 @@ class PDFPrintService {
   useRenderedPage() {
     this.throwIfInactive();
     const img = document.createElement("img");
-    const scratchCanvas = this.scratchCanvas;
-    if ("toBlob" in scratchCanvas) {
-      scratchCanvas.toBlob(function (blob) {
-        img.src = URL.createObjectURL(blob);
-      });
-    } else {
-      img.src = scratchCanvas.toDataURL();
-    }
+    this.scratchCanvas.toBlob(blob => {
+      img.src = URL.createObjectURL(blob);
+    });
 
     const wrapper = document.createElement("div");
     wrapper.className = "printedPage";


### PR DESCRIPTION
The fallback is very old code, and according to the MDN compatibility data `HTMLCanvasElement.toBlob()` should be available in all browsers that we support now: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility