### PR TITLE
Prevent Webpack from resolving `import.meta.url` statements during building (issue 19145)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -380,6 +380,11 @@ function createWebpackConfig(
     },
     devtool: enableSourceMaps ? "source-map" : undefined,
     module: {
+      parser: {
+        javascript: {
+          importMeta: false,
+        },
+      },
       rules: [
         {
           test: /\.[mc]?js$/,


### PR DESCRIPTION
This fixes a Node.js-specific regression from PR #18959.