### PR TITLE
Fix autolinking errors

### DIFF
--- a/test/unit/autolinker_spec.js
+++ b/test/unit/autolinker_spec.js
@@ -87,6 +87,9 @@ describe("autolinker", function () {
         "CAP.cap@Gmail.Com", // Keep the original case.
         "mailto:CAP.cap@Gmail.Com",
       ],
+      ["partl@mail.boku.ac.at", "mailto:partl@mail.boku.ac.at"],
+      ["Irene.Hyna@bmwf.ac.at", "mailto:Irene.Hyna@bmwf.ac.at"],
+      ["<hi@foo.bar.baz>", "mailto:hi@foo.bar.baz"],
     ]);
   });
 
@@ -140,6 +143,7 @@ describe("autolinker", function () {
         "http//[00:00:00:00:00:00", // Invalid IPv6 address.
         "http//[]", // Empty IPv6 address.
         "abc.example.com", // URL without scheme.
+        "JD?M$0QP)lKn06l1apKDC@\\qJ4B!!(5m+j.7F790m", // Not a valid email.
       ].join("\n")
     );
     expect(matches.length).toEqual(0);

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -77,6 +77,8 @@ class AnnotationLayerBuilder {
 
   #eventAbortController = null;
 
+  #linksInjected = false;
+
   /**
    * @param {AnnotationLayerBuilderOptions} options
    */
@@ -235,9 +237,10 @@ class AnnotationLayerBuilder {
         "`render` method must be called before `injectLinkAnnotations`."
       );
     }
-    if (this._cancelled) {
+    if (this._cancelled || this.#linksInjected) {
       return;
     }
+    this.#linksInjected = true;
 
     const newLinks = this.#annotations.length
       ? this.#checkInferredLinks(inferredLinks)


### PR DESCRIPTION
This commit fixes some edge cases in the autolinking logic and adds tests for them. It fixes the issues with regexp, email validation as well as link annotations being injected multiple times on zoom.

Fixes: https://github.com/mozilla/pdf.js/issues/19462