### PR TITLE
[Editor] Ensure that `highlightSelection` waits until we've fully updated the editing-mode (issue 19369)

### DIFF
--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1481,23 +1481,33 @@ describe("Highlight Editor", () => {
     it("must check that clicking on the highlight floating button triggers an highlight", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          const rect = await getSpanRectFromText(page, 1, "Abstract");
-          const x = rect.x + rect.width / 2;
-          const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          async function floatingHighlight(text, editorId) {
+            const rect = await getSpanRectFromText(page, 1, text);
+            const x = rect.x + rect.width / 2;
+            const y = rect.y + rect.height / 2;
+            await page.mouse.click(x, y, { count: 2, delay: 100 });
 
-          await page.waitForSelector(".textLayer .highlightButton");
-          await page.click(".textLayer .highlightButton");
+            await page.waitForSelector(".textLayer .highlightButton");
+            await page.click(".textLayer .highlightButton");
 
-          await page.waitForSelector(getEditorSelector(0));
-          const usedColor = await page.evaluate(() => {
-            const highlight = document.querySelector(
-              `.page[data-page-number = "1"] .canvasWrapper > svg.highlight`
-            );
-            return highlight.getAttribute("fill");
-          });
+            await page.waitForSelector(getEditorSelector(editorId));
+            const usedColor = await page.evaluate(() => {
+              const highlight = document.querySelector(
+                `.page[data-page-number = "1"] .canvasWrapper > svg.highlight`
+              );
+              return highlight.getAttribute("fill");
+            });
 
-          expect(usedColor).withContext(`In ${browserName}`).toEqual("#AB0000");
+            expect(usedColor)
+              .withContext(`In ${browserName}`)
+              .toEqual("#AB0000");
+          }
+
+          await floatingHighlight("Abstract", 0);
+
+          // Disable editing mode, and highlight another string (issue 19369).
+          await switchToHighlight(page, /* disable */ true);
+          await floatingHighlight("Introduction", 1);
         })
       );
     });

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2339,11 +2339,22 @@ class PDFViewer {
       this.#mlManager?.loadModel("altText");
     }
 
-    const { eventBus } = this;
-    const updater = () => {
+    const { eventBus, pdfDocument } = this;
+    const updater = async () => {
       this.#cleanupSwitchAnnotationEditorMode();
       this.#annotationEditorMode = mode;
-      this.#annotationEditorUIManager.updateMode(mode, editId, isFromKeyboard);
+      await this.#annotationEditorUIManager.updateMode(
+        mode,
+        editId,
+        isFromKeyboard
+      );
+      if (
+        mode !== this.#annotationEditorMode ||
+        pdfDocument !== this.pdfDocument
+      ) {
+        // Since `updateMode` is async, the active mode could have changed.
+        return;
+      }
       eventBus.dispatch("annotationeditormodechanged", {
         source: this,
         mode,


### PR DESCRIPTION
With the changes in PR #18843 the `AnnotationEditorUIManager.prototype.updateMode` method is now asynchronous, which we need to take into account when dispatching the "annotationeditormodechanged" event.

*Edit:* I don't know if this is necessarily the "correct" way to address this, but it appears to work.