### PR TITLE
Enable the "should have an alt attribute from toolTip" unit-test in Node.js

### DIFF
--- a/test/unit/xfa_tohtml_spec.js
+++ b/test/unit/xfa_tohtml_spec.js
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import { isNodeJS } from "../../src/shared/util.js";
 import { XFAFactory } from "../../src/core/xfa/factory.js";
 
 describe("XFAFactory", function () {
@@ -145,9 +144,6 @@ describe("XFAFactory", function () {
     });
 
     it("should have an alt attribute from toolTip", async () => {
-      if (isNodeJS) {
-        pending("Image is not supported in Node.js.");
-      }
       const xml = `
 <?xml version="1.0"?>
 <xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/">


### PR DESCRIPTION
Despite the pending-message mentioning "Image", this appears to be another case where the code actually depends on [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob#browser_compatibility); note https://github.com/mozilla/pdf.js/blob/cf3ca8b5bc95154712bcde96ee85a0bf7afacb2f/src/core/xfa/template.js#L3453