### PR TITLE
Use Python 3.13 in the GitHub workflows

### DIFF
--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Python 3.12
+      - name: Use Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install Fluent dependencies

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Use Python 3.12
+      - name: Use Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install Fonttools

--- a/test/font/README.md
+++ b/test/font/README.md
@@ -32,5 +32,5 @@ it before running the font tests:
 python3 -m venv venv
 source venv/bin/activate
 pip install fonttools
-gulp fonttest
+npx gulp fonttest
 ```


### PR DESCRIPTION
Python 3.13 is the current version and was released over a month ago (see https://devguide.python.org/versions). The dependencies we use now support Python 3.13, most importantly `fonttools` which uses OS-specific builds and for which compatibility got introduced in https://github.com/fonttools/fonttools/pull/3656 and the corresponding `cp313` wheels for all distributions are published on https://pypi.org/project/fonttools/#files.

Moreover, we fix forgotten `npx` usage in the font tests README which was encountered while testing this patch.