### PR TITLE
Enable the `import/no-restricted-paths` ESLint plugin rule for the viewer

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,6 +91,17 @@ export default [
       "import/no-empty-named-blocks": "error",
       "import/no-commonjs": "error",
       "import/no-mutable-exports": "error",
+      "import/no-restricted-paths": [
+        "error",
+        {
+          zones: [
+            {
+              target: "./web",
+              from: "./src",
+            },
+          ],
+        },
+      ],
       "import/no-self-import": "error",
       "import/no-unresolved": [
         "error",


### PR DESCRIPTION
Code in the `web/` folder cannot import directly from the `src/` folder, since that could result in most (or all) main-thread code being bundled into the viewer, and must rather be imported via the `pdfjs-lib` alias.

Let's use ESLint to help enforce this, please find additional details in https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md