### PR TITLE
Don't cache free/missing XRef entries (issue 19510)

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -842,7 +842,6 @@ class XRef {
 
     if (xrefEntry === null) {
       // The referenced entry can be free.
-      this._cacheMap.set(num, xrefEntry);
       return xrefEntry;
     }
     // Prevent circular references, in corrupt PDF documents, from hanging the

--- a/test/pdfs/issue19510.pdf.link
+++ b/test/pdfs/issue19510.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/18841919/geht_nicht_02.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5627,6 +5627,14 @@
     "lastPage": 1
   },
   {
+    "id": "issue19510",
+    "file": "pdfs/issue19510.pdf",
+    "md5": "3ff133f633cea3e2f13f08f8c3414cc6",
+    "link": true,
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue11768",
     "file": "pdfs/issue11768_reduced.pdf",
     "md5": "0cafde97d78bb6883531a325a996a5ef",


### PR DESCRIPTION
During the XRef stream parsing we're attempting to lookup an entry that hasn't yet been found, since parsing is currently running, and given that we'd also cache free/missing XRef entries we'd then return an incorrect value during normal PDF parsing.

The simplest solution here is to just not cache free/missing XRef entries, since a properly generated PDF document shouldn't be trying to access objects it doesn't contain.
Furthermore, the amount of "extra" parsing now needed for such XRef entries shouldn't be significant enough to be an issue.