### PR TITLE
Check more of the stream when looking for commands after inline image (issue 19494)

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -248,8 +248,12 @@ class Parser {
           }
           // Check that the "EI" sequence isn't part of the image data, since
           // that would cause the image to be truncated (fixes issue11124.pdf).
+          //
+          // Check more than the `followingBytes` to be able to find operators
+          // with multiple arguments, e.g. transform (cm) with decimal arguments
+          // (fixes issue19494.pdf).
           const tmpLexer = new Lexer(
-            new Stream(followingBytes.slice()),
+            new Stream(stream.peekBytes(5 * n)),
             knownCommands
           );
           // Reduce the number of (potential) warning messages.

--- a/test/pdfs/issue19494.pdf.link
+++ b/test/pdfs/issue19494.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/18810079/VERAPDF-1335-InlineImage.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5618,6 +5618,15 @@
     "type": "eq"
   },
   {
+    "id": "issue19494",
+    "file": "pdfs/issue19494.pdf",
+    "md5": "2ec2ccbe6aa7e622ef981ca5ca443d55",
+    "link": true,
+    "rounds": 1,
+    "type": "eq",
+    "lastPage": 1
+  },
+  {
     "id": "issue11768",
     "file": "pdfs/issue11768_reduced.pdf",
     "md5": "0cafde97d78bb6883531a325a996a5ef",


### PR DESCRIPTION
Currently we only check `followingBytes`, which turns out to be too short to find e.g. valid transform (cm) commands with decimal arguments.