### PR TITLE
Catch and ignore any errors during auto-linking parsing (PR 19110 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1112,12 +1112,17 @@ class PDFPageView {
           await this.#renderAnnotationLayer();
 
           if (this.#enableAutoLinking) {
-            await textLayerPromise;
-            this.annotationLayer?.injectLinkAnnotations({
-              inferredLinks: Autolinker.processLinks(this),
-              viewport: this.viewport,
-              structTreeLayer: this.structTreeLayer,
-            });
+            try {
+              await textLayerPromise;
+
+              this.annotationLayer?.injectLinkAnnotations({
+                inferredLinks: Autolinker.processLinks(this),
+                viewport: this.viewport,
+                structTreeLayer: this.structTreeLayer,
+              });
+            } catch (ex) {
+              console.error("enableAutoLinking:", ex);
+            }
           }
         }
 


### PR DESCRIPTION
While investigating a bug, that I've not yet had time to fully investigate and report, I found that if there's ever an error thrown from the `Autolinker` class it'll prevent the annotationEditorLayer from rendering *and* the renderTask itself will be treated as having failed.