### PR TITLE
[Editor] Fix the position in the page of a drawing after it has been moved with the keyboard

### DIFF
--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -280,9 +280,9 @@ class DrawingEditor extends AnnotationEditor {
   }
 
   /** @inheritdoc */
-  _onTranslating(x, y) {
+  _onTranslating(_x, _y) {
     this.parent?.drawLayer.updateProperties(this._drawId, {
-      bbox: this.#rotateBox(x, y),
+      bbox: this.#rotateBox(),
     });
   }
 

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -476,6 +476,10 @@ class AnnotationEditor {
     this.div.scrollIntoView({ block: "nearest" });
   }
 
+  translationDone() {
+    this._onTranslated(this.x, this.y);
+  }
+
   drag(tx, ty) {
     this.#initialRect ||= [this.x, this.y, this.width, this.height];
     const {

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -2264,6 +2264,7 @@ class AnnotationEditorUIManager {
           for (const editor of editors) {
             if (this.#allEditors.has(editor.id)) {
               editor.translateInPage(totalX, totalY);
+              editor.translationDone();
             }
           }
         },
@@ -2271,6 +2272,7 @@ class AnnotationEditorUIManager {
           for (const editor of editors) {
             if (this.#allEditors.has(editor.id)) {
               editor.translateInPage(-totalX, -totalY);
+              editor.translationDone();
             }
           }
         },
@@ -2280,6 +2282,7 @@ class AnnotationEditorUIManager {
 
     for (const editor of editors) {
       editor.translateInPage(x, y);
+      editor.translationDone();
     }
   }
 

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -40,6 +40,7 @@ import {
   kbSelectAll,
   kbUndo,
   loadAndWait,
+  moveEditor,
   paste,
   pasteFromClipboard,
   scrollIntoView,
@@ -48,7 +49,6 @@ import {
   unselectEditor,
   waitForAnnotationEditorLayer,
   waitForAnnotationModeChanged,
-  waitForEditorMovedInDOM,
   waitForSelectedEditor,
   waitForSerialized,
   waitForStorageEntries,
@@ -78,33 +78,6 @@ const commit = async page => {
 };
 
 const switchToFreeText = switchToEditor.bind(null, "FreeText");
-
-const getXY = async (page, selector) => {
-  const rect = await getRect(page, selector);
-  return `${rect.x}::${rect.y}`;
-};
-
-const waitForPositionChange = (page, selector, xy) =>
-  page.waitForFunction(
-    (sel, currentXY) => {
-      const bbox = document.querySelector(sel).getBoundingClientRect();
-      return `${bbox.x}::${bbox.y}` !== currentXY;
-    },
-    {},
-    selector,
-    xy
-  );
-
-const moveEditor = async (page, selector, n, pressKey) => {
-  let xy = await getXY(page, selector);
-  for (let i = 0; i < n; i++) {
-    const handle = await waitForEditorMovedInDOM(page);
-    await pressKey();
-    await awaitPromise(handle);
-    await waitForPositionChange(page, selector, xy);
-    xy = await getXY(page, selector);
-  }
-};
 
 const cancelFocusIn = async (page, selector) => {
   page.evaluate(sel => {


### PR DESCRIPTION
When a drawing was moved with arrow keys and then printed or saved, the drawing wasn't moved finally. So the fix is just about calling onTranslated once the translation is done.