### PR TITLE
Change `PDFImage` to use `ColorSpace.parseAsync`

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -371,7 +371,14 @@ class ColorSpace {
     resources = null,
     pdfFunctionFactory,
     localColorSpaceCache,
+    checkCache = false,
   }) {
+    if (checkCache) {
+      const cachedColorSpace = this.getCached(cs, xref, localColorSpaceCache);
+      if (cachedColorSpace) {
+        return cachedColorSpace;
+      }
+    }
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       assert(
         !this.getCached(cs, xref, localColorSpaceCache),


### PR DESCRIPTION
Given that the `ColorSpace` parsing happens in the constructor we cannot just await it, which required a slightly more complicated solution (without having to attempt a full re-write of this class).

In particular the final parsing in the constructor will now wait for the `ColorSpace` parsing before completing, and the already asynchronous `createImageData`-method (which all images need to use) will ensure that all images are completely initialized.

*Smaller diff with https://github.com/mozilla/pdf.js/pull/19570/files?w=1*