### PR TITLE
When zooming replace the css-zoomed canvas by the new one only when rendering is finished

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -276,9 +276,20 @@ describe("PDF viewer", () => {
       beforeEach(async () => {
         await Promise.all(
           pages.map(async ([browserName, page]) => {
-            await page.evaluate(() => {
-              window.PDFViewerApplication.pdfViewer.currentScale = 0.5;
-            });
+            const handle = await waitForPageRendered(page);
+            if (
+              await page.evaluate(() => {
+                if (
+                  window.PDFViewerApplication.pdfViewer.currentScale !== 0.5
+                ) {
+                  window.PDFViewerApplication.pdfViewer.currentScale = 0.5;
+                  return true;
+                }
+                return false;
+              })
+            ) {
+              await awaitPromise(handle);
+            }
           })
         );
       });
@@ -317,12 +328,14 @@ describe("PDF viewer", () => {
             const originalCanvasSize = await getCanvasSize(page);
             const factor = 2;
 
+            const handle = await waitForPageRendered(page);
             await page.evaluate(scaleFactor => {
               window.PDFViewerApplication.pdfViewer.increaseScale({
                 drawingDelay: 0,
                 scaleFactor,
               });
             }, factor);
+            await awaitPromise(handle);
 
             const canvasSize = await getCanvasSize(page);
 
@@ -343,12 +356,14 @@ describe("PDF viewer", () => {
             const originalCanvasSize = await getCanvasSize(page);
             const factor = 4;
 
+            const handle = await waitForPageRendered(page);
             await page.evaluate(scaleFactor => {
               window.PDFViewerApplication.pdfViewer.increaseScale({
                 drawingDelay: 0,
                 scaleFactor,
               });
             }, factor);
+            await awaitPromise(handle);
 
             const canvasSize = await getCanvasSize(page);
 

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -83,19 +83,14 @@
     height: 100%;
 
     canvas {
+      position: absolute;
+      top: 0;
+      left: 0;
       margin: 0;
       display: block;
       width: 100%;
       height: 100%;
-
-      &[hidden] {
-        display: none;
-      }
-
-      &[zooming] {
-        width: 100%;
-        height: 100%;
-      }
+      contain: content;
 
       .structTree {
         contain: strict;


### PR DESCRIPTION
It fixes #18622.

It avoids to recreate a canvasWrapper element in order minimize the DOM operations.