### PR TITLE
Handle *empty* BigInt64Array/BigUint64Array in the `isNumberArray` helper

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -280,7 +280,7 @@ function isNumberArray(arr, len) {
   // BigInt64Array/BigUint64Array types (their elements aren't "number").
   return (
     ArrayBuffer.isView(arr) &&
-    (arr.length === 0 || typeof arr[0] === "number") &&
+    !(arr instanceof BigInt64Array || arr instanceof BigUint64Array) &&
     (len === null || arr.length === len)
   );
 }


### PR DESCRIPTION
The current checks would accidentally allow *empty* BigInt64Array/BigUint64Array, which we can fix by instead checking directly for those types.
This should be fine since those types are available in all environments that we support, see:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array#browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array#browser_compatibility