### PR TITLE
Improve how empty findbar messages are localized

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -253,6 +253,8 @@ pdfjs-find-match-count-limit =
     }
 
 pdfjs-find-not-found = Phrase not found
+# Must contain an empty string.
+pdfjs-find-empty-message = {""}
 
 ## Predefined zoom values
 

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -16,8 +16,6 @@
 import { FindState } from "./pdf_find_controller.js";
 import { toggleExpandedBtn } from "./ui_utils.js";
 
-const MATCHES_COUNT_LIMIT = 1000;
-
 /**
  * Creates a "search bar" given a set of DOM elements that act as controls
  * for searching or for setting search preferences in the UI. This object
@@ -25,6 +23,8 @@ const MATCHES_COUNT_LIMIT = 1000;
  * is done by PDFFindController.
  */
 class PDFFindBar {
+  #matchesCountLimit = 1000;
+
   #resizeObserver = new ResizeObserver(this.#resizeObserverCallback.bind(this));
 
   constructor(options, eventBus) {
@@ -109,7 +109,7 @@ class PDFFindBar {
 
   updateUIState(state, previous, matchesCount) {
     const { findField, findMsg } = this;
-    let findMsgId = "",
+    let findMsgId = "pdfjs-find-empty-message",
       status = "";
 
     switch (state) {
@@ -132,36 +132,27 @@ class PDFFindBar {
     findField.setAttribute("aria-invalid", state === FindState.NOT_FOUND);
 
     findMsg.setAttribute("data-status", status);
-    if (findMsgId) {
-      findMsg.setAttribute("data-l10n-id", findMsgId);
-    } else {
-      findMsg.removeAttribute("data-l10n-id");
-      findMsg.textContent = "";
-    }
+    findMsg.setAttribute("data-l10n-id", findMsgId);
 
     this.updateResultsCount(matchesCount);
   }
 
   updateResultsCount({ current = 0, total = 0 } = {}) {
     const { findResultsCount } = this;
+    let l10nId = "pdfjs-find-empty-message",
+      l10nArgs = "{}";
 
     if (total > 0) {
-      const limit = MATCHES_COUNT_LIMIT;
+      const limit = this.#matchesCountLimit;
 
-      findResultsCount.setAttribute(
-        "data-l10n-id",
+      l10nId =
         total > limit
           ? "pdfjs-find-match-count-limit"
-          : "pdfjs-find-match-count"
-      );
-      findResultsCount.setAttribute(
-        "data-l10n-args",
-        JSON.stringify({ limit, current, total })
-      );
-    } else {
-      findResultsCount.removeAttribute("data-l10n-id");
-      findResultsCount.textContent = "";
+          : "pdfjs-find-match-count";
+      l10nArgs = JSON.stringify({ limit, current, total });
     }
+    findResultsCount.setAttribute("data-l10n-id", l10nId);
+    findResultsCount.setAttribute("data-l10n-args", l10nArgs);
   }
 
   open() {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -169,8 +169,8 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
 
           <div id="findbarMessageContainer" aria-live="polite">
-            <span id="findResultsCount" class="toolbarLabel"></span>
-            <span id="findMsg" class="toolbarLabel"></span>
+            <span id="findResultsCount" class="toolbarLabel" data-l10n-id="pdfjs-find-empty-message" data-l10n-args='{}'></span>
+            <span id="findMsg" class="toolbarLabel" data-l10n-id="pdfjs-find-empty-message"></span>
           </div>
         </div>  <!-- findbar -->
 


### PR DESCRIPTION
*Note:* In the Firefox PDF Viewer this findbar is only being used when a PDF document is placed in e.g. an `iframe` element.

By introducing a l10n-string for *empty* findbar messages we can simplify the `PDFFindBar` code a little bit by not having to remove the "data-l10n-id" attributes in some cases.

Also, moves the `MATCHES_COUNT_LIMIT` constant into the `PDFFindBar` class instead since it doesn't need to be globally defined.