### PR TITLE
Ensure the text layer uses the correct font to determine the scaleX transformation of text divs.

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -111,8 +111,6 @@ class TextLayer {
     this.#scale = viewport.scale * (globalThis.devicePixelRatio || 1);
     this.#rotation = viewport.rotation;
     this.#layoutTextParams = {
-      prevFontSize: null,
-      prevFontFamily: null,
       div: null,
       properties: null,
       ctx: null,
@@ -195,8 +193,6 @@ class TextLayer {
       onBefore?.();
       this.#scale = scale;
       const params = {
-        prevFontSize: null,
-        prevFontFamily: null,
         div: null,
         properties: null,
         ctx: TextLayer.#getCtx(this.#lang),
@@ -394,7 +390,7 @@ class TextLayer {
   }
 
   #layout(params) {
-    const { div, properties, ctx, prevFontSize, prevFontFamily } = params;
+    const { div, properties, ctx } = params;
     const { style } = div;
 
     let transform = "";
@@ -406,10 +402,9 @@ class TextLayer {
       const { fontFamily } = style;
       const { canvasWidth, fontSize } = properties;
 
-      if (prevFontSize !== fontSize || prevFontFamily !== fontFamily) {
-        ctx.font = `${fontSize * this.#scale}px ${fontFamily}`;
-        params.prevFontSize = fontSize;
-        params.prevFontFamily = fontFamily;
+      const font = `${fontSize * this.#scale}px ${fontFamily}`;
+      if (ctx.font !== font) {
+        ctx.font = font;
       }
 
       // Only measure the width for multi-char text divs, see `appendText`.


### PR DESCRIPTION
I was having issues with the text layer since I was upgraded from PDF.js version 3 to 4. One of the initially rendered pages (mostly the second page), seemed to be subject to some kind of race condition, which caused problems with the text layer.

Most of the times there was at least a part of the page, where the scaleX transformation of the text divs (spans) had a very small value of ~0.09. After spending some time debugging I noticed that the result of `ctx.measureText(div.textContent)` in `text_layer.js` was not consistent for every run. After that I noticed that the font used by the canvas to calculate the text width was off (~150px instead of the ~10px passed to the `#layout` method.

This causes the the text divs to be very small, which makes text selection impossible.

This PR should hopefully fix the issue while having no side effects. As I am new to the project and do not really know the codebase, I cannot tell if this is the right way to do it.

For now I am using `patch-package` to get rid of the problem and I just wanted to share the findings here.