### PR TITLE
Don't add the grey outline when hovering a selected highlight

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -735,14 +735,6 @@ class AnnotationEditorLayer {
   }
 
   /**
-   * Check if the editor is selected.
-   * @param {AnnotationEditor} editor
-   */
-  isSelected(editor) {
-    return this.#uiManager.isSelected(editor);
-  }
-
-  /**
    * Unselect an editor.
    * @param {AnnotationEditor} editor
    */

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -1109,6 +1109,10 @@ class AnnotationEditor {
     this.#selectOnPointerEvent(event);
   }
 
+  get isSelected() {
+    return this._uiManager.isSelected(this);
+  }
+
   #selectOnPointerEvent(event) {
     const { isMac } = FeatureTest.platform;
     if (
@@ -1123,7 +1127,7 @@ class AnnotationEditor {
   }
 
   #setUpDragSession(event) {
-    const isSelected = this._uiManager.isSelected(this);
+    const { isSelected } = this;
     this._uiManager.setUpDragSession();
 
     const ac = new AbortController();

--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -596,11 +596,15 @@ class HighlightEditor extends AnnotationEditor {
   }
 
   pointerover() {
-    this.parent.drawLayer.addClass(this.#outlineId, "hovered");
+    if (!this.isSelected) {
+      this.parent.drawLayer.addClass(this.#outlineId, "hovered");
+    }
   }
 
   pointerleave() {
-    this.parent.drawLayer.removeClass(this.#outlineId, "hovered");
+    if (!this.isSelected) {
+      this.parent.drawLayer.removeClass(this.#outlineId, "hovered");
+    }
   }
 
   #keydown(event) {


### PR DESCRIPTION
When playing with a pen, I noticed that sometimes a free highlight has still its gray outline when an other one is drawn: for any reason the pointerleave event isn't triggered.