### PR TITLE
Simplify the `NetworkManager.prototype.requestRange` method

### DIFF
--- a/src/display/network.js
+++ b/src/display/network.js
@@ -53,14 +53,7 @@ class NetworkManager {
   }
 
   requestRange(begin, end, listeners) {
-    const args = {
-      begin,
-      end,
-    };
-    for (const prop in listeners) {
-      args[prop] = listeners[prop];
-    }
-    return this.request(args);
+    return this.request({ begin, end, ...listeners });
   }
 
   requestFull(listeners) {


### PR DESCRIPTION
Thanks to modern JavaScript we don't need to "manually" build the arguments object.