### PR TITLE
[Editor] Fix the color of the labels in the editing doorhangers

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1132,6 +1132,11 @@ dialog :link {
       line-height: 150%;
       width: fit-content;
       inset-inline-start: 0;
+      color: var(--main-color);
+    }
+
+    button:is(:hover, :focus-visible) .editorParamsLabel {
+      color: var(--doorhanger-hover-color);
     }
 
     .editorParamsToolbarContainer {


### PR DESCRIPTION
The fix in #19522 wasn't correct.
This one should be better.