### PR TITLE
Disable the loading of node types in the type tests

### DIFF
--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -10,7 +10,7 @@
     "module": "ESNext",
     "baseUrl": "./",
     "strict": true,
-    "types": ["node"],
+    "types": [],
     "lib": ["ESNext", "DOM"],
     "paths": {
       "pdfjs-dist": ["../../build/typestest"],


### PR DESCRIPTION
Those type tests are performing type checking on a project using DOM APIs, intended to reflect the usage in a non-node project. Not loading the node types in that project ensures that the library type declarations don't force a dependency on the node types. See my comment in https://github.com/mozilla/pdf.js/pull/19000#issuecomment-2674029148

The changes in https://github.com/mozilla/pdf.js/pull/19341 already removed the relying on the type `import("@napi-rs/canvas").Canvas` (which depends on the node types) in the types of the public API, solving the actual issue for the next release.