### PR TITLE
Drop trailing whitespace from test/unit/api_spec.js

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2438,19 +2438,19 @@ describe("api", function () {
       const manifesto = `
       The Mozilla Manifesto Addendum
       Pledge for a Healthy Internet
-      
+
       The open, global internet is the most powerful communication and collaboration resource we have ever seen.
       It embodies some of our deepest hopes for human progress.
       It enables new opportunities for learning, building a sense of shared humanity, and solving the pressing problems
       facing people everywhere.
-      
+
       Over the last decade we have seen this promise fulfilled in many ways.
       We have also seen the power of the internet used to magnify divisiveness,
       incite violence, promote hatred, and intentionally manipulate fact and reality.
       We have learned that we should more explicitly set out our aspirations for the human experience of the internet.
       We do so now.
       `.repeat(100);
-      expect(manifesto.length).toEqual(80500);
+      expect(manifesto.length).toEqual(79300);
 
       let loadingTask = getDocument(buildGetDocumentParams("empty.pdf"));
       let pdfDoc = await loadingTask.promise;


### PR DESCRIPTION
test/unit/api_spec.js is the only JS file in the tree with trailing whitespace. Because [`trim_trailing_whitespace = true` in .editorconfig](https://github.com/mozilla/pdf.js/blob/d45a61b579df021b65d1f924a1ad864c58407b09/.editorconfig#L10), any editor supporting EditorConfig would trim whitespace when the file is changed, which results in test failures (e.g. at https://github.com/mozilla/pdf.js/pull/19074#discussion_r1850235715).

This commit fixes the issue by trimming the trailing whitespace and adjusting the test expectations.

The test was originally introduced in https://github.com/mozilla/pdf.js/pull/16559 and I don't expect any impact on the validity of the test.