### PR TITLE
Do not stringify errors when logging them

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,6 +112,7 @@ export default [
       "perfectionist/sort-named-exports": "error",
       "unicorn/no-abusive-eslint-disable": "error",
       "unicorn/no-array-push-push": "error",
+      "unicorn/no-console-spaces": "error",
       "unicorn/no-instanceof-array": "error",
       "unicorn/no-invalid-remove-event-listener": "error",
       "unicorn/no-new-buffer": "error",

--- a/test/downloadutils.mjs
+++ b/test/downloadutils.mjs
@@ -86,7 +86,7 @@ async function downloadManifestFiles(manifest) {
     try {
       await downloadFile(file, url);
     } catch (ex) {
-      console.error(`Error during downloading of ${url}: ${ex}`);
+      console.error(`Error during downloading of ${url}:`, ex);
       fs.writeFileSync(file, ""); // making it empty file
       fs.writeFileSync(`${file}.error`, ex);
     }

--- a/test/driver.js
+++ b/test/driver.js
@@ -1192,7 +1192,7 @@ class Driver {
         resolve();
       })
       .catch(reason => {
-        console.warn(`Driver._send failed (${url}): ${reason}`);
+        console.warn(`Driver._send failed (${url}):`, reason);
 
         this.inFlightRequests--;
         resolve();

--- a/test/unit/testreporter.js
+++ b/test/unit/testreporter.js
@@ -18,7 +18,7 @@ const TestReporter = function (browser) {
           resolve();
         })
         .catch(reason => {
-          console.warn(`TestReporter - send failed (${action}): ${reason}`);
+          console.warn(`TestReporter - send failed (${action}):`, reason);
           resolve();
 
           send(action, json);

--- a/web/app.js
+++ b/web/app.js
@@ -202,7 +202,7 @@ const PDFViewerApplication = {
     try {
       await this.preferences.initializedPromise;
     } catch (ex) {
-      console.error(`initialize: "${ex.message}".`);
+      console.error("initialize:", ex);
     }
     if (AppOptions.get("pdfBugEnabled")) {
       await this._parseHashParams();
@@ -306,7 +306,7 @@ const PDFViewerApplication = {
           await __non_webpack_import__(PDFWorker.workerSrc);
         }
       } catch (ex) {
-        console.error(`_parseHashParams: "${ex.message}".`);
+        console.error("_parseHashParams:", ex);
       }
     }
     if (params.has("textlayer")) {
@@ -322,7 +322,7 @@ const PDFViewerApplication = {
             await loadPDFBug();
             this._PDFBug.loadCSS();
           } catch (ex) {
-            console.error(`_parseHashParams: "${ex.message}".`);
+            console.error("_parseHashParams:", ex);
           }
           break;
       }
@@ -335,7 +335,7 @@ const PDFViewerApplication = {
         await loadPDFBug();
         this._PDFBug.init(mainContainer, enabled);
       } catch (ex) {
-        console.error(`_parseHashParams: "${ex.message}".`);
+        console.error("_parseHashParams:", ex);
       }
     }
     // It is not possible to change locale for the (various) extension builds.
@@ -1121,7 +1121,7 @@ const PDFViewerApplication = {
       this.downloadManager.download(data, this._downloadUrl, this._docFilename);
     } catch (reason) {
       // When the PDF document isn't ready, fallback to a "regular" download.
-      console.error(`Error when saving the document: ${reason.message}`);
+      console.error(`Error when saving the document:`, reason);
       await this.download();
     } finally {
       await this.pdfScriptingManager.dispatchDidSave();

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -93,7 +93,7 @@ class DownloadManager {
         window.open(viewerUrl);
         return true;
       } catch (ex) {
-        console.error(`openOrDownloadData: ${ex}`);
+        console.error("openOrDownloadData:", ex);
         // Release the `blobUrl`, since opening it failed, and fallback to
         // downloading the PDF file.
         URL.revokeObjectURL(blobUrl);

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -121,7 +121,7 @@ class DownloadManager {
         window.open(viewerUrl);
         return true;
       } catch (ex) {
-        console.error(`openOrDownloadData: ${ex}`);
+        console.error("openOrDownloadData:", ex);
         // Release the `blobUrl`, since opening it failed, and fallback to
         // downloading the PDF file.
         URL.revokeObjectURL(blobUrl);

--- a/web/l10n.js
+++ b/web/l10n.js
@@ -85,7 +85,7 @@ class L10n {
     try {
       await this.#l10n.translateElements([element]);
     } catch (ex) {
-      console.error(`translateOnce: "${ex}".`);
+      console.error("translateOnce:", ex);
     }
   }
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -401,7 +401,7 @@ class PDFPageView {
         "display"
       );
     } catch (ex) {
-      console.error(`#renderAnnotationLayer: "${ex}".`);
+      console.error("#renderAnnotationLayer:", ex);
       error = ex;
     } finally {
       this.#dispatchLayerRendered("annotationlayerrendered", error);
@@ -413,7 +413,7 @@ class PDFPageView {
     try {
       await this.annotationEditorLayer.render(this.viewport, "display");
     } catch (ex) {
-      console.error(`#renderAnnotationEditorLayer: "${ex}".`);
+      console.error("#renderAnnotationEditorLayer:", ex);
       error = ex;
     } finally {
       this.#dispatchLayerRendered("annotationeditorlayerrendered", error);
@@ -424,7 +424,7 @@ class PDFPageView {
     try {
       await this.drawLayer.render("display");
     } catch (ex) {
-      console.error(`#renderDrawLayer: "${ex}".`);
+      console.error("#renderDrawLayer:", ex);
     }
   }
 
@@ -440,7 +440,7 @@ class PDFPageView {
         this.#buildXfaTextContentItems(result.textDivs);
       }
     } catch (ex) {
-      console.error(`#renderXfaLayer: "${ex}".`);
+      console.error("#renderXfaLayer:", ex);
       error = ex;
     } finally {
       if (this.xfaLayer?.div) {
@@ -465,7 +465,7 @@ class PDFPageView {
       if (ex instanceof AbortException) {
         return;
       }
-      console.error(`#renderTextLayer: "${ex}".`);
+      console.error("#renderTextLayer:", ex);
       error = ex;
     }
     this.#dispatchLayerRendered("textlayerrendered", error);

--- a/web/pdf_rendering_queue.js
+++ b/web/pdf_rendering_queue.js
@@ -201,7 +201,7 @@ class PDFRenderingQueue {
             if (reason instanceof RenderingCancelledException) {
               return;
             }
-            console.error(`renderView: "${reason}"`);
+            console.error("renderView:", reason);
           });
         break;
     }

--- a/web/pdf_scripting_manager.js
+++ b/web/pdf_scripting_manager.js
@@ -105,7 +105,7 @@ class PDFScriptingManager {
     try {
       this.#scripting = this.#initScripting();
     } catch (error) {
-      console.error(`setDocument: "${error.message}".`);
+      console.error("setDocument:", error);
 
       await this.#destroyScripting();
       return;
@@ -192,7 +192,7 @@ class PDFScriptingManager {
 
       eventBus.dispatch("sandboxcreated", { source: this });
     } catch (error) {
-      console.error(`setDocument: "${error.message}".`);
+      console.error("setDocument:", error);
 
       await this.#destroyScripting();
       return;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -248,7 +248,7 @@ function webViewerLoad() {
     } catch (ex) {
       // The viewer could be in e.g. a cross-origin <iframe> element,
       // fallback to dispatching the event at the current `document`.
-      console.error(`webviewerloaded: ${ex}`);
+      console.error("webviewerloaded:", ex);
       document.dispatchEvent(event);
     }
   }


### PR DESCRIPTION
Converting errors to string drops their stack trace, making it more difficult to debug their actual reason. We can instead pass the error objects as-is to console.warn/error, so that Firefox/Chrome devtools will show both the stack trace of the console.warn/error call, and the original stack trace of the error.