### PR TITLE
Reduce duplication when handling "DocException" and "PasswordRequest" messages

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -18,14 +18,10 @@ import {
   assert,
   getVerbosityLevel,
   info,
-  InvalidPDFException,
   isNodeJS,
-  MissingPDFException,
   PasswordException,
   setVerbosityLevel,
   stringToPDFString,
-  UnexpectedResponseException,
-  UnknownErrorException,
   VerbosityLevel,
   warn,
 } from "../shared/util.js";
@@ -36,10 +32,10 @@ import {
 } from "./core_utils.js";
 import { Dict, isDict, Ref, RefSetCache } from "./primitives.js";
 import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
+import { MessageHandler, wrapReason } from "../shared/message_handler.js";
 import { AnnotationFactory } from "./annotation.js";
 import { clearGlobalCaches } from "./cleanup_helper.js";
 import { incrementalUpdate } from "./writer.js";
-import { MessageHandler } from "../shared/message_handler.js";
 import { PDFWorkerStream } from "./worker_stream.js";
 import { StructTreeRoot } from "./struct_tree.js";
 
@@ -347,18 +343,9 @@ class WorkerMessageHandler {
               finishWorkerTask(task);
               handler.send("DocException", ex);
             });
-        } else if (
-          ex instanceof InvalidPDFException ||
-          ex instanceof MissingPDFException ||
-          ex instanceof UnexpectedResponseException ||
-          ex instanceof UnknownErrorException
-        ) {
-          handler.send("DocException", ex);
         } else {
-          handler.send(
-            "DocException",
-            new UnknownErrorException(ex.message, ex.toString())
-          );
+          // Ensure that we always fallback to `UnknownErrorException`.
+          handler.send("DocException", wrapReason(ex));
         }
       }
 

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -16,6 +16,7 @@
 import {
   AbortException,
   assert,
+  InvalidPDFException,
   MissingPDFException,
   PasswordException,
   UnexpectedResponseException,
@@ -24,13 +25,11 @@ import {
 } from "./util.js";
 
 const CallbackKind = {
-  UNKNOWN: 0,
   DATA: 1,
   ERROR: 2,
 };
 
 const StreamKind = {
-  UNKNOWN: 0,
   CANCEL: 1,
   CANCEL_COMPLETE: 2,
   CLOSE: 3,
@@ -43,31 +42,39 @@ const StreamKind = {
 
 function onFn() {}
 
-function wrapReason(reason) {
+function wrapReason(ex) {
   if (
-    !(
-      reason instanceof Error ||
-      (typeof reason === "object" && reason !== null)
-    )
+    ex instanceof AbortException ||
+    ex instanceof InvalidPDFException ||
+    ex instanceof MissingPDFException ||
+    ex instanceof PasswordException ||
+    ex instanceof UnexpectedResponseException ||
+    ex instanceof UnknownErrorException
   ) {
+    // Avoid re-creating the exception when its type is already correct.
+    return ex;
+  }
+
+  if (!(ex instanceof Error || (typeof ex === "object" && ex !== null))) {
     unreachable(
       'wrapReason: Expected "reason" to be a (possibly cloned) Error.'
     );
   }
-  switch (reason.name) {
+  switch (ex.name) {
     case "AbortException":
-      return new AbortException(reason.message);
+      return new AbortException(ex.message);
+    case "InvalidPDFException":
+      return new InvalidPDFException(ex.message);
     case "MissingPDFException":
-      return new MissingPDFException(reason.message);
+      return new MissingPDFException(ex.message);
     case "PasswordException":
-      return new PasswordException(reason.message, reason.code);
+      return new PasswordException(ex.message, ex.code);
     case "UnexpectedResponseException":
-      return new UnexpectedResponseException(reason.message, reason.status);
+      return new UnexpectedResponseException(ex.message, ex.status);
     case "UnknownErrorException":
-      return new UnknownErrorException(reason.message, reason.details);
-    default:
-      return new UnknownErrorException(reason.message, reason.toString());
+      return new UnknownErrorException(ex.message, ex.details);
   }
+  return new UnknownErrorException(ex.message, ex.toString());
 }
 
 class MessageHandler {
@@ -532,4 +539,4 @@ class MessageHandler {
   }
 }
 
-export { MessageHandler };
+export { MessageHandler, wrapReason };


### PR DESCRIPTION
Rather than having to manually implement the exception-handling for the "DocException" message, we can instead re-use (and slightly extend) the existing `wrapReason` function since that one already does what we need.

Furthermore, we can also simplify handling of the "PasswordRequest" message a little bit and again re-use the `wrapReason` function.

Finally, the patch makes the following smaller changes:
 - Avoid needlessly re-creating exceptions in the `wrapReason` function.
 - Use a slightly shorter parameter name in the `wrapReason` function.
 - Remove the unused entries in the `CallbackKind`/`StreamKind` enumerations.