### PR TITLE
Slightly shorten an `Array.from` usage in the `SignatureManager` class

### DIFF
--- a/web/signature_manager.js
+++ b/web/signature_manager.js
@@ -739,12 +739,8 @@ class SignatureManager {
         .then(async signatures => [
           signatures,
           await Promise.all(
-            Array.from(
-              signatures
-                .values()
-                .map(({ signatureData }) =>
-                  SignatureExtractor.decompressSignature(signatureData)
-                )
+            Array.from(signatures.values(), ({ signatureData }) =>
+              SignatureExtractor.decompressSignature(signatureData)
             )
           ),
         ]);


### PR DESCRIPTION
This should be equivalent to the old code, and besides being ever so slightly shorter I'm also finding it a little bit easier to read at a glance.