### PR TITLE
Use the URL global instead of the deprecated url.parse

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -26,7 +26,6 @@ import path from "path";
 import puppeteer from "puppeteer";
 import readline from "readline";
 import { translateFont } from "./font/ttxdriver.mjs";
-import url from "url";
 import { WebServer } from "./webserver.mjs";
 import yargs from "yargs";
 
@@ -670,8 +669,7 @@ function checkRefTestResults(browser, id, results) {
   });
 }
 
-function refTestPostHandler(req, res) {
-  var parsedUrl = url.parse(req.url, true);
+function refTestPostHandler(parsedUrl, req, res) {
   var pathname = parsedUrl.pathname;
   if (
     pathname !== "/tellMeToQuit" &&
@@ -691,7 +689,7 @@ function refTestPostHandler(req, res) {
 
     var session;
     if (pathname === "/tellMeToQuit") {
-      session = getSession(parsedUrl.query.browser);
+      session = getSession(parsedUrl.searchParams.get("browser"));
       monitorBrowserTimeout(session, null);
       closeSession(session.name);
       return;
@@ -821,8 +819,7 @@ async function startIntegrationTest() {
   await Promise.all(sessions.map(session => closeSession(session.name)));
 }
 
-function unitTestPostHandler(req, res) {
-  var parsedUrl = url.parse(req.url);
+function unitTestPostHandler(parsedUrl, req, res) {
   var pathname = parsedUrl.pathname;
   if (
     pathname !== "/tellMeToQuit" &&

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -24,17 +24,13 @@ if (!isNodeJS) {
   );
 }
 
-const path = await __non_webpack_import__("path");
 const url = await __non_webpack_import__("url");
 
 describe("node_stream", function () {
   let tempServer = null;
 
-  const pdf = url.parse(
-    encodeURI(
-      "file://" + path.join(process.cwd(), "./test/pdfs/tracemonkey.pdf")
-    )
-  ).href;
+  const cwdURL = url.pathToFileURL(process.cwd()) + "/";
+  const pdf = new URL("./test/pdfs/tracemonkey.pdf", cwdURL).href;
   const pdfLength = 1016315;
 
   beforeAll(function () {


### PR DESCRIPTION
> **Use the URL global instead of the deprecated url.parse**
>
> The Node.js url.parse API (https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost) is deprecated because it's prone to security issues (to the point that Node.js doesn't even publish CVEs for it anymore).
>
> The official reccomendation is to instead use the global URL constructor, available both in Node.js and in browsers. Node.js filesystem APIs accept URL objects as parameter, so this also avoids a few URL->filepath conversions.

The changes in `test/webserver.mjs` are mostly because I needed to pass the URL to the hooks, and then at that point decided to just use it everywhere in the file instead of keeping the regexp-based parsing to get the filepath and query params.