### PR TITLE
fixCss: Fix the broken layout of the CSS toolbar

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -866,7 +866,7 @@ a:focus > .thumbnail > .thumbnailImage,
   display: none;
 
   #sidebarContainer:has(#outlineView:not(.hidden)) & {
-    display: inline flex;
+    display: inline-flex;
   }
 }
 
@@ -1344,7 +1344,7 @@ dialog :link {
     gap: 4px;
 
     &:has(> :is(#findResultsCount, #findMsg):not(:empty)) {
-      display: inline flex;
+      display: inline-flex;
     }
 
     #findResultsCount {
@@ -1475,7 +1475,7 @@ dialog :link {
   cursor: default;
   box-sizing: border-box;
 
-  display: inline flex;
+  display: inline-flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -1487,7 +1487,7 @@ dialog :link {
 
 .toolbarHorizontalGroup {
   height: 100%;
-  display: inline flex;
+  display: inline-flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
@@ -1496,7 +1496,7 @@ dialog :link {
 }
 
 .dropdownToolbarButton {
-  display: inline flex;
+  display: inline-flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The viewer.css used in the downloaded pdf-dist package references display: inline flex; this css is wrong, which will cause the layout of the toolbar to be messy, and the layout will be normal after using inline-flex