### PR TITLE
Re-factor how a pending `#switchAnnotationEditorModeTimeoutId` is cancelled when closing the document

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1139,8 +1139,6 @@ class PDFViewer {
 
     this.#hiddenCopyElement?.remove();
     this.#hiddenCopyElement = null;
-
-    this.#cleanupSwitchAnnotationEditorMode();
   }
 
   #ensurePageViewVisible() {
@@ -2323,9 +2321,13 @@ class PDFViewer {
       this.#mlManager?.loadModel("altText");
     }
 
-    const { eventBus } = this;
+    const { eventBus } = this,
+      eventSignal = this.#eventAbortController.signal;
     const updater = () => {
       this.#cleanupSwitchAnnotationEditorMode();
+      if (eventSignal.aborted) {
+        return;
+      }
       this.#annotationEditorMode = mode;
       this.#annotationEditorUIManager.updateMode(mode, editId, isFromKeyboard);
       eventBus.dispatch("annotationeditormodechanged", {
@@ -2354,7 +2356,7 @@ class PDFViewer {
         this.#cleanupSwitchAnnotationEditorMode();
         this.#switchAnnotationEditorModeAC = new AbortController();
         const signal = AbortSignal.any([
-          this.#eventAbortController.signal,
+          eventSignal,
           this.#switchAnnotationEditorModeAC.signal,
         ]);
 


### PR DESCRIPTION
The likelihood of the document being closed while the `#switchAnnotationEditorModeTimeoutId` is pending is obviously very low, but it's still a situation we need to account for to prevent errors.
However it seems a bit unfortunate that we have to remember to manually invoke the cleanup-method, and instead we can let a pending timeout run and just check that the relevant `AbortSignal` hasn't been aborted before updating editor-state.