### PR TITLE
[api-minor] Add a `getDocument` option to disable `ImageDecoder` usage

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -72,6 +72,7 @@ import { getGlyphsUnicode } from "./glyphlist.js";
 import { getMetrics } from "./metrics.js";
 import { getUnicodeForGlyph } from "./unicode.js";
 import { ImageResizer } from "./image_resizer.js";
+import { JpegStream } from "./jpeg_stream.js";
 import { MurmurHash3_64 } from "../shared/murmurhash3.js";
 import { OperatorList } from "./operator_list.js";
 import { PDFImage } from "./image.js";
@@ -83,6 +84,7 @@ const DefaultPartialEvaluatorOptions = Object.freeze({
   ignoreErrors: false,
   isEvalSupported: true,
   isOffscreenCanvasSupported: false,
+  isImageDecoderSupported: false,
   isChrome: false,
   canvasMaxAreaInBytes: -1,
   fontExtraProperties: false,
@@ -233,14 +235,9 @@ class PartialEvaluator {
 
     this._regionalImageCache = new RegionalImageCache();
     this._fetchBuiltInCMapBound = this.fetchBuiltInCMap.bind(this);
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-      ImageResizer.setMaxArea(this.options.canvasMaxAreaInBytes);
-    } else {
-      ImageResizer.setOptions({
-        isChrome: this.options.isChrome,
-        maxArea: this.options.canvasMaxAreaInBytes,
-      });
-    }
+
+    ImageResizer.setOptions(this.options);
+    JpegStream.setOptions(this.options);
   }
 
   /**

--- a/src/core/jpeg_stream.js
+++ b/src/core/jpeg_stream.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { shadow, warn } from "../shared/util.js";
+import { FeatureTest, shadow, warn } from "../shared/util.js";
 import { DecodeStream } from "./decode_stream.js";
 import { Dict } from "./primitives.js";
 import { JpegImage } from "./jpg.js";
@@ -23,6 +23,8 @@ import { JpegImage } from "./jpg.js";
  * like all the other DecodeStreams.
  */
 class JpegStream extends DecodeStream {
+  static #isImageDecoderSupported = FeatureTest.isImageDecoderSupported;
+
   constructor(stream, maybeLength, params) {
     super(maybeLength);
 
@@ -36,10 +38,14 @@ class JpegStream extends DecodeStream {
     return shadow(
       this,
       "canUseImageDecoder",
-      typeof ImageDecoder === "undefined"
-        ? Promise.resolve(false)
-        : ImageDecoder.isTypeSupported("image/jpeg")
+      this.#isImageDecoderSupported
+        ? ImageDecoder.isTypeSupported("image/jpeg")
+        : Promise.resolve(false)
     );
+  }
+
+  static setOptions({ isImageDecoderSupported = false }) {
+    this.#isImageDecoderSupported = isImageDecoderSupported;
   }
 
   get bytes() {

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -48,10 +48,12 @@ class BasePdfManager {
     this._password = args.password;
     this.enableXfa = args.enableXfa;
 
-    // Check `OffscreenCanvas` support once, rather than repeatedly throughout
-    // the worker-thread code.
+    // Check `OffscreenCanvas` and `ImageDecoder` support once,
+    // rather than repeatedly throughout the worker-thread code.
     args.evaluatorOptions.isOffscreenCanvasSupported &&=
       FeatureTest.isOffscreenCanvasSupported;
+    args.evaluatorOptions.isImageDecoderSupported &&=
+      FeatureTest.isImageDecoderSupported;
     this.evaluatorOptions = Object.freeze(args.evaluatorOptions);
   }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -177,6 +177,10 @@ const DefaultStandardFontDataFactory =
  *   `OffscreenCanvas` in the worker. Primarily used to improve performance of
  *   image conversion/rendering.
  *   The default value is `true` in web environments and `false` in Node.js.
+ * @property {boolean} [isImageDecoderSupported] - Determines if we can use
+ *   `ImageDecoder` in the worker. Primarily used to improve performance of
+ *   image conversion/rendering.
+ *   The default value is `true` in web environments and `false` in Node.js.
  * @property {boolean} [isChrome] - Determines if we can use bmp ImageDecoder.
  *   NOTE: Temporary option until [https://issues.chromium.org/issues/374807001]
  *   is fixed.
@@ -283,6 +287,10 @@ function getDocument(src = {}) {
   const isOffscreenCanvasSupported =
     typeof src.isOffscreenCanvasSupported === "boolean"
       ? src.isOffscreenCanvasSupported
+      : !isNodeJS;
+  const isImageDecoderSupported =
+    typeof src.isImageDecoderSupported === "boolean"
+      ? src.isImageDecoderSupported
       : !isNodeJS;
   const isChrome =
     typeof src.isChrome === "boolean"
@@ -395,6 +403,7 @@ function getDocument(src = {}) {
       ignoreErrors,
       isEvalSupported,
       isOffscreenCanvasSupported,
+      isImageDecoderSupported,
       isChrome,
       canvasMaxAreaInBytes,
       fontExtraProperties,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -623,6 +623,14 @@ class FeatureTest {
     );
   }
 
+  static get isImageDecoderSupported() {
+    return shadow(
+      this,
+      "isImageDecoderSupported",
+      typeof ImageDecoder !== "undefined"
+    );
+  }
+
   static get platform() {
     if (
       (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||


### PR DESCRIPTION
This allows end-users to forcibly disable `ImageDecoder` usage, even if the browser appears to support it (similar to the pre-existing option for `OffscreenCanvas`).