### PR TITLE
Prevent `.visibleMediumView` from overriding already hidden elements (issue 18704, PR 18596 follow-up)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1581,7 +1581,7 @@ dialog :link {
   #outerContainer .hiddenMediumView {
     display: none !important;
   }
-  #outerContainer .visibleMediumView {
+  #outerContainer .visibleMediumView:not(.hidden, [hidden]) {
     display: inherit !important;
   }
 }


### PR DESCRIPTION
*Please note:* As a general rule we probably don't need to fix things affecting *custom* implementations of the default viewer, but in this case a "targeted" fix seem possible that shouldn't (famous last words) break anything else.

Ensure that the `.visibleMediumView` class, which is used when the viewer becomes narrow, cannot override the `display`-value for DOM elements that are being *explicitly* hidden either through the associated attribute or class.