### PR TITLE
Use Calibri and Lucida Console, when it's possible, in place of sans-serif and monospaced (bug 1922063)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -636,9 +636,18 @@ class FeatureTest {
     ) {
       return shadow(this, "platform", {
         isMac: navigator.platform.includes("Mac"),
+        isWindows: navigator.platform.includes("Win"),
+        isFirefox:
+          (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+          (typeof navigator?.userAgent === "string" &&
+            navigator.userAgent.includes("Firefox")),
       });
     }
-    return shadow(this, "platform", { isMac: false });
+    return shadow(this, "platform", {
+      isMac: false,
+      isWindows: false,
+      isFirefox: false,
+    });
   }
 
   static get isCSSRoundSupported() {


### PR DESCRIPTION
A recent change in Firefox induced too much difference between the text widths computed in using a Canvas and the ones computed by the text layout engine when rendering the text layer. Consequently, the text selection can be bad on Windows with some fonts like Arial or Consolas. This patch is a workaround to try to use in first place some fonts which don't have the problem.