### PR TITLE
Shorten the code that inits `AnnotationEditorLayerBuilder` in the `web/pdf_page_view.js` file

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1078,27 +1078,24 @@ class PDFPageView {
         if (!annotationEditorUIManager) {
           return;
         }
-
         this.drawLayer ||= new DrawLayerBuilder({
           pageIndex: this.id,
         });
         await this.#renderDrawLayer();
         this.drawLayer.setParent(canvasWrapper);
 
-        if (!this.annotationEditorLayer) {
-          this.annotationEditorLayer = new AnnotationEditorLayerBuilder({
-            uiManager: annotationEditorUIManager,
-            pdfPage,
-            l10n,
-            accessibilityManager: this._accessibilityManager,
-            annotationLayer: this.annotationLayer?.annotationLayer,
-            textLayer: this.textLayer,
-            drawLayer: this.drawLayer.getDrawLayer(),
-            onAppend: annotationEditorLayerDiv => {
-              this.#addLayer(annotationEditorLayerDiv, "annotationEditorLayer");
-            },
-          });
-        }
+        this.annotationEditorLayer ||= new AnnotationEditorLayerBuilder({
+          uiManager: annotationEditorUIManager,
+          pdfPage,
+          l10n,
+          accessibilityManager: this._accessibilityManager,
+          annotationLayer: this.annotationLayer?.annotationLayer,
+          textLayer: this.textLayer,
+          drawLayer: this.drawLayer.getDrawLayer(),
+          onAppend: annotationEditorLayerDiv => {
+            this.#addLayer(annotationEditorLayerDiv, "annotationEditorLayer");
+          },
+        });
         this.#renderAnnotationEditorLayer();
       },
       error => {


### PR DESCRIPTION
This code can now utilize logical OR assignment, which is ever so slightly shorter.

*Smaller diff with https://github.com/mozilla/pdf.js/pull/18672/files?w=1*