### PR TITLE
Simplify logic to insert canvas as first element

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -989,12 +989,7 @@ class PDFPageView {
         // drawing is complete when `!this.renderingQueue`, to prevent black
         // flickering.
         // In whatever case, the canvas must be the first child.
-        const { firstChild } = canvasWrapper;
-        if (firstChild) {
-          firstChild.before(canvas);
-        } else {
-          canvasWrapper.append(canvas);
-        }
+        canvasWrapper.prepend(canvas);
         showCanvas = null;
         return;
       }
@@ -1006,12 +1001,7 @@ class PDFPageView {
         prevCanvas.replaceWith(canvas);
         prevCanvas.width = prevCanvas.height = 0;
       } else {
-        const { firstChild } = canvasWrapper;
-        if (firstChild) {
-          firstChild.before(canvas);
-        } else {
-          canvasWrapper.append(canvas);
-        }
+        canvasWrapper.prepend(canvas);
       }
 
       showCanvas = null;


### PR DESCRIPTION
Instead of conditionally checking if the `.cavnasWrapper` already has a child element and then inserting the `canvas` before it, we can use `.prepend` which always injects the new element as the first child.

https://developer.mozilla.org/en-US/docs/Web/API/Element/prepend