### PR TITLE
[Editor] Fix the outline of a focused button in the doorhanger while navigating with the keyboard

### DIFF
--- a/web/signature_manager.css
+++ b/web/signature_manager.css
@@ -682,10 +682,11 @@
 }
 
 #editorSignatureParamsToolbar {
-  padding: 10px;
+  padding: 8px;
 
   #addSignatureDoorHanger {
     gap: 8px;
+    padding: 2px;
 
     .toolbarAddSignatureButtonContainer {
       height: 32px;


### PR DESCRIPTION
It's a follow-up of #19507.
Without this patch the outline is partially hidden.