### PR TITLE
Update `typescript` to version 5.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "terser-webpack-plugin": "^5.3.10",
         "tsc-alias": "^1.8.10",
         "ttest": "^4.0.0",
-        "typescript": "^5.5.4",
+        "typescript": "^5.6.2",
         "vinyl": "^3.0.0",
         "webpack": "^5.94.0",
         "webpack-stream": "^7.0.0",
@@ -13783,9 +13783,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "terser-webpack-plugin": "^5.3.10",
     "tsc-alias": "^1.8.10",
     "ttest": "^4.0.0",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.2",
     "vinyl": "^3.0.0",
     "webpack": "^5.94.0",
     "webpack-stream": "^7.0.0",


### PR DESCRIPTION
This is unblocked because in commit bb302dd the default value for the constructor got removed, which apparently confused TypeScript before.

Fixes #18770.