### PR TITLE
Run CI tests in Node.js version 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, lts/*, 22]
+        node-version: [18, lts/*, 22, 23]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Node.js version 23 was recently released, see https://github.com/nodejs/release#release-schedule, hence it cannot hurt to start testing in that environment.