### PR TITLE
Use `Headers` consistently in the different `IPDFStream` implementations

### DIFF
--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -21,6 +21,21 @@ import {
 import { getFilenameFromContentDispositionHeader } from "./content_disposition.js";
 import { isPdfFile } from "./display_utils.js";
 
+function createHeaders(isHttp, httpHeaders) {
+  const headers = new Headers();
+
+  if (!isHttp || !httpHeaders || typeof httpHeaders !== "object") {
+    return headers;
+  }
+  for (const key in httpHeaders) {
+    const val = httpHeaders[key];
+    if (val !== undefined) {
+      headers.append(key, val);
+    }
+  }
+  return headers;
+}
+
 function validateRangeRequestCapabilities({
   getResponseHeader,
   isHttp,
@@ -98,6 +113,7 @@ function validateResponseStatus(status) {
 }
 
 export {
+  createHeaders,
   createResponseStatusError,
   extractFilenameFromHeader,
   validateRangeRequestCapabilities,

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -14,6 +14,7 @@
  */
 
 import {
+  createHeaders,
   createResponseStatusError,
   extractFilenameFromHeader,
   validateRangeRequestCapabilities,
@@ -25,6 +26,44 @@ import {
 } from "../../src/shared/util.js";
 
 describe("network_utils", function () {
+  describe("createHeaders", function () {
+    it("returns empty `Headers` for invalid input", function () {
+      const headersArr = [
+        createHeaders(
+          /* isHttp = */ false,
+          /* httpHeaders = */ { "Content-Length": 100 }
+        ),
+        createHeaders(/* isHttp = */ true, /* httpHeaders = */ undefined),
+        createHeaders(/* isHttp = */ true, /* httpHeaders = */ null),
+        createHeaders(/* isHttp = */ true, /* httpHeaders = */ "abc"),
+        createHeaders(/* isHttp = */ true, /* httpHeaders = */ 123),
+      ];
+      const emptyObj = Object.create(null);
+
+      for (const headers of headersArr) {
+        expect(Object.fromEntries(headers)).toEqual(emptyObj);
+      }
+    });
+
+    it("returns populated `Headers` for valid input", function () {
+      const headers = createHeaders(
+        /* isHttp = */ true,
+        /* httpHeaders = */ {
+          "Content-Length": 100,
+          "Accept-Ranges": "bytes",
+          "Dummy-null": null,
+          "Dummy-undefined": undefined,
+        }
+      );
+
+      expect(Object.fromEntries(headers)).toEqual({
+        "content-length": "100",
+        "accept-ranges": "bytes",
+        "dummy-null": "null",
+      });
+    });
+  });
+
   describe("validateRangeRequestCapabilities", function () {
     it("rejects invalid rangeChunkSize", function () {
       expect(function () {


### PR DESCRIPTION
The `Headers` functionality is now available in all browsers/environments that we support, which allows us to consolidate and simplify how the `httpHeaders` API-option is handled; see https://developer.mozilla.org/en-US/docs/Web/API/Headers#browser_compatibility

Also, simplifies the old `NetworkManager`-constructor a little bit.