### PR TITLE
Alias ArialMT with Arial when ArialMT isn't embedded (bug 1928458)

### DIFF
--- a/src/core/font_substitutions.js
+++ b/src/core/font_substitutions.js
@@ -307,7 +307,12 @@ const substitutionMap = new Map([
   ],
 ]);
 
-const fontAliases = new Map([["Arial-Black", "ArialBlack"]]);
+const fontAliases = new Map([
+  ["Arial-Black", "ArialBlack"],
+  // Some fonts can have a bad postscript name ! (see bug 1928458) and it's very
+  // unlikely that we want to find a font called ArialMT which is not Arial.
+  ["ArialMT", "Arial"],
+]);
 
 function getStyleToAppend(style) {
   switch (style) {
@@ -395,7 +400,12 @@ function generateFont(
   if (local) {
     const extra = append ? ` ${append}` : "";
     for (const name of local) {
-      src.push(`local(${name}${extra})`);
+      const localFont = `local(${name}${extra})`;
+      if (src[0] !== localFont) {
+        // The first local(...) is for the font we've in the pdf: no need to
+        // duplicate it.
+        src.push(localFont);
+      }
     }
   }
   if (alias) {

--- a/test/pdfs/bug1928458.pdf.link
+++ b/test/pdfs/bug1928458.pdf.link
@@ -1,0 +1,1 @@
+https://bugzilla.mozilla.org/attachment.cgi?id=9435915

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -10757,5 +10757,15 @@
     "md5": "73e8cd32bd063e42fcc4b270c78549b1",
     "rounds": 1,
     "type": "eq"
+  },
+  {
+    "id": "bug1928458",
+    "file": "pdfs/bug1928458.pdf",
+    "md5": "f116e876ab8c4733a9fd9c802bbd5f39",
+    "rounds": 1,
+    "firstPage": 1,
+    "lastPage": 1,
+    "link": true,
+    "type": "eq"
   }
 ]

--- a/test/unit/font_substitutions_spec.js
+++ b/test/unit/font_substitutions_spec.js
@@ -416,4 +416,29 @@ describe("getFontSubstitution", function () {
       /^"ArialBlack",g_d(\d+)_sf(\d+),sans-serif$/
     );
   });
+
+  it("should substitute ArialMT with Arial", () => {
+    const fontName = "ArialMT";
+    const fontSubstitution = getFontSubstitution(
+      new Map(),
+      idFactory,
+      localFontPath,
+      fontName,
+      undefined,
+      "TrueType"
+    );
+    console.log(fontSubstitution);
+    expect(fontSubstitution).toEqual(
+      jasmine.objectContaining({
+        guessFallback: true,
+        baseFontName: "Arial",
+        src: "local(Arial)",
+        style: {
+          style: "normal",
+          weight: "normal",
+        },
+      })
+    );
+    expect(fontSubstitution.css).toMatch(/^"Arial",g_d(\d+)_sf(\d+)$/);
+  });
 });


### PR DESCRIPTION
It'll avoid to use a font with a wrong PS name (ArialMT) and let us try to match a font called Arial which is very likely what we want at the end.