### PR TITLE
Remove the `getSelectedEditors` integration test helper function

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -25,7 +25,6 @@ import {
   getEditorSelector,
   getFirstSerialized,
   getRect,
-  getSelectedEditors,
   getSerialized,
   hover,
   isCanvasWhite,
@@ -371,7 +370,7 @@ describe("FreeText Editor", () => {
             `${getEditorSelector(8)} .overlay.enabled`
           );
 
-          expect(await getSelectedEditors(page))
+          expect(await getEditors(page, "selected"))
             .withContext(`In ${browserName}`)
             .toEqual([8]);
 
@@ -387,7 +386,7 @@ describe("FreeText Editor", () => {
 
           await waitForSelectedEditor(page, getEditorSelector(8));
 
-          expect(await getSelectedEditors(page))
+          expect(await getEditors(page, "selected"))
             .withContext(`In ${browserName}`)
             .toEqual([8]);
 
@@ -574,7 +573,7 @@ describe("FreeText Editor", () => {
 
         await selectAll(page);
 
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 1, 2, 3]);
 
@@ -583,14 +582,14 @@ describe("FreeText Editor", () => {
         await page.mouse.click(editorCenters[1].x, editorCenters[1].y);
         await waitForUnselectedEditor(page, getEditorSelector(1));
 
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 2, 3]);
 
         await page.mouse.click(editorCenters[2].x, editorCenters[2].y);
         await waitForUnselectedEditor(page, getEditorSelector(2));
 
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 3]);
 
@@ -598,7 +597,7 @@ describe("FreeText Editor", () => {
         await kbModifierUp(page);
         await waitForSelectedEditor(page, getEditorSelector(1));
 
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 1, 3]);
 
@@ -609,20 +608,20 @@ describe("FreeText Editor", () => {
         });
 
         // 0,1,3 are unselected and new pasted editors are selected.
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([4, 5, 6]);
 
         // No ctrl here, hence all are unselected and 2 is selected.
         await page.mouse.click(editorCenters[2].x, editorCenters[2].y);
         await waitForSelectedEditor(page, getEditorSelector(2));
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([2]);
 
         await page.mouse.click(editorCenters[1].x, editorCenters[1].y);
         await waitForSelectedEditor(page, getEditorSelector(1));
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([1]);
 
@@ -630,7 +629,7 @@ describe("FreeText Editor", () => {
 
         await page.mouse.click(editorCenters[3].x, editorCenters[3].y);
         await waitForSelectedEditor(page, getEditorSelector(3));
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([1, 3]);
 
@@ -646,7 +645,7 @@ describe("FreeText Editor", () => {
 
         await selectAll(page);
 
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 2, 4, 5, 6]);
 
@@ -658,14 +657,14 @@ describe("FreeText Editor", () => {
         await page.waitForSelector(getEditorSelector(7), {
           visible: true,
         });
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([7]);
 
         // Set the focus to 2 and check that only 2 is selected.
         await page.mouse.click(editorCenters[2].x, editorCenters[2].y);
         await waitForSelectedEditor(page, getEditorSelector(2));
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([2]);
 
@@ -677,7 +676,7 @@ describe("FreeText Editor", () => {
         await page.waitForSelector(getEditorSelector(8), {
           visible: true,
         });
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([8]);
         // Dismiss it.
@@ -692,7 +691,7 @@ describe("FreeText Editor", () => {
 
         // Check that all the editors are correctly selected (and the focus
         // didn't move to the body when the empty editor was removed).
-        expect(await getSelectedEditors(page))
+        expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 2, 4, 5, 6]);
       }

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -22,7 +22,6 @@ import {
   getEditors,
   getEditorSelector,
   getRect,
-  getSelectedEditors,
   getSerialized,
   isCanvasWhite,
   kbRedo,
@@ -101,7 +100,7 @@ describe("Ink Editor", () => {
           await kbUndo(page);
           await waitForStorageEntries(page, 3);
 
-          expect(await getSelectedEditors(page))
+          expect(await getEditors(page, "selected"))
             .withContext(`In ${browserName}`)
             .toEqual([]);
         })
@@ -180,7 +179,7 @@ describe("Ink Editor", () => {
 
           await selectAll(page);
 
-          expect(await getSelectedEditors(page))
+          expect(await getEditors(page, "selected"))
             .withContext(`In ${browserName}`)
             .toEqual([0]);
         })
@@ -487,7 +486,7 @@ describe("Ink Editor", () => {
             await page.mouse.move(xStart, yStart);
             await page.mouse.down();
             if (i === 1) {
-              expect(await getSelectedEditors(page))
+              expect(await getEditors(page, "selected"))
                 .withContext(`In ${browserName}`)
                 .toEqual([]);
             }

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -229,18 +229,6 @@ function getAnnotationSelector(id) {
   return `[data-annotation-id="${id}"]`;
 }
 
-function getSelectedEditors(page) {
-  return page.evaluate(() => {
-    const elements = document.querySelectorAll(".selectedEditor");
-    const results = [];
-    for (const { id } of elements) {
-      results.push(parseInt(id.split("_").at(-1)));
-    }
-    results.sort();
-    return results;
-  });
-}
-
 async function getSpanRectFromText(page, pageNumber, text) {
   await page.waitForSelector(
     `.page[data-page-number="${pageNumber}"] > .textLayer .endOfContent`
@@ -479,8 +467,9 @@ function getEditors(page, kind) {
     const elements = document.querySelectorAll(`.${aKind}Editor`);
     const results = [];
     for (const { id } of elements) {
-      results.push(id);
+      results.push(parseInt(id.split("_").at(-1)));
     }
+    results.sort();
     return results;
   }, kind);
 }
@@ -853,7 +842,6 @@ export {
   getFirstSerialized,
   getQuerySelector,
   getRect,
-  getSelectedEditors,
   getSelector,
   getSerialized,
   getSpanRectFromText,


### PR DESCRIPTION
The `getSelectedEditors` function is largely a copy of the `getEditors` function, with three small differences:

1. `getEditors` allows getting any kind of editor whereas `getSelectedEditors` is harcoded to only getting selected editors.
2. `getEditors` returns editor selectors (strings) whereas `getSelectedEditors` returns editor IDs (integers).
3. `getSelectedEditors` returns a sorted array of editor IDs whereas `getEditors` does not ensure that the array is sorted.

This commit makes the `getEditors` function a drop-in replacement for the `getSelectedEditors` function to deduplicate the code and to have a unified way of getting editors.

Note that we don't actually use the contents of the returned array (only its length), so we can safely change `getEditors` to return a sorted array of integer editor IDs instead. Sorting the array makes the return value deterministic, which is a nice property for test stability, and integer IDs are also easier to handle in test assertions. Note that the corresponding selector strings can also easily be obtained from the integer IDs using the `getEditorSelector` function if needed.

Fixes a part of #19065.