### PR TITLE
Update highlight.js fix deserialize typo error

### DIFF
--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -857,9 +857,9 @@ class HighlightEditor extends AnnotationEditor {
       for (let i = 0; i < quadPoints.length; i += 8) {
         boxes.push({
           x: (quadPoints[i] - pageX) / pageWidth,
-          y: 1 - (quadPoints[i + 1] - pageY) / pageHeight,
+          y: 1 - (quadPoints[i + 5] - pageY) / pageHeight,
           width: (quadPoints[i + 2] - quadPoints[i]) / pageWidth,
-          height: (quadPoints[i + 1] - quadPoints[i + 5]) / pageHeight,
+          height: (quadPoints[i + 5] - quadPoints[i + 1]) / pageHeight,
         });
       }
       editor.#createOutlines();


### PR DESCRIPTION
When researching for pdf.js library I found that this code block was refactor from commit https://github.com/mozilla/pdf.js/commit/a62ceedb692f33bf9d7b25e2ca1a9fe9d25f3c84 has a minor typo error. 

Current code has problem,

```javascript
if (quadPoints) {
      const boxes = (editor.#boxes = []);
      for (let i = 0; i < quadPoints.length; i += 8) {
        boxes.push({
          x: (quadPoints[i] - pageX) / pageWidth,
          y: 1 - (quadPoints[i + 1] - pageY) / pageHeight,
          width: (quadPoints[i + 2] - quadPoints[i]) / pageWidth,
          height: (quadPoints[i + 1] - quadPoints[i + 5]) / pageHeight,
        });
      }
      editor.#createOutlines();
      editor.#addToDrawLayer();
      editor.rotate(editor.rotation);
    }
```

The value at index quadPoints[i + 1] and quadPoints[i + 5] was reversed. From the logic of the #serializeBoxes I found that the correct logic should be like this

```javascript
if (quadPoints) {
      const boxes = (editor.#boxes = []);
      for (let i = 0; i < quadPoints.length; i += 8) {
        boxes.push({
          x: (quadPoints[i] - pageX) / pageWidth,
          y: 1 - (quadPoints[i + 5] - pageY) / pageHeight,
          width: (quadPoints[i + 2] - quadPoints[i]) / pageWidth,
          height: (quadPoints[i + 5] - quadPoints[i + 1]) / pageHeight,
        });
      }
      editor.#createOutlines();
      editor.#addToDrawLayer();
      editor.rotate(editor.rotation);
    }
```