### PR TITLE
[Editor] Add a test for copy & paste a signature editor

### DIFF
--- a/src/display/editor/drawers/inkdraw.js
+++ b/src/display/editor/drawers/inkdraw.js
@@ -552,7 +552,7 @@ class InkDrawOutline extends Outline {
       });
     }
 
-    const outlines = new InkDrawOutline();
+    const outlines = new this.prototype.constructor();
     outlines.build(
       newLines,
       pageWidth,

--- a/src/display/editor/signature.js
+++ b/src/display/editor/signature.js
@@ -391,7 +391,7 @@ class SignatureEditor extends DrawingEditor {
   static async deserialize(data, parent, uiManager) {
     const editor = await super.deserialize(data, parent, uiManager);
     editor.#isExtracted = data.areContours;
-    editor.description = data.accessibilityData?.alt || "";
+    editor.#description = data.accessibilityData?.alt || "";
     editor.#signatureUUID = data.uuid;
     return editor;
   }


### PR DESCRIPTION
This patch fixes an issue when pasting: an exception was thrown when pasting. And while writing the test and comparing the paths in the svg, I found a difference which is fixed thanks to call to the right constructor (to take into account the inheritance) in inkdraw.js