### PR TITLE
Add custom external logger

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -37,6 +37,7 @@ import {
   UnknownErrorException,
   unreachable,
   warn,
+  setCustomLogger,
 } from "../shared/util.js";
 import {
   AnnotationStorage,
@@ -137,6 +138,7 @@ const DefaultStandardFontDataFactory =
  *   parsing the PDF data.
  * @property {number} [verbosity] - Controls the logging level; the constants
  *   from {@link VerbosityLevel} should be used.
+ * @property {Function} [logger] - Optional external logger
  * @property {string} [docBaseUrl] - The base URL of the document, used when
  *   attempting to recover valid absolute URLs for annotations, and outline
  *   items, that (incorrectly) only specify relative URLs.
@@ -270,6 +272,7 @@ function getDocument(src = {}) {
       : DEFAULT_RANGE_CHUNK_SIZE;
   let worker = src.worker instanceof PDFWorker ? src.worker : null;
   const verbosity = src.verbosity;
+  const logger = src.logger;
   // Ignore "data:"-URLs, since they can't be used to recover valid absolute
   // URLs anyway. We want to avoid sending them to the worker-thread, since
   // they contain the *entire* PDF document and can thus be arbitrarily long.
@@ -3543,6 +3546,7 @@ export {
   DefaultFilterFactory,
   DefaultStandardFontDataFactory,
   getDocument,
+  setCustomLogger,
   LoopbackPort,
   PDFDataRangeTransport,
   PDFDocumentLoadingTask,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -138,7 +138,6 @@ const DefaultStandardFontDataFactory =
  *   parsing the PDF data.
  * @property {number} [verbosity] - Controls the logging level; the constants
  *   from {@link VerbosityLevel} should be used.
- * @property {Function} [logger] - Optional external logger
  * @property {string} [docBaseUrl] - The base URL of the document, used when
  *   attempting to recover valid absolute URLs for annotations, and outline
  *   items, that (incorrectly) only specify relative URLs.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -361,6 +361,9 @@ function getVerbosityLevel() {
 
 let customLogger = null;
 
+/**
+ * @param {Function} logger
+ */
 function setCustomLogger(logger) {
   customLogger = logger;
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -359,11 +359,19 @@ function getVerbosityLevel() {
   return verbosity;
 }
 
+let customLogger = null;
+
+function setCustomLogger(logger) {
+  customLogger = logger;
+}
+
 // A notice for devs. These are good for things that are helpful to devs, such
 // as warning that Workers were disabled, which is important to devs but not
 // end users.
 function info(msg) {
-  if (verbosity >= VerbosityLevel.INFOS) {
+  if (customLogger) {
+    customLogger({ type: "info", verbosity, message: msg });
+  } else if (verbosity >= VerbosityLevel.INFOS) {
     // eslint-disable-next-line no-console
     console.log(`Info: ${msg}`);
   }
@@ -371,7 +379,9 @@ function info(msg) {
 
 // Non-fatal warnings.
 function warn(msg) {
-  if (verbosity >= VerbosityLevel.WARNINGS) {
+  if (customLogger) {
+    customLogger({ type: "warn", verbosity, message: msg });
+  } else if (verbosity >= VerbosityLevel.WARNINGS) {
     // eslint-disable-next-line no-console
     console.log(`Warning: ${msg}`);
   }
@@ -1187,4 +1197,5 @@ export {
   Util,
   VerbosityLevel,
   warn,
+  setCustomLogger,
 };


### PR DESCRIPTION
Many production systems will either omit console logs or emit them on a different platform (e.g. datadog). With the current system, there is no easy way to do this.

This PR introduces an optional `setCustomLogger` export to set the package wide logger. It takes in an object with 3 properties
- `type` - "info" | "warn"
- `verbosity` - 0 | 1 | 5 (info, warning, error)
- `message` - string