### PR TITLE
Fix `toolbarViewer`/`toolbarContainer` regressions (PR 18385, 18786 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -876,6 +876,7 @@ const PDFViewerApplication = {
 
   moveCaret(isUp, select) {
     this._caretBrowsing ||= new CaretBrowsingMode(
+      this._globalAbortController.signal,
       this.appConfig.mainContainer,
       this.appConfig.viewerContainer,
       this.appConfig.toolbar?.container

--- a/web/app.js
+++ b/web/app.js
@@ -376,18 +376,16 @@ const PDFViewerApplication = {
   async _initializeViewerComponents() {
     const { appConfig, externalServices, l10n } = this;
 
-    let eventBus;
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-      eventBus = AppOptions.eventBus = new FirefoxEventBus(
-        AppOptions.get("allowedGlobalEvents"),
-        externalServices,
-        AppOptions.get("isInAutomation")
-      );
-    } else {
-      eventBus = new EventBus();
-    }
+    const eventBus =
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+        ? new FirefoxEventBus(
+            AppOptions.get("allowedGlobalEvents"),
+            externalServices,
+            AppOptions.get("isInAutomation")
+          )
+        : new EventBus();
+    this.eventBus = AppOptions.eventBus = eventBus;
     this.mlManager?.setEventBus(eventBus, this._globalAbortController.signal);
-    this.eventBus = eventBus;
 
     this.overlayManager = new OverlayManager();
 

--- a/web/caret_browsing.js
+++ b/web/caret_browsing.js
@@ -19,14 +19,32 @@ const PRECISION = 1e-1;
 class CaretBrowsingMode {
   #mainContainer;
 
-  #toolBarHeight;
+  #toolBarHeight = 0;
 
   #viewerContainer;
 
-  constructor(mainContainer, viewerContainer, toolbarContainer) {
+  constructor(abortSignal, mainContainer, viewerContainer, toolbarContainer) {
     this.#mainContainer = mainContainer;
     this.#viewerContainer = viewerContainer;
-    this.#toolBarHeight = toolbarContainer?.getBoundingClientRect().height ?? 0;
+
+    if (!toolbarContainer) {
+      return;
+    }
+    this.#toolBarHeight = toolbarContainer.getBoundingClientRect().height;
+
+    const toolbarObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === toolbarContainer) {
+          this.#toolBarHeight = Math.floor(entry.borderBoxSize[0].blockSize);
+          break;
+        }
+      }
+    });
+    toolbarObserver.observe(toolbarContainer);
+
+    abortSignal.addEventListener("abort", () => toolbarObserver.disconnect(), {
+      once: true,
+    });
   }
 
   /**

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -41,7 +41,7 @@ function getViewerConfiguration() {
     mainContainer: document.getElementById("viewerContainer"),
     viewerContainer: document.getElementById("viewer"),
     toolbar: {
-      container: document.getElementById("toolbarViewer"),
+      container: document.getElementById("toolbarContainer"),
       numPages: document.getElementById("numPages"),
       pageNumber: document.getElementById("pageNumber"),
       scaleSelect: document.getElementById("scaleSelect"),


### PR DESCRIPTION
 - **Use the "correct" toolbar container element in `getViewerConfiguration` (PR 18385 follow-up)**

   With the changes made in PR #18385 the `toolbarViewer` element is now shorter than before, since the padding is applied on its `toolbarContainer` parent-element instead.
   This causes two separate regressions:
    - Clicking at the very top/bottom of the toolbar no longer closes the secondaryToolbar like previously.
    - The `CaretBrowsingMode`-constructor no longer computes the toolbar-height correctly.

   Given how/where the `container`-property is being used these changes *should* thus be safe.

 - **Update the `CaretBrowsingMode` toolbar-height if the `toolbarDensity` preference changes (PR 18786 follow-up)**

   Otherwise the isVisible-calculations may not work correctly.