### PR TITLE
Centralize the editor selector definitions in the freetext editor integration tests

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -141,9 +141,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -178,9 +176,7 @@ describe("FreeText Editor", () => {
         await copy(page);
         await paste(page);
         const secondEditorSelector = getEditorSelector(1);
-        await page.waitForSelector(secondEditorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(secondEditorSelector, { visible: true });
         await waitForStorageEntries(page, 2);
 
         const content = await page.$eval(firstEditorSelector, el =>
@@ -196,9 +192,7 @@ describe("FreeText Editor", () => {
         await copy(page);
         await paste(page);
         const thirdEditorSelector = getEditorSelector(2);
-        await page.waitForSelector(thirdEditorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(thirdEditorSelector, { visible: true });
         await waitForStorageEntries(page, 3);
 
         pastedContent = await page.$eval(thirdEditorSelector, el =>
@@ -234,9 +228,7 @@ describe("FreeText Editor", () => {
         let editorSelector = getEditorSelector(3);
         const data = "Hello PDF.js World !!";
         await page.mouse.click(rect.x + 100, rect.y + 100);
-        await page.waitForSelector(editorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(editorSelector, { visible: true });
         await page.type(`${editorSelector} .internal`, data);
         await commit(page);
 
@@ -244,9 +236,7 @@ describe("FreeText Editor", () => {
         await copy(page);
         await paste(page);
         editorSelector = getEditorSelector(4);
-        await page.waitForSelector(editorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(editorSelector, { visible: true });
 
         await kbUndo(page);
         await page.waitForFunction(
@@ -299,9 +289,7 @@ describe("FreeText Editor", () => {
             stacksRect.x + stacksRect.width + 1,
             stacksRect.y + stacksRect.height / 2
           );
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -328,9 +316,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(8);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -374,9 +360,7 @@ describe("FreeText Editor", () => {
 
         const editorSelector = getEditorSelector(9);
         await page.mouse.click(rect.x + 200, rect.y + 100);
-        await page.waitForSelector(editorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(editorSelector, { visible: true });
 
         for (let i = 0; i < 5; i++) {
           await page.type(`${editorSelector} .internal`, "A");
@@ -436,9 +420,7 @@ describe("FreeText Editor", () => {
         );
 
         await kbRedo(page);
-        await page.waitForSelector(editorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(editorSelector, { visible: true });
 
         text = await getText();
         expect(text).withContext(`In ${browserName}`).toEqual("A");
@@ -478,9 +460,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(i);
           const data = `FreeText ${i}`;
           await page.mouse.click(lastX, rect.y + rect.height / 10);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -524,9 +504,7 @@ describe("FreeText Editor", () => {
 
         await copy(page);
         await paste(page);
-        await page.waitForSelector(getEditorSelector(6), {
-          visible: true,
-        });
+        await page.waitForSelector(getEditorSelector(6), { visible: true });
 
         // 0,1,3 are unselected and new pasted editors are selected.
         expect(await getEditors(page, "selected"))
@@ -575,9 +553,7 @@ describe("FreeText Editor", () => {
           rect.x + (rect.width / 10) * 7,
           rect.y + rect.height / 10
         );
-        await page.waitForSelector(getEditorSelector(7), {
-          visible: true,
-        });
+        await page.waitForSelector(getEditorSelector(7), { visible: true });
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([7]);
@@ -594,9 +570,7 @@ describe("FreeText Editor", () => {
           rect.x + (rect.width / 10) * 8,
           rect.y + rect.height / 10
         );
-        await page.waitForSelector(getEditorSelector(8), {
-          visible: true,
-        });
+        await page.waitForSelector(getEditorSelector(8), { visible: true });
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([8]);
@@ -656,9 +630,7 @@ describe("FreeText Editor", () => {
             const data = `Hello PDF.js World !! on page ${pageNumber}`;
             expected.push(data);
             await page.mouse.click(rect.x + 100, rect.y + 100);
-            await page.waitForSelector(editorSelector, {
-              visible: true,
-            });
+            await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
 
@@ -790,9 +762,7 @@ describe("FreeText Editor", () => {
             const x = Math.max(rect.x + 0.1 * rect.width, 10);
             const y = Math.max(rect.y + 0.1 * rect.height, 10);
             await page.mouse.click(x, y);
-            await page.waitForSelector(editorSelector, {
-              visible: true,
-            });
+            await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
 
@@ -999,15 +969,12 @@ describe("FreeText Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           // Show the popup on "Hello World from Firefox"
-          await page.click(`[data-annotation-id='32R']`);
-          await page.waitForSelector(`[data-annotation-id='popup_32R']`, {
-            visible: true,
-          });
+          await page.click("[data-annotation-id='32R']");
+          const popupSelector = "[data-annotation-id='popup_32R']";
+          await page.waitForSelector(popupSelector, { visible: true });
 
           await switchToFreeText(page);
-          await page.waitForSelector(`[data-annotation-id='popup_32R']`, {
-            visible: false,
-          });
+          await page.waitForSelector(popupSelector, { visible: false });
 
           const editorSelector = getEditorSelector(1);
           await selectEditor(page, editorSelector, /* count = */ 2);
@@ -1028,13 +995,10 @@ describe("FreeText Editor", () => {
 
           // Disable editing mode.
           await switchToFreeText(page, /* disable = */ true);
-
-          await page.waitForSelector(`[data-annotation-id='popup_32R']`, {
-            visible: true,
-          });
+          await page.waitForSelector(popupSelector, { visible: true });
 
           const newPopupText = await page.$eval(
-            "[data-annotation-id='popup_32R'] .popupContent",
+            `${popupSelector} .popupContent`,
             el => el.innerText.replaceAll("\xa0", " ")
           );
           expect(newPopupText)
@@ -1151,9 +1115,7 @@ describe("FreeText Editor", () => {
         await selectEditor(page, getEditorSelector(1));
         await copy(page);
         await paste(page);
-        await page.waitForSelector(getEditorSelector(6), {
-          visible: true,
-        });
+        await page.waitForSelector(getEditorSelector(6), { visible: true });
         await waitForStorageEntries(page, 7);
       }
     });
@@ -1302,9 +1264,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -1413,9 +1373,7 @@ describe("FreeText Editor", () => {
             const editorSelector = getEditorSelector(currentId);
             const data = `Hello PDF.js World !! on page ${pageNumber}`;
             await page.mouse.click(rect.x + 100, rect.y + 100);
-            await page.waitForSelector(editorSelector, {
-              visible: true,
-            });
+            await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
 
@@ -1757,9 +1715,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -1804,9 +1760,7 @@ describe("FreeText Editor", () => {
           const data = "Hello PDF.js World !!";
           const editorSelector = getEditorSelector(0);
           await page.mouse.click(rect.x + 200, rect.y + 200);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -1898,9 +1852,7 @@ describe("FreeText Editor", () => {
           const data = "Hello PDF.js World !!";
           let editorSelector = getEditorSelector(1);
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -1909,9 +1861,7 @@ describe("FreeText Editor", () => {
           await clearAll(page);
           editorSelector = getEditorSelector(2);
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 20, () =>
             page.keyboard.press("ArrowRight")
@@ -1976,9 +1926,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await cancelFocusIn(page, editorSelector);
           await commit(page);
@@ -2031,9 +1979,7 @@ describe("FreeText Editor", () => {
 
           const firstEditorSelector = getEditorSelector(0);
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(firstEditorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(firstEditorSelector, { visible: true });
           await page.type(`${firstEditorSelector} .internal`, "A");
           await commit(page);
 
@@ -2044,9 +1990,7 @@ describe("FreeText Editor", () => {
             rect.x + 5 * rect.width,
             rect.y + 5 * rect.height
           );
-          await page.waitForSelector(secondEditorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(secondEditorSelector, { visible: true });
           await page.type(`${secondEditorSelector} .internal`, "B");
           await commit(page);
 
@@ -2113,9 +2057,7 @@ describe("FreeText Editor", () => {
           for (let i = 0; i < 10; i++) {
             const editorSelector = getEditorSelector(i);
             await page.mouse.click(rect.x + 10 + 30 * i, rect.y + 100 + 5 * i);
-            await page.waitForSelector(editorSelector, {
-              visible: true,
-            });
+            await page.waitForSelector(editorSelector, { visible: true });
             await page.type(
               `${editorSelector} .internal`,
               String.fromCharCode(65 + i)
@@ -2175,9 +2117,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await cancelFocusIn(page, editorSelector);
           await commit(page);
@@ -2229,9 +2169,7 @@ describe("FreeText Editor", () => {
           let rect = await getRect(page, page1Selector);
           const firstEditorSelector = getEditorSelector(0);
           await page.mouse.click(rect.x + 10, rect.y + 10);
-          await page.waitForSelector(firstEditorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(firstEditorSelector, { visible: true });
           await page.type(`${firstEditorSelector} .internal`, "Hello");
           await cancelFocusIn(page, firstEditorSelector);
           await commit(page);
@@ -2254,9 +2192,7 @@ describe("FreeText Editor", () => {
           rect = await getRect(page, page14Selector);
           const secondEditorSelector = getEditorSelector(1);
           await page.mouse.click(rect.x + 10, rect.y + 10);
-          await page.waitForSelector(secondEditorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(secondEditorSelector, { visible: true });
           await page.type(`${secondEditorSelector} .internal`, "World");
           await commit(page);
 
@@ -2271,9 +2207,7 @@ describe("FreeText Editor", () => {
             });
           }
 
-          await page.waitForSelector(firstEditorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(firstEditorSelector, { visible: true });
           await selectEditor(page, firstEditorSelector);
           const content = await page.$eval(firstEditorSelector, el =>
             el.innerText.trimEnd()
@@ -2304,9 +2238,7 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, page1Selector);
           const editorSelector = getEditorSelector(0);
           await page.mouse.click(rect.x + 10, rect.y + 10);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, "Hello");
           await cancelFocusIn(page, editorSelector);
           await commit(page);
@@ -2321,10 +2253,7 @@ describe("FreeText Editor", () => {
           await scrollIntoView(page, `.page[data-page-number = "14"]`);
           await page.waitForSelector(
             `.page[data-page-number = "14"] > .annotationEditorLayer.freetextEditing`,
-            {
-              visible: true,
-              timeout: 0,
-            }
+            { visible: true, timeout: 0 }
           );
 
           await clearAll(page);
@@ -2342,9 +2271,7 @@ describe("FreeText Editor", () => {
           await kbUndo(page);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
         })
       );
     });
@@ -2384,9 +2311,7 @@ describe("FreeText Editor", () => {
             rect.x + rect.width + 5,
             rect.y + rect.height / 2
           );
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, "Hello Wolrd");
           await commit(page);
 
@@ -2419,9 +2344,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           const internalEditorSelector = `${editorSelector} .internal`;
           await page.type(internalEditorSelector, data);
           await commit(page);
@@ -2461,9 +2384,7 @@ describe("FreeText Editor", () => {
           await page.keyboard.press("Enter");
 
           let editorSelector = getEditorSelector(0);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 5, () => kbBigMoveUp(page));
 
@@ -2483,9 +2404,7 @@ describe("FreeText Editor", () => {
           await page.focus("#editorFreeTextButton");
           await page.keyboard.press(" ");
           editorSelector = getEditorSelector(1);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 5, () => kbBigMoveDown(page));
 
@@ -2509,9 +2428,7 @@ describe("FreeText Editor", () => {
         pages.map(async ([browserName, page]) => {
           await page.keyboard.press("Enter");
           let editorSelector = getEditorSelector(2);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 10, () => kbBigMoveLeft(page));
 
@@ -2530,9 +2447,7 @@ describe("FreeText Editor", () => {
 
           await page.keyboard.press(" ");
           editorSelector = getEditorSelector(3);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 10, () =>
             kbBigMoveRight(page)
@@ -2574,9 +2489,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -2630,9 +2543,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -2649,9 +2560,7 @@ describe("FreeText Editor", () => {
           await kbUndo(page);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
         })
       );
     });
@@ -2680,9 +2589,7 @@ describe("FreeText Editor", () => {
           for (let i = 1; i <= 2; i++) {
             const editorSelector = getEditorSelector(i - 1);
             await page.mouse.click(rect.x + i * 100, rect.y + i * 100);
-            await page.waitForSelector(editorSelector, {
-              visible: true,
-            });
+            await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
           }
@@ -2706,14 +2613,8 @@ describe("FreeText Editor", () => {
           // Undo.
           await kbUndo(page);
           await waitForSerialized(page, 2);
-
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
-
-          await page.waitForSelector(getEditorSelector(1), {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
+          await page.waitForSelector(getEditorSelector(1), { visible: true });
         })
       );
     });
@@ -2801,9 +2702,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello\nPDF.js\nWorld\n!!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -2837,9 +2736,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
@@ -2940,9 +2837,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
@@ -2992,9 +2887,7 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
@@ -3040,9 +2933,7 @@ describe("FreeText Editor", () => {
         let editorSelector = getEditorSelector(0);
         const data = "Hello PDF.js World !!";
         await page.mouse.click(rect.x + 100, rect.y + 100);
-        await page.waitForSelector(editorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(editorSelector, { visible: true });
         await page.type(`${editorSelector} .internal`, data);
         await commit(page);
 
@@ -3128,9 +3019,7 @@ describe("FreeText Editor", () => {
 
         editorSelector = getEditorSelector(1);
         await page.mouse.click(rect.x + 200, rect.y + 200);
-        await page.waitForSelector(editorSelector, {
-          visible: true,
-        });
+        await page.waitForSelector(editorSelector, { visible: true });
 
         const fooBar = "Foo\nBar\nOof";
         await copyToClipboard(page, {
@@ -3297,9 +3186,7 @@ describe("FreeText Editor", () => {
 
           const data = "Hello\nPDF.js\nWorld\n!!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           for (const line of data.split("\n")) {
             await page.type(`${editorSelector} .internal`, line);
             await page.keyboard.down("Shift");
@@ -3336,9 +3223,7 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
@@ -3363,9 +3248,7 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
@@ -3398,9 +3281,7 @@ describe("FreeText Editor", () => {
           let rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(editorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
@@ -3414,9 +3295,7 @@ describe("FreeText Editor", () => {
           const secondEditorSelector = getEditorSelector(1);
           const newData = "This is a new text box!";
           await page.mouse.click(rect.x + 150, rect.y + 150);
-          await page.waitForSelector(secondEditorSelector, {
-            visible: true,
-          });
+          await page.waitForSelector(secondEditorSelector, { visible: true });
           await page.type(`${secondEditorSelector} .internal`, newData);
           await commit(page);
           await waitForSerialized(page, 1);

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -138,19 +138,19 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
-          await waitForSelectedEditor(page, getEditorSelector(0));
+          await waitForSelectedEditor(page, editorSelector);
           await waitForStorageEntries(page, 1);
 
-          let content = await page.$eval(getEditorSelector(0), el =>
+          let content = await page.$eval(editorSelector, el =>
             el.innerText.trimEnd()
           );
           expect(content).withContext(`In ${browserName}`).toEqual(data);
@@ -158,11 +158,11 @@ describe("FreeText Editor", () => {
           // Edit again.
           await page.keyboard.press("Enter");
           await page.waitForSelector(
-            `${getEditorSelector(0)} .overlay:not(.enabled)`
+            `${editorSelector} .overlay:not(.enabled)`
           );
           await commit(page);
 
-          content = await page.$eval(getEditorSelector(0), el =>
+          content = await page.$eval(editorSelector, el =>
             el.innerText.trimEnd()
           );
           expect(content).withContext(`In ${browserName}`).toEqual(data);
@@ -173,19 +173,21 @@ describe("FreeText Editor", () => {
     it("must copy/paste", async () => {
       // Run sequentially to avoid clipboard issues.
       for (const [browserName, page] of pages) {
-        await selectEditor(page, getEditorSelector(0));
+        const firstEditorSelector = getEditorSelector(0);
+        await selectEditor(page, firstEditorSelector);
         await copy(page);
         await paste(page);
-        await page.waitForSelector(getEditorSelector(1), {
+        const secondEditorSelector = getEditorSelector(1);
+        await page.waitForSelector(secondEditorSelector, {
           visible: true,
         });
         await waitForStorageEntries(page, 2);
 
-        const content = await page.$eval(getEditorSelector(0), el =>
+        const content = await page.$eval(firstEditorSelector, el =>
           el.innerText.trimEnd().replaceAll("\xa0", " ")
         );
 
-        let pastedContent = await page.$eval(getEditorSelector(1), el =>
+        let pastedContent = await page.$eval(secondEditorSelector, el =>
           el.innerText.trimEnd().replaceAll("\xa0", " ")
         );
 
@@ -193,12 +195,13 @@ describe("FreeText Editor", () => {
 
         await copy(page);
         await paste(page);
-        await page.waitForSelector(getEditorSelector(2), {
+        const thirdEditorSelector = getEditorSelector(2);
+        await page.waitForSelector(thirdEditorSelector, {
           visible: true,
         });
         await waitForStorageEntries(page, 3);
 
-        pastedContent = await page.$eval(getEditorSelector(2), el =>
+        pastedContent = await page.$eval(thirdEditorSelector, el =>
           el.innerText.trimEnd().replaceAll("\xa0", " ")
         );
         expect(pastedContent).withContext(`In ${browserName}`).toEqual(content);
@@ -228,19 +231,20 @@ describe("FreeText Editor", () => {
       // Run sequentially to avoid clipboard issues.
       for (const [, page] of pages) {
         const rect = await getRect(page, ".annotationEditorLayer");
-
+        let editorSelector = getEditorSelector(3);
         const data = "Hello PDF.js World !!";
         await page.mouse.click(rect.x + 100, rect.y + 100);
-        await page.waitForSelector(getEditorSelector(3), {
+        await page.waitForSelector(editorSelector, {
           visible: true,
         });
-        await page.type(`${getEditorSelector(3)} .internal`, data);
+        await page.type(`${editorSelector} .internal`, data);
         await commit(page);
 
-        await selectEditor(page, getEditorSelector(3));
+        await selectEditor(page, editorSelector);
         await copy(page);
         await paste(page);
-        await page.waitForSelector(getEditorSelector(4), {
+        editorSelector = getEditorSelector(4);
+        await page.waitForSelector(editorSelector, {
           visible: true,
         });
 
@@ -248,7 +252,7 @@ describe("FreeText Editor", () => {
         await page.waitForFunction(
           sel => !document.querySelector(sel),
           {},
-          getEditorSelector(4)
+          editorSelector
         );
 
         for (let i = 0; i < 2; i++) {
@@ -289,15 +293,16 @@ describe("FreeText Editor", () => {
 
           expect(oldAriaOwns).withContext(`In ${browserName}`).toEqual(null);
 
+          const editorSelector = getEditorSelector(7);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(
             stacksRect.x + stacksRect.width + 1,
             stacksRect.y + stacksRect.height / 2
           );
-          await page.waitForSelector(getEditorSelector(7), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(7)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           const ariaOwns = await page.$eval(".textLayer", el => {
@@ -320,12 +325,13 @@ describe("FreeText Editor", () => {
 
           await clearAll(page);
 
+          const editorSelector = getEditorSelector(8);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(8), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(8)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           expect(await getEditors(page, "selected"))
@@ -337,7 +343,7 @@ describe("FreeText Editor", () => {
             () => !document.querySelector(".selectedEditor")
           );
 
-          await selectEditor(page, getEditorSelector(8));
+          await selectEditor(page, editorSelector);
           expect(await getEditors(page, "selected"))
             .withContext(`In ${browserName}`)
             .toEqual([8]);
@@ -469,15 +475,16 @@ describe("FreeText Editor", () => {
         const editorCenters = [];
         let lastX = rect.x + rect.width / 10;
         for (let i = 0; i < 4; i++) {
+          const editorSelector = getEditorSelector(i);
           const data = `FreeText ${i}`;
           await page.mouse.click(lastX, rect.y + rect.height / 10);
-          await page.waitForSelector(getEditorSelector(i), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(i)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
-          const editorRect = await getRect(page, getEditorSelector(i));
+          const editorRect = await getRect(page, editorSelector);
           lastX = editorRect.x + editorRect.width + 10;
           editorCenters.push({
             x: editorRect.x + editorRect.width / 2,
@@ -645,20 +652,20 @@ describe("FreeText Editor", () => {
             }
 
             const rect = await getRect(page, annotationLayerSelector);
-
+            const editorSelector = getEditorSelector(currentId);
             const data = `Hello PDF.js World !! on page ${pageNumber}`;
             expected.push(data);
             await page.mouse.click(rect.x + 100, rect.y + 100);
-            await page.waitForSelector(getEditorSelector(currentId), {
+            await page.waitForSelector(editorSelector, {
               visible: true,
             });
-            await page.type(`${getEditorSelector(currentId)} .internal`, data);
+            await page.type(`${editorSelector} .internal`, data);
             await commit(page);
 
-            await waitForSelectedEditor(page, getEditorSelector(currentId));
+            await waitForSelectedEditor(page, editorSelector);
             await waitForStorageEntries(page, currentId + 1);
 
-            const content = await page.$eval(getEditorSelector(currentId), el =>
+            const content = await page.$eval(editorSelector, el =>
               el.innerText.trimEnd()
             );
             expect(content).withContext(`In ${browserName}`).toEqual(data);
@@ -778,15 +785,15 @@ describe("FreeText Editor", () => {
           for (let step = 0; step < 3; step++) {
             await firstPageOnTop(page);
             const rect = await getRect(page, ".annotationEditorLayer");
-
+            const editorSelector = getEditorSelector(currentId);
             const data = `Hello ${step}`;
             const x = Math.max(rect.x + 0.1 * rect.width, 10);
             const y = Math.max(rect.y + 0.1 * rect.height, 10);
             await page.mouse.click(x, y);
-            await page.waitForSelector(getEditorSelector(currentId), {
+            await page.waitForSelector(editorSelector, {
               visible: true,
             });
-            await page.type(`${getEditorSelector(currentId)} .internal`, data);
+            await page.type(`${editorSelector} .internal`, data);
             await commit(page);
 
             const promise = await waitForAnnotationEditorLayer(page);
@@ -903,19 +910,20 @@ describe("FreeText Editor", () => {
           let editorIds = await getEditors(page, "freeText");
           expect(editorIds.length).withContext(`In ${browserName}`).toEqual(6);
 
-          const editorRect = await getRect(page, getEditorSelector(0));
-          await selectEditor(page, getEditorSelector(0), /* count = */ 2);
+          const editorSelector = getEditorSelector(0);
+          const editorRect = await getRect(page, editorSelector);
+          await selectEditor(page, editorSelector, /* count = */ 2);
           await kbGoToEnd(page);
           await page.waitForFunction(
             sel =>
               document.getSelection().anchorOffset ===
               document.querySelector(sel).innerText.length,
             {},
-            `${getEditorSelector(0)} .internal`
+            `${editorSelector} .internal`
           );
 
           await page.type(
-            `${getEditorSelector(0)} .internal`,
+            `${editorSelector} .internal`,
             " and edited in Firefox"
           );
           await commit(page);
@@ -1079,12 +1087,13 @@ describe("FreeText Editor", () => {
           let editorIds = await getEditors(page, "freeText");
           expect(editorIds.length).withContext(`In ${browserName}`).toEqual(6);
 
-          await selectEditor(page, getEditorSelector(3));
+          const editorSelector = getEditorSelector(3);
+          await selectEditor(page, editorSelector);
           await page.keyboard.press("Backspace");
           await page.waitForFunction(
             sel => !document.querySelector(sel),
             {},
-            getEditorSelector(3)
+            editorSelector
           );
 
           const serialized = await getSerialized(page);
@@ -1290,13 +1299,13 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           // Make Chrome happy.
@@ -1401,13 +1410,13 @@ describe("FreeText Editor", () => {
             }
 
             const rect = await getRect(page, annotationLayerSelector);
-
+            const editorSelector = getEditorSelector(currentId);
             const data = `Hello PDF.js World !! on page ${pageNumber}`;
             await page.mouse.click(rect.x + 100, rect.y + 100);
-            await page.waitForSelector(getEditorSelector(currentId), {
+            await page.waitForSelector(editorSelector, {
               visible: true,
             });
-            await page.type(`${getEditorSelector(currentId)} .internal`, data);
+            await page.type(`${editorSelector} .internal`, data);
             await commit(page);
 
             currentId += 1;
@@ -1745,13 +1754,13 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           await page.focus("#editorFreeTextColor");
@@ -1760,14 +1769,14 @@ describe("FreeText Editor", () => {
           await page.waitForFunction(
             sel => !document.querySelector(sel),
             {},
-            getEditorSelector(0)
+            editorSelector
           );
 
           await kbRedo(page);
           await page.waitForFunction(
             sel => !!document.querySelector(sel),
             {},
-            getEditorSelector(0)
+            editorSelector
           );
         })
       );
@@ -1964,14 +1973,14 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
-          await cancelFocusIn(page, getEditorSelector(0));
+          await page.type(`${editorSelector} .internal`, data);
+          await cancelFocusIn(page, editorSelector);
           await commit(page);
 
           const oneToFourteen = Array.from(new Array(14).keys(), x => x + 1);
@@ -2020,58 +2029,60 @@ describe("FreeText Editor", () => {
 
           let rect = await getRect(page, ".annotationEditorLayer");
 
+          const firstEditorSelector = getEditorSelector(0);
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(firstEditorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, "A");
+          await page.type(`${firstEditorSelector} .internal`, "A");
           await commit(page);
 
           // Create a new editor.
-          rect = await getRect(page, getEditorSelector(0));
+          rect = await getRect(page, firstEditorSelector);
+          const secondEditorSelector = getEditorSelector(1);
           await page.mouse.click(
             rect.x + 5 * rect.width,
             rect.y + 5 * rect.height
           );
-          await page.waitForSelector(getEditorSelector(1), {
+          await page.waitForSelector(secondEditorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(1)} .internal`, "B");
+          await page.type(`${secondEditorSelector} .internal`, "B");
           await commit(page);
 
           // Select the second editor.
-          await selectEditor(page, getEditorSelector(1));
+          await selectEditor(page, secondEditorSelector);
 
-          const pos = n =>
+          const pos = selector =>
             page.evaluate(sel => {
               const editor = document.querySelector(sel);
               return Array.prototype.indexOf.call(
                 editor.parentNode.childNodes,
                 editor
               );
-            }, getEditorSelector(n));
+            }, selector);
 
-          expect(await pos(0))
+          expect(await pos(firstEditorSelector))
             .withContext(`In ${browserName}`)
             .toEqual(0);
-          expect(await pos(1))
+          expect(await pos(secondEditorSelector))
             .withContext(`In ${browserName}`)
             .toEqual(1);
 
-          const { y: y0, height } = await getRect(page, getEditorSelector(0));
-          const editorSelector = getEditorSelector(1);
+          const { y: y0, height } = await getRect(page, firstEditorSelector);
+          const editorSelector = secondEditorSelector;
           while ((await getRect(page, editorSelector)).y > y0 - height) {
             await moveEditor(page, editorSelector, 1, () => kbBigMoveUp(page));
           }
 
           // The editor must be moved in the DOM and potentially the focus
           // will be lost, hence there's a callback will get back the focus.
-          await page.waitForSelector(`${getEditorSelector(1)}:focus`);
+          await page.waitForSelector(`${secondEditorSelector}:focus`);
 
-          expect(await pos(0))
+          expect(await pos(firstEditorSelector))
             .withContext(`In ${browserName}`)
             .toEqual(1);
-          expect(await pos(1))
+          expect(await pos(secondEditorSelector))
             .withContext(`In ${browserName}`)
             .toEqual(0);
         })
@@ -2161,14 +2172,14 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
-          await cancelFocusIn(page, getEditorSelector(0));
+          await page.type(`${editorSelector} .internal`, data);
+          await cancelFocusIn(page, editorSelector);
           await commit(page);
 
           await page.evaluate(() => {
@@ -2216,20 +2227,20 @@ describe("FreeText Editor", () => {
 
           const page1Selector = `.page[data-page-number = "1"] > .annotationEditorLayer.freetextEditing`;
           let rect = await getRect(page, page1Selector);
-          const editorSelector = getEditorSelector(0);
+          const firstEditorSelector = getEditorSelector(0);
           await page.mouse.click(rect.x + 10, rect.y + 10);
-          await page.waitForSelector(editorSelector, {
+          await page.waitForSelector(firstEditorSelector, {
             visible: true,
           });
-          await page.type(`${editorSelector} .internal`, "Hello");
-          await cancelFocusIn(page, editorSelector);
+          await page.type(`${firstEditorSelector} .internal`, "Hello");
+          await cancelFocusIn(page, firstEditorSelector);
           await commit(page);
 
           // Unselect.
-          await unselectEditor(page, editorSelector);
+          await unselectEditor(page, firstEditorSelector);
 
           // Select the editor created previously.
-          await selectEditor(page, editorSelector);
+          await selectEditor(page, firstEditorSelector);
 
           // Go to the last page.
           await scrollIntoView(page, `.page[data-page-number = "14"]`);
@@ -2241,11 +2252,12 @@ describe("FreeText Editor", () => {
           });
 
           rect = await getRect(page, page14Selector);
+          const secondEditorSelector = getEditorSelector(1);
           await page.mouse.click(rect.x + 10, rect.y + 10);
-          await page.waitForSelector(getEditorSelector(1), {
+          await page.waitForSelector(secondEditorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(1)} .internal`, "World");
+          await page.type(`${secondEditorSelector} .internal`, "World");
           await commit(page);
 
           for (let i = 0; i < 13; i++) {
@@ -2259,11 +2271,11 @@ describe("FreeText Editor", () => {
             });
           }
 
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(firstEditorSelector, {
             visible: true,
           });
-          await selectEditor(page, getEditorSelector(0));
-          const content = await page.$eval(getEditorSelector(0), el =>
+          await selectEditor(page, firstEditorSelector);
+          const content = await page.$eval(firstEditorSelector, el =>
             el.innerText.trimEnd()
           );
           expect(content).withContext(`In ${browserName}`).toEqual("Hello");
@@ -2330,7 +2342,7 @@ describe("FreeText Editor", () => {
           await kbUndo(page);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
         })
@@ -2355,6 +2367,7 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const parentId = "p3R_mc8";
+          const editorSelector = getEditorSelector(0);
           const rect = await page.evaluate(id => {
             const parent = document.getElementById(id);
             let span = null;
@@ -2371,10 +2384,10 @@ describe("FreeText Editor", () => {
             rect.x + rect.width + 5,
             rect.y + rect.height / 2
           );
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, "Hello Wolrd");
+          await page.type(`${editorSelector} .internal`, "Hello Wolrd");
           await commit(page);
 
           await waitForStorageEntries(page, 1);
@@ -2403,19 +2416,19 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          const internalEditorSelector = `${getEditorSelector(0)} .internal`;
+          const internalEditorSelector = `${editorSelector} .internal`;
           await page.type(internalEditorSelector, data);
           await commit(page);
 
-          await page.click(getEditorSelector(0), { count: 2 });
+          await page.click(editorSelector, { count: 2 });
           await page.waitForSelector(
-            `${getEditorSelector(0)} .overlay:not(.enabled)`
+            `${editorSelector} .overlay:not(.enabled)`
           );
           await page.click(internalEditorSelector, {
             count: 3,
@@ -2482,7 +2495,7 @@ describe("FreeText Editor", () => {
           // Unselect.
           await unselectEditor(page, editorSelector);
 
-          content = await page.$eval(getEditorSelector(1), el =>
+          content = await page.$eval(editorSelector, el =>
             el.innerText.trimEnd()
           );
 
@@ -2509,7 +2522,7 @@ describe("FreeText Editor", () => {
           // Unselect.
           await unselectEditor(page, editorSelector);
 
-          let content = await page.$eval(getEditorSelector(2), el =>
+          let content = await page.$eval(editorSelector, el =>
             el.innerText.trimEnd()
           );
 
@@ -2558,13 +2571,13 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           let handle = await createPromise(page, resolve => {
@@ -2588,7 +2601,7 @@ describe("FreeText Editor", () => {
           );
           expect(content).withContext(`In ${browserName}`).toEqual("");
 
-          content = await page.$eval(getEditorSelector(0), el =>
+          content = await page.$eval(editorSelector, el =>
             el.innerText.trimEnd()
           );
           expect(content).withContext(`In ${browserName}`).toEqual(data);
@@ -2614,21 +2627,21 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           // Delete it in using the button.
-          await page.click(`${getEditorSelector(0)} button.delete`);
+          await page.click(`${editorSelector} button.delete`);
           await page.waitForFunction(
             sel => !document.querySelector(sel),
             {},
-            getEditorSelector(0)
+            editorSelector
           );
           await waitForStorageEntries(page, 0);
 
@@ -2636,7 +2649,7 @@ describe("FreeText Editor", () => {
           await kbUndo(page);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
         })
@@ -2675,17 +2688,18 @@ describe("FreeText Editor", () => {
           }
 
           // Select the editor created previously.
-          await selectEditor(page, getEditorSelector(0));
+          const editorSelector = getEditorSelector(0);
+          await selectEditor(page, editorSelector);
 
           await selectAll(page);
 
           // Delete it in using the button.
-          await page.focus(`${getEditorSelector(0)} button.delete`);
+          await page.focus(`${editorSelector} button.delete`);
           await page.keyboard.press("Enter");
           await page.waitForFunction(
             sel => !document.querySelector(sel),
             {},
-            getEditorSelector(0)
+            editorSelector
           );
           await waitForStorageEntries(page, 0);
 
@@ -2693,7 +2707,7 @@ describe("FreeText Editor", () => {
           await kbUndo(page);
           await waitForSerialized(page, 2);
 
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
 
@@ -2720,8 +2734,10 @@ describe("FreeText Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToFreeText(page);
-          await page.click(getEditorSelector(0), { count: 2 });
-          await page.type(`${getEditorSelector(0)} .internal`, "C");
+
+          const editorSelector = getEditorSelector(0);
+          await page.click(editorSelector, { count: 2 });
+          await page.type(`${editorSelector} .internal`, "C");
 
           await switchToFreeText(page, /* disable = */ true);
 
@@ -2749,8 +2765,10 @@ describe("FreeText Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToFreeText(page);
-          await page.click(getEditorSelector(0), { count: 2 });
-          await page.type(`${getEditorSelector(0)} .internal`, "Z");
+
+          const editorSelector = getEditorSelector(0);
+          await page.click(editorSelector, { count: 2 });
+          await page.type(`${editorSelector} .internal`, "Z");
 
           await switchToFreeText(page, /* disable = */ true);
 
@@ -2780,13 +2798,13 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello\nPDF.js\nWorld\n!!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           await waitForSerialized(page, 1);
@@ -2816,13 +2834,13 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           await page.evaluate(() => {
@@ -2919,18 +2937,18 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(`${getEditorSelector(0)} button.delete`);
-          await page.click(`${getEditorSelector(0)} button.delete`);
+          await page.waitForSelector(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`);
           await waitForSerialized(page, 0);
 
           const twoToFourteen = Array.from(new Array(13).keys(), n => n + 2);
@@ -2948,7 +2966,7 @@ describe("FreeText Editor", () => {
             await scrollIntoView(page, pageSelector);
           }
 
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(editorSelector);
         })
       );
     });
@@ -2971,18 +2989,18 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const rect = await getRect(page, ".annotationEditorLayer");
-
+          const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
-          await page.waitForSelector(getEditorSelector(0), {
+          await page.waitForSelector(editorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(0)} .internal`, data);
+          await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
-          await page.waitForSelector(`${getEditorSelector(0)} button.delete`);
-          await page.click(`${getEditorSelector(0)} button.delete`);
+          await page.waitForSelector(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`);
           await waitForSerialized(page, 0);
 
           const twoToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
@@ -2995,7 +3013,7 @@ describe("FreeText Editor", () => {
 
           await kbUndo(page);
           await waitForSerialized(page, 1);
-          await page.waitForSelector(getEditorSelector(0));
+          await page.waitForSelector(editorSelector);
         })
       );
     });
@@ -3393,12 +3411,13 @@ describe("FreeText Editor", () => {
 
           await page.waitForSelector("#editorUndoBar:not([hidden])");
           rect = await getRect(page, ".annotationEditorLayer");
+          const secondEditorSelector = getEditorSelector(1);
           const newData = "This is a new text box!";
           await page.mouse.click(rect.x + 150, rect.y + 150);
-          await page.waitForSelector(getEditorSelector(1), {
+          await page.waitForSelector(secondEditorSelector, {
             visible: true,
           });
-          await page.type(`${getEditorSelector(1)} .internal`, newData);
+          await page.type(`${secondEditorSelector} .internal`, newData);
           await commit(page);
           await waitForSerialized(page, 1);
           await page.waitForSelector("#editorUndoBar", { hidden: true });

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -105,9 +105,7 @@ describe("Highlight Editor", () => {
 
           await page.waitForSelector(
             `.page[data-page-number = "1"] svg.highlight`,
-            {
-              visible: true,
-            }
+            { visible: true }
           );
         })
       );

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -1751,9 +1751,7 @@ describe("Stamp Editor", () => {
           const pageOneSelector = `.page[data-page-number = "1"]`;
           const pageTwoSelector = `.page[data-page-number = "2"]`;
           await scrollIntoView(page, pageTwoSelector);
-          await page.waitForSelector(pageOneSelector, {
-            visible: false,
-          });
+          await page.waitForSelector(pageOneSelector, { visible: false });
 
           await switchToStamp(page);
           await scrollIntoView(page, pageOneSelector);


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Fixes a part of #19065.