### PR TITLE
Let be more tolerant with predefined phone number format

### DIFF
--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -1685,6 +1685,67 @@ describe("Scripting", function () {
         send_queue.delete(refId);
       });
 
+      it("should validate a US phone number with digits and dashes (long) on a keystroke event", async () => {
+        const refId = getId();
+        const data = {
+          objects: {
+            field: [
+              {
+                id: refId,
+                value: "",
+                actions: {
+                  Keystroke: [`AFSpecial_Keystroke(2);`],
+                },
+                type: "text",
+              },
+            ],
+          },
+          appInfo: { language: "en-US", platform: "Linux x86_64" },
+          calculationOrder: [],
+          dispatchEventName: "_dispatchMe",
+        };
+        sandbox.createSandbox(data);
+
+        let value = "";
+        const changes = "123-456-7890";
+        let i = 0;
+
+        for (; i < changes.length; i++) {
+          const change = changes.charAt(i);
+          await sandbox.dispatchEventInSandbox({
+            id: refId,
+            value,
+            change,
+            name: "Keystroke",
+            willCommit: false,
+            selStart: i,
+            selEnd: i,
+          });
+          expect(send_queue.has(refId)).toEqual(true);
+          send_queue.delete(refId);
+          value += change;
+        }
+
+        await sandbox.dispatchEventInSandbox({
+          id: refId,
+          value,
+          change: "A",
+          name: "Keystroke",
+          willCommit: false,
+          selStart: i,
+          selEnd: i,
+        });
+        expect(send_queue.has(refId)).toEqual(true);
+        expect(send_queue.get(refId)).toEqual({
+          id: refId,
+          siblings: null,
+          value,
+          selRange: [i, i],
+        });
+
+        send_queue.delete(refId);
+      });
+
       it("should validate a US phone number (short) on a keystroke event", async () => {
         const refId = getId();
         const data = {


### PR DESCRIPTION
The long US phone number format should be '(999) 999-9999' but the parenthesis can be omitted or the space replaced with a dash, ...