### PR TITLE
[Editor] Add validation for the target element of curve endpoints  

### DIFF
--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -834,7 +834,7 @@ class DrawingEditor extends AnnotationEditor {
     parent.toggleDrawing(true);
     this._cleanup(false);
 
-    if (event) {
+    if (event?.target === parent.div) {
       parent.drawLayer.updateProperties(
         this._currentDrawId,
         DrawingEditor.#currentDraw.end(event.offsetX, event.offsetY)


### PR DESCRIPTION
Issue: drawing a shape may have an unwanted path element added.
Steps to reproduce:

Go to https://mozilla.github.io/pdf.js/web/viewer.html;
Select the pen tool and draw a shape on the second page;
While drawing the shape, move the cursor out of the left-hand side of the second page, then stop the action.
On the third step, the shape will be extended with a path element that starts where the cursor left the page and ends at a random position on the page. Correct this issue to ensure that the path element is not added.
Fix: Incorrect End Position of Curve on Target Page
The issue of the curve's unintended end position is caused by obtaining improper coordinates from the end-drawing event. These coordinates are derived from an element other than the intended target page.

Changes:
To resolve this, I added a check to verify the element where the drawing ends. If the drawing ends on an element other than the target page, the coordinates registration are skipped.


Notes: 
* this PR is instead of https://github.com/mozilla/pdf.js/pull/19362
* this commit pass integration tests
