### PR TITLE
Use "full" localization ids in the `ColorPicker` class (PR 18674 follow-up)

### DIFF
--- a/src/display/editor/color_picker.js
+++ b/src/display/editor/color_picker.js
@@ -42,6 +42,8 @@ class ColorPicker {
 
   #type;
 
+  static #l10nColor = null;
+
   static get _keyboardManager() {
     return shadow(
       this,
@@ -81,6 +83,14 @@ class ColorPicker {
       editor?.color ||
       this.#uiManager?.highlightColors.values().next().value ||
       "#FFFF98";
+
+    ColorPicker.#l10nColor ||= Object.freeze({
+      blue: "pdfjs-editor-colorpicker-blue",
+      green: "pdfjs-editor-colorpicker-green",
+      pink: "pdfjs-editor-colorpicker-pink",
+      red: "pdfjs-editor-colorpicker-red",
+      yellow: "pdfjs-editor-colorpicker-yellow",
+    });
   }
 
   renderButton() {
@@ -123,7 +133,7 @@ class ColorPicker {
       button.role = "option";
       button.setAttribute("data-color", color);
       button.title = name;
-      button.setAttribute("data-l10n-id", `pdfjs-editor-colorpicker-${name}`);
+      button.setAttribute("data-l10n-id", ColorPicker.#l10nColor[name]);
       const swatch = document.createElement("span");
       button.append(swatch);
       swatch.className = "swatch";


### PR DESCRIPTION
Apparently I missed these in PR #18674.