### PR TITLE
Use `fs/promises` in the Node.js unit-tests (PR 17714 follow-up)

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -782,7 +782,7 @@ class Driver {
       }
     }
 
-    if (task.skipPages && task.skipPages.includes(task.pageNum)) {
+    if (task.skipPages?.includes(task.pageNum)) {
       this._log(
         " Skipping page " + task.pageNum + "/" + task.pdfDoc.numPages + "...\n"
       );

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -161,7 +161,7 @@ function parseOptions() {
       );
     })
     .check(argv => {
-      if (argv.testfilter && argv.testfilter.length > 0 && argv.xfaOnly) {
+      if (argv.testfilter?.length > 0 && argv.xfaOnly) {
         throw new Error("--testfilter and --xfaOnly cannot be used together.");
       }
       return true;


### PR DESCRIPTION
This is available in all Node.js versions that we currently support, and using it allows us to remove callback-functions; please see https://nodejs.org/docs/latest-v18.x/api/fs.html#promises-api