### PR TITLE
Remove the raw path-strings after creating the actual `Path2D` glyph-objects

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2839,6 +2839,7 @@ class WorkerTransport {
               : null;
           const font = new FontFaceObject(exportedData, {
             disableFontFace,
+            fontExtraProperties,
             inspectFont,
           });
 
@@ -3240,6 +3241,20 @@ class PDFObjects {
   has(objId) {
     const obj = this.#objs[objId];
     return !!obj && obj.data !== INITIAL_DATA;
+  }
+
+  /**
+   * @param {string} objId
+   * @returns {boolean}
+   */
+  delete(objId) {
+    const obj = this.#objs[objId];
+    if (!obj || obj.data === INITIAL_DATA) {
+      // Only allow removing the object *after* it's been resolved.
+      return false;
+    }
+    delete this.#objs[objId];
+    return true;
   }
 
   /**

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -359,13 +359,17 @@ class FontLoader {
 }
 
 class FontFaceObject {
-  constructor(translatedData, { disableFontFace = false, inspectFont = null }) {
+  constructor(
+    translatedData,
+    { disableFontFace = false, fontExtraProperties = false, inspectFont = null }
+  ) {
     this.compiledGlyphs = Object.create(null);
     // importing translated data
     for (const i in translatedData) {
       this[i] = translatedData[i];
     }
     this.disableFontFace = disableFontFace === true;
+    this.fontExtraProperties = fontExtraProperties === true;
     this._inspectFont = inspectFont;
   }
 
@@ -420,13 +424,20 @@ class FontFaceObject {
       return this.compiledGlyphs[character];
     }
 
+    const objId = this.loadedName + "_path_" + character;
     let cmds;
     try {
-      cmds = objs.get(this.loadedName + "_path_" + character);
+      cmds = objs.get(objId);
     } catch (ex) {
       warn(`getPathGenerator - ignoring character: "${ex}".`);
     }
-    return (this.compiledGlyphs[character] = new Path2D(cmds || ""));
+    const path = new Path2D(cmds || "");
+
+    if (!this.fontExtraProperties) {
+      // Remove the raw path-string, since we don't need it anymore.
+      objs.delete(objId);
+    }
+    return (this.compiledGlyphs[character] = path);
   }
 }
 


### PR DESCRIPTION
The `Path2D` glyph-objects are cached on the `FontFaceObject`-instance, so we can save a little bit of memory by removing the raw path-strings once they're no longer needed.