### PR TITLE
Unconditionally cache built-in CMaps on the worker-thread

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -398,11 +398,9 @@ class PartialEvaluator {
       // Get the data on the main-thread instead.
       data = await this.handler.sendWithPromise("FetchBuiltInCMap", { name });
     }
+    // Cache the CMap data, to avoid fetching it repeatedly.
+    this.builtInCMapCache.set(name, data);
 
-    if (data.compressionType !== CMapCompressionType.NONE) {
-      // Given the size of uncompressed CMaps, only cache compressed ones.
-      this.builtInCMapCache.set(name, data);
-    }
     return data;
   }
 


### PR DESCRIPTION
Given that we've not shipped, nor used, anything except binary CMaps for years let's just cache them unconditionally (since that's a tiny bit less code).