### PR TITLE
Fluent: use explicit NUMBER() in plural variants

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -239,7 +239,7 @@ pdfjs-find-reached-bottom = Reached end of document, continued from top
 #   $current (Number) - the index of the currently active find result
 #   $total (Number) - the total number of matches in the document
 pdfjs-find-match-count =
-    { $total ->
+    { NUMBER($total) ->
         [one] { $current } of { $total } match
        *[other] { $current } of { $total } matches
     }
@@ -247,7 +247,7 @@ pdfjs-find-match-count =
 # Variables:
 #   $limit (Number) - the maximum number of matches
 pdfjs-find-match-count-limit =
-    { $limit ->
+    { NUMBER($limit) ->
         [one] More than { $limit } match
        *[other] More than { $limit } matches
     }


### PR DESCRIPTION
I've already included this change in the [patch for mozilla-central](https://phabricator.services.mozilla.com/D221992), but need to fix upstream.