### PR TITLE
Install and use the most recent Node types for the types tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@jazzer.js/core": "^2.1.0",
         "@metalsmith/layouts": "^2.7.0",
         "@metalsmith/markdown": "^1.10.0",
+        "@types/node": "^22.8.7",
         "autoprefixer": "^10.4.20",
         "babel-loader": "^9.2.1",
         "caniuse-lite": "^1.0.30001677",
@@ -2468,10 +2469,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.45.tgz",
-      "integrity": "sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==",
-      "dev": true
+      "version": "22.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.7.tgz",
+      "integrity": "sha512-LidcG+2UeYIWcMuMUpBKOnryBWG/rnmOHQR5apjn8myTQcx3rinFRn7DcIFhMnS0PPFSC6OafdIKEad0lj6U0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -13512,6 +13517,13 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@jazzer.js/core": "^2.1.0",
     "@metalsmith/layouts": "^2.7.0",
     "@metalsmith/markdown": "^1.10.0",
+    "@types/node": "^22.8.7",
     "autoprefixer": "^10.4.20",
     "babel-loader": "^9.2.1",
     "caniuse-lite": "^1.0.30001677",

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -10,7 +10,7 @@
     "module": "ESNext",
     "baseUrl": "./",
     "strict": true,
-    "types": [],
+    "types": ["node"],
     "lib": ["ESNext", "DOM"],
     "paths": {
       "pdfjs-dist": ["../../build/typestest"],


### PR DESCRIPTION
The types tests run in Node.js and therefore use Node types for e.g. builtins. However, we didn't explicitly indicate this in `tsconfig.json` (see [1] for more information and [2] for the PR where we found this). Moreover, we didn't explicitly install the most recent version of `@types/node` which implicitly made us fall back to version 14.14.45 (because that was installed as a dependency of other modules) whereas much newer versions are available and we need those after changes in Node.js (see [3] for more information and [4] for the PR where we found this).

This commit fixes both issues by explicitly installing and using the most recent Node.js types, which should also avoid future issues with the types tests.

[1] https://github.com/TypeStrong/ts-node/issues/1012
[2] https://github.com/mozilla/pdf.js/pull/18237
[3] https://stackoverflow.com/questions/78790943/in-typescript-5-6-buffer-is-not-assignable-to-arraybufferview-or-uint8arr
[4] https://github.com/mozilla/pdf.js/pull/18959