### PR TITLE
Check that the annotationLayer is still active before injecting inferred links (PR 19110 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1113,7 +1113,7 @@ class PDFPageView {
 
           if (this.#enableAutoLinking) {
             await textLayerPromise;
-            this.annotationLayer.injectLinkAnnotations({
+            this.annotationLayer?.injectLinkAnnotations({
               inferredLinks: Autolinker.processLinks(this),
               viewport: this.viewport,
               structTreeLayer: this.structTreeLayer,


### PR DESCRIPTION
This issue is quite difficult to trigger reliably, however it's possible for rendering to have been aborted and thus for the annotationLayer to have been removed once we're invoking `injectLinkAnnotations`. In that case, an Error is thrown[1].

The way that I'm able to *intermittently* trigger this is by:
 - Loading http://localhost:8888/web/viewer.html?file=/test/pdfs/pdf.pdf#disableHistory=true
 - Enable "Wrapped Srolling" mode.
 - Quickly zoom out, to the minimum zoom level.

---
[1]
```
renderView: TypeError: can't access property "injectLinkAnnotations", this.annotationLayer is null
    resultPromise http://localhost:8888/web/pdf_page_view.js:1116
    draw http://localhost:8888/web/pdf_page_view.js:1099
    renderView http://localhost:8888/web/pdf_rendering_queue.js:196
    forceRendering http://localhost:8888/web/pdf_viewer.js:1849
    promise callback*forceRendering http://localhost:8888/web/pdf_viewer.js:1848
    renderHighestPriority http://localhost:8888/web/pdf_rendering_queue.js:79
    renderView http://localhost:8888/web/pdf_rendering_queue.js:198
    renderView http://localhost:8888/web/pdf_rendering_queue.js:197
    forceRendering http://localhost:8888/web/pdf_viewer.js:1849
    promise callback*forceRendering http://localhost:8888/web/pdf_viewer.js:1848
    renderHighestPriority http://localhost:8888/web/pdf_rendering_queue.js:79
    renderView http://localhost:8888/web/pdf_rendering_queue.js:198
    renderView http://localhost:8888/web/pdf_rendering_queue.js:197
    forceRendering http://localhost:8888/web/pdf_viewer.js:1849
    promise callback*forceRendering http://localhost:8888/web/pdf_viewer.js:1848
    renderHighestPriority http://localhost:8888/web/pdf_rendering_queue.js:79
    renderView http://localhost:8888/web/pdf_rendering_queue.js:198
    renderView http://localhost:8888/web/pdf_rendering_queue.js:197
    forceRendering http://localhost:8888/web/pdf_viewer.js:1849
    promise callback*forceRendering http://localhost:8888/web/pdf_viewer.js:1848
    renderHighestPriority http://localhost:8888/web/pdf_rendering_queue.js:79
    renderView http://localhost:8888/web/pdf_rendering_queue.js:198
    renderView http://localhost:8888/web/pdf_rendering_queue.js:197
    forceRendering http://localhost:8888/web/pdf_viewer.js:1849
    promise callback*forceRendering http://localhost:8888/web/pdf_viewer.js:1848
    renderHighestPriority http://localhost:8888/web/pdf_rendering_queue.js:79
    update http://localhost:8888/web/pdf_viewer.js:1677
    onScaleChanging http://localhost:8888/web/app.js:2550
    dispatch http://localhost:8888/web/event_utils.js:115
    #setScaleUpdatePages http://localhost:8888/web/pdf_viewer.js:1363
    #setScale http://localhost:8888/web/pdf_viewer.js:1389
    updateScale http://localhost:8888/web/pdf_viewer.js:2263
    updateZoom http://localhost:8888/web/app.js:814
    zoomOut http://localhost:8888/web/app.js:827
    onKeyDown http://localhost:8888/web/app.js:2780
    bindWindowEvents http://localhost:8888/web/app.js:2097
    initialize http://localhost:8888/web/app.js:262
    run http://localhost:8888/web/app.js:704
    webViewerLoad http://localhost:8888/web/viewer.js:294
    <anonymous> http://localhost:8888/web/viewer.js:305
pdf_rendering_queue.js:204:21
```