### PR TITLE
Add normalizedTextContents function

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -378,6 +378,19 @@ function getOriginalIndex(diffs, pos, len) {
   return [oldStart, oldLen];
 }
 
+function normalizedTextContent(textContent) {
+  const strBuf = [];
+
+  for (const textItem of textContent.items) {
+    strBuf.push(textItem.str);
+    if (textItem.hasEOL) {
+      strBuf.push("\n");
+    }
+  }
+
+  return normalize(strBuf.join(""));
+}
+
 /**
  * @typedef {Object} PDFFindControllerOptions
  * @property {IPDFLinkService} linkService - The navigation/linking service.
@@ -873,21 +886,12 @@ class PDFFindController {
           .then(pdfPage => pdfPage.getTextContent(textOptions))
           .then(
             textContent => {
-              const strBuf = [];
-
-              for (const textItem of textContent.items) {
-                strBuf.push(textItem.str);
-                if (textItem.hasEOL) {
-                  strBuf.push("\n");
-                }
-              }
-
               // Store the normalized page content (text items) as one string.
               [
                 this._pageContents[i],
                 this._pageDiffs[i],
                 this._hasDiacritics[i],
-              ] = normalize(strBuf.join(""));
+              ] = normalizedTextContent(textContent);
               resolve();
             },
             reason => {
@@ -1165,4 +1169,4 @@ class PDFFindController {
   }
 }
 
-export { FindState, PDFFindController };
+export { FindState, normalizedTextContent, PDFFindController };


### PR DESCRIPTION
Move the code to concatenate and normalize the contents of a page into its own function in pdf_find_controller so that it could be reused elsewhere.

This is a small part of the ongoing work to address #3172, which I decided to break off and post already as a PR so that we could start iterating on it in parts and be more agile.

There's two open questions with this patch, beyond the common "what can we name this function":

* Where should this new refactored function live? It's currently still in pdf_find_controller but that might not be ideal and we might want to move stuff to a more central location (this would incur a bigger diff unfortunately).
* Do we need to normalize the text for our upcoming use case as well? While the concat logic is definitely required the normalization might not be entirely necessary especially with the `v` flag.