### PR TITLE
Combine the main-thread message handlers for CMap-, StandardFontData-, and Wasm-files

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -386,13 +386,16 @@ class PartialEvaluator {
 
     if (this.options.cMapUrl !== null) {
       // Only compressed CMaps are (currently) supported here.
-      const cMapData = await fetchBinaryData(
-        `${this.options.cMapUrl}${name}.bcmap`
-      );
-      data = { cMapData, isCompressed: true };
+      data = {
+        cMapData: await fetchBinaryData(`${this.options.cMapUrl}${name}.bcmap`),
+        isCompressed: true,
+      };
     } else {
       // Get the data on the main-thread instead.
-      data = await this.handler.sendWithPromise("FetchBuiltInCMap", { name });
+      data = await this.handler.sendWithPromise("FetchBinaryData", {
+        type: "cMapReaderFactory",
+        name,
+      });
     }
     // Cache the CMap data, to avoid fetching it repeatedly.
     this.builtInCMapCache.set(name, data);
@@ -427,7 +430,8 @@ class PartialEvaluator {
         );
       } else {
         // Get the data on the main-thread instead.
-        data = await this.handler.sendWithPromise("FetchStandardFontData", {
+        data = await this.handler.sendWithPromise("FetchBinaryData", {
+          type: "standardFontDataFactory",
           filename,
         });
       }

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -49,9 +49,10 @@ class JpxImage {
         if (this.#wasmUrl !== null) {
           this.#buffer = await fetchBinaryData(`${this.#wasmUrl}${filename}`);
         } else {
-          this.#buffer = await this.#handler.sendWithPromise("FetchWasm", {
-            filename,
-          });
+          this.#buffer = await this.#handler.sendWithPromise(
+            "FetchBinaryData",
+            { type: "wasmFactory", filename }
+          );
         }
       }
       const results = await WebAssembly.instantiate(this.#buffer, imports);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2881,49 +2881,21 @@ class WorkerTransport {
       });
     });
 
-    messageHandler.on("FetchBuiltInCMap", async data => {
+    messageHandler.on("FetchBinaryData", async data => {
       if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-        throw new Error("Not implemented: FetchBuiltInCMap");
+        throw new Error("Not implemented: FetchBinaryData");
       }
       if (this.destroyed) {
         throw new Error("Worker was destroyed.");
       }
-      if (!this.cMapReaderFactory) {
-        throw new Error(
-          "CMapReaderFactory not initialized, see the `useWorkerFetch` parameter."
-        );
-      }
-      return this.cMapReaderFactory.fetch(data);
-    });
+      const factory = this[data.type];
 
-    messageHandler.on("FetchStandardFontData", async data => {
-      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-        throw new Error("Not implemented: FetchStandardFontData");
-      }
-      if (this.destroyed) {
-        throw new Error("Worker was destroyed.");
-      }
-      if (!this.standardFontDataFactory) {
+      if (!factory) {
         throw new Error(
-          "StandardFontDataFactory not initialized, see the `useWorkerFetch` parameter."
+          `${data.type} not initialized, see the \`useWorkerFetch\` parameter.`
         );
       }
-      return this.standardFontDataFactory.fetch(data);
-    });
-
-    messageHandler.on("FetchWasm", async data => {
-      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-        throw new Error("Not implemented: FetchWasm");
-      }
-      if (this.destroyed) {
-        throw new Error("Worker was destroyed.");
-      }
-      if (!this.wasmFactory) {
-        throw new Error(
-          "WasmFactory not initialized, see the `useWorkerFetch` parameter."
-        );
-      }
-      return this.wasmFactory.fetch(data);
+      return factory.fetch(data);
     });
   }
 


### PR DESCRIPTION
Currently we have three separate and virtually identical message handlers for this data, which can easily be combined into a single message handler instead.