### PR TITLE
Apply gradient when stroking text

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -498,6 +498,9 @@ class FontFaceObject {
           break;
       }
     }
+    // From https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#paths
+    // All contours must be closed with a lineto operation.
+    commands.push(ctx => ctx.closePath());
 
     return (this.compiledGlyphs[character] = function glyphDrawer(ctx, size) {
       commands[0](ctx);

--- a/test/pdfs/issue19022.pdf.link
+++ b/test/pdfs/issue19022.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/17703776/linear-gradient-on-rect_text.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -10757,5 +10757,13 @@
     "md5": "73e8cd32bd063e42fcc4b270c78549b1",
     "rounds": 1,
     "type": "eq"
+  },
+  {
+    "id": "issue19022",
+    "file": "pdfs/issue19022.pdf",
+    "md5": "7d7a9c45f93a9db269800855ccffe7cd",
+    "rounds": 1,
+    "type": "eq",
+    "link": true
   }
 ]


### PR DESCRIPTION
It fixes #19022.

I noticed that the glyph contours weren't correct (for T and x) and because we forgot to close the contour.