### PR TITLE
Enable editor when double-clicking on stamp annotation

### DIFF
--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -1814,4 +1814,35 @@ describe("Stamp Editor", () => {
       );
     });
   });
+
+  describe("Switch to edit mode by double clicking on an existing stamp annotation", () => {
+    const annotationSelector = getAnnotationSelector("999R");
+
+    let pages;
+
+    beforeAll(async () => {
+      pages = await loadAndWait("issue19239.pdf", annotationSelector);
+    });
+
+    afterAll(async () => {
+      await closePages(pages);
+    });
+
+    it("must switch to edit mode", async () => {
+      await Promise.all(
+        pages.map(async ([, page]) => {
+          await page.waitForSelector(annotationSelector);
+          await scrollIntoView(page, annotationSelector);
+
+          await page.click(annotationSelector, { count: 2 });
+
+          await page.waitForFunction(() =>
+            document
+              .querySelector(".annotationEditorLayer")
+              .classList.contains("stampEditing")
+          );
+        })
+      );
+    });
+  });
 });

--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -108,7 +108,6 @@
       white-space: nowrap;
       font: 10px sans-serif;
       line-height: 1.35;
-      user-select: none;
     }
   }
 
@@ -118,6 +117,7 @@
     pointer-events: auto;
     box-sizing: border-box;
     transform-origin: 0 0;
+    user-select: none;
 
     &:has(div.annotationContent) {
       canvas.annotationContent {
@@ -315,6 +315,7 @@
     white-space: normal;
     word-wrap: break-word;
     pointer-events: auto;
+    user-select: text;
   }
 
   .popupAnnotation.focused .popup {


### PR DESCRIPTION
> In Firefox, double-clicking on a stamp annotation triggers text selection (selecting the last text element in the dom before the annotation): this triggers the logic to make annotations not interfere with text selection, which in turns prevents the double click from triggering the annotation editor.
> 
> This commit fixes the problem by making annotations non-selectable, so that clicking on them does not trigger text selection. Freetext annotations were already non-selectable, so this commit doesn't change that. However, we need to explicitly mark text in popups as selectable.

Fixes https://github.com/mozilla/pdf.js/issues/19315

Note that only annotations that are included in the PDF are editable by double-clicking on them. All user-created annotations are not, because they are only in the annotationEditorLayer what has `pointer-events: none`.