### PR TITLE
Fix Typo:XFATemplate class Para Styling paddingight => paddingRight

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -4317,7 +4317,7 @@ class Para extends XFAObject {
       style.paddingLeft = measureToString(this.marginLeft);
     }
     if (this.marginRight !== "") {
-      style.paddingight = measureToString(this.marginRight);
+      style.paddingRight = measureToString(this.marginRight);
     }
     if (this.spaceAbove !== "") {
       style.paddingTop = measureToString(this.spaceAbove);


### PR DESCRIPTION
This replaces PR #18819, obviously with the author information kept intact, since recent GitHub Actions changes now prevent that one from being merged.
*Please note:* That PR did have some "regressions", but as discussed on Matrix we're fine with accepting them.

Closes #18819