### PR TITLE
Ensure that the CursorTools-buttons are disabled e.g. during editing (PR 15522 follow-up)

### DIFF
--- a/web/pdf_cursor_tools.js
+++ b/web/pdf_cursor_tools.js
@@ -65,7 +65,19 @@ class PDFCursorTools {
       // Cursor tools cannot be used in PresentationMode/AnnotationEditor.
       return;
     }
+    this.#switchTool(tool);
+  }
+
+  #switchTool(tool, disabled = false) {
     if (tool === this.#active) {
+      if (this.#prevActive !== null) {
+        // Ensure that the `disabled`-attribute of the buttons will be updated.
+        this.eventBus.dispatch("cursortoolchanged", {
+          source: this,
+          tool,
+          disabled,
+        });
+      }
       return; // The requested tool is already active.
     }
 
@@ -103,6 +115,7 @@ class PDFCursorTools {
     this.eventBus.dispatch("cursortoolchanged", {
       source: this,
       tool,
+      disabled,
     });
   }
 
@@ -122,21 +135,17 @@ class PDFCursorTools {
       presentationModeState = PresentationModeState.NORMAL;
 
     const disableActive = () => {
-      const prevActive = this.#active;
-
-      this.switchTool(CursorTool.SELECT);
-      this.#prevActive ??= prevActive; // Keep track of the first one.
+      this.#prevActive ??= this.#active; // Keep track of the first one.
+      this.#switchTool(CursorTool.SELECT, /* disabled = */ true);
     };
     const enableActive = () => {
-      const prevActive = this.#prevActive;
-
       if (
-        prevActive !== null &&
+        this.#prevActive !== null &&
         annotationEditorMode === AnnotationEditorType.NONE &&
         presentationModeState === PresentationModeState.NORMAL
       ) {
+        this.#switchTool(this.#prevActive);
         this.#prevActive = null;
-        this.switchTool(prevActive);
       }
     };
 

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -240,11 +240,14 @@ class SecondaryToolbar {
     eventBus._on("spreadmodechanged", this.#spreadModeChanged.bind(this));
   }
 
-  #cursorToolChanged({ tool }) {
+  #cursorToolChanged({ tool, disabled }) {
     const { cursorSelectToolButton, cursorHandToolButton } = this.#opts;
 
     toggleCheckedBtn(cursorSelectToolButton, tool === CursorTool.SELECT);
     toggleCheckedBtn(cursorHandToolButton, tool === CursorTool.HAND);
+
+    cursorSelectToolButton.disabled = disabled;
+    cursorHandToolButton.disabled = disabled;
   }
 
   #scrollModeChanged({ mode }) {


### PR DESCRIPTION
We disable any non-default CursorTool in PresentationMode and during Editing, since they don't make sense there and to prevent problems such as e.g. [bug 1792422](https://bugzilla.mozilla.org/show_bug.cgi?id=1792422).
Hence it seems like a good idea to *also* disable the relevant SecondaryToolbar-buttons, to avoid the user being surprised that the CursorTools-buttons do nothing if clicked.