### PR TITLE
Use `Dict` iteration more (PR 19051 follow-up)

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -923,8 +923,7 @@ class Catalog {
     }
     let prefs = null;
 
-    for (const key of obj.getKeys()) {
-      const value = obj.get(key);
+    for (const [key, value] of obj) {
       let prefValue;
 
       switch (key) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1472,9 +1472,7 @@ class PDFDocument {
       return shadow(this, "documentInfo", docInfo);
     }
 
-    for (const key of infoDict.getKeys()) {
-      const value = infoDict.get(key);
-
+    for (const [key, value] of infoDict) {
       switch (key) {
         case "Title":
         case "Author":

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1133,8 +1133,7 @@ class PartialEvaluator {
     // This array holds the converted/processed state data.
     const gStateObj = [];
     let promise = Promise.resolve();
-    for (const key of gState.getKeys()) {
-      const value = gState.get(key);
+    for (const [key, value] of gState) {
       switch (key) {
         case "Type":
           break;


### PR DESCRIPTION
There's a few cases where we're looping through the result of `Dict.prototype.getKeys` and then manually look-up the values, which after PR #19051 can be replaced with direct iteration instead.