### PR TITLE
Disable the `handle reading ranges with missing/invalid "Content-Range" header` unit-test in Google Chrome (PR 19114 follow-up)

### DIFF
--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -122,6 +122,10 @@ describe("network", function () {
   });
 
   it(`handle reading ranges with missing/invalid "Content-Range" header`, async function () {
+    if (globalThis.chrome) {
+      pending("Fails intermittently in Google Chrome.");
+    }
+
     async function readRanges(mode) {
       const rangeSize = 32768;
       const stream = new PDFNetworkStream({


### PR DESCRIPTION
Note that PR #19212 tried to change the test-server to fix the intermittent failure in Google Chrome, however that unfortunately caused *other* unit-tests to start failing.
As long as this unit-test still runs successfully in Mozilla Firefox that should be enough, and it doesn't seem like a good use of our time to hunt down a bug that only happens in Google Chrome.