### PR TITLE
[api-minor] Disable `ImageDecoder` usage by default in Chromium browsers

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -85,7 +85,6 @@ const DefaultPartialEvaluatorOptions = Object.freeze({
   isEvalSupported: true,
   isOffscreenCanvasSupported: false,
   isImageDecoderSupported: false,
-  isChrome: false,
   canvasMaxAreaInBytes: -1,
   fontExtraProperties: false,
   useSystemFonts: true,

--- a/src/core/image_resizer.js
+++ b/src/core/image_resizer.js
@@ -120,17 +120,13 @@ class ImageResizer {
 
   static setOptions({
     canvasMaxAreaInBytes = -1,
-    isChrome = false,
     isImageDecoderSupported = false,
   }) {
     if (!this._hasMaxArea) {
       // Divide by 4 to have the value in pixels.
       this.MAX_AREA = canvasMaxAreaInBytes >> 2;
     }
-    // TODO: remove the isChrome, once Chrome doesn't crash anymore with
-    // issue6741.pdf.
-    // https://issues.chromium.org/issues/374807001.
-    this.#isImageDecoderSupported = isImageDecoderSupported && !isChrome;
+    this.#isImageDecoderSupported = isImageDecoderSupported;
   }
 
   static _areGoodDims(width, height) {


### PR DESCRIPTION
Given that there are multiple issues with `ImageDecoder` in Chromium browsers, affecting both BMP and JPEG images, for now we (by default) disable that functionality there to avoid problems.

This also means that we can remove the previously added, and separate, `isChrome` API-option.