### PR TITLE
[CRX] Fix feature detect of DNR responseHeaders option

### DIFF
--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -227,8 +227,10 @@ async function isHeaderConditionSupported() {
       addRules: [
         {
           id: ruleId,
-          urlFilter: "|does_not_match_anything",
-          condition: { responseHeaders: [{ header: "whatever" }] },
+          condition: {
+            responseHeaders: [{ header: "whatever" }],
+            urlFilter: "|does_not_match_anything",
+          },
           action: { type: "block" },
         },
       ],
@@ -244,8 +246,10 @@ async function isHeaderConditionSupported() {
       addRules: [
         {
           id: ruleId,
-          urlFilter: "|does_not_match_anything",
-          condition: { responseHeaders: [] },
+          condition: {
+            responseHeaders: [],
+            urlFilter: "|does_not_match_anything",
+          },
           action: { type: "block" },
         },
       ],


### PR DESCRIPTION
Fix regression from #18711. `urlFilter` is a key of `condition`, not of the `rule`. Consequently, the feature detection method failed to detect the availability of the feature in Chrome 128+.

Verified in Chrome 120 and 130.

Fixes #18725.