### PR TITLE
[api-minor] Stop exporting, by default, a few additional Font properties (PR 11777 follow-up)

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -82,7 +82,6 @@ const EXPORT_DATA_PROPERTIES = [
   "black",
   "bold",
   "charProcOperatorList",
-  "composite",
   "cssFontInfo",
   "data",
   "defaultVMetrics",
@@ -98,22 +97,23 @@ const EXPORT_DATA_PROPERTIES = [
   "missingFile",
   "name",
   "remeasure",
-  "subtype",
   "systemFontInfo",
-  "type",
   "vertical",
 ];
 
 const EXPORT_DATA_EXTRA_PROPERTIES = [
   "cMap",
+  "composite",
   "defaultEncoding",
   "differences",
   "isMonospace",
   "isSerifFont",
   "isSymbolicFont",
   "seacMap",
+  "subtype",
   "toFontChar",
   "toUnicode",
+  "type",
   "vmetrics",
   "widths",
 ];


### PR DESCRIPTION
None of the "composite", "subtype", or "type" properties are normally used on the main-thread and/or in the API, hence there's no need to include them in the exported font-data by default.
Given that these properties may still be useful when debugging, and that `debugger.mjs` actually relies on the "type" property, they will instead only be sent to the main-thread when the `fontExtraProperties` API-option is used.