### PR TITLE
Removed incorrect/useless argument line

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3020,7 +3020,6 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
         evaluator,
         task,
         intent,
-        false, // we use normalAppearance to render the button
         annotationStorage
       );
     }


### PR DESCRIPTION
I found this line that calls parent function in widgetAnnotation with five arguments instead of four. "false" is passed instead of annotationStorage. Is this expected/normal ? 

annotationStorage does not seem to be used in the function anyway but I thought I might report.