### PR TITLE
Don't initialize `L10n.#elements` eagerly since it's unused in MOZCENTRAL builds

### DIFF
--- a/web/l10n.js
+++ b/web/l10n.js
@@ -23,7 +23,7 @@
 class L10n {
   #dir;
 
-  #elements = new Set();
+  #elements;
 
   #lang;
 
@@ -71,7 +71,7 @@ class L10n {
 
   /** @inheritdoc */
   async translate(element) {
-    this.#elements.add(element);
+    (this.#elements ||= new Set()).add(element);
     try {
       this.#l10n.connectRoot(element);
       await this.#l10n.translateRoots();
@@ -91,10 +91,13 @@ class L10n {
 
   /** @inheritdoc */
   async destroy() {
-    for (const element of this.#elements) {
-      this.#l10n.disconnectRoot(element);
+    if (this.#elements) {
+      for (const element of this.#elements) {
+        this.#l10n.disconnectRoot(element);
+      }
+      this.#elements.clear();
+      this.#elements = null;
     }
-    this.#elements.clear();
     this.#l10n.pauseObserving();
   }
 


### PR DESCRIPTION
It's not necessary to manually start translation in the Firefox PDF Viewer, and doing so would even cause problems there (see issue #17142).