### PR TITLE
[api-minor] Expose response headers, when available, in `PDFDocumentLoadingTask`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -673,6 +673,26 @@ class PDFDocumentLoadingTask {
       this._worker = null;
     }
   }
+
+  /**
+   * @returns {Promise<Headers | null>}
+   */
+  async getResponseHeaders() {
+    if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("GENERIC")) {
+      throw new Error("Not implemented: getResponseHeaders");
+    }
+    try {
+      await this.promise;
+    } catch {}
+
+    if (this.destroyed) {
+      throw new Error("LoadingTask destroyed.");
+    }
+    if (!this._transport) {
+      throw new Error("WorkerTransport unset.");
+    }
+    return this._transport._responseHeaders;
+  }
 }
 
 /**
@@ -2449,6 +2469,23 @@ class WorkerTransport {
     this.downloadInfoCapability = Promise.withResolvers();
 
     this.setupMessageHandler();
+
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      // NOTE: This getter should *not* be invoked until after
+      // the `IPDFStreamReader.headersReady`-promise has settled.
+      Object.defineProperty(this, "_responseHeaders", {
+        get() {
+          if (!networkStream) {
+            return null;
+          }
+          assert(this._fullReader, "No `IPDFStreamReader`-instance available.");
+
+          const headers = this._fullReader.responseHeaders;
+          // Always create a copy of the *internal* response headers.
+          return headers ? new Headers(headers) : null;
+        },
+      });
+    }
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -97,6 +97,8 @@ class PDFFetchStream {
 
 /** @implements {IPDFStreamReader} */
 class PDFFetchStreamReader {
+  #responseHeaders = null;
+
   constructor(stream) {
     this._stream = stream;
     this._reader = null;
@@ -126,13 +128,13 @@ class PDFFetchStreamReader {
       .then(response => {
         stream._responseOrigin = getResponseOrigin(response.url);
 
+        const responseHeaders = (this.#responseHeaders = response.headers);
+
         if (!validateResponseStatus(response.status)) {
           throw createResponseStatusError(response.status, url);
         }
         this._reader = response.body.getReader();
         this._headersCapability.resolve();
-
-        const responseHeaders = response.headers;
 
         const { allowRangeRequests, suggestedLength } =
           validateRangeRequestCapabilities({
@@ -161,6 +163,10 @@ class PDFFetchStreamReader {
 
   get headersReady() {
     return this._headersCapability.promise;
+  }
+
+  get responseHeaders() {
+    return this.#responseHeaders;
   }
 
   get filename() {

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -241,6 +241,8 @@ class PDFNetworkStream {
 
 /** @implements {IPDFStreamReader} */
 class PDFNetworkStreamFullRequestReader {
+  #responseHeaders = null;
+
   constructor(manager, source) {
     this._manager = manager;
 
@@ -281,7 +283,7 @@ class PDFNetworkStreamFullRequestReader {
     );
 
     const rawResponseHeaders = fullRequestXhr.getAllResponseHeaders();
-    const responseHeaders = new Headers(
+    const responseHeaders = (this.#responseHeaders = new Headers(
       rawResponseHeaders
         ? rawResponseHeaders
             .trim()
@@ -291,7 +293,7 @@ class PDFNetworkStreamFullRequestReader {
               return [key, val.join(": ")];
             })
         : []
-    );
+    ));
 
     const { allowRangeRequests, suggestedLength } =
       validateRangeRequestCapabilities({
@@ -374,6 +376,10 @@ class PDFNetworkStreamFullRequestReader {
 
   get headersReady() {
     return this._headersCapability.promise;
+  }
+
+  get responseHeaders() {
+    return this.#responseHeaders;
   }
 
   async read() {

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -123,6 +123,10 @@ class PDFNodeStreamFsFullReader {
     return this._headersCapability.promise;
   }
 
+  get responseHeaders() {
+    return null;
+  }
+
   get filename() {
     return this._filename;
   }

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -211,6 +211,10 @@ class PDFDataTransportStreamReader {
     return this._headersReady;
   }
 
+  get responseHeaders() {
+    return null;
+  }
+
   get filename() {
     return this._filename;
   }


### PR DESCRIPTION
This is a feature that's been requested a few times over the years, see e.g. issue #14630, #16341, and #18792.

Note that by placing the `getResponseHeaders` method in `PDFDocumentLoadingTask` it's possible to access the response headers even if loading failed, e.g. with `MissingPDFException`, which wouldn't have been possible if the method was placed elsewhere (e.g. in `PDFDocumentProxy`).
Given the following JSDoc comment, this also seems generally reasonable: https://github.com/mozilla/pdf.js/blob/689ffda9df29f24e03f6e5145a096584d7f166cc/src/display/api.js#L570-L575

Considering that this functionality isn't relevant in e.g. the Firefox PDF Viewer, pre-processor statements are being used to limit the code-size impact of the implementation to GENERIC-builds as much as possible.

---

***Please note:*** This will further increase the maintenance/support burden of the general PDF.js library, for a feature that's completely unused within the project itself.
Hence, if you'd like to see this patch landed, please contact me privately to discuss sponsoring this work (email address can be found in my GitHub profile).