### PR TITLE
Shorten the `CipherTransformFactory.prototype.#buildObjectKey` method

### DIFF
--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -1595,12 +1595,10 @@ class CipherTransformFactory {
   }
 
   #buildObjectKey(num, gen, encryptionKey, isAes = false) {
-    const key = new Uint8Array(encryptionKey.length + 9);
     const n = encryptionKey.length;
-    let i;
-    for (i = 0; i < n; ++i) {
-      key[i] = encryptionKey[i];
-    }
+    const key = new Uint8Array(n + 9);
+    key.set(encryptionKey);
+    let i = n;
     key[i++] = num & 0xff;
     key[i++] = (num >> 8) & 0xff;
     key[i++] = (num >> 16) & 0xff;
@@ -1613,7 +1611,7 @@ class CipherTransformFactory {
       key[i++] = 0x54;
     }
     const hash = calculateMD5(key, 0, i);
-    return hash.subarray(0, Math.min(encryptionKey.length + 5, 16));
+    return hash.subarray(0, Math.min(n + 5, 16));
   }
 
   #buildCipherConstructor(cf, name, num, gen, key) {


### PR DESCRIPTION
 - Use `TypedArray.prototype.set()` rather than a manual loop when building the `key`.

 - Use an existing local variable to avoid re-computing the length of the `encryptionKey`.