### PR TITLE
Use the "pageColorsBackground" option as background-color for non-loaded pages (issue 18680)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -222,6 +222,13 @@ class PDFPageView {
         this.scale * PixelsPerInch.PDF_TO_CSS_UNITS
       );
 
+      if (this.pageColors?.background) {
+        container?.style.setProperty(
+          "--page-bg-color",
+          this.pageColors.background
+        );
+      }
+
       const { optionalContentConfigPromise } = options;
       if (optionalContentConfigPromise) {
         // Ensure that the thumbnails always display the *initial* document

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -61,6 +61,7 @@
   /* Define this variable here and not in :root to avoid to reflow all the UI
      when scaling (see #15929). */
   --scale-factor: 1;
+  --page-bg-color: unset;
 
   padding-bottom: var(--pdfViewer-padding-bottom);
 
@@ -114,7 +115,7 @@
   overflow: visible;
   border: var(--page-border);
   background-clip: content-box;
-  background-color: rgb(255 255 255);
+  background-color: var(--page-bg-color, rgb(255 255 255));
 }
 
 .pdfViewer .dummyPage {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -927,6 +927,10 @@ class PDFViewer {
         // Ensure that the various layers always get the correct initial size,
         // see issue 15795.
         viewer.style.setProperty("--scale-factor", viewport.scale);
+
+        if (pageColors?.background) {
+          viewer.style.setProperty("--page-bg-color", pageColors.background);
+        }
         if (
           pageColors?.foreground === "CanvasText" ||
           pageColors?.background === "Canvas"


### PR DESCRIPTION
This should prevent non-loaded pages from flashing white in e.g. high contrast mode (HCM).