### PR TITLE
[GENERIC viewer] Add Fluent `PLATFORM` function (PR 19414 follow-up)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -632,18 +632,24 @@ class FeatureTest {
     if (
       (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
       (typeof navigator !== "undefined" &&
-        typeof navigator?.platform === "string")
+        typeof navigator?.platform === "string" &&
+        typeof navigator?.userAgent === "string")
     ) {
+      const { platform, userAgent } = navigator;
+
       return shadow(this, "platform", {
-        isMac: navigator.platform.includes("Mac"),
-        isWindows: navigator.platform.includes("Win"),
+        isAndroid: userAgent.includes("Android"),
+        isLinux: platform.includes("Linux"),
+        isMac: platform.includes("Mac"),
+        isWindows: platform.includes("Win"),
         isFirefox:
           (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-          (typeof navigator?.userAgent === "string" &&
-            navigator.userAgent.includes("Firefox")),
+          userAgent.includes("Firefox"),
       });
     }
     return shadow(this, "platform", {
+      isAndroid: false,
+      isLinux: false,
       isMac: false,
       isWindows: false,
       isFirefox: false,

--- a/web/genericl10n.js
+++ b/web/genericl10n.js
@@ -15,14 +15,33 @@
 
 /** @typedef {import("./interfaces").IL10n} IL10n */
 
+import { FeatureTest, fetchData } from "pdfjs-lib";
 import { FluentBundle, FluentResource } from "fluent-bundle";
 import { DOMLocalization } from "fluent-dom";
-import { fetchData } from "pdfjs-lib";
 import { L10n } from "./l10n.js";
+
+function PLATFORM() {
+  const { isAndroid, isLinux, isMac, isWindows } = FeatureTest.platform;
+  if (isLinux) {
+    return "linux";
+  }
+  if (isWindows) {
+    return "windows";
+  }
+  if (isMac) {
+    return "macos";
+  }
+  if (isAndroid) {
+    return "android";
+  }
+  return "other";
+}
 
 function createBundle(lang, text) {
   const resource = new FluentResource(text);
-  const bundle = new FluentBundle(lang);
+  const bundle = new FluentBundle(lang, {
+    functions: { PLATFORM },
+  });
   const errors = bundle.addResource(resource);
   if (errors.length) {
     console.error("L10n errors", errors);


### PR DESCRIPTION
This patch extends the `FeatureTest.platform` getter to provide the necessary information, and uses that one to implement a Fluent `PLATFORM` function based on: https://searchfox.org/mozilla-central/rev/d1fbe983fb7720f0a4aca0e748817af11c1a374e/intl/l10n/rust/fluent-ffi/src/bundle.rs#81-98