### PR TITLE
Invoke `TranslatedFont.prototype.loadType3Data` only *once* per font

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1177,9 +1177,7 @@ class Catalog {
     this.pageDictCache.clear();
     this.nonBlendModesSet.clear();
 
-    const translatedFonts = await Promise.all(this.fontCache);
-
-    for (const { dict } of translatedFonts) {
+    for (const { dict } of await Promise.all(this.fontCache)) {
       delete dict.cacheKey;
     }
     this.fontCache.clear();


### PR DESCRIPTION
Currently we're first loading the font, and then for Type3 fonts we're invoking `loadType3Data` every time that the font is encountered.
That seems completely unnecessary, and it's probably connected to the age of this code, since the `loadType3Data`-method will only run once anyway (note the caching).