### PR TITLE
Set the padding of the buttons in the toolbars to zero

### DIFF
--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -309,6 +309,10 @@
       gap: 0;
       height: 100%;
 
+      button {
+        padding: 0;
+      }
+
       .divider {
         width: 0;
         height: calc(

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -996,6 +996,7 @@ dialog :link {
   font: message-box;
   flex: none;
   position: relative;
+  padding: 0;
 
   > span {
     display: inline-block;


### PR DESCRIPTION
It fixes #19008.
In Firefox on mac, the default padding is set to 4px and with Firefox for iOS, it's set to 13px. The padding is useless for such buttons.