### PR TITLE
Avoid redundant CMap-value lookup in `extendCMap` (PR 5101 follow-up)

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -662,7 +662,7 @@ async function extendCMap(cMap, fetchBuiltInCMap, useCMap) {
   // any previously defined entries.
   cMap.useCMap.forEach(function (key, value) {
     if (!cMap.contains(key)) {
-      cMap.mapOne(key, cMap.useCMap.lookup(key));
+      cMap.mapOne(key, value);
     }
   });
 


### PR DESCRIPTION
When iterating through `useCMap` the value is already available, without having to manually invoke the `lookup`-method.
While this will likely not affect performance in any noticeable way, it's nonetheless unnecessary to lookup an already available value twice.