### PR TITLE
Ensure that a missing/invalid "Content-Range" header is handled in `PDFNetworkStream` (issue 19075)

### DIFF
--- a/src/display/network.js
+++ b/src/display/network.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assert, stringToBytes } from "../shared/util.js";
+import { assert, stringToBytes, warn } from "../shared/util.js";
 import {
   createHeaders,
   createResponseStatusError,
@@ -161,10 +161,15 @@ class NetworkManager {
     if (xhrStatus === PARTIAL_CONTENT_RESPONSE) {
       const rangeHeader = xhr.getResponseHeader("Content-Range");
       const matches = /bytes (\d+)-(\d+)\/(\d+)/.exec(rangeHeader);
-      pendingRequest.onDone({
-        begin: parseInt(matches[1], 10),
-        chunk,
-      });
+      if (matches) {
+        pendingRequest.onDone({
+          begin: parseInt(matches[1], 10),
+          chunk,
+        });
+      } else {
+        warn(`Missing or invalid "Content-Range" header.`);
+        pendingRequest.onError?.(0);
+      }
     } else if (chunk) {
       pendingRequest.onDone({
         begin: 0,

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -85,11 +85,10 @@ class NetworkManager {
     }
     xhr.responseType = "arraybuffer";
 
-    if (args.onError) {
-      xhr.onerror = function (evt) {
-        args.onError(xhr.status);
-      };
-    }
+    assert(args.onError, "Expected `onError` callback to be provided.");
+    xhr.onerror = () => {
+      args.onError(xhr.status);
+    };
     xhr.onreadystatechange = this.onStateChange.bind(this, xhrId);
     xhr.onprogress = this.onProgress.bind(this, xhrId);
 
@@ -137,7 +136,7 @@ class NetworkManager {
 
     // Success status == 0 can be on ftp, file and other protocols.
     if (xhr.status === 0 && this.isHttp) {
-      pendingRequest.onError?.(xhr.status);
+      pendingRequest.onError(xhr.status);
       return;
     }
     const xhrStatus = xhr.status || OK_RESPONSE;
@@ -153,7 +152,7 @@ class NetworkManager {
       !ok_response_on_range_request &&
       xhrStatus !== pendingRequest.expectedStatus
     ) {
-      pendingRequest.onError?.(xhr.status);
+      pendingRequest.onError(xhr.status);
       return;
     }
 
@@ -168,7 +167,7 @@ class NetworkManager {
         });
       } else {
         warn(`Missing or invalid "Content-Range" header.`);
-        pendingRequest.onError?.(0);
+        pendingRequest.onError(0);
       }
     } else if (chunk) {
       pendingRequest.onDone({
@@ -176,7 +175,7 @@ class NetworkManager {
         chunk,
       });
     } else {
-      pendingRequest.onError?.(xhr.status);
+      pendingRequest.onError(xhr.status);
     }
   }
 

--- a/test/webserver.mjs
+++ b/test/webserver.mjs
@@ -177,6 +177,7 @@ class WebServer {
       this.#serveFileRange(
         response,
         localURL,
+        url.searchParams,
         fileSize,
         start,
         isNaN(end) ? fileSize : end + 1
@@ -307,7 +308,7 @@ class WebServer {
     stream.pipe(response);
   }
 
-  #serveFileRange(response, fileURL, fileSize, start, end) {
+  #serveFileRange(response, fileURL, searchParams, fileSize, start, end) {
     if (end > fileSize || start > end) {
       response.writeHead(416);
       response.end();
@@ -330,6 +331,16 @@ class WebServer {
       "Content-Range",
       `bytes ${start}-${end - 1}/${fileSize}`
     );
+
+    // Support test in `test/unit/network_spec.js`.
+    switch (searchParams.get("test-network-break-ranges")) {
+      case "missing":
+        response.removeHeader("Content-Range");
+        break;
+      case "invalid":
+        response.setHeader("Content-Range", "bytes abc-def/qwerty");
+        break;
+    }
     response.writeHead(206);
     stream.pipe(response);
   }


### PR DESCRIPTION
In the event that the "Content-Range" header is missing/invalid, loading will now be aborted rather than hanging indefinitely.