### PR TITLE
Add "scripts" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "pdf.js",
   "type": "module",
+  "scripts": {
+    "watch": "npx gulp server",
+    "build": "npx gulp generic",
+    "build-legacy": "npx gulp generic-legacy"
+  },
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",


### PR DESCRIPTION
This patch aims to fix #19267 by adding "scripts" field to package.json with watch, build and build-legacy commands/scripts