### PR TITLE
Reduce console spam when running tests in Firefox

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -952,6 +952,8 @@ async function startBrowser({
       "browser.newtabpage.enabled": false,
       // Disable network connections to Contile.
       "browser.topsites.contile.enabled": false,
+      // Disable logging for remote settings.
+      "services.settings.loglevel": "off",
       ...extraPrefsFirefox,
     };
   }


### PR DESCRIPTION
Rather than waiting for the upstream patch to reach the Firefox version we're using with Puppeteer, let's just set the same preference as done in https://phabricator.services.mozilla.com/D234320.