### PR TITLE
[Editor] Define the "pdfjs-editor-new-alt-text-generated-alt-text-with-disclaimer" string once

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -219,27 +219,20 @@ class AnnotationEditor {
       middleLeft: "pdfjs-editor-resizer-middle-left",
     });
 
-    AnnotationEditor._l10nPromise ||= new Map(
-      [
+    AnnotationEditor._l10nPromise ||= new Map([
+      ...[
         "pdfjs-editor-alt-text-button-label",
         "pdfjs-editor-alt-text-edit-button-label",
         "pdfjs-editor-alt-text-decorative-tooltip",
         "pdfjs-editor-new-alt-text-added-button-label",
         "pdfjs-editor-new-alt-text-missing-button-label",
         "pdfjs-editor-new-alt-text-to-review-button-label",
-      ].map(str => [str, l10n.get(str)])
-    );
-
-    // The string isn't in the above list because the string has a parameter
-    // (i.e. the guessed text) and we must pass it to the l10n function to get
-    // the correct translation.
-    AnnotationEditor._l10nPromise.set(
-      "pdfjs-editor-new-alt-text-generated-alt-text-with-disclaimer",
-      l10n.get.bind(
-        l10n,
-        "pdfjs-editor-new-alt-text-generated-alt-text-with-disclaimer"
-      )
-    );
+      ].map(str => [str, l10n.get(str)]),
+      ...[
+        // Strings that need l10n-arguments.
+        "pdfjs-editor-new-alt-text-generated-alt-text-with-disclaimer",
+      ].map(str => [str, l10n.get.bind(l10n, str)]),
+    ]);
 
     if (options?.strings) {
       for (const str of options.strings) {


### PR DESCRIPTION
This l10n-string is being re-defined once for every editor, i.e. currently four times, which seems unnecessary.
To avoid having to check if this l10n-string exists first, we can utilize rest parameters to move it into the `AnnotationEditor._l10nPromise` Map-definition instead.