### PR TITLE
Fix #serializeBoxes function not output correct quadPoints values for deserialize (issue19056)

### DIFF
--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -693,15 +693,14 @@ class HighlightEditor extends AnnotationEditor {
     let i = 0;
     for (const { x, y, width, height } of boxes) {
       const sx = x * pageWidth + pageX;
-      const sy = (1 - y - height) * pageHeight + pageY;
-      // The specifications say that the rectangle should start from the bottom
-      // left corner and go counter-clockwise.
-      // But when opening the file in Adobe Acrobat it appears that this isn't
-      // correct hence the 4th and 6th numbers are just swapped.
+      const sy = (1 - y) * pageHeight + pageY;
+      // Serializes the rectangle in the Adobe Acrobat format.
+      // The rectangle's coordinates (b = bottom, t = top, L = left, R = right)
+      // are ordered as follows: tL, tR, bL, bR (bL origin).
       quadPoints[i] = quadPoints[i + 4] = sx;
       quadPoints[i + 1] = quadPoints[i + 3] = sy;
       quadPoints[i + 2] = quadPoints[i + 6] = sx + width * pageWidth;
-      quadPoints[i + 5] = quadPoints[i + 7] = sy + height * pageHeight;
+      quadPoints[i + 5] = quadPoints[i + 7] = sy - height * pageHeight;
       i += 8;
     }
     return quadPoints;

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1272,7 +1272,8 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(getEditorSelector(0));
           await waitForSerialized(page, 1);
           const quadPoints = await getFirstSerialized(page, e => e.quadPoints);
-          const expected = [263, 674, 346, 674, 263, 696, 346, 696];
+          // Expected quadPoints tL, tR, bL, bR with bL coordinate.
+          const expected = [263, 696, 346, 696, 263, 674, 346, 674];
           expect(quadPoints.every((x, i) => Math.abs(x - expected[i]) <= 5))
             .withContext(`In ${browserName}`)
             .toBeTrue();
@@ -1307,7 +1308,8 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(getEditorSelector(0));
           await waitForSerialized(page, 1);
           const quadPoints = await getFirstSerialized(page, e => e.quadPoints);
-          const expected = [148, 624, 176, 624, 148, 637, 176, 637];
+          // Expected quadPoints tL, tR, bL, bR with bL coordinate.
+          const expected = [148, 637, 176, 637, 148, 624, 176, 624];
           expect(quadPoints.every((x, i) => Math.abs(x - expected[i]) <= 5))
             .withContext(`In ${browserName} (got ${quadPoints})`)
             .toBeTrue();


### PR DESCRIPTION
This PR fixes the #serializeBoxes in the highlight editor to output the correct quadPoints sequence used by the deserialize method after the commit https://github.com/mozilla/pdf.js/commit/a62ceedb692f33bf9d7b25e2ca1a9fe9d25f3c84 introduce a conflict logic between two methods.

I also added the integration test to ensure both methods (#serializeBoxes and deserialize) always output the correct values for the serializing/deserializing process.

Reproduce step
```javascript
// Some code to create highlight annotation

const { map } = PDFViewerApplication.pdfDocument.annotationStorage.serializable;
const vals = Array.from(map.values());
const serialized = vals[0]; // Get first serialized highlight annotation

const layer =  PDFViewerApplication.pdfViewer.getPageView(0).annotationEditorLayer.annotationEditorLayer;
const editor = await layer.deserialize(serialized);
layer.add(editor);

// New deserialized highlight will not shown.
// If you check the #boxes field, the height value of the boxes gets a negative value.
// And all y value of boxes are not correct
```