### PR TITLE
Ignore non-existing /Shading resources during parsing (issue 18765)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2132,14 +2132,26 @@ class PartialEvaluator {
             break;
 
           case OPS.shadingFill:
-            var shadingRes = resources.get("Shading");
-            if (!shadingRes) {
-              throw new FormatError("No shading resource found");
-            }
+            let shading;
+            try {
+              const shadingRes = resources.get("Shading");
+              if (!shadingRes) {
+                throw new FormatError("No shading resource found");
+              }
 
-            var shading = shadingRes.get(args[0].name);
-            if (!shading) {
-              throw new FormatError("No shading object found");
+              shading = shadingRes.get(args[0].name);
+              if (!shading) {
+                throw new FormatError("No shading object found");
+              }
+            } catch (reason) {
+              if (reason instanceof AbortException) {
+                continue;
+              }
+              if (self.options.ignoreErrors) {
+                warn(`getOperatorList - ignoring Shading: "${reason}".`);
+                continue;
+              }
+              throw reason;
             }
             const patternId = self.parseShading({
               shading,

--- a/test/pdfs/issue18765.pdf.link
+++ b/test/pdfs/issue18765.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/17065251/LUCID.-.Asif.Rasha-1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3022,6 +3022,16 @@
     "type": "eq"
   },
   {
+    "id": "issue18765",
+    "file": "pdfs/issue18765.pdf",
+    "md5": "7763ead2aa69db3a5263f92bb1922e31",
+    "link": true,
+    "talos": false,
+    "rounds": 1,
+    "lastPage": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue11139",
     "file": "pdfs/issue11139.pdf",
     "md5": "006dd4f4bb1878bc14a12072d81a4524",


### PR DESCRIPTION
*Slightly smaller diff with https://github.com/mozilla/pdf.js/pull/18766/files?w=1*