### PR TITLE
Improve the promise-caching in the `PDFDocument.fieldObjects` getter

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1947,12 +1947,7 @@ class PDFDocument {
   }
 
   get calculationOrderIds() {
-    const acroForm = this.catalog.acroForm;
-    if (!acroForm?.has("CO")) {
-      return shadow(this, "calculationOrderIds", null);
-    }
-
-    const calculationOrder = acroForm.get("CO");
+    const calculationOrder = this.catalog.acroForm?.get("CO");
     if (!Array.isArray(calculationOrder) || calculationOrder.length === 0) {
       return shadow(this, "calculationOrderIds", null);
     }
@@ -1963,10 +1958,7 @@ class PDFDocument {
         ids.push(id.toString());
       }
     }
-    if (ids.length === 0) {
-      return shadow(this, "calculationOrderIds", null);
-    }
-    return shadow(this, "calculationOrderIds", ids);
+    return shadow(this, "calculationOrderIds", ids.length ? ids : null);
   }
 
   get annotationGlobals() {


### PR DESCRIPTION
 - **Improve the promise-caching in the `PDFDocument.fieldObjects` getter**

   After PR #18845 we're accessing this getter more, hence it seems like a good idea to ensure that the initial `formInfo` access is covered as well.
   While unlikely to be a problem in practice, at least theoretically that data may not be available and the code in `fieldObjects` could thus currently be *unintentionally* invoked more than once.

 - **Reduce duplication in the `PDFDocument.calculationOrderIds` getter**

*Smaller diff with https://github.com/mozilla/pdf.js/pull/18871/files?w=1*