### PR TITLE
Re-factor the `toHexUtil` helper (PR 17862 follow-up)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1102,11 +1102,7 @@ function toHexUtil(arr) {
   if (Uint8Array.prototype.toHex) {
     return arr.toHex();
   }
-  const buf = [];
-  for (const num of arr) {
-    buf.push(num.toString(16).padStart(2, "0"));
-  }
-  return buf.join("");
+  return Array.from(arr, num => hexNumbers[num]).join("");
 }
 
 // TODO: Remove this once `Uint8Array.prototype.toBase64` is generally


### PR DESCRIPTION
We can re-use the `hexNumbers` structure, since that allows us to directly lookup the hexadecimal values and shortens the code.