### PR TITLE
Allow searching for number-number on two lines

### DIFF
--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -1104,6 +1104,40 @@ describe("pdf_find_controller", function () {
     });
   });
 
+  it("performs a search with a dash between two digits", async () => {
+    const { eventBus, pdfFindController } = await initPdfFindController();
+
+    await testSearch({
+      eventBus,
+      pdfFindController,
+      state: {
+        query: "2008-02",
+      },
+      matchesPerPage: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+      selectedMatch: {
+        pageIndex: 13,
+        matchIndex: 0,
+      },
+      pageMatches: [[], [], [], [], [], [], [], [], [], [], [], [], [], [314]],
+      pageMatchesLength: [
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [7],
+      ],
+    });
+  });
+
   describe("custom matcher", () => {
     it("calls to the matcher with the right arguments", async () => {
       const QUERY = "Foo  bar";


### PR DESCRIPTION
> When a dash separates two digits, it's very likely to not be a hyphen inserted to split a word into two lines (e.g. "par\n-ser"), but rather either a minus sign, a range, or a date. For example, in the tracemonkey PDF there is `2008-02` (a date) split across two lines.
>
> Preserving the dash, similarly to how we do for compound words, allows searches for "2008-02" to find a match.

I was originally going for a more complex regexp that checks for "letter"+"diacritics"+"dash"+"newline"+"letter", but if there are diacritics it's already _very likely_ that they are preceded by a letter so the existing `(\\p{M}+(?:-\\n)?)` is good enough.