### PR TITLE
Allow `StreamsSequenceStream` to skip sub-streams that are not actual Streams (issue 18973)

### DIFF
--- a/src/core/decode_stream.js
+++ b/src/core/decode_stream.js
@@ -132,6 +132,8 @@ class DecodeStream extends BaseStream {
 
 class StreamsSequenceStream extends DecodeStream {
   constructor(streams, onError = null) {
+    streams = streams.filter(s => s instanceof BaseStream);
+
     let maybeLength = 0;
     for (const stream of streams) {
       maybeLength +=

--- a/test/pdfs/issue18973.pdf.link
+++ b/test/pdfs/issue18973.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/17550758/doc1520828609.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2058,6 +2058,15 @@
     "type": "eq"
   },
   {
+    "id": "issue18973",
+    "file": "pdfs/issue18973.pdf",
+    "md5": "b9bbd312269862bf39bb2a31023a9d02",
+    "link": true,
+    "rounds": 1,
+    "firstPage": 45,
+    "type": "eq"
+  },
+  {
     "id": "issue9262",
     "file": "pdfs/issue9262_reduced.pdf",
     "md5": "5347ce2d7b3866625c22e115fd90e0de",


### PR DESCRIPTION
This extends PR #13796 to also handle the case where sub-streams contain invalid data, i.e. anything that isn't a Stream, however please note that in these cases there's no guarantee that we'll render the page "correctly".

Note that Adobe Reader, i.e. the PDF reference implementation, cannot render the last page of the referenced PDF document.