### PR TITLE
Add a new `closeIfActive` method in the `OverlayManager` class

### DIFF
--- a/web/alt_text_manager.js
+++ b/web/alt_text_manager.js
@@ -245,9 +245,7 @@ class AltTextManager {
   }
 
   #finish() {
-    if (this.#overlayManager.active === this.#dialog) {
-      this.#overlayManager.close(this.#dialog);
-    }
+    this.#overlayManager.closeIfActive(this.#dialog);
   }
 
   #close() {

--- a/web/new_alt_text_manager.js
+++ b/web/new_alt_text_manager.js
@@ -440,9 +440,7 @@ class NewAltTextManager {
   }
 
   #finish() {
-    if (this.#overlayManager.active === this.#dialog) {
-      this.#overlayManager.close(this.#dialog);
-    }
+    this.#overlayManager.closeIfActive(this.#dialog);
   }
 
   #close() {
@@ -696,9 +694,7 @@ class ImageAltTextSettings {
   }
 
   #finish() {
-    if (this.#overlayManager.active === this.#dialog) {
-      this.#overlayManager.close(this.#dialog);
-    }
+    this.#overlayManager.closeIfActive(this.#dialog);
   }
 }
 

--- a/web/overlay_manager.js
+++ b/web/overlay_manager.js
@@ -81,6 +81,17 @@ class OverlayManager {
     dialog.close();
     this.#active = null;
   }
+
+  /**
+   * @param {HTMLDialogElement} dialog - The overlay's DOM element.
+   * @returns {Promise} A promise that is resolved when the overlay has been
+   *                    closed.
+   */
+  async closeIfActive(dialog) {
+    if (this.#active === dialog) {
+      await this.close(dialog);
+    }
+  }
 }
 
 export { OverlayManager };

--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -89,9 +89,7 @@ class PasswordPrompt {
   }
 
   async close() {
-    if (this.overlayManager.active === this.dialog) {
-      this.overlayManager.close(this.dialog);
-    }
+    this.overlayManager.closeIfActive(this.dialog);
   }
 
   #verify() {

--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -148,9 +148,7 @@ class PDFPrintService {
     this.scratchCanvas = null;
     activeService = null;
     ensureOverlay().then(function () {
-      if (overlayManager.active === dialog) {
-        overlayManager.close(dialog);
-      }
+      overlayManager.closeIfActive(dialog);
     });
   }
 
@@ -260,9 +258,7 @@ window.print = function () {
     if (!activeService) {
       console.error("Expected print service to be initialized.");
       ensureOverlay().then(function () {
-        if (overlayManager.active === dialog) {
-          overlayManager.close(dialog);
-        }
+        overlayManager.closeIfActive(dialog);
       });
       return; // eslint-disable-line no-unsafe-finally
     }

--- a/web/signature_manager.js
+++ b/web/signature_manager.js
@@ -826,9 +826,7 @@ class SignatureManager {
   }
 
   #finish() {
-    if (this.#overlayManager.active === this.#dialog) {
-      this.#overlayManager.close(this.#dialog);
-    }
+    this.#overlayManager.closeIfActive(this.#dialog);
   }
 
   #close() {
@@ -993,9 +991,7 @@ class EditDescriptionDialog {
   }
 
   #finish() {
-    if (this.#overlayManager.active === this.#dialog) {
-      this.#overlayManager.close(this.#dialog);
-    }
+    this.#overlayManager.closeIfActive(this.#dialog);
   }
 
   #close() {


### PR DESCRIPTION
It's now pretty common that we only want to close a `dialog` *if* it's currently active, to avoid throwing errors, and this new method provides a shorter and more convenient way to achieve that.