### PR TITLE
feat(verbosity): expose method per change verbosity level

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3474,5 +3474,6 @@ export {
   PDFPageProxy,
   PDFWorker,
   RenderTask,
+  setVerbosityLevel,
   version,
 };


### PR DESCRIPTION
it because change the verbosity level calling "getDocument" method is very difficult and in any case I think it could be useful to also change the verbosity level at runtime