### PR TITLE
Enable the "checks that the viewer re-exports the expected API functionality" unit-test in Node.js

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1950,20 +1950,25 @@ function createBaseline(done) {
 
 gulp.task(
   "unittestcli",
-  gulp.series(setTestEnv, "lib-legacy", function runUnitTestCli(done) {
-    const options = [
-      "node_modules/jasmine/bin/jasmine",
-      "JASMINE_CONFIG_PATH=test/unit/clitests.json",
-    ];
-    const jasmineProcess = startNode(options, { stdio: "inherit" });
-    jasmineProcess.on("close", function (code) {
-      if (code !== 0) {
-        done(new Error("Unit tests failed."));
-        return;
-      }
-      done();
-    });
-  })
+  gulp.series(
+    setTestEnv,
+    "generic-legacy",
+    "lib-legacy",
+    function runUnitTestCli(done) {
+      const options = [
+        "node_modules/jasmine/bin/jasmine",
+        "JASMINE_CONFIG_PATH=test/unit/clitests.json",
+      ];
+      const jasmineProcess = startNode(options, { stdio: "inherit" });
+      jasmineProcess.on("close", function (code) {
+        if (code !== 0) {
+          done(new Error("Unit tests failed."));
+          return;
+        }
+        done();
+      });
+    }
+  )
 );
 
 gulp.task("lint", function (done) {

--- a/test/unit/pdf_spec.js
+++ b/test/unit/pdf_spec.js
@@ -22,7 +22,6 @@ import {
   FeatureTest,
   ImageKind,
   InvalidPDFException,
-  isNodeJS,
   normalizeUnicode,
   OPS,
   PasswordResponses,
@@ -129,13 +128,20 @@ describe("pdfjs_api", function () {
 
 describe("web_pdfjsLib", function () {
   it("checks that the viewer re-exports the expected API functionality", async function () {
-    if (isNodeJS) {
-      pending("loadScript is not supported in Node.js.");
-    }
-    const apiPath = "../../build/generic/build/pdf.mjs";
-    await import(apiPath);
+    // Load the API globally, as the viewer does.
+    // eslint-disable-next-line no-unsanitized/method
+    await import(
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB")
+        ? "../../../generic-legacy/build/pdf.mjs"
+        : "../../build/generic/build/pdf.mjs"
+    );
 
-    const webPdfjsLib = await import("../../web/pdfjs.js");
+    // eslint-disable-next-line no-unsanitized/method
+    const webPdfjsLib = await import(
+      typeof PDFJSDev !== "undefined" && PDFJSDev.test("LIB")
+        ? "../../../../web/pdfjs.js"
+        : "../../web/pdfjs.js"
+    );
 
     expect(Object.keys(webPdfjsLib).sort()).toEqual(
       Object.keys(expectedAPI).sort()


### PR DESCRIPTION
By also running `gulp generic-legacy` before the Node.js unit-tests, we can enable one more test-case in Node.js environments.