### PR TITLE
Avoid exceptions in the console with ill-formed flate streams

### DIFF
--- a/src/core/flate_stream.js
+++ b/src/core/flate_stream.js
@@ -161,8 +161,17 @@ class FlateStream extends DecodeStream {
     try {
       const { readable, writable } = new DecompressionStream("deflate");
       const writer = writable.getWriter();
-      writer.write(bytes);
-      writer.close();
+      await writer.ready;
+
+      // We can't await writer.write() because it'll block until the reader
+      // starts which happens few lines below.
+      writer
+        .write(bytes)
+        .then(async () => {
+          await writer.ready;
+          await writer.close();
+        })
+        .catch(() => {});
 
       const chunks = [];
       let totalLength = 0;

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -71,8 +71,14 @@ async function writeStream(stream, buffer, transform) {
     try {
       const cs = new CompressionStream("deflate");
       const writer = cs.writable.getWriter();
-      writer.write(bytes);
-      writer.close();
+      await writer.ready;
+      writer
+        .write(bytes)
+        .then(async () => {
+          await writer.ready;
+          await writer.close();
+        })
+        .catch(() => {});
 
       // Response::text doesn't return the correct data.
       const buf = await new Response(cs.readable).arrayBuffer();


### PR DESCRIPTION
It fixes #18876.