### PR TITLE
Update svglint to 3.1.0

### DIFF
--- a/.svglintrc.js
+++ b/.svglintrc.js
@@ -18,4 +18,18 @@ export default {
       },
     ],
   },
+  ignore: [
+    "build/**",
+    "l10n/**",
+    "docs/**",
+    "node_modules/**",
+    "external/bcmaps/**",
+    "external/builder/fixtures/**",
+    "external/builder/fixtures_babel/**",
+    "external/quickjs/**",
+    "test/tmp/**",
+    "test/pdfs/**",
+    "web/locale/**",
+    "*~/**",
+  ],
 };

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1983,8 +1983,9 @@ gulp.task("lint", function (done) {
 
   const svgLintOptions = [
     "node_modules/svglint/bin/cli.js",
-    "web/**/*.svg",
+    "**/*.svg",
     "--ci",
+    "--no-summary",
   ];
 
   const esLintProcess = startNode(esLintOptions, { stdio: "inherit" });
@@ -2009,12 +2010,7 @@ gulp.task("lint", function (done) {
         }
 
         const svgLintProcess = startNode(svgLintOptions, {
-          stdio: "pipe",
-        });
-        svgLintProcess.stdout.setEncoding("utf8");
-        svgLintProcess.stdout.on("data", m => {
-          m = m.toString().replace(/-+ Summary -+.*/ms, "");
-          console.log(m);
+          stdio: "inherit",
         });
         svgLintProcess.on("close", function (svgLintCode) {
           if (svgLintCode !== 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "puppeteer": "23.3.1",
         "stylelint": "^16.10.0",
         "stylelint-prettier": "^5.0.2",
-        "svglint": "^3.0.0",
+        "svglint": "^3.1.0",
         "terser-webpack-plugin": "^5.3.10",
         "tsc-alias": "^1.8.10",
         "ttest": "^4.0.0",
@@ -12521,10 +12521,11 @@
       "dev": true
     },
     "node_modules/svglint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/svglint/-/svglint-3.0.0.tgz",
-      "integrity": "sha512-WX1gta0wz0dH35J5Dq3CP4Mz2jrrxrSqmEyehtraZaw4L4KRKAcTADaHxmj4Z+qYB6DP3IbDnaKNaQDFrpvVvA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/svglint/-/svglint-3.1.0.tgz",
+      "integrity": "sha512-5poEBAiB1VpswI2YLS2tx50/KfbcYc3AWWjsXBQJxcl6nkx632+LvN3biopFJbPGU1qrSnPQ22Iq42pFzbvBZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1",
         "chalk": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "puppeteer": "23.3.1",
     "stylelint": "^16.10.0",
     "stylelint-prettier": "^5.0.2",
-    "svglint": "^3.0.0",
+    "svglint": "^3.1.0",
     "terser-webpack-plugin": "^5.3.10",
     "tsc-alias": "^1.8.10",
     "ttest": "^4.0.0",


### PR DESCRIPTION
The new release contains:
 - https://github.com/simple-icons/svglint/pull/110
 - https://github.com/simple-icons/svglint/pull/111

which allow us to slightly simplify our code.