### PR TITLE
Remove the `eslint-plugin-{fetch-options,html}` and `eslint-config-prettier` dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
         "core-js": "^3.38.1",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-fetch-options": "^0.0.5",
-        "eslint-plugin-html": "^8.1.2",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jasmine": "^4.2.2",
         "eslint-plugin-json": "^3.1.0",
@@ -5386,28 +5384,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-fetch-options": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-fetch-options/-/eslint-plugin-fetch-options-0.0.5.tgz",
-      "integrity": "sha512-ZMxrccsOAZ7uMQ4nMvPJLqLg6oyLF96YOEwTKWAIbDHpwWUp1raXALZom8ikKucaEnhqWSRuBWI8jBXveFwkJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-html": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-8.1.2.tgz",
-      "integrity": "sha512-pbRchDV2SmqbCi/Ev/q3aAikzG9BcFe0IjjqjtMn8eTLq71ZUggyJB6CDmuwGAXmYZHrXI12XTfCqvgcnPRqGw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "htmlparser2": "^9.1.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "canvas": "^3.0.0-rc2",
         "core-js": "^3.38.1",
         "eslint": "^8.57.1",
-        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jasmine": "^4.2.2",
         "eslint-plugin-json": "^3.1.0",
@@ -5331,6 +5330,8 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "canvas": "^3.0.0-rc2",
     "core-js": "^3.38.1",
     "eslint": "^8.57.1",
-    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jasmine": "^4.2.2",
     "eslint-plugin-json": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "core-js": "^3.38.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-fetch-options": "^0.0.5",
-    "eslint-plugin-html": "^8.1.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jasmine": "^4.2.2",
     "eslint-plugin-json": "^3.1.0",


### PR DESCRIPTION
The commit messages contains more details about the individual changes.

Fixes a part of #17928.