### PR TITLE
Check for the correct link-id prefix in "must not add links when unnecessary" integration-test (PR 19110 follow-up)

### DIFF
--- a/test/integration/autolinker_spec.mjs
+++ b/test/integration/autolinker_spec.mjs
@@ -82,7 +82,7 @@ describe("autolinker", function () {
           linkIds.forEach(id =>
             expect(id)
               .withContext(`In ${browserName}`)
-              .not.toContain("added_link_")
+              .not.toContain("inferred_link_")
           );
         })
       );


### PR DESCRIPTION
Currently this test-case would never fail, even if the actual implementation was broken, since it checks for a link-id prefix that we're not using.