### PR TITLE
Abort various timeouts, in `PDFViewer`, when closing the document (PR 19128 follow-up)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1173,6 +1173,7 @@ class PDFViewer {
     this.#hiddenCopyElement?.remove();
     this.#hiddenCopyElement = null;
 
+    this.#cleanupTimeouts();
     this.#cleanupSwitchAnnotationEditorMode();
   }
 
@@ -2340,6 +2341,17 @@ class PDFViewer {
     ]);
   }
 
+  #cleanupTimeouts() {
+    if (this.#scaleTimeoutId !== null) {
+      clearTimeout(this.#scaleTimeoutId);
+      this.#scaleTimeoutId = null;
+    }
+    if (this.#scrollTimeoutId !== null) {
+      clearTimeout(this.#scrollTimeoutId);
+      this.#scrollTimeoutId = null;
+    }
+  }
+
   #cleanupSwitchAnnotationEditorMode() {
     this.#switchAnnotationEditorModeAC?.abort();
     this.#switchAnnotationEditorModeAC = null;
@@ -2466,14 +2478,8 @@ class PDFViewer {
     for (const pageView of this._pages) {
       pageView.update(updateArgs);
     }
-    if (this.#scaleTimeoutId !== null) {
-      clearTimeout(this.#scaleTimeoutId);
-      this.#scaleTimeoutId = null;
-    }
-    if (this.#scrollTimeoutId !== null) {
-      clearTimeout(this.#scrollTimeoutId);
-      this.#scrollTimeoutId = null;
-    }
+    this.#cleanupTimeouts();
+
     if (!noUpdate) {
       this.update();
     }


### PR DESCRIPTION
Looking at recent integration-test logs there's occasionally warnings about trying to invoke `PDFViewer.prototype.update` too late, which probably started with PR #19128 (see log excerpt below).
Given that we already had another timeout before that PR the problem was pre-existing, but it seems to trigger more easily now.

```
JavaScript warning: http://127.0.0.1:42333/build/generic/web/viewer.mjs, line 12668: Script terminated by timeout at:
update@http://127.0.0.1:42333/build/generic/web/viewer.mjs:12668:9
@http://127.0.0.1:42333/build/generic/web/viewer.mjs:12373:12
setTimeout handler*_scrollUpdate@http://127.0.0.1:42333/build/generic/web/viewer.mjs:12371:29
viewAreaElementScrolled@http://127.0.0.1:42333/build/generic/web/viewer.mjs:154:15
FrameRequestCallback*debounceScroll@http://127.0.0.1:42333/build/generic/web/viewer.mjs:140:18
EventListener.handleEvent*watchScroll@http://127.0.0.1:42333/build/generic/web/viewer.mjs:165:19
PDFViewer@http://127.0.0.1:42333/build/generic/web/viewer.mjs:11777:19
_initializeViewerComponents@http://127.0.0.1:42333/build/generic/web/viewer.mjs:15081:23
initialize@http://127.0.0.1:42333/build/generic/web/viewer.mjs:14931:16
async*run@http://127.0.0.1:42333/build/generic/web/viewer.mjs:15227:16
webViewerLoad@http://127.0.0.1:42333/build/generic/web/viewer.mjs:17078:24
@http://127.0.0.1:42333/build/generic/web/viewer.mjs:17082:3
```