### PR TITLE
Consider textRise when showing Type3 font glyphs (issue 19532)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2362,7 +2362,7 @@ class CanvasGraphics {
 
     ctx.save();
     ctx.transform(...current.textMatrix);
-    ctx.translate(current.x, current.y);
+    ctx.translate(current.x, current.y + current.textRise);
 
     ctx.scale(textHScale, fontDirection);
 

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -122,6 +122,7 @@
 !issue10542_reduced.pdf
 !issue10665_reduced.pdf
 !issue11016_reduced.pdf
+!issue19532.pdf
 !issue15516_reduced.pdf
 !issue11045.pdf
 !bug1057544.pdf

--- a/test/pdfs/issue19532.pdf
+++ b/test/pdfs/issue19532.pdf
@@ -1,0 +1,402 @@
+%PDF-1.5
+%´ÈÜð
+1 0 obj
+<<
+  /N 1
+  /Alternate/DeviceGray
+  /Length 339
+  /Filter[/ASCII85Decode/FlateDecode]
+>>
+stream
+GhRS,5t_8V'SXjiPnmDY>T+"_XU:eO5_P59g8I;9X4J;-UmYY;DaN_j7/rnq[VZiAVO$TP_3JoV
+XW%F&,0r@97R?M'E5'<%O)k?HG.9&h%D_W<O\276fB/&)BgP<0CY6Q8j3k]dS7b,4=]+`T31-.@
+%9huG6^r@%q<'A6/q%U8^D+EN9C4qpSeWb'3Vb=BO8C+DDio4$JPW@9M<!B'(3+s$i$"Rb&ml1h
+Y4KRZs+Chj3U\Fb*pt9rOb1C?SBU7HPGEC*KK%66,4d2&j/pr_eSHYah$5.-^u.qdrju'\%m[<s
+ogbV\2Tk<\V0i=-Hib66Y[%:\Dhlsd8aH~>
+endstream
+endobj
+2 0 obj
+<<
+  /Type/OutputIntent
+  /S/GTS_PDFA1
+  /OutputConditionIdentifier(sGry)
+  /Info(Compact-ICC-Profiles ICC v4 Grayscale Parametric Curve)
+  /DestOutputProfile 1 0 R
+>>
+endobj
+4 0 obj
+<<
+  /Title(BERGTALB.SDO)
+  /Creator(SIGNUM \251 1986-93 F. Schmerbeck)
+  /Producer(Signum! Document Toolbox)
+  /CreationDate(D:20250221204852+01'00)
+  /ModDate(D:20250221204852+01'00)
+>>
+endobj
+5 0 obj
+<<
+  /Type/Metadata
+  /Subtype/XML
+  /Length 1499
+>>
+stream
+<?xpacket begin='ï»¿' id='W5M0MpCehiHzreSzNTczkc9d' ?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 4.0-c316 44.253921, Sun Oct 01 2006 17:14:39">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <rdf:Description rdf:about="" xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+    <pdf:Producer>Signum! Document Toolbox</pdf:Producer>
+   </rdf:Description>
+   <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
+   <dc:format>application/pdf</dc:format>
+   <dc:title><rdf:Alt><rdf:li xml:lang="x-default">BERGTALB.SDO</rdf:li></rdf:Alt></dc:title>
+   </rdf:Description>
+   <rdf:Description rdf:about="" xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/">
+    <pdfaid:part>2</pdfaid:part>
+    <pdfaid:conformance>B</pdfaid:conformance>
+   </rdf:Description>
+   <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+    <xmp:CreatorTool>Signum! Document Toolbox</xmp:CreatorTool>
+    <xmp:ModifyDate>2025-02-21T20:48:52.938610971+01:00</xmp:ModifyDate>
+    <xmp:CreateDate>2025-02-21T20:48:52.938610971+01:00</xmp:CreateDate>
+    <xmp:MetadataDate>2025-02-21T20:48:52.939843822+01:00</xmp:MetadataDate>
+   </rdf:Description>
+   <rdf:Description rdf:about="" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/">
+    <xmpMM:DocumentID>uuid:578bb2f0-ee9a-4054-99fc-7a2ab071a816</xmpMM:DocumentID>
+    <xmpMM:InstanceID>uuid:9e47b968-b52e-4836-8541-a78a8a417e6c</xmpMM:InstanceID>
+   </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>
+endstream
+endobj
+8 0 obj
+<<
+  /Length 283
+>>
+stream
+0 g
+q
+BT
+1 0 0 1 76 758 Tm
+/C0 10 Tf
+0 -28 TD
+[(B)] TJ
+1.3333334 Ts
+[(e)] TJ
+2.6666667 Ts
+[(r)] TJ
+4 Ts
+[(g-)] TJ
+5.3333335 Ts
+[-560(und)] TJ
+4 Ts
+[-560(T)] TJ
+2.6666667 Ts
+[(a)] TJ
+1.3333334 Ts
+[(l)] TJ
+0 Ts
+[(b)] TJ
+-1.3333334 Ts
+[(a)] TJ
+-2.6666667 Ts
+[(h)] TJ
+-4 Ts
+[(n)] TJ
+ET
+Q
+endstream
+endobj
+7 0 obj
+<<
+  /Type/Page
+  /Parent 6 0 R
+  /MediaBox[0 0 592 842]
+  /Resources
+  <<
+    /Font 9 0 R
+    /ProcSet[/PDF/Text]
+  >>
+  /Contents 8 0 R
+>>
+endobj
+9 0 obj
+<<
+  /C0 10 0 R
+>>
+endobj
+10 0 obj
+<<
+  /Type/Font
+  /Subtype/Type3
+  /BaseFont/ANTIKRO
+  /FontBBox[0 -200 720 920]
+  /FontMatrix[0.001 0 0 0.001 0 0]
+  /FirstChar 45
+  /LastChar 117
+  /Encoding
+  <<
+    /Type/Encoding
+    /BaseEncoding/WinAnsiEncoding
+    /Differences[]
+  >>
+  /CharProcs
+  <<
+    /B 11 0 R
+    /T 12 0 R
+    /a 13 0 R
+    /b 14 0 R
+    /d 15 0 R
+    /e 16 0 R
+    /g 17 0 R
+    /h 18 0 R
+    /hyphen 19 0 R
+    /l 20 0 R
+    /n 21 0 R
+    /r 22 0 R
+    /u 23 0 R
+  >>
+  /Widths[560 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 720 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 720 0 0 0 0 0 0 0 0 0 0 0 0 560 640 0 640 560 0 640 640 0 0 0 400 0 640 0 0 0 480 0 0 640]
+  /FontDescriptor
+  <<
+    /Type/FontDescriptor
+    /FontName/ANTIKRO
+    /FontFamily(ANTIKRO)
+    /Flags 4
+    /FontBBox[0 -200 720 920]
+    /ItalicAngle 0
+    /Ascent 480
+    /Descent -110
+  >>
+  /ToUnicode 24 0 R
+>>
+endobj
+18 0 obj
+<<
+  /Length 233
+  /Filter/ASCII85Decode
+>>
+stream
+2Dd*10H`)(0H`%l2E!632`<?4A2+EK2D?7-+>=os2D?7.0JFV'+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O3!pcN01[3A3!pcN01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU3'KM58ONnLTk)YU\,ZL.s"f$FpeR[BTS%YGDm03@s8W-!s8Vq0_$1H)!<<["
+8I>~>
+endstream
+endobj
+20 0 obj
+<<
+  /Length 211
+  /Filter/ASCII85Decode
+>>
+stream
+1b^U+0H`)*0H`%l1H$p02`<?4A2+EH1b^%++>=os2D?7.1,'h)+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398N1(#-H01[3A3!pcN01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pT1-Rl/8ONnLX!<WGs8W-!s8W-!s8W-!VZ[D.5QjMI$3~>
+endstream
+endobj
+14 0 obj
+<<
+  /Length 234
+  /Filter/ASCII85Decode
+>>
+stream
+2Dd*10H`>/+>=or1,'h02D?7a0a]cp0H`%l0H`;40H`>/+>=pJD$iU$$6UHE8PL=LEckq#+<W==
++>Pk_+<W=.+>Yta+<W=(:dZ?[$6UHE6sD>f0jP,/+>62;6UO<M+<W=);_LWJ+<W=*:cpin9->f@
+010YoF_u#;+>Pl>4pjkL$9k,gC+MJ3s8W,]a20_>cp<GEDr.,CTAT\Ks7P!pf@JB)(dUHD:]UP-
+77dg~>
+endstream
+endobj
+16 0 obj
+<<
+  /Length 224
+  /Filter/ASCII85Decode
+>>
+stream
+2)[-20H`)(0H`%l2)I!01cR03A2+EJ1b^%++>=op3%uI00JFV'+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O1(#-H01[3@1^Y?J01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU1-Rl/8ONnA*$\j1Jda\7f(AY-gA`6H5Q1Pp'"56c:r.f!0a[n'!_#Zf~>
+endstream
+endobj
+17 0 obj
+<<
+  /Length 264
+  /Filter/ASCII85Decode
+>>
+stream
+2Dd*10H`)*0H_r&0JFV-1,'h-3%uIc0a]cl0H`%l0H`850H`)*0H_r&0JFVZD$iU$$6UHE8PL=L
+Eckq#+<W==+>Pe]+<W=.+>Yh]+<W=(:dZ?[$6UHE6sD>f0jP,/+>62;6UO<M+<W=);_LWJ+<W=*
+:cpin9->f@010YoF_u#;+>Pf<4pjkL$8WG0\:c^F+R([hdVo0cmA9\o=CE]k:du:gh1oN;_]^F'
+,h\\-,6mB:kr8YAg/cXV$kQ6E$321M77dg~>
+endstream
+endobj
+21 0 obj
+<<
+  /Length 223
+  /Filter/ASCII85Decode
+>>
+stream
+2Dd*10H`)(0H`%l2E!631cR03A2+EK2D?7-+>=op3%uI00JFV'+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O3!pcN01[3@1^Y?J01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU3'KM58ONn>Ao7qeF)35Oo?^5(T74QTs8W-!s8W,`VZ[i%^]XX&77dg~>
+endstream
+endobj
+13 0 obj
+<<
+  /Length 233
+  /Filter/ASCII85Decode
+>>
+stream
+2)[-20H`)*0H`%l2D?g-1cR03A2+EJ3%uI/+>=op3%uI01,'h)+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O1^Y?J01[3@1^Y?J01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU1d4)18ONnL3(:>rJHk<bp!S>0r"aZB&O+&8de25ls46MCGA>c%K8(O,!"]0"
+8I>~>
+endstream
+endobj
+11 0 obj
+<<
+  /Length 242
+  /Filter/ASCII85Decode
+>>
+stream
+2_m'00H`)*0H`%l2_Zp.2_m'0A2+EK3%uI/+>=os1,'h*1,'h)+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O3=6lO01[3A2@:QL01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU3BfV68ONn4Ts>)f_mhDtGCP&@s8SqpK&J7IhG;&J^)2:qJ*m:9s65!$=CEZj
+TRf?2!'itE$3~>
+endstream
+endobj
+12 0 obj
+<<
+  /Length 217
+  /Filter/ASCII85Decode
+>>
+stream
+2_m'00H`)(0H`%l2_Zp.2`*32A2+EL0JFV'+>=os1b^%,0JFV'+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398P0FApF01[3A2[UZM01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pV0KqZ-8ONn4WFP(a*;%_2s8G+[s8W-!s8W-!l-k;*!'gZU8I>~>
+endstream
+endobj
+23 0 obj
+<<
+  /Length 224
+  /Filter/ASCII85Decode
+>>
+stream
+2Dd*10H`)(0H`%l2Dd*12)$^,A2+EK1b^%++>=oq0JFV(0JFV'+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O2[UZM01[3@2$tHK01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU2a0D48ONnE&Eu%iT]*fEs8W-!s8W-!s6J'"p6TSAik#QVKa%N"!_#Zf~>
+endstream
+endobj
+24 0 obj
+<<
+  /Length 1454
+  /Filter/ASCII85Decode
+>>
+stream
+,p?)`/O<oc@V%,I/heDGATMd4EarZ46VV!.$7-udDe!p,ASuTbAS#C`A5Zu[Dfp)1ATKmT:i^Ja
+;e:%n-ppQo8T&6a.1.@I8T&$SF_#&]ATMd4EarZA+Ad)s@oHr\+=KTK6qM91F=@PC,sl0UBl6g[
+F)Q2A@q@\D6VV!.+=L0&B5Vj//O<-28P;rW/MJk4.1.@I<,$GjANCq^;e]l^F_r]r:/jeX;GSku
+0JFVJBkM=+D'2,><(T_\:EV>?$7.!!ATDj+Df.TY0eP.60FB*P7;cX'Df'?&DKKq,$84b<6qM91
+F<E55Ec5GdATT&,Bl7I%ATMd4EarZ'@V'1dD@/*R+Co1rF<D]8AS5^p$4:6RB5)6nD..Aj01/<!
+;gEG+ASk"VAoAeS4:32R02c@oBleB:Gp"M6BkM=+D(,f7+>6N2A7]dqDJ((?5u(BN92\P7$6UHE
+;g!%uCh7HpDKI!T$9gWrA7]?[$84b@@;ntMD.OhC;e]l^F_r]r:/jeX;GSku0JFV[AS)9&6VV!.
+<b6;mBl@l30eP.60Han;AdU1Y9jr!?H#R=;1*C+=AdSl"+C\npBl7F!A7]h$@:Nkh@;]^h$9U!r
+0JG[54@Ve07Qq/jDId6qA7]h$@:Nkh@;]^h$48RI+C\npBl7Bl@q]:k$9U!r4s2sA0JG1E$9U!s
+4s2sA0K2<^$9U!t4s2sA0K2B`$9U!u4s2sW7Rfd0$9U"!4s2sW7Rfd0$9U""4s2sW7Rfd0$9U"#
+4s2sW7Rfd0$9U"$4s2sC0f_$R$9U"%4s2sW7Rfd0$9U"&4s2sC0f^pO$9U".4s2sW7Rfd0$9U"/
+4s2sC0f_!Q$9U"04s2sW7Rfd0$9U"14s2sC0f^sP$9U"24s2sW7Rfd0$9U"34s2sA0Ju0\$9U$s
+4s2sA0Ju6^$9U$t4s2sA0Jc'[$9U$u4s2sA0Jc-]$9U%24s2sW7Rfd0$9U%34s2sW7Rfd0$9U%4
+4s2sW7Rfd0$9U't4s2sA0L7W]$9U+34s2sA0L8#h$9U+44s2sA0Jc*\$9U+54s2sA0LA)i$9U+6
+4s2sA0Jc0^$9U.!4s2sA0LeDn$9U144s2sA0Ldra$9U154s2sA0LS8l$9U164s2sA0L[f^$9U76
+4s2sA0LRf_$9U774s2sA0K2?_$9U784s2sA0LIZ\$9U794s2sC0JP7F$9U7:4s2sA0LSAo$>"*c
+@V0+`@<)\^1a$7=B5)6mAo_<tB4VE40f)!94>B2e+?VD53&!N'4>JWT+?VGH4s2sA0JY@H$9U."
+4s2sF5s?DR0JG=<4pjD076VhV2aKVM4>8HH76V&iDId3gEa`iuAI8cUDId6o@;lQ@9jr!9@;TQu
+@s)g4ASuU#Bk)6-01/HBE$/\&Anc-oEb0<1F`Lu'+E27<$>"*c$>"*c$48(*7;cX6ATMd4EarYf
+,pbuU7LB~>
+endstream
+endobj
+15 0 obj
+<<
+  /Length 240
+  /Filter/ASCII85Decode
+>>
+stream
+2Dd*10H`)*0H`%l2E!632`<?4A2+EK1b^%++>=os2D?7.1,'h)+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O2[UZM01[3A3!pcN01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU2a0D48ONn.e/!0B*ZtF^s3/O#2@%))2pu34pSIVfs8W-!n,D4qheb>]KONXj
+$5`bn#Xq;l~>
+endstream
+endobj
+22 0 obj
+<<
+  /Length 218
+  /Filter/ASCII85Decode
+>>
+stream
+1cR030H`)(0H`%l2)6j.1cR03A2+EJ1,'h)+>=op3%uI00JFV'+Cf6q6:hM,+>6;\+EVXHAI9P&
+0398O0a]$G01[3@1^Y?J01&K&+>F3G+>6,e0H`)U$6UHE7P@+r7LC7\01/Yk7g^@]018W!4>0>M
+/MSnGDesQ5DK?pU0g7c.8ONnJO!P0K9h'h&d6mb)IBJ\(\+Te$s8>.f2unI777dg~>
+endstream
+endobj
+19 0 obj
+<<
+  /Length 192
+  /Filter/ASCII85Decode
+>>
+stream
+2)[-20H`)*0H`/,0H`5.0H`/00Ham\$8aFj+>=ol+>bbp0etF*1GUX,@r2Q>8I?R_01ek\FE2M8
+$6UHE=!07P$6UHE80BYp+<W=(:dZ?[$6UHE6sD>f0jP,/+>62;6UO<M+<W=);_LWJ+<W=*:cpin
+9->f@010YoF_u#;+>PW74pjkL$7;IA!"]0"8I>~>
+endstream
+endobj
+6 0 obj
+<<
+  /Type/Pages
+  /Count 1
+  /Kids[7 0 R]
+>>
+endobj
+3 0 obj
+<<
+  /Type/Catalog
+  /Pages 6 0 R
+  /OutputIntents[2 0 R]
+  /Metadata 5 0 R
+>>
+endobj
+xref
+0 25
+0000000000 65535 f 
+0000000015 00000 n 
+0000000476 00000 n 
+0000009406 00000 n 
+0000000659 00000 n 
+0000000862 00000 n 
+0000009345 00000 n 
+0000002783 00000 n 
+0000002447 00000 n 
+0000002939 00000 n 
+0000002973 00000 n 
+0000006011 00000 n 
+0000006331 00000 n 
+0000005700 00000 n 
+0000004443 00000 n 
+0000008461 00000 n 
+0000004755 00000 n 
+0000005057 00000 n 
+0000003843 00000 n 
+0000009075 00000 n 
+0000004154 00000 n 
+0000005399 00000 n 
+0000008779 00000 n 
+0000006626 00000 n 
+0000006928 00000 n 
+trailer
+<<
+  /Size 25
+  /Info 4 0 R
+  /Root 3 0 R
+  /ID[<ea27651ab0a5801b1b6254379638d1fe><ea27651ab0a5801b1b6254379638d1fe>]
+>>
+startxref
+9500
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5801,6 +5801,13 @@
     "type": "eq"
   },
   {
+    "id": "issue19532",
+    "file": "pdfs/issue19532.pdf",
+    "md5": "87bf39acbb306479fa8994f441a5cb1e",
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue5540",
     "file": "pdfs/issue5540.pdf",
     "md5": "12b69b19e366232422812ad8b2534f37",


### PR DESCRIPTION
Consider the `Ts` text operator (textRise) in text using a Type3 font by doing the same in `showType3Text` as `showText` does at
https://github.com/mozilla/pdf.js/blob/e3ea92603d17595aad4b1c37c7113cb7dee0c90e/src/display/canvas.js#L2170

fixes #19532