### PR TITLE
Introduce a `readInt16` helper function in the `src/core/core_utils.js` file

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -28,6 +28,7 @@ import {
   ISOAdobeCharset,
 } from "./charsets.js";
 import { ExpertEncoding, StandardEncoding } from "./encodings.js";
+import { readInt16 } from "./core_utils.js";
 
 // Maximum subroutine call depth of type 2 charstrings. Matches OTS.
 const MAX_SUBR_NESTING = 10;
@@ -359,8 +360,8 @@ class CFFParser {
       if (value === 30) {
         return parseFloatOperand();
       } else if (value === 28) {
-        value = dict[pos++];
-        value = ((value << 24) | (dict[pos++] << 16)) >> 16;
+        value = readInt16(dict, pos);
+        pos += 2;
         return value;
       } else if (value === 29) {
         value = dict[pos++];
@@ -510,7 +511,7 @@ class CFFParser {
         }
       } else if (value === 28) {
         // number (16 bit)
-        stack[stackSize] = ((data[j] << 24) | (data[j + 1] << 16)) >> 16;
+        stack[stackSize] = readInt16(data, j);
         j += 2;
         stackSize++;
       } else if (value === 14) {

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -227,6 +227,10 @@ function readInt8(data, offset) {
   return (data[offset] << 24) >> 24;
 }
 
+function readInt16(data, offset) {
+  return ((data[offset] << 24) | (data[offset + 1] << 16)) >> 16;
+}
+
 function readUint16(data, offset) {
   return (data[offset] << 8) | data[offset + 1];
 }
@@ -733,6 +737,7 @@ export {
   ParserEOFException,
   parseXFAPath,
   PDF_VERSION_REGEXP,
+  readInt16,
   readInt8,
   readUint16,
   readUint32,

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -24,6 +24,7 @@ import {
 } from "../shared/util.js";
 import {
   isNumberArray,
+  readInt16,
   readInt8,
   readUint16,
   readUint32,
@@ -35,12 +36,8 @@ import { Stream } from "./stream.js";
 
 // TODO: use DataView and its methods.
 
-function getInt16(data, offset) {
-  return ((data[offset] << 24) | (data[offset + 1] << 16)) >> 16;
-}
-
 function getFloat214(data, offset) {
-  return getInt16(data, offset) / 16384;
+  return readInt16(data, offset) / 16384;
 }
 
 function getSubroutineBias(subrs) {
@@ -185,7 +182,7 @@ function compileGlyf(code, cmds, font) {
   }
 
   let i = 0;
-  const numberOfContours = getInt16(code, i);
+  const numberOfContours = readInt16(code, i);
   let flags;
   let firstPoint = null;
   let x = 0,
@@ -200,8 +197,8 @@ function compileGlyf(code, cmds, font) {
       let arg1, arg2;
       if (flags & 0x01) {
         if (flags & 0x02) {
-          arg1 = getInt16(code, i);
-          arg2 = getInt16(code, i + 2);
+          arg1 = readInt16(code, i);
+          arg2 = readInt16(code, i + 2);
         } else {
           arg1 = readUint16(code, i);
           arg2 = readUint16(code, i + 2);
@@ -279,7 +276,7 @@ function compileGlyf(code, cmds, font) {
     for (j = 0; j < numberOfPoints; j++) {
       switch (points[j].flags & 0x12) {
         case 0x00:
-          x += getInt16(code, i);
+          x += readInt16(code, i);
           i += 2;
           break;
         case 0x02:
@@ -294,7 +291,7 @@ function compileGlyf(code, cmds, font) {
     for (j = 0; j < numberOfPoints; j++) {
       switch (points[j].flags & 0x24) {
         case 0x00:
-          y += getInt16(code, i);
+          y += readInt16(code, i);
           i += 2;
           break;
         case 0x04:
@@ -653,7 +650,7 @@ function compileCharString(charStringCode, cmds, font, glyphId) {
           }
           break;
         case 28:
-          stack.push(((code[i] << 24) | (code[i + 1] << 16)) >> 16);
+          stack.push(readInt16(code, i));
           i += 2;
           break;
         case 29: // callgsubr


### PR DESCRIPTION
Rather than manually repeating code needed to get an int16, we can move and re-use an existing helper function instead.