### PR TITLE
Reset `#renderError` on `RenderingCancelledException` (PR 19128 follow-up)

### DIFF
--- a/web/base_pdf_page_view.js
+++ b/web/base_pdf_page_view.js
@@ -169,16 +169,18 @@ class BasePDFPageView {
       await renderTask.promise;
       this.#showCanvas?.(true);
     } catch (e) {
-      error = e;
       // When zooming with a `drawingDelay` set, avoid temporarily showing
       // a black canvas if rendering was cancelled before the `onContinue`-
       // callback had been invoked at least once.
-      if (error instanceof RenderingCancelledException) {
+      if (e instanceof RenderingCancelledException) {
         return;
       }
+      error = e;
 
       this.#showCanvas?.(true);
     } finally {
+      this.#renderError = error;
+
       // The renderTask may have been replaced by a new one, so only remove
       // the reference to the renderTask if it matches the one that is
       // triggering this callback.
@@ -186,8 +188,6 @@ class BasePDFPageView {
         this.renderTask = null;
       }
     }
-    this.#renderError = error;
-
     this.renderingState = RenderingStates.FINISHED;
 
     onFinish(renderTask);


### PR DESCRIPTION
This restores the behaviour that existed prior to PR #19128, see e.g. https://github.com/mozilla/pdf.js/blob/8727a04ae588545c8e954c143b9fc64384712461/web/pdf_page_view.js#L908-L911, since `RenderingCancelledException` should still overwrite any previously seen Error.

/cc @nicolo-ribaudo 