### PR TITLE
Skip LinkAnnotations when collecting field objects (issue 19281)

### DIFF
--- a/test/pdfs/issue19281.pdf.link
+++ b/test/pdfs/issue19281.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/18304780/Antarctica-Grid.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -11239,5 +11239,13 @@
     "link": true,
     "disableFontFace": true,
     "type": "eq"
+  },
+  {
+    "id": "issue19281",
+    "file": "pdfs/issue19281.pdf",
+    "md5": "c5db558965e4189cc6db2720cdaa3e55",
+    "rounds": 1,
+    "link": true,
+    "type": "other"
   }
 ]

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1713,6 +1713,20 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
+    it("gets fieldObjects and skipping LinkAnnotations", async function () {
+      if (isNodeJS) {
+        pending("Linked test-cases are not supported in Node.js.");
+      }
+
+      const loadingTask = getDocument(buildGetDocumentParams("issue19281.pdf"));
+      const pdfDoc = await loadingTask.promise;
+      const fieldObjects = await pdfDoc.getFieldObjects();
+
+      expect(fieldObjects).toEqual(null);
+
+      await loadingTask.destroy();
+    });
+
     it("gets non-existent calculationOrder", async function () {
       const calculationOrder = await pdfDocument.getCalculationOrderIds();
       expect(calculationOrder).toEqual(null);


### PR DESCRIPTION
The `/Root/AcroForm/Fields` array contains a "ridiculous" number of LinkAnnotations, which obviously makes no sense since those are not form fields. To improve performance we'll thus ignore those when collecting the field objects.