### PR TITLE
[Editor] Wait for switching to stamp mode before adding a new editor when dnd'ing an image

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -621,9 +621,9 @@ class AnnotationEditorLayer {
    * @param {number} mode
    * @param {Object} params
    */
-  pasteEditor(mode, params) {
+  async pasteEditor(mode, params) {
     this.#uiManager.updateToolbar(mode);
-    this.#uiManager.updateMode(mode);
+    await this.#uiManager.updateMode(mode);
 
     const { offsetX, offsetY } = this.#getCenterPoint();
     const id = this.getNextId();


### PR DESCRIPTION
When dnd'ing an image with the FreeText mode enabled, the image wasn't correctly added.