### PR TITLE
Change how we handle l10n-args for dates in the DocumentProperties dialog (bug 1922618)

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -329,7 +329,9 @@ class PDFDocumentProperties {
   async #parseDate(inputDate) {
     const dateObj = PDFDateString.toDateObject(inputDate);
     return dateObj
-      ? this.l10n.get("pdfjs-document-properties-date-time-string", { dateObj })
+      ? this.l10n.get("pdfjs-document-properties-date-time-string", {
+          dateObj: dateObj.valueOf(),
+        })
       : undefined;
   }
 


### PR DESCRIPTION
Strangely enough the code works just fine as-is in the GENERIC viewer, so there must be some difference between the Firefox built-in Fluent implementation and the Fluent.js one.

It seems that we can work-around the problem by handling this l10n-arg the same way that we handle dates in the AnnotationLayer, and testing this with the Firefox Devtools it seems that it should work.