### PR TITLE
Don't remove trailing regular spaces from the "raw" response headers (issue 19205)

### DIFF
--- a/src/display/network.js
+++ b/src/display/network.js
@@ -288,7 +288,8 @@ class PDFNetworkStreamFullRequestReader {
     const responseHeaders = new Headers(
       rawResponseHeaders
         ? rawResponseHeaders
-            .trim()
+            .trimStart()
+            .replace(/[^\S ]+$/, "") // Not `trimEnd`, to keep regular spaces.
             .split(/[\r\n]+/)
             .map(x => {
               const [key, ...val] = x.split(": ");


### PR DESCRIPTION
This bug only seems to reproduce in Google Chrome, since browsers apparently sort response headers differently. When the issue occurs the "raw" response headers string looks like this:
```
content-length: 525404\r\ncontent-type: \r\n
```
and since we trim *any* leading/trailing white-space characters the "content-type" header isn't detected correctly, which thus leads to `new Headers(...)` throwing.

Hence we'll keep regular spaces at the end of the "raw" response headers string, while still removing all other kinds of trailing white-space characters.

*Note:* The response headers parsing was based on https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders#examples