### PR TITLE
Remove unused `isInEditingMode` method (PR 19311 follow-up)

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1716,10 +1716,6 @@ class AnnotationEditorUIManager {
     this.#updateModeCapability.resolve();
   }
 
-  isInEditingMode() {
-    return this.#mode !== AnnotationEditorType.NONE;
-  }
-
   addNewEditorFromKeyboard() {
     if (this.currentLayer.canCreateNewEmptyEditor()) {
       this.currentLayer.addNewEditor();


### PR DESCRIPTION
This method was added in PR #19311, however it's not actually used anywhere in the code-base.