### PR TITLE
Handle null parentElement for selection anchor

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -299,7 +299,7 @@ class TextLayerBuilder {
           anchor = anchor.parentNode;
         }
 
-        const parentTextLayer = anchor.parentElement.closest(".textLayer");
+        const parentTextLayer = anchor.parentElement?.closest(".textLayer");
         const endDiv = this.#textLayers.get(parentTextLayer);
         if (endDiv) {
           endDiv.style.width = parentTextLayer.style.width;


### PR DESCRIPTION
In [the `selectionchange` handler](https://github.com/mozilla/pdf.js/blob/c6d01caf6509ba11aca4c616634f8178277a012b/web/text_layer_builder.js#L238-L318) that's added to the document by `TextLayerBuilder`, there is [a line](https://github.com/mozilla/pdf.js/blob/c6d01caf6509ba11aca4c616634f8178277a012b/web/text_layer_builder.js#L302C33-L302C75) which accesses `anchor.parentElement.closest(".textLayer")`.

This throws an error if `anchor.parentElement` is null, which can happen if the selection is inside a shadow root - I can reproduce it by selecting text inside Grammarly's popover on a page where PDF.is is being used.

![grammarly-error](https://github.com/user-attachments/assets/4d388f0f-61e4-4343-850d-905e924b77e1)

![grammarly-element](https://github.com/user-attachments/assets/495d77d7-ea3b-4d04-ab17-01f1a63a177c)

The error is only seen in non-Firefox browsers, as there is [a line which returns earlier in Firefox](https://github.com/mozilla/pdf.js/blob/c6d01caf6509ba11aca4c616634f8178277a012b/web/text_layer_builder.js#L281-L283).

This change handles the `null` parentElement gracefully, to avoid throwing the error.
