### PR TITLE
Add support for callout arrow in FreeTextAnnotation

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -970,6 +970,37 @@ class Annotation {
   }
 
   /**
+   * Set the line ending; should only be used with FreeText annotations.
+   * @param {Name} lineEnding - The line ending name.
+   */
+  setLineEnding(lineEnding) {
+    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+      throw new Error("Not implemented: setLineEnding");
+    }
+
+    this.lineEnding = "None"; // The default value.
+
+    if (lineEnding instanceof Name) {
+      switch (lineEnding.name) {
+        case "None":
+          return;
+        case "Square":
+        case "Circle":
+        case "Diamond":
+        case "OpenArrow":
+        case "ClosedArrow":
+        case "Butt":
+        case "ROpenArrow":
+        case "RClosedArrow":
+        case "Slash":
+          this.lineEnding = lineEnding.name;
+          return;
+      }
+    }
+    warn(`Ignoring invalid lineEnding: ${lineEnding}`);
+  }
+
+  /**
    * Set the line endings; should only be used with specific annotation types.
    * @param {Array} lineEndings - The line endings array.
    */
@@ -3882,10 +3913,15 @@ class FreeTextAnnotation extends MarkupAnnotation {
     // We want to be able to add mouse listeners to the annotation.
     this.data.noHTML = false;
 
-    const { evaluatorOptions, xref } = params;
+    const { evaluatorOptions, xref, dict } = params;
     this.data.annotationType = AnnotationType.FREETEXT;
     this.setDefaultAppearance(params);
     this._hasAppearance = !!this.appearance;
+
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      this.setLineEnding(dict.getArray("LE"));
+      this.data.lineEnding = this.lineEnding;
+    }
 
     if (this._hasAppearance) {
       const { fontColor, fontSize } = parseAppearanceStream(

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -45,6 +45,7 @@ import {
   getParentToUpdate,
   getRotationMatrix,
   isNumberArray,
+  lookupLineEnding,
   lookupMatrix,
   lookupNormalRect,
   lookupRect,
@@ -978,26 +979,7 @@ class Annotation {
       throw new Error("Not implemented: setLineEnding");
     }
 
-    this.lineEnding = "None"; // The default value.
-
-    if (lineEnding instanceof Name) {
-      switch (lineEnding.name) {
-        case "None":
-          return;
-        case "Square":
-        case "Circle":
-        case "Diamond":
-        case "OpenArrow":
-        case "ClosedArrow":
-        case "Butt":
-        case "ROpenArrow":
-        case "RClosedArrow":
-        case "Slash":
-          this.lineEnding = lineEnding.name;
-          return;
-      }
-    }
-    warn(`Ignoring invalid lineEnding: ${lineEnding}`);
+    this.lineEnding = lookupLineEnding(lineEnding, "None");
   }
 
   /**
@@ -1012,26 +994,7 @@ class Annotation {
 
     if (Array.isArray(lineEndings) && lineEndings.length === 2) {
       for (let i = 0; i < 2; i++) {
-        const obj = lineEndings[i];
-
-        if (obj instanceof Name) {
-          switch (obj.name) {
-            case "None":
-              continue;
-            case "Square":
-            case "Circle":
-            case "Diamond":
-            case "OpenArrow":
-            case "ClosedArrow":
-            case "Butt":
-            case "ROpenArrow":
-            case "RClosedArrow":
-            case "Slash":
-              this.lineEndings[i] = obj.name;
-              continue;
-          }
-        }
-        warn(`Ignoring invalid lineEnding: ${obj}`);
+        this.lineEndings[i] = lookupLineEnding(lineEndings[i], "None");
       }
     }
   }
@@ -3922,7 +3885,6 @@ class FreeTextAnnotation extends MarkupAnnotation {
       if (dict.has("CL")) {
         this.setLineEnding(dict.getArray("LE"));
         this.data.calloutLine = dict.getArray("CL");
-        this.data.rectDifference = dict.getArray("RD");
         this.data.lineEnding = this.lineEnding;
       }
     }

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3882,12 +3882,12 @@ class FreeTextAnnotation extends MarkupAnnotation {
     this._hasAppearance = !!this.appearance;
 
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-      if (dict.has("CL")) {
-        this.setLineEnding(dict.getArray("LE"));
+      if (this.data.it === "FreeTextCallout") {
+        this.setLineEnding(dict.get("LE"));
         this.data.lineEnding = this.lineEnding;
 
         const calloutLine = dict.getArray("CL");
-        if (isNumberArray(calloutLine)) {
+        if (isNumberArray(calloutLine, 4) || isNumberArray(calloutLine, 6)) {
           this.data.calloutLine = calloutLine;
         }
       }
@@ -3940,8 +3940,17 @@ class FreeTextAnnotation extends MarkupAnnotation {
   }
 
   static createNewDict(annotation, xref, { apRef, ap }) {
-    const { color, fontSize, oldAnnotation, rect, rotation, user, value } =
-      annotation;
+    const {
+      calloutLine,
+      color,
+      fontSize,
+      lineEnding,
+      oldAnnotation,
+      rect,
+      rotation,
+      user,
+      value,
+    } = annotation;
     const freetext = oldAnnotation || new Dict(xref);
     freetext.set("Type", Name.get("Annot"));
     freetext.set("Subtype", Name.get("FreeText"));
@@ -3960,6 +3969,15 @@ class FreeTextAnnotation extends MarkupAnnotation {
     freetext.set("F", 4);
     freetext.set("Border", [0, 0, 0]);
     freetext.set("Rotate", rotation);
+
+    if (calloutLine) {
+      freetext.set("IT", Name.get("FreeTextCallout"));
+
+      freetext.set("CL", calloutLine);
+      if (lineEnding) {
+        freetext.set("LE", Name.get(lineEnding));
+      }
+    }
 
     if (user) {
       freetext.set("T", stringToAsciiOrUTF16BE(user));

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3884,8 +3884,12 @@ class FreeTextAnnotation extends MarkupAnnotation {
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       if (dict.has("CL")) {
         this.setLineEnding(dict.getArray("LE"));
-        this.data.calloutLine = dict.getArray("CL");
         this.data.lineEnding = this.lineEnding;
+
+        const calloutLine = dict.getArray("CL");
+        if (isNumberArray(calloutLine)) {
+          this.data.calloutLine = calloutLine;
+        }
       }
     }
 

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3919,8 +3919,12 @@ class FreeTextAnnotation extends MarkupAnnotation {
     this._hasAppearance = !!this.appearance;
 
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-      this.setLineEnding(dict.getArray("LE"));
-      this.data.lineEnding = this.lineEnding;
+      if (dict.has("CL")) {
+        this.setLineEnding(dict.getArray("LE"));
+        this.data.calloutLine = dict.getArray("CL");
+        this.data.rectDifference = dict.getArray("RD");
+        this.data.lineEnding = this.lineEnding;
+      }
     }
 
     if (this._hasAppearance) {

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -23,7 +23,7 @@ import {
   Util,
   warn,
 } from "../shared/util.js";
-import { Dict, isName, Ref, RefSet } from "./primitives.js";
+import { Dict, isName, Name, Ref, RefSet } from "./primitives.js";
 import { BaseStream } from "./base_stream.js";
 
 const PDF_VERSION_REGEXP = /^[1-9]\.\d$/;
@@ -298,6 +298,27 @@ function lookupRect(arr, fallback) {
 // Returns the normalized rectangle, or the fallback value if it's invalid.
 function lookupNormalRect(arr, fallback) {
   return isNumberArray(arr, 4) ? Util.normalizeRect(arr) : fallback;
+}
+
+// Returns the line ending style, or the fallback value if it's invalid.
+function lookupLineEnding(value, fallback) {
+  if (value instanceof Name) {
+    switch (value.name) {
+      case "None":
+      case "Square":
+      case "Circle":
+      case "Diamond":
+      case "OpenArrow":
+      case "ClosedArrow":
+      case "Butt":
+      case "ROpenArrow":
+      case "RClosedArrow":
+      case "Slash":
+        return value.name;
+    }
+  }
+
+  return fallback;
 }
 
 /**
@@ -723,6 +744,7 @@ export {
   isNumberArray,
   isWhiteSpace,
   log2,
+  lookupLineEnding,
   lookupMatrix,
   lookupNormalRect,
   lookupRect,


### PR DESCRIPTION
This PR adds callout information to the `FreeTextAnnotation` model.
This data are required to extend the editor support for this kind of annotations.