### PR TITLE
Improve text selection accuracy by using the real font family

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -2526,7 +2526,7 @@ class PartialEvaluator {
       if (!seenStyles.has(loadedName)) {
         seenStyles.add(loadedName);
         textContent.styles[loadedName] = {
-          fontFamily: font.fallbackName,
+          fontFamily: loadedName,
           ascent: font.ascent,
           descent: font.descent,
           vertical: font.vertical,

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -66,10 +66,12 @@ class FontLoader {
   }
 
   clear() {
-    for (const nativeFontFace of this.nativeFontFaces) {
-      this._document.fonts.delete(nativeFontFace);
+    const fontFacesToRemove = new Set(this.nativeFontFaces);
+    for (const font of fontFacesToRemove) {
+      if (!this._document.fonts.has(font)) {
+        this.nativeFontFaces.delete(font);
+      }
     }
-    this.nativeFontFaces.clear();
     this.#systemFonts.clear();
 
     if (this.styleElement) {


### PR DESCRIPTION
Enhanced the text layer creation process by using the real font family instead of the fallback font name. This change ensures that text selection is more accurate. 

fixes: #19207