### PR TITLE
Initialize the image-options, on the worker-thread, once per document

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -75,9 +75,6 @@ import { getFontSubstitution } from "./font_substitutions.js";
 import { getGlyphsUnicode } from "./glyphlist.js";
 import { getMetrics } from "./metrics.js";
 import { getUnicodeForGlyph } from "./unicode.js";
-import { ImageResizer } from "./image_resizer.js";
-import { JpegStream } from "./jpeg_stream.js";
-import { JpxImage } from "./jpx.js";
 import { MurmurHash3_64 } from "../shared/murmurhash3.js";
 import { OperatorList } from "./operator_list.js";
 import { PDFImage } from "./image.js";
@@ -240,13 +237,6 @@ class PartialEvaluator {
 
     this._regionalImageCache = new RegionalImageCache();
     this._fetchBuiltInCMapBound = this.fetchBuiltInCMap.bind(this);
-
-    ImageResizer.setOptions(this.options);
-    JpegStream.setOptions(this.options);
-    JpxImage.setOptions({
-      wasmUrl: this.options.wasmUrl,
-      handler,
-    });
   }
 
   /**


### PR DESCRIPTION
Currently we're initializing the image-options for every page, which seems unnecessary since it should suffice to do that once per document.

Also, changes the `BasePdfManager` constructor to improve readability/documentation a little bit.