### PR TITLE
Improve clean-up of `#_hcmCache`-data in `DOMFilterFactory.prototype.destroy`

### DIFF
--- a/src/display/filter_factory.js
+++ b/src/display/filter_factory.js
@@ -423,17 +423,18 @@ class DOMFilterFactory extends BaseFilterFactory {
   }
 
   destroy(keepHCM = false) {
-    if (keepHCM && this.#hcmCache.size !== 0) {
+    if (keepHCM && this.#_hcmCache?.size) {
       return;
     }
-    if (this.#_defs) {
-      this.#_defs.parentNode.parentNode.remove();
-      this.#_defs = null;
-    }
-    if (this.#_cache) {
-      this.#_cache.clear();
-      this.#_cache = null;
-    }
+    this.#_defs?.parentNode.parentNode.remove();
+    this.#_defs = null;
+
+    this.#_cache?.clear();
+    this.#_cache = null;
+
+    this.#_hcmCache?.clear();
+    this.#_hcmCache = null;
+
     this.#id = 0;
   }
 


### PR DESCRIPTION
 - Use optional chaining when clearing various data-structures, since that's slightly shorter.

 - Ensure that checking for the existence of `#_hcmCache`-data won't cause it to be initialized. (Note how `this.#hcmCache` is actually a getter.)

 - Actually reset the `#_hcmCache`-data when that's appropriate, e.g. when closing the PDF document.