### PR TITLE
Use "full" localization ids throughout the code-base

### DIFF
--- a/src/display/editor/toolbar.js
+++ b/src/display/editor/toolbar.js
@@ -26,8 +26,17 @@ class EditorToolbar {
 
   #altText = null;
 
+  static #l10nRemove = null;
+
   constructor(editor) {
     this.#editor = editor;
+
+    EditorToolbar.#l10nRemove ||= Object.freeze({
+      freetext: "pdfjs-editor-remove-freetext-button",
+      highlight: "pdfjs-editor-remove-highlight-button",
+      ink: "pdfjs-editor-remove-ink-button",
+      stamp: "pdfjs-editor-remove-stamp-button",
+    });
   }
 
   render() {
@@ -105,20 +114,19 @@ class EditorToolbar {
   }
 
   #addDeleteButton() {
+    const { editorType, _uiManager } = this.#editor;
+
     const button = document.createElement("button");
     button.className = "delete";
     button.tabIndex = 0;
-    button.setAttribute(
-      "data-l10n-id",
-      `pdfjs-editor-remove-${this.#editor.editorType}-button`
-    );
+    button.setAttribute("data-l10n-id", EditorToolbar.#l10nRemove[editorType]);
     this.#addListenersToElement(button);
     button.addEventListener(
       "click",
       e => {
-        this.#editor._uiManager.delete();
+        _uiManager.delete();
       },
-      { signal: this.#editor._uiManager._signal }
+      { signal: _uiManager._signal }
     );
     this.#buttons.append(button);
   }

--- a/web/new_alt_text_manager.js
+++ b/web/new_alt_text_manager.js
@@ -177,7 +177,9 @@ class NewAltTextManager {
     this.#isEditing = isEditing;
     this.#title.setAttribute(
       "data-l10n-id",
-      `pdfjs-editor-new-alt-text-dialog-${isEditing ? "edit" : "add"}-label`
+      isEditing
+        ? "pdfjs-editor-new-alt-text-dialog-edit-label"
+        : "pdfjs-editor-new-alt-text-dialog-add-label"
     );
   }
 

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -84,7 +84,7 @@ class PasswordPrompt {
     }
     this.label.setAttribute(
       "data-l10n-id",
-      `pdfjs-password-${passwordIncorrect ? "invalid" : "label"}`
+      passwordIncorrect ? "pdfjs-password-invalid" : "pdfjs-password-label"
     );
   }
 

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -123,7 +123,9 @@ class PDFFindBar {
         status = "notFound";
         break;
       case FindState.WRAPPED:
-        findMsgId = `pdfjs-find-reached-${previous ? "top" : "bottom"}`;
+        findMsgId = previous
+          ? "pdfjs-find-reached-top"
+          : "pdfjs-find-reached-bottom";
         break;
     }
     findField.setAttribute("data-status", status);
@@ -148,7 +150,9 @@ class PDFFindBar {
 
       findResultsCount.setAttribute(
         "data-l10n-id",
-        `pdfjs-find-match-count${total > limit ? "-limit" : ""}`
+        total > limit
+          ? "pdfjs-find-match-count-limit"
+          : "pdfjs-find-match-count"
       );
       findResultsCount.setAttribute(
         "data-l10n-args",


### PR DESCRIPTION
It was recently [brought to my attention](https://github.com/mozilla/pdf.js/pull/18649#discussion_r1731152856) that using partial or generated localization ids is bad for maintainability, hence this patch goes through the code-base and replaces any such occurrences.