### PR TITLE
[api-minor] Update the minimum supported Google Chrome version to 110

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -80,7 +80,7 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 
 const ENV_TARGETS = [
   "last 2 versions",
-  "Chrome >= 103",
+  "Chrome >= 110",
   "Firefox ESR",
   "Safari >= 16.4",
   "Node >= 20",


### PR DESCRIPTION
This patch updates the minimum supported browsers as follows:
 - Google Chrome 110, which was released on 2023-02-07; see https://chromereleases.googleblog.com/2023/02/stable-channel-update-for-desktop.html

Note that nowadays we usually try, where feasible and possible, to support browsers that are about two years old. By limiting support to only "recent" browsers we reduce the risk of holding back improvements of the *built-in* Firefox PDF Viewer, and also (significantly) reduce the maintenance/support burden for the PDF.js contributors.

*Please note:* As always, the minimum supported browser version assumes that a `legacy`-build of the PDF.js library is being used; see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support