### PR TITLE
Fix the "Text selection using mouse doesn't jump when hovering on an empty area in a single page" integration test

### DIFF
--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -39,17 +39,23 @@ describe("Text layer", () => {
     }
 
     function middlePosition(rect) {
-      return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+      return {
+        x: Math.round(rect.x + rect.width / 2),
+        y: Math.round(rect.y + rect.height / 2),
+      };
     }
 
     function middleLeftPosition(rect) {
-      return { x: rect.x + 1, y: rect.y + Math.floor(rect.height / 2) };
+      return {
+        x: Math.round(rect.x + 1),
+        y: Math.round(rect.y + rect.height / 2),
+      };
     }
 
     function belowEndPosition(rect) {
       return {
-        x: rect.x + rect.width,
-        y: rect.y + Math.floor(rect.height * 1.5),
+        x: Math.round(rect.x + rect.width),
+        y: Math.round(rect.y + rect.height * 1.5),
       };
     }
 


### PR DESCRIPTION
The `getSpanRectFromText` helper function returns the location as float values. This could be desirable in cases where the exact values matter (for example during comparisons), but in the text layer tests we don't need this precision. Moreover, the Puppeteer `page.mouse.move` API apparently doesn't work correctly if float values are given as input.

Note that this test only failed because it couldn't move to the initial selection position; any subsequent moves actually worked because the `moveInSteps` helper function already rounded all values correctly.

This commit fixes the issue by consistently rounding all values that we pass to Puppeteer's `page.mouse.move` API.

Fixes #18774.