### PR TITLE
[CRX] Enable WebAssembly in Chrome extension

### DIFF
--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -27,6 +27,9 @@
       "js": ["contentscript.js"]
     }
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  },
   "storage": {
     "managed_schema": "preferences_schema.json"
   },


### PR DESCRIPTION
After the removal of 'unsafe-eval' CSP from the Chrome extension in #18651 (as part of #15161), WebAssembly fails to load, resulting in issues such as seen in #18457.

Manifest Version 3 does not allow 'unsafe-eval', does accept the more specific 'wasm-unsafe-eval' as of Chrome 103. Note that manifest.json already sets minimum_chrome_version to 103.

This patch also adds `object-src 'self'` because it was required until Chrome 110. As of Chrome 111, the default is `object-src 'self'` and `object-src` is no longer required. We could drop `object-src` in the future, but for now we need to include it to support Chrome 103 - 110.

Tested by opening the PDF from #18457. Before this fix, the page was blank. With this patch, the image is rendered.