### PR TITLE
Avoid to display an alert or a confirm dialog if the message is empty

### DIFF
--- a/src/scripting_api/app.js
+++ b/src/scripting_api/app.js
@@ -447,6 +447,9 @@ class App extends PDFObject {
       cMsg = cMsg.cMsg;
     }
     cMsg = (cMsg || "").toString();
+    if (!cMsg) {
+      return 0;
+    }
     nType =
       typeof nType !== "number" || isNaN(nType) || nType < 0 || nType > 3
         ? 0


### PR DESCRIPTION
It fixes #19171.