### PR TITLE
Improve performance when reading very large TrueType "cmap" tables (issue 19319)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1760,17 +1760,22 @@ class Font {
       mappings.sort(function (a, b) {
         return a.charCode - b.charCode;
       });
-      for (let i = 1; i < mappings.length; i++) {
-        if (mappings[i - 1].charCode === mappings[i].charCode) {
-          mappings.splice(i, 1);
-          i--;
+      const finalMappings = [],
+        seenCharCodes = new Set();
+      for (const map of mappings) {
+        const { charCode } = map;
+
+        if (seenCharCodes.has(charCode)) {
+          continue;
         }
+        seenCharCodes.add(charCode);
+        finalMappings.push(map);
       }
 
       return {
         platformId: potentialTable.platformId,
         encodingId: potentialTable.encodingId,
-        mappings,
+        mappings: finalMappings,
         hasShortCmap,
       };
     }

--- a/test/pdfs/issue19319.pdf.link
+++ b/test/pdfs/issue19319.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/18396493/2023-ESG-report-eng.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -11254,5 +11254,15 @@
     "rounds": 1,
     "link": true,
     "type": "other"
+  },
+  {
+    "id": "issue19319",
+    "file": "pdfs/issue19319.pdf",
+    "md5": "8612d3f0cf2dd067ea4aec9c8bf98763",
+    "rounds": 1,
+    "link": true,
+    "firstPage": 2,
+    "lastPage": 2,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
In the affected font the total number of mapping-entries is `1142348`, and no less than `997473` of them are duplicates.
Given that every duplicate causes a lot of Array elements to be moved this becomes extremely inefficient, which we can avoid by keeping track of seen `charCode`s and directly build the final mappings-Array instead.