### PR TITLE
Disable the browser-tests in Google Chrome on the bots

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -686,12 +686,9 @@ function runTests(testsName, { bot = false, xfaOnly = false } = {}) {
         if (!bot) {
           args.push("--reftest");
         } else {
-          const os = process.env.OS;
-          if (/windows/i.test(os)) {
-            // The browser-tests are too slow in Google Chrome on the Windows
-            // bot, causing a timeout, hence disabling them for now.
-            forceNoChrome = true;
-          }
+          // The browser-tests are too slow in Google Chrome on the bots,
+          // causing a timeout, hence disabling them for now.
+          forceNoChrome = true;
         }
         if (xfaOnly) {
           args.push("--xfaOnly");
@@ -770,12 +767,10 @@ function makeRef(done, bot) {
   let forceNoChrome = false;
   const args = ["test.mjs", "--masterMode"];
   if (bot) {
-    const os = process.env.OS;
-    if (/windows/i.test(os)) {
-      // The browser-tests are too slow in Google Chrome on the Windows
-      // bot, causing a timeout, hence disabling them for now.
-      forceNoChrome = true;
-    }
+    // The browser-tests are too slow in Google Chrome on the bots,
+    // causing a timeout, hence disabling them for now.
+    forceNoChrome = true;
+
     args.push("--noPrompts", "--strictVerify");
   }
   if (process.argv.includes("--noChrome") || forceNoChrome) {

--- a/test/driver.js
+++ b/test/driver.js
@@ -609,13 +609,6 @@ class Driver {
         return;
       }
 
-      if (task.noChrome && window?.chrome) {
-        this._log(`Skipping file "${task.file}" (because on Chrome)\n`);
-        this.currentTask++;
-        this._nextTask();
-        return;
-      }
-
       this._log('Loading file "' + task.file + '"\n');
 
       try {

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -10749,8 +10749,7 @@
     "rounds": 1,
     "type": "eq",
     "link": true,
-    "talos": false,
-    "noChrome": true
+    "talos": false
   },
   {
     "id": "issue18956",


### PR DESCRIPTION
Given that `browsertest` repeatedly timeout in Google Chrome, and considering that Firefox is the primary development target, we stop running them on the bots to avoid having to repeatedly deal with this.

Note that we already disabled these tests *on Windows* almost three years ago, because of stability issues; see PR #14392.