### PR TITLE
Fix 'must load a SVG, delete it and undo' integration test

### DIFF
--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -195,14 +195,14 @@ describe("Stamp Editor", () => {
           );
           const editorSelector = getEditorSelector(0);
           await waitForImage(page, editorSelector);
-
           await waitForSerialized(page, 1);
+
           await page.waitForSelector(`${editorSelector} button.delete`);
           await page.click(`${editorSelector} button.delete`);
-
           await waitForSerialized(page, 0);
 
           await kbUndo(page);
+          await waitForImage(page, editorSelector);
           await waitForSerialized(page, 1);
 
           await waitForSelectedEditor(page, editorSelector);
@@ -654,8 +654,8 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 0);
 
         await kbUndo(page);
+        await waitForImage(page, selector);
         await waitForSerialized(page, 1);
-        await page.waitForSelector(`${selector} canvas`);
       }
     });
   });
@@ -739,8 +739,8 @@ describe("Stamp Editor", () => {
         }
 
         await kbUndo(page);
+        await waitForImage(page, selector);
         await waitForSerialized(page, 1);
-        await page.waitForSelector(`${selector} canvas`);
       }
     });
   });

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -327,9 +327,18 @@ async function waitForStorageEntries(page, nEntries) {
 
 async function waitForSerialized(page, nEntries) {
   return page.waitForFunction(
-    n =>
-      (window.PDFViewerApplication.pdfDocument.annotationStorage.serializable
-        .map?.size ?? 0) === n,
+    n => {
+      try {
+        return (
+          (window.PDFViewerApplication.pdfDocument.annotationStorage
+            .serializable.map?.size ?? 0) === n
+        );
+      } catch {
+        // When serializing a stamp annotation with a SVG, the transfer
+        // can fail because of the SVG, so we just retry.
+        return false;
+      }
+    },
     {},
     nEntries
   );


### PR DESCRIPTION
We wait for the canvas before trying to serialize the annotation in order to make sure the image has been loaded.