### PR TITLE
Support multiple wasm-files in the development viewer

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -650,10 +650,12 @@ function createStandardFontBundle() {
 }
 
 function createWasmBundle() {
-  return gulp.src(["external/openjpeg/openjpeg.wasm"], {
-    base: "external/openjpeg",
-    encoding: false,
-  });
+  return ordered([
+    gulp.src(["external/openjpeg/*.wasm"], {
+      base: "external/openjpeg",
+      encoding: false,
+    }),
+  ]);
 }
 
 function checkFile(filePath) {
@@ -2077,6 +2079,15 @@ gulp.task(
   )
 );
 
+gulp.task("dev-wasm", function () {
+  const VIEWER_WASM_OUTPUT = "web/wasm/";
+
+  fs.rmSync(VIEWER_WASM_OUTPUT, { recursive: true, force: true });
+  fs.mkdirSync(VIEWER_WASM_OUTPUT, { recursive: true });
+
+  return createWasmBundle().pipe(gulp.dest(VIEWER_WASM_OUTPUT));
+});
+
 gulp.task(
   "dev-sandbox",
   gulp.series(
@@ -2110,6 +2121,13 @@ gulp.task(
         "l10n/**/*.ftl",
         { ignoreInitial: false },
         gulp.series("locale")
+      );
+    },
+    function watchWasm() {
+      gulp.watch(
+        "external/openjpeg/*",
+        { ignoreInitial: false },
+        gulp.series("dev-wasm")
       );
     },
     function watchDevSandbox() {

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,3 +1,3 @@
-locale.properties
 locale/
 cmaps/
+wasm/

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -434,12 +434,9 @@ const defaultOptions = {
   wasmUrl: {
     /** @type {string} */
     value:
-      // eslint-disable-next-line no-nested-ternary
-      typeof PDFJSDev === "undefined"
-        ? "../external/openjpeg/"
-        : PDFJSDev.test("MOZCENTRAL")
-          ? "resource://pdf.js/web/wasm/"
-          : "../web/wasm/",
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+        ? "resource://pdf.js/web/wasm/"
+        : "../web/wasm/",
     kind: OptionKind.API,
   },
 


### PR DESCRIPTION
This prepares for a future where we're using more than one wasm-file, originating in different `external/`-folders, by extending the existing `gulp.watch` usage.
The following diff illustrates how to add more entries:

```diff
diff --git a/gulpfile.mjs b/gulpfile.mjs
index 0e0a5a1ac..1502755be 100644
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -655,6 +655,10 @@ function createWasmBundle() {
       base: "external/openjpeg",
       encoding: false,
     }),
+    gulp.src(["external/foobar/*.wasm"], {
+      base: "external/foobar",
+      encoding: false,
+    }),
   ]);
 }

@@ -2125,7 +2129,7 @@ gulp.task(
     },
     function watchWasm() {
       gulp.watch(
-        "external/openjpeg/*",
+        ["external/openjpeg/*", "external/foobar/*"],
         { ignoreInitial: false },
         gulp.series("dev-wasm")
       );
```