### PR TITLE
Ensure that the response-origin of range requests match the full request (issue 12744)

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -18,6 +18,7 @@ import {
   createHeaders,
   createResponseStatusError,
   extractFilenameFromHeader,
+  getResponseOrigin,
   validateRangeRequestCapabilities,
   validateResponseStatus,
 } from "./network_utils.js";
@@ -52,6 +53,8 @@ function getArrayBuffer(val) {
 
 /** @implements {IPDFStream} */
 class PDFFetchStream {
+  _responseOrigin = null;
+
   constructor(source) {
     this.source = source;
     this.isHttp = /^https?:/i.test(source.url);
@@ -121,6 +124,8 @@ class PDFFetchStreamReader {
       createFetchOptions(headers, this._withCredentials, this._abortController)
     )
       .then(response => {
+        stream._responseOrigin = getResponseOrigin(response.url);
+
         if (!validateResponseStatus(response.status)) {
           throw createResponseStatusError(response.status, url);
         }
@@ -217,6 +222,13 @@ class PDFFetchStreamRangeReader {
       createFetchOptions(headers, this._withCredentials, this._abortController)
     )
       .then(response => {
+        const responseOrigin = getResponseOrigin(response.url);
+
+        if (responseOrigin !== stream._responseOrigin) {
+          throw new Error(
+            `Expected range response-origin "${responseOrigin}" to match "${stream._responseOrigin}".`
+          );
+        }
         if (!validateResponseStatus(response.status)) {
           throw createResponseStatusError(response.status, url);
         }

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -36,6 +36,16 @@ function createHeaders(isHttp, httpHeaders) {
   return headers;
 }
 
+function getResponseOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    // `new URL()` will throw on incorrect data.
+  }
+  // Notably, null is distinct from "null" string (e.g. from file:-URLs).
+  return null;
+}
+
 function validateRangeRequestCapabilities({
   responseHeaders,
   isHttp,
@@ -116,6 +126,7 @@ export {
   createHeaders,
   createResponseStatusError,
   extractFilenameFromHeader,
+  getResponseOrigin,
   validateRangeRequestCapabilities,
   validateResponseStatus,
 };

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -30,6 +30,10 @@ class IPDFStream {
 
   /**
    * Gets a reader for the range of the PDF data.
+   *
+   * NOTE: Currently this method is only expected to be invoked *after*
+   * the `IPDFStreamReader.prototype.headersReady` promise has resolved.
+   *
    * @param {number} begin - the start offset of the data.
    * @param {number} end - the end offset of the data.
    * @returns {IPDFStreamRangeReader}

--- a/test/unit/fetch_stream_spec.js
+++ b/test/unit/fetch_stream_spec.js
@@ -54,7 +54,7 @@ describe("fetch_stream", function () {
     const fullReader = stream.getFullReader();
 
     let isStreamingSupported, isRangeSupported;
-    const promise = fullReader.headersReady.then(function () {
+    await fullReader.headersReady.then(function () {
       isStreamingSupported = fullReader.isStreamingSupported;
       isRangeSupported = fullReader.isRangeSupported;
     });
@@ -71,7 +71,7 @@ describe("fetch_stream", function () {
       });
     };
 
-    await Promise.all([read(), promise]);
+    await read();
 
     expect(len).toEqual(pdfLength);
     expect(isStreamingSupported).toEqual(true);
@@ -90,7 +90,7 @@ describe("fetch_stream", function () {
     const fullReader = stream.getFullReader();
 
     let isStreamingSupported, isRangeSupported, fullReaderCancelled;
-    const promise = fullReader.headersReady.then(function () {
+    await fullReader.headersReady.then(function () {
       isStreamingSupported = fullReader.isStreamingSupported;
       isRangeSupported = fullReader.isRangeSupported;
       // We shall be able to close full reader without any issue.
@@ -121,7 +121,6 @@ describe("fetch_stream", function () {
     await Promise.all([
       read(rangeReader1, result1),
       read(rangeReader2, result2),
-      promise,
     ]);
 
     expect(isStreamingSupported).toEqual(true);

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -31,7 +31,7 @@ describe("network", function () {
     const fullReader = stream.getFullReader();
 
     let isStreamingSupported, isRangeSupported;
-    const promise = fullReader.headersReady.then(function () {
+    await fullReader.headersReady.then(function () {
       isStreamingSupported = fullReader.isStreamingSupported;
       isRangeSupported = fullReader.isRangeSupported;
     });
@@ -49,7 +49,7 @@ describe("network", function () {
       });
     };
 
-    await Promise.all([read(), promise]);
+    await read();
 
     expect(len).toEqual(pdf1Length);
     expect(count).toEqual(1);
@@ -72,7 +72,7 @@ describe("network", function () {
     const fullReader = stream.getFullReader();
 
     let isStreamingSupported, isRangeSupported, fullReaderCancelled;
-    const promise = fullReader.headersReady.then(function () {
+    await fullReader.headersReady.then(function () {
       isStreamingSupported = fullReader.isStreamingSupported;
       isRangeSupported = fullReader.isRangeSupported;
       // we shall be able to close the full reader without issues
@@ -107,7 +107,6 @@ describe("network", function () {
     await Promise.all([
       read(range1Reader, result1),
       read(range2Reader, result2),
-      promise,
     ]);
 
     expect(result1.value).toEqual(rangeSize);


### PR DESCRIPTION
The following cases are excluded in the patch:
 - The Firefox PDF Viewer, since it has been fixed on the platform side already; please see https://bugzilla.mozilla.org/show_bug.cgi?id=1683940

 - The `PDFNodeStream`-implementation, used in Node.js environments, since after recent changes that code only supports `file://`-URLs.

Also updates the `read`-methods, on both `PDFNetworkStreamFullRequestReader` and `PDFNetworkStreamRangeRequestReader`, to await the headers before returning any data similarly to the implementation in `src/display/fetch_stream.js`.

*Note:* The relevant unit-tests are updated to await the `headersReady` Promise before dispatching range requests, since that's consistent with the actual usage in the `src/`-folder.

Fixes #12744