### PR TITLE
[Viewer] Improve rendering when using fractional scaling on non-Firefox browsers

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -625,7 +625,7 @@ function setLayerDimensions(
  */
 class OutputScale {
   constructor() {
-    const pixelRatio = window.devicePixelRatio || 1;
+    const pixelRatio = Math.ceil(window.devicePixelRatio) || 1;
 
     /**
      * @type {number} Horizontal scale.


### PR DESCRIPTION
## Summary
Aims to fix (or reduce the extent of) the blurry rendering I've noticed on non-Firefox based browsers when using fractional scaling.

## Issue being fixed
PDF.js seems to produce a blurry result when `window.devicePixelRatio` is not easily representable in binary (such as 1.15 and 1.1 as opposed to 1.25, 1.5, 1.75 etc). On Firefox-based browsers, it seems `window.devicePixelRatio` is rounded up to the nearest integer, at least on my system (Linux Wayland), but other browsers report the true value. The result is a blurry image on such browsers which also affects VSCode extensions (for example, a LaTeX document preview).

## Workaround/fix
This seems like a more fundamental problem with PDF.js in general, but for now, a fix/workaround is to take the ceiling of `devicePixelRatio` when determining the render scale. This seems to greatly improve the clarity of the final output.

I tried rounding `devicePixelRatio` up to the nearest 0.5 or 0.25, but the result still seemed blurry.

## Side-by-side comparison
I have a 1440p display with 115% display scaling. To properly see the difference, please download the image and zoom appropriately so that 1 pixel in your image viewer = 1 pixel on your display (if, for example, the browser address bar text is blurry, your zoom is not set correctly).

This PR's pdf render is on the left.

75%:
![75% zoom comparison](https://github.com/user-attachments/assets/5242fc33-689d-444a-8fa4-8916c5e45300)

125%:
![125% zoom comparison](https://github.com/user-attachments/assets/3c55d689-5900-4f70-b68b-74e2811dbce6)

200%:
![200% zoom comparison](https://github.com/user-attachments/assets/e5f2b7df-06e0-4353-916c-edde89dd2a14)
