### PR TITLE
Disable touch-zooming, in the viewer, if `AbortSignal.any` is unsupported (PR 19216 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2045,14 +2045,19 @@ const PDFViewerApplication = {
       _windowAbortController: { signal },
     } = this;
 
-    this._touchManager = new TouchManager({
-      container: window,
-      isPinchingDisabled: () => this.pdfViewer.isInPresentationMode,
-      isPinchingStopped: () => this.overlayManager?.active,
-      onPinching: this.touchPinchCallback.bind(this),
-      onPinchEnd: this.touchPinchEndCallback.bind(this),
-      signal,
-    });
+    if (
+      (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+      typeof AbortSignal.any === "function"
+    ) {
+      this._touchManager = new TouchManager({
+        container: window,
+        isPinchingDisabled: () => pdfViewer.isInPresentationMode,
+        isPinchingStopped: () => this.overlayManager?.active,
+        onPinching: this.touchPinchCallback.bind(this),
+        onPinchEnd: this.touchPinchEndCallback.bind(this),
+        signal,
+      });
+    }
 
     function addWindowResolutionChange(evt = null) {
       if (evt) {


### PR DESCRIPTION
This way loading of the *entire* viewer won't break in older browsers that lack `AbortSignal.any` support; see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static#browser_compatibility