### PR TITLE
fix: unescape meta character last

### DIFF
--- a/src/core/file_spec.js
+++ b/src/core/file_spec.js
@@ -78,9 +78,9 @@ class FileSpec {
     const item = pickPlatformItem(this.root);
     if (item && typeof item === "string") {
       filename = stringToPDFString(item)
-        .replaceAll("\\\\", "\\")
         .replaceAll("\\/", "/")
-        .replaceAll("\\", "/");
+        .replaceAll("\\", "/")
+        .replaceAll("\\\\", "\\");
     }
     return shadow(this, "filename", filename || "unnamed");
   }


### PR DESCRIPTION
We were informed of a potential security risk via CodeQL regarding the string replacements happening on the affected lines. 

The warning is present on the original PR as well [here](https://github.com/mozilla/pdf.js/pull/16196) and is about Double Escaping happening [here](https://github.com/mozilla/pdf.js/blob/2b69fb76ac463c36f82f37cedb5c004ec364654a/src/core/file_spec.js#L80-L83).

According to the [CodeQL Documentation](https://codeql.github.com/codeql-query-help/javascript/js-double-escaping/), unescaping meta characters should be done last to avoid potential security risks.

That is the fix that has been applied here. 

I did run CodeQL locally before and after. The issue is getting detected before and disappears afterwards. 

I did attempt to run the tests locally, but there seems to be a number of tests that fail already in master for me, so it was difficult to validate if the final tests results were comparable to baseline (side-note: Maybe there are some prerequisites in terms of running them inside of a VM or Docker container? I know this can affect the final output of the rendering. Did not find any notes on how you are supposed to run the tests). 

Creating the PR and hoping that the running the tests in the CI pipeline will be more informative.
