### PR TITLE
Handle JPX wasm fetch-response errors correctly (PR 19329 follow-up)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -103,6 +103,16 @@ function arrayBuffersToBytes(arr) {
   return data;
 }
 
+async function fetchBinaryData(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch file "${url}" with "${response.statusText}".`
+    );
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
 /**
  * Get the value of an inheritable property.
  *
@@ -701,6 +711,7 @@ export {
   encodeToXmlString,
   escapePDFName,
   escapeString,
+  fetchBinaryData,
   getInheritableProperty,
   getLookupTableFactory,
   getNewAnnotationsMap,

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -14,6 +14,7 @@
  */
 
 import { BaseException, warn } from "../shared/util.js";
+import { fetchBinaryData } from "./core_utils.js";
 import OpenJPEG from "../../external/openjpeg/openjpeg.js";
 import { Stream } from "./stream.js";
 
@@ -44,14 +45,14 @@ class JpxImage {
   }
 
   static async #instantiateWasm(imports, successCallback) {
+    const filename = "openjpeg.wasm";
     try {
       if (!this.#buffer) {
         if (this.#wasmUrl !== null) {
-          const response = await fetch(`${this.#wasmUrl}openjpeg.wasm`);
-          this.#buffer = await response.arrayBuffer();
+          this.#buffer = await fetchBinaryData(`${this.#wasmUrl}${filename}`);
         } else {
           this.#buffer = await this.#handler.sendWithPromise("FetchWasm", {
-            filename: "openjpeg.wasm",
+            filename,
           });
         }
       }
@@ -59,7 +60,7 @@ class JpxImage {
       return successCallback(results.instance);
     } catch (e) {
       this.#instantiationFailed = true;
-      warn(`Cannot load openjpeg.wasm: "${e}".`);
+      warn(`Cannot load ${filename}: "${e}".`);
       return false;
     } finally {
       this.#handler = null;


### PR DESCRIPTION
Currently we're not checking that the response is actually OK before getting the data, which means that rather than throwing an error we can get an empty `ArrayBuffer`.

To avoid duplicating code we can move an existing helper into `src/core/core_utils.js` and re-use it when fetching the JPX wasm-file as well.