### PR TITLE
Polyfill `AbortSignal.any` in PDF.js `legacy` builds

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -531,11 +531,7 @@ const PDFViewerApplication = {
     }
 
     if (appConfig.annotationEditorParams) {
-      if (
-        ((typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-          typeof AbortSignal.any === "function") &&
-        annotationEditorMode !== AnnotationEditorType.DISABLE
-      ) {
+      if (annotationEditorMode !== AnnotationEditorType.DISABLE) {
         this.annotationEditorParams = new AnnotationEditorParams(
           appConfig.annotationEditorParams,
           eventBus
@@ -2046,7 +2042,7 @@ const PDFViewerApplication = {
 
     this._touchManager = new TouchManager({
       container: window,
-      isPinchingDisabled: () => this.pdfViewer.isInPresentationMode,
+      isPinchingDisabled: () => pdfViewer.isInPresentationMode,
       isPinchingStopped: () => this.overlayManager?.active,
       onPinching: this.touchPinchCallback.bind(this),
       onPinchEnd: this.touchPinchEndCallback.bind(this),

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -686,13 +686,7 @@ class PDFViewer {
           hiddenCapability.resolve();
         }
       },
-      {
-        signal:
-          (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-          typeof AbortSignal.any === "function"
-            ? AbortSignal.any([signal, ac.signal])
-            : signal,
-      }
+      { signal: AbortSignal.any([signal, ac.signal]) }
     );
 
     await Promise.race([
@@ -889,11 +883,7 @@ class PDFViewer {
           viewer.before(element);
         }
 
-        if (
-          ((typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-            typeof AbortSignal.any === "function") &&
-          annotationEditorMode !== AnnotationEditorType.DISABLE
-        ) {
+        if (annotationEditorMode !== AnnotationEditorType.DISABLE) {
           const mode = annotationEditorMode;
 
           if (pdfDocument.isPureXfa) {


### PR DESCRIPTION
With recent changes, in particular PR #19216, we're now relying on `AbortSignal.any` in a way that cannot just be skipped with pre-processor statements as done previously.
This is problematical since `AbortSignal.any` is fairly new functionality, see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static#browser_compatibility, that's not available in all browsers that we support.

Instead it seems that we need to add a polyfill, however I unfortunately wasn't able to find one on NPM. In fact the only one I could find was https://gist.github.com/CNSeniorious000/9fc1a72e45358dd7c9e2f16e5d26df5c, which doesn't contain any licensing information.

*Note:* Given the use of pre-processor statements, this polfill will *not* be included in the Firefox PDF Viewer.