### PR TITLE
Send `disableFontFace` and `fontExtraProperties` as part of the exported font-data

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1169,17 +1169,6 @@ class Catalog {
     return shadow(this, "jsActions", actions);
   }
 
-  async fontFallback(id, handler) {
-    const translatedFonts = await Promise.all(this.fontCache);
-
-    for (const translatedFont of translatedFonts) {
-      if (translatedFont.loadedName === id) {
-        translatedFont.fallback(handler);
-        return;
-      }
-    }
-  }
-
   async cleanup(manuallyTriggered = false) {
     clearGlobalCaches();
     this.globalImageCache.clear(/* onlyData = */ manuallyTriggered);

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1745,8 +1745,15 @@ class PDFDocument {
     }
   }
 
-  fontFallback(id, handler) {
-    return this.catalog.fontFallback(id, handler);
+  async fontFallback(id, handler) {
+    const { catalog, pdfManager } = this;
+
+    for (const translatedFont of await Promise.all(catalog.fontCache)) {
+      if (translatedFont.loadedName === id) {
+        translatedFont.fallback(handler, pdfManager.evaluatorOptions);
+        return;
+      }
+    }
   }
 
   async cleanup(manuallyTriggered = false) {

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1086,8 +1086,7 @@ class PartialEvaluator {
       if (
         isAddToPathSet ||
         state.fillColorSpace.name === "Pattern" ||
-        font.disableFontFace ||
-        this.options.disableFontFace
+        font.disableFontFace
       ) {
         PartialEvaluator.buildFontPaths(
           font,
@@ -4367,7 +4366,7 @@ class PartialEvaluator {
             newProperties
           );
         }
-        return new Font(baseFontName, file, newProperties);
+        return new Font(baseFontName, file, newProperties, this.options);
       }
     }
 
@@ -4559,7 +4558,7 @@ class PartialEvaluator {
     const newProperties = await this.extractDataStructures(dict, properties);
     this.extractWidths(dict, descriptor, newProperties);
 
-    return new Font(fontName.name, fontFile, newProperties);
+    return new Font(fontName.name, fontFile, newProperties, this.options);
   }
 
   static buildFontPaths(font, glyphs, handler, evaluatorOptions) {
@@ -4626,7 +4625,7 @@ class TranslatedFont {
     handler.send("commonobj", [
       this.loadedName,
       "Font",
-      this.font.exportData(this._evaluatorOptions.fontExtraProperties),
+      this.font.exportData(),
     ]);
   }
 

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1065,7 +1065,6 @@ class PartialEvaluator {
           loadedName: "g_font_error",
           font: new ErrorFont(`Type3 font load error: ${reason}`),
           dict: translated.font,
-          evaluatorOptions: this.options,
         });
       }
     }
@@ -1237,7 +1236,6 @@ class PartialEvaluator {
         loadedName: "g_font_error",
         font: new ErrorFont(`Font "${fontName}" is not available.`),
         dict: font,
-        evaluatorOptions: this.options,
       });
 
     let fontRef;
@@ -1364,7 +1362,6 @@ class PartialEvaluator {
             loadedName: font.loadedName,
             font: translatedFont,
             dict: font,
-            evaluatorOptions: this.options,
           })
         );
       })
@@ -1379,7 +1376,6 @@ class PartialEvaluator {
               reason instanceof Error ? reason.message : reason
             ),
             dict: font,
-            evaluatorOptions: this.options,
           })
         );
       });
@@ -4606,11 +4602,10 @@ class PartialEvaluator {
 }
 
 class TranslatedFont {
-  constructor({ loadedName, font, dict, evaluatorOptions }) {
+  constructor({ loadedName, font, dict }) {
     this.loadedName = loadedName;
     this.font = font;
     this.dict = dict;
-    this._evaluatorOptions = evaluatorOptions || DefaultPartialEvaluatorOptions;
     this.type3Loaded = null;
     this.type3Dependencies = font.isType3Font ? new Set() : null;
     this.sent = false;
@@ -4629,7 +4624,7 @@ class TranslatedFont {
     ]);
   }
 
-  fallback(handler) {
+  fallback(handler, evaluatorOptions) {
     if (!this.font.data) {
       return;
     }
@@ -4645,7 +4640,7 @@ class TranslatedFont {
       this.font,
       /* glyphs = */ this.font.glyphCacheValues,
       handler,
-      this._evaluatorOptions
+      evaluatorOptions
     );
   }
 

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -88,7 +88,9 @@ const EXPORT_DATA_PROPERTIES = [
   "defaultVMetrics",
   "defaultWidth",
   "descent",
+  "disableFontFace",
   "fallbackName",
+  "fontExtraProperties",
   "fontMatrix",
   "isInvalidPDFjsFont",
   "isType3Font",
@@ -970,11 +972,12 @@ function createNameTable(name, proto) {
  * decoding logics whatever type it is (assuming the font type is supported).
  */
 class Font {
-  constructor(name, file, properties) {
+  constructor(name, file, properties, evaluatorOptions) {
     this.name = name;
     this.psName = null;
     this.mimetype = null;
-    this.disableFontFace = false;
+    this.disableFontFace = evaluatorOptions.disableFontFace;
+    this.fontExtraProperties = evaluatorOptions.fontExtraProperties;
 
     this.loadedName = properties.loadedName;
     this.isType3Font = properties.isType3Font;
@@ -1141,18 +1144,17 @@ class Font {
     return shadow(this, "renderer", renderer);
   }
 
-  exportData(extraProperties = false) {
-    const exportDataProperties = extraProperties
+  exportData() {
+    const exportDataProps = this.fontExtraProperties
       ? [...EXPORT_DATA_PROPERTIES, ...EXPORT_DATA_EXTRA_PROPERTIES]
       : EXPORT_DATA_PROPERTIES;
 
     const data = Object.create(null);
-    let property, value;
-    for (property of exportDataProperties) {
-      value = this[property];
+    for (const prop of exportDataProps) {
+      const value = this[prop];
       // Ignore properties that haven't been explicitly set.
       if (value !== undefined) {
-        data[property] = value;
+        data[prop] = value;
       }
     }
     return data;
@@ -3602,7 +3604,7 @@ class ErrorFont {
     return [chars];
   }
 
-  exportData(extraProperties = false) {
+  exportData() {
     return { error: this.error };
   }
 }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -422,8 +422,6 @@ function getDocument(src = {}) {
     },
   };
   const transportParams = {
-    disableFontFace,
-    fontExtraProperties,
     ownerDocument,
     pdfBug,
     styleElement,
@@ -2787,8 +2785,6 @@ class WorkerTransport {
 
       switch (type) {
         case "Font":
-          const { disableFontFace, fontExtraProperties, pdfBug } = this._params;
-
           if ("error" in exportedData) {
             const exportedError = exportedData.error;
             warn(`Error during font loading: ${exportedError}`);
@@ -2797,20 +2793,16 @@ class WorkerTransport {
           }
 
           const inspectFont =
-            pdfBug && globalThis.FontInspector?.enabled
+            this._params.pdfBug && globalThis.FontInspector?.enabled
               ? (font, url) => globalThis.FontInspector.fontAdded(font, url)
               : null;
-          const font = new FontFaceObject(exportedData, {
-            disableFontFace,
-            fontExtraProperties,
-            inspectFont,
-          });
+          const font = new FontFaceObject(exportedData, inspectFont);
 
           this.fontLoader
             .bind(font)
             .catch(() => messageHandler.sendWithPromise("FontFallback", { id }))
             .finally(() => {
-              if (!fontExtraProperties && font.data) {
+              if (!font.fontExtraProperties && font.data) {
                 // Immediately release the `font.data` property once the font
                 // has been attached to the DOM, since it's no longer needed,
                 // rather than waiting for a `PDFDocumentProxy.cleanup` call.

--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -351,17 +351,20 @@ class FontLoader {
 }
 
 class FontFaceObject {
-  constructor(
-    translatedData,
-    { disableFontFace = false, fontExtraProperties = false, inspectFont = null }
-  ) {
+  constructor(translatedData, inspectFont = null) {
     this.compiledGlyphs = Object.create(null);
     // importing translated data
     for (const i in translatedData) {
       this[i] = translatedData[i];
     }
-    this.disableFontFace = disableFontFace === true;
-    this.fontExtraProperties = fontExtraProperties === true;
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+      if (typeof this.disableFontFace !== "boolean") {
+        unreachable("disableFontFace must be available.");
+      }
+      if (typeof this.fontExtraProperties !== "boolean") {
+        unreachable("fontExtraProperties must be available.");
+      }
+    }
     this._inspectFont = inspectFont;
   }
 

--- a/test/font/font_fpgm_spec.js
+++ b/test/font/font_fpgm_spec.js
@@ -16,17 +16,22 @@ describe("font_fpgm", function () {
       const cMap = await CMapFactory.create({
         encoding: Name.get("Identity-H"),
       });
-      const font = new Font("font", new Stream(font2324), {
-        loadedName: "font",
-        type: "CIDFontType2",
-        differences: [],
-        defaultEncoding: [],
-        cMap,
-        toUnicode: new ToUnicodeMap([]),
-        xHeight: 0,
-        capHeight: 0,
-        italicAngle: 0,
-      });
+      const font = new Font(
+        "font",
+        new Stream(font2324),
+        {
+          loadedName: "font",
+          type: "CIDFontType2",
+          differences: [],
+          defaultEncoding: [],
+          cMap,
+          toUnicode: new ToUnicodeMap([]),
+          xHeight: 0,
+          capHeight: 0,
+          italicAngle: 0,
+        },
+        {}
+      );
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);

--- a/test/font/font_os2_spec.js
+++ b/test/font/font_os2_spec.js
@@ -17,16 +17,21 @@ describe("font_post", function () {
 
   describe("OS/2 table removal on bad post table values", function () {
     it("has invalid version number", async function () {
-      const font = new Font("font", new Stream(font2154), {
-        loadedName: "font",
-        type: "TrueType",
-        differences: [],
-        defaultEncoding: [],
-        toUnicode: new ToUnicodeMap([]),
-        xHeight: 0,
-        capHeight: 0,
-        italicAngle: 0,
-      });
+      const font = new Font(
+        "font",
+        new Stream(font2154),
+        {
+          loadedName: "font",
+          type: "TrueType",
+          differences: [],
+          defaultEncoding: [],
+          toUnicode: new ToUnicodeMap([]),
+          xHeight: 0,
+          capHeight: 0,
+          italicAngle: 0,
+        },
+        {}
+      );
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);
@@ -39,17 +44,22 @@ describe("font_post", function () {
       const cMap = await CMapFactory.create({
         encoding: Name.get("Identity-H"),
       });
-      const font = new Font("font", new Stream(font1282), {
-        loadedName: "font",
-        type: "CIDFontType2",
-        differences: [],
-        defaultEncoding: [],
-        cMap,
-        toUnicode: new ToUnicodeMap([]),
-        xHeight: 0,
-        capHeight: 0,
-        italicAngle: 0,
-      });
+      const font = new Font(
+        "font",
+        new Stream(font1282),
+        {
+          loadedName: "font",
+          type: "CIDFontType2",
+          differences: [],
+          defaultEncoding: [],
+          cMap,
+          toUnicode: new ToUnicodeMap([]),
+          xHeight: 0,
+          capHeight: 0,
+          italicAngle: 0,
+        },
+        {}
+      );
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);

--- a/test/font/font_post_spec.js
+++ b/test/font/font_post_spec.js
@@ -24,17 +24,22 @@ describe("font_post", function () {
       const cMap = await CMapFactory.create({
         encoding: Name.get("Identity-H"),
       });
-      const font = new Font("font", new Stream(font2109), {
-        loadedName: "font",
-        type: "CIDFontType2",
-        differences: [],
-        defaultEncoding: [],
-        cMap,
-        toUnicode: new ToUnicodeMap([]),
-        xHeight: 0,
-        capHeight: 0,
-        italicAngle: 0,
-      });
+      const font = new Font(
+        "font",
+        new Stream(font2109),
+        {
+          loadedName: "font",
+          type: "CIDFontType2",
+          differences: [],
+          defaultEncoding: [],
+          cMap,
+          toUnicode: new ToUnicodeMap([]),
+          xHeight: 0,
+          capHeight: 0,
+          italicAngle: 0,
+        },
+        {}
+      );
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);
@@ -42,16 +47,21 @@ describe("font_post", function () {
     });
 
     it("has invalid glyph name indexes", async function () {
-      const font = new Font("font", new Stream(font2189), {
-        loadedName: "font",
-        type: "TrueType",
-        differences: [],
-        defaultEncoding: [],
-        toUnicode: new ToUnicodeMap([]),
-        xHeight: 0,
-        capHeight: 0,
-        italicAngle: 0,
-      });
+      const font = new Font(
+        "font",
+        new Stream(font2189),
+        {
+          loadedName: "font",
+          type: "TrueType",
+          differences: [],
+          defaultEncoding: [],
+          toUnicode: new ToUnicodeMap([]),
+          xHeight: 0,
+          capHeight: 0,
+          italicAngle: 0,
+        },
+        {}
+      );
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);
@@ -59,16 +69,21 @@ describe("font_post", function () {
     });
 
     it("has right amount of glyphs specified", async function () {
-      const font = new Font("font", new Stream(font2374), {
-        loadedName: "font",
-        type: "TrueType",
-        differences: [],
-        defaultEncoding: [],
-        toUnicode: new ToUnicodeMap([]),
-        xHeight: 0,
-        capHeight: 0,
-        italicAngle: 0,
-      });
+      const font = new Font(
+        "font",
+        new Stream(font2374),
+        {
+          loadedName: "font",
+          type: "TrueType",
+          differences: [],
+          defaultEncoding: [],
+          toUnicode: new ToUnicodeMap([]),
+          xHeight: 0,
+          capHeight: 0,
+          italicAngle: 0,
+        },
+        {}
+      );
       const output = await ttx(font.data);
 
       verifyTtxOutput(output);


### PR DESCRIPTION
 - **Send `disableFontFace` and `fontExtraProperties` as part of the exported font-data**

   These options are needed in the `FontFaceObject` class, and indirectly in `FontLoader` as well, which means that we currently need to pass them around manually in the API.
   Given that the options are (obviously) available on the worker-thread, it's very easy to just provide them when creating `Font`-instances and then send them as part of the exported font-data. This way we're able to simplify the code (primarily on the main-thread), and note that `Font`-instances even had a `disableFontFace`-field already (but it wasn't properly initialized).

 - **Improve the "FontFallback" handling on the worker-thread**

   Remove the `Catalog.prototype.fontFallback` method, and move its code into `PDFDocument.prototype.fontFallback` instead, to reduce the indirection a little bit.
   Pass the `evaluatorOptions` directly to the `TranslatedFont.prototype.fallback` method, since nothing else in the `TranslatedFont`-class needs it now.