### PR TITLE
Replace a couple of loops with `TypedArray.prototype.fill()`

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -252,12 +252,9 @@ class PDFFunction {
       // Building the cube vertices: its part and sample index
       // http://rjwagner49.com/Mathematics/Interpolation.pdf
       const cubeVertices = 1 << inputSize;
-      const cubeN = new Float64Array(cubeVertices);
+      const cubeN = new Float64Array(cubeVertices).fill(1);
       const cubeVertex = new Uint32Array(cubeVertices);
       let i, j;
-      for (j = 0; j < cubeVertices; j++) {
-        cubeN[j] = 1;
-      }
 
       let k = outputSize,
         pos = 1;

--- a/src/core/jbig2.js
+++ b/src/core/jbig2.js
@@ -805,9 +805,7 @@ function decodeTextRegion(
   for (i = 0; i < height; i++) {
     row = new Uint8Array(width);
     if (defaultPixelValue) {
-      for (let j = 0; j < width; j++) {
-        row[j] = defaultPixelValue;
-      }
+      row.fill(defaultPixelValue);
     }
     bitmap.push(row);
   }
@@ -1041,9 +1039,7 @@ function decodeHalftoneRegion(
   for (i = 0; i < regionHeight; i++) {
     row = new Uint8Array(regionWidth);
     if (defaultPixelValue) {
-      for (j = 0; j < regionWidth; j++) {
-        row[j] = defaultPixelValue;
-      }
+      row.fill(defaultPixelValue);
     }
     regionBitmap.push(row);
   }


### PR DESCRIPTION
When you want to initialize a TypedArray with a non-zero value for all elements the `fill`-method is simpler than manually looping through it.