### PR TITLE
Fluent: remove NUMBER() function from variant selector

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -239,7 +239,7 @@ pdfjs-find-reached-bottom = Reached end of document, continued from top
 #   $current (Number) - the index of the currently active find result
 #   $total (Number) - the total number of matches in the document
 pdfjs-find-match-count =
-    { NUMBER($total) ->
+    { $total ->
         [one] { $current } of { $total } match
        *[other] { $current } of { $total } matches
     }
@@ -247,7 +247,7 @@ pdfjs-find-match-count =
 # Variables:
 #   $limit (Number) - the maximum number of matches
 pdfjs-find-match-count-limit =
-    { NUMBER($limit) ->
+    { $limit ->
         [one] More than { $limit } match
        *[other] More than { $limit } matches
     }


### PR DESCRIPTION
This undoes a recent change that I made.

The plan was to move the entire tree to use `NUMBER()` in variant selectors. Sadly, we realized that something doesn't work as expected across Firefox (likely due to the Rust run-time), and figuring that out is going to take a lot longer
https://bugzilla.mozilla.org/show_bug.cgi?id=1918729

In general, the use of `NUMBER()` in PDF.js is safe, but we need this change to work around [another bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1916943) in the CI.