### PR TITLE
[Editor] Avoid an exception when undoing the deletion of a pre-existing annotation

### DIFF
--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -837,6 +837,9 @@ class StampEditor extends AnnotationEditor {
       editor.altTextData = accessibilityData;
     }
     editor._initialData = initialData;
+    // No need to be add in the undo stack if the editor is created from an
+    // existing one.
+    editor.#hasBeenAddedInUndoStack = !!initialData;
 
     return editor;
   }


### PR DESCRIPTION
It fixes #18849.

When such an annotation is deleted, we make sure that there are some data to restore.
The version of this patch was making undoing a svg deletion buggy, so it's fixed now and an integration test has been added for this case.