### PR TITLE
[api-minor] Update the minimum supported Google Chrome version to 103

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -81,7 +81,7 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 
 const ENV_TARGETS = [
   "last 2 versions",
-  "Chrome >= 98",
+  "Chrome >= 103",
   "Firefox ESR",
   "Safari >= 16.4",
   "Node >= 18",


### PR DESCRIPTION
This patch updates the minimum supported browsers as follows:
 - Google Chrome 103[1], which was released on 2022-06-21; see https://chromereleases.googleblog.com/2022/06/stable-channel-update-for-desktop_21.html

Note that nowadays we usually try, where feasible and possible, to support browsers that are about two years old. By limiting support to only "recent" browsers we reduce the risk of holding back improvements of the *built-in* Firefox PDF Viewer, and also (significantly) reduce the maintenance/support burden for the PDF.js contributors.

*Please note:* As always, the minimum supported browser version assumes that a `legacy`-build of the PDF.js library is being used; see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support

---

[1] This is consistent with the minimum supported version in the recently updated Google Chrome addon.