### PR TITLE
Remove unnecessary options from `removeEventListener` in the `web/app.js` file

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2117,7 +2117,7 @@ const PDFViewerApplication = {
         return;
       }
 
-      mainContainer.removeEventListener("scroll", scroll, { passive: true });
+      mainContainer.removeEventListener("scroll", scroll);
       this._isScrolling = true;
       mainContainer.addEventListener("scrollend", scrollend, { signal });
       mainContainer.addEventListener("blur", scrollend, { signal });


### PR DESCRIPTION
Only the `capture` parameter matters when removing an event listener, see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#matching_event_listeners_for_removal