### PR TITLE
Add text wrapping to FreeText editors (issue 18191)

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -3267,4 +3267,56 @@ describe("FreeText Editor", () => {
       );
     });
   });
+
+  describe("FreeText text wrapping", () => {
+    let pages;
+
+    beforeAll(async () => {
+      pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+    });
+
+    afterAll(async () => {
+      await closePages(pages);
+    });
+
+    it("must wrap long text into multiple lines", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await switchToFreeText(page);
+
+          const rect = await getRect(page, ".annotationEditorLayer");
+          const editorSelector = getEditorSelector(0);
+
+          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.waitForSelector(editorSelector, { visible: true });
+
+          const longText =
+            "This is a very long text string that should definitely need to wrap onto multiple lines of text so that it can be displayed properly within the FreeText annotation editor.";
+          await page.type(`${editorSelector} .internal`, longText);
+
+          const hasMultipleLines = await page.evaluate(selector => {
+            const el = document.querySelector(`${selector} .internal`);
+            const style = window.getComputedStyle(el);
+            const lineHeight = parseFloat(style.lineHeight);
+            const totalHeight = el.getBoundingClientRect().height;
+            return totalHeight > lineHeight;
+          }, editorSelector);
+
+          expect(hasMultipleLines).withContext(`In ${browserName}`).toBeTrue();
+
+          await commit(page);
+
+          const maintainsWrapping = await page.evaluate(selector => {
+            const el = document.querySelector(`${selector} .internal`);
+            const style = window.getComputedStyle(el);
+            const lineHeight = parseFloat(style.lineHeight);
+            const totalHeight = el.getBoundingClientRect().height;
+            return totalHeight > lineHeight * 1.5;
+          }, editorSelector);
+
+          expect(maintainsWrapping).withContext(`In ${browserName}`).toBeTrue();
+        })
+      );
+    });
+  });
 });

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -523,7 +523,8 @@
   border: none;
   inset: 0;
   overflow: visible;
-  white-space: nowrap;
+  white-space: pre-wrap;
+  word-wrap: break-word;
   font: 10px sans-serif;
   line-height: var(--freetext-line-height);
   user-select: none;


### PR DESCRIPTION
I'm aware that there is already an [PR open](https://github.com/mozilla/pdf.js/pull/18447) with the similar promise, but the implementation is different.

Note: please read the gist comments https://gist.github.com/bennadel/033e0158f47bff9e066016f99567ebba
This solution might face performance issues with very large text being added.

Fixes: https://github.com/mozilla/pdf.js/issues/18191


<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/2f687ddb-c2c0-4398-83da-fde3b0261518

</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/d591a1ae-52cf-4382-828d-2fe033b2e5ed

</details>