### PR TITLE
Remove `mask-image` duplication for the print/download buttons

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -572,7 +572,7 @@ body {
   mask-image: var(--toolbarButton-editorStamp-icon);
 }
 
-:is(#printButton, #secondaryPrint)::before {
+#printButton::before {
   mask-image: var(--toolbarButton-print-icon);
 }
 
@@ -582,7 +582,7 @@ body {
 }
 /*#endif*/
 
-:is(#downloadButton, #secondaryDownload)::before {
+#downloadButton::before {
   mask-image: var(--toolbarButton-download-icon);
 }
 


### PR DESCRIPTION
With the recent re-factoring of the viewer CSS rules we now have some duplication of the `mask-image` definitions for the print/download buttons in the secondaryToolbar; note https://github.com/mozilla/pdf.js/blob/17419de15709892935ece25ffd6af105a7e6814d/web/viewer.css#L1204-L1210