### PR TITLE
Ensure that the `.toggleButton`, as used in the findbar, always have visible hover/focus state (issue 19165)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -634,14 +634,14 @@ body {
 .toggleButton {
   display: inline;
 
-  &:is(:hover, :has(> input:focus-visible)) {
-    color: var(--toggled-btn-color);
-    background-color: var(--button-hover-color);
-  }
-
   &:has(> input:checked) {
     color: var(--toggled-btn-color);
     background-color: var(--toggled-btn-bg-color);
+  }
+
+  &:is(:hover, :has(> input:focus-visible)) {
+    color: var(--toggled-btn-color);
+    background-color: var(--button-hover-color);
   }
 
   & > input {


### PR DESCRIPTION
Similar to the regular toolbarButtons that can be toggled, this ensure that it's always possible to tell when the findbar "buttons" are hovered/focused.