### PR TITLE
Fix: Draw outside of page while using pen tool is fixed

### DIFF
--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -834,7 +834,7 @@ class DrawingEditor extends AnnotationEditor {
     parent.toggleDrawing(true);
     this._cleanup(false);
 
-    if (event) {
+    if (event?.target === parent.div) {
       parent.drawLayer.updateProperties(
         this._currentDrawId,
         DrawingEditor.#currentDraw.end(event.offsetX, event.offsetY)


### PR DESCRIPTION
**Issue**

If we start drawing using the pen tool and take the cursor out of the left side, it draws an additional random line at the tail.

<img width="907" alt="{7CD5D2D0-7FB6-44B1-8968-8FB1FA85F643}" src="https://github.com/user-attachments/assets/7c197c38-62fe-4167-9784-73848209db9a" />

**After Fix**

<img width="941" alt="{3BF5C776-C53F-41A4-A8FC-B56690FE520A}" src="https://github.com/user-attachments/assets/5b743b23-9148-4fc0-8270-a2ac5c926bfa" />
