### PR TITLE
Move the `getPage` call in `PDFDocumentProperties` class

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -112,12 +112,13 @@ class PDFDocumentProperties {
     }
 
     // Get the document properties.
-    const {
-      info,
-      /* metadata, */
-      /* contentDispositionFilename, */
-      contentLength,
-    } = await this.pdfDocument.getMetadata();
+    const [
+      { info, /* metadata, contentDispositionFilename, */ contentLength },
+      pdfPage,
+    ] = await Promise.all([
+      this.pdfDocument.getMetadata(),
+      this.pdfDocument.getPage(currentPageNumber),
+    ]);
 
     const [
       fileName,
@@ -131,10 +132,7 @@ class PDFDocumentProperties {
       this.#parseFileSize(contentLength),
       this.#parseDate(info.CreationDate),
       this.#parseDate(info.ModDate),
-      // eslint-disable-next-line arrow-body-style
-      this.pdfDocument.getPage(currentPageNumber).then(pdfPage => {
-        return this.#parsePageSize(getPageSizeInches(pdfPage), pagesRotation);
-      }),
+      this.#parsePageSize(getPageSizeInches(pdfPage), pagesRotation),
       this.#parseLinearization(info.IsLinearized),
     ]);
 


### PR DESCRIPTION
This allows us to remove an ESLint disable-statement for `arrow-body-style`, without affecting readability of the code, and fetching the metadata and the page in parallel should be a *tiny* bit more efficient as well.