### PR TITLE
Enable the ESLint `no-console` rule in parts of the code-base

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -313,6 +313,12 @@ export default [
       "template-curly-spacing": ["error", "never"],
     },
   },
+  {
+    files: jsFiles("src"),
+    rules: {
+      "no-console": "error",
+    },
+  },
 
   /* ======================================================================== *\
                             Test-specific rules
@@ -354,11 +360,13 @@ export default [
     files: jsFiles("test/unit"),
     rules: {
       "import/no-unresolved": ["error", { ignore: ["pdfjs/"] }],
+      "no-console": ["error", { allow: ["warn", "error"] }],
     },
   },
   {
     files: jsFiles("test/integration"),
     rules: {
+      "no-console": ["error", { allow: ["warn", "error"] }],
       "no-restricted-syntax": [
         "error",
         {

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -413,6 +413,7 @@ function noContextMenu(e) {
 
 // Deprecated API function -- display regardless of the `verbosity` setting.
 function deprecated(details) {
+  // eslint-disable-next-line no-console
   console.log("Deprecated API usage: " + details);
 }
 

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -166,7 +166,7 @@ class ImageManager {
       }
       data.refCounter = 1;
     } catch (e) {
-      console.error(e);
+      warn(e);
       data = null;
     }
     this.#cache.set(key, data);

--- a/src/pdf.sandbox.js
+++ b/src/pdf.sandbox.js
@@ -84,6 +84,7 @@ class Sandbox {
         [buf, this._alertOnError]
       );
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error);
     } finally {
       if (buf) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -363,6 +363,7 @@ function getVerbosityLevel() {
 // end users.
 function info(msg) {
   if (verbosity >= VerbosityLevel.INFOS) {
+    // eslint-disable-next-line no-console
     console.log(`Info: ${msg}`);
   }
 }
@@ -370,6 +371,7 @@ function info(msg) {
 // Non-fatal warnings.
 function warn(msg) {
   if (verbosity >= VerbosityLevel.WARNINGS) {
+    // eslint-disable-next-line no-console
     console.log(`Warning: ${msg}`);
   }
 }

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -309,9 +309,11 @@ async function waitForEvent({
 
   const success = await awaitPromise(handle);
   if (success === null) {
-    console.log(`waitForEvent: ${eventName} didn't trigger within the timeout`);
+    console.warn(
+      `waitForEvent: ${eventName} didn't trigger within the timeout`
+    );
   } else if (!success) {
-    console.log(`waitForEvent: ${eventName} triggered, but validation failed`);
+    console.warn(`waitForEvent: ${eventName} triggered, but validation failed`);
   }
 }
 


### PR DESCRIPTION
The purpose of these changes is to make it more difficult to accidentally include logging statements, used during development and debugging, when submitting patches for review.

For (almost) all code residing in the `src/` folder we should use our existing helper functions to ensure that all logging can be controlled via the `verbosity` API-option.

For the `test/unit/` respectively `test/integration/` folders we shouldn't need any "normal" logging, but it should be OK to print the *occasional* warning/error message.

Please find additional details about the ESLint rule at https://eslint.org/docs/latest/rules/no-console