### PR TITLE
Use the `waitForUnselectedEditor` integration test helper function more

### DIFF
--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -38,6 +38,7 @@ import {
   waitForSelectedEditor,
   waitForSerialized,
   waitForTimeout,
+  waitForUnselectedEditor,
 } from "./test_utils.mjs";
 import { fileURLToPath } from "url";
 import fs from "fs";
@@ -1044,9 +1045,7 @@ describe("Highlight Editor", () => {
           await page.mouse.click(x, y, { count: 2, delay: 100 });
           await page.waitForSelector(`${getEditorSelector(0)}`);
           await page.keyboard.press("Escape");
-          await page.waitForSelector(
-            `${getEditorSelector(0)}:not(.selectedEditor)`
-          );
+          await waitForUnselectedEditor(page, getEditorSelector(0));
 
           await setCaretAt(
             page,
@@ -1797,7 +1796,7 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
           await page.keyboard.press("Escape");
-          await page.waitForSelector(`${editorSelector}:not(.selectedEditor)`);
+          await waitForUnselectedEditor(page, editorSelector);
 
           const clickHandle = await waitForPointerUp(page);
           y = rect.y - rect.height;
@@ -1868,7 +1867,7 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
           await page.keyboard.press("Escape");
-          await page.waitForSelector(`${editorSelector}:not(.selectedEditor)`);
+          await waitForUnselectedEditor(page, editorSelector);
 
           const clickHandle = await waitForPointerUp(page);
           y = rect.y - 3 * rect.height;


### PR DESCRIPTION
This commit applies the `waitForUnselectedEditor` helper function to the remaining places, that most likely predate the introduction of the helper function, to deduplicate the code and to have a unified way of checking if a given editor is unselected.

Fixes a part of #19065.