### PR TITLE
Add a helper function for http/https requests in `src/display/node_stream.js`

### DIFF
--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -36,6 +36,15 @@ function parseUrlOrPath(sourceUrl) {
   return new URL(url.pathToFileURL(sourceUrl));
 }
 
+function createRequest(url, headers, callback) {
+  if (url.protocol === "http:") {
+    const http = NodePackages.get("http");
+    return http.request(url, { headers }, callback);
+  }
+  const https = NodePackages.get("https");
+  return https.request(url, { headers }, callback);
+}
+
 class PDFNodeStream {
   constructor(source) {
     this.source = source;
@@ -312,22 +321,11 @@ class PDFNodeStreamFullReader extends BaseFullReader {
       this._filename = extractFilenameFromHeader(getResponseHeader);
     };
 
-    this._request = null;
-    if (this._url.protocol === "http:") {
-      const http = NodePackages.get("http");
-      this._request = http.request(
-        this._url,
-        { headers: stream.httpHeaders },
-        handleResponse
-      );
-    } else {
-      const https = NodePackages.get("https");
-      this._request = https.request(
-        this._url,
-        { headers: stream.httpHeaders },
-        handleResponse
-      );
-    }
+    this._request = createRequest(
+      this._url,
+      stream.httpHeaders,
+      handleResponse
+    );
 
     this._request.on("error", reason => {
       this._storedError = reason;
@@ -363,22 +361,7 @@ class PDFNodeStreamRangeReader extends BaseRangeReader {
       this._setReadableStream(response);
     };
 
-    this._request = null;
-    if (this._url.protocol === "http:") {
-      const http = NodePackages.get("http");
-      this._request = http.request(
-        this._url,
-        { headers: this._httpHeaders },
-        handleResponse
-      );
-    } else {
-      const https = NodePackages.get("https");
-      this._request = https.request(
-        this._url,
-        { headers: this._httpHeaders },
-        handleResponse
-      );
-    }
+    this._request = createRequest(this._url, this._httpHeaders, handleResponse);
 
     this._request.on("error", reason => {
       this._storedError = reason;


### PR DESCRIPTION
Currently we repeat virtually the same http/https request code in two different classes in this file, which seems unnecessary and it leads to more code.