### PR TITLE
Try to discourage "unrelated" information under `Attach (recommended) or Link to PDF file` in the bug report template (PR 18535 follow-up)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,6 +6,7 @@ body:
     attributes:
       label: Attach (recommended) or Link to PDF file
       description: Without this information the issue may be closed without comment
+      placeholder: Please place only the PDF file in this field
     validations:
       required: true
 


### PR DESCRIPTION
Unfortunately it turns out to be somewhat common for users to provide a bunch of "unrelated" information in this field, or even stating their entire problem there, rather than placing it under the appropriate headings further down in the template.