### PR TITLE
Create the `borderStyle` of inferred links lazily (PR 19110 follow-up)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -3254,6 +3254,8 @@ class AnnotationLayer {
       parent: this,
     };
     for (const data of annotations) {
+      data.borderStyle ||= AnnotationLayer._defaultBorderStyle;
+
       elementParams.data = data;
       const element = AnnotationElementFactory.create(elementParams);
 
@@ -3328,6 +3330,24 @@ class AnnotationLayer {
 
   getEditableAnnotation(id) {
     return this.#editableAnnotations.get(id);
+  }
+
+  /**
+   * @private
+   */
+  static get _defaultBorderStyle() {
+    return shadow(
+      this,
+      "_defaultBorderStyle",
+      Object.freeze({
+        width: 1,
+        rawWidth: 1,
+        style: AnnotationBorderStyleType.SOLID,
+        dashArray: [3],
+        horizontalCornerRadius: 0,
+        verticalCornerRadius: 0,
+      })
+    );
   }
 }
 

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -24,7 +24,6 @@
 
 import {
   AbortException,
-  AnnotationBorderStyleType,
   AnnotationEditorParamsType,
   AnnotationEditorType,
   AnnotationMode,
@@ -92,7 +91,6 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING || GENERIC")) {
 
 export {
   AbortException,
-  AnnotationBorderStyleType,
   AnnotationEditorLayer,
   AnnotationEditorParamsType,
   AnnotationEditorType,

--- a/test/unit/pdf_spec.js
+++ b/test/unit/pdf_spec.js
@@ -15,7 +15,6 @@
 
 import {
   AbortException,
-  AnnotationBorderStyleType,
   AnnotationEditorParamsType,
   AnnotationEditorType,
   AnnotationMode,
@@ -69,7 +68,6 @@ import { XfaLayer } from "../../src/display/xfa_layer.js";
 
 const expectedAPI = Object.freeze({
   AbortException,
-  AnnotationBorderStyleType,
   AnnotationEditorLayer,
   AnnotationEditorParamsType,
   AnnotationEditorType,

--- a/web/autolinker.js
+++ b/web/autolinker.js
@@ -13,12 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  AnnotationBorderStyleType,
-  AnnotationType,
-  createValidAbsoluteUrl,
-  Util,
-} from "pdfjs-lib";
+import { AnnotationType, createValidAbsoluteUrl, Util } from "pdfjs-lib";
 import { getOriginalIndex, normalize } from "./pdf_find_controller.js";
 
 function DOMRectToPDF({ width, height, left, top }, pdfPageView) {
@@ -89,15 +84,9 @@ function createLinkAnnotation({ url, index, length }, pdfPageView, id) {
     annotationType: AnnotationType.LINK,
     rotation: 0,
     ...calculateLinkPosition(range, pdfPageView),
-    // This is just the default for AnnotationBorderStyle.
-    borderStyle: {
-      width: 1,
-      rawWidth: 1,
-      style: AnnotationBorderStyleType.SOLID,
-      dashArray: [3],
-      horizontalCornerRadius: 0,
-      verticalCornerRadius: 0,
-    },
+    // Populated in the annotationLayer to avoid unnecessary object creation,
+    // since most inferred links overlap existing LinkAnnotations:
+    borderStyle: null,
   };
 }
 

--- a/web/pdfjs.js
+++ b/web/pdfjs.js
@@ -15,7 +15,6 @@
 
 const {
   AbortException,
-  AnnotationBorderStyleType,
   AnnotationEditorLayer,
   AnnotationEditorParamsType,
   AnnotationEditorType,
@@ -65,7 +64,6 @@ const {
 
 export {
   AbortException,
-  AnnotationBorderStyleType,
   AnnotationEditorLayer,
   AnnotationEditorParamsType,
   AnnotationEditorType,


### PR DESCRIPTION
Given that most inferred links will overlap existing LinkAnnotations, creating a lot of unused `borderStyle` objects seem unnecessary.
Hence we can move that into the `AnnotationLayer.prototype.addLinkAnnotations` method instead, which also allows us to slightly reduce the API-surface.