### PR TITLE
Add the missing return type for `PDFWorker.fromPort()`

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2336,6 +2336,7 @@ class PDFWorker {
 
   /**
    * @param {PDFWorkerParameters} params - The worker initialization parameters.
+   * @returns {PDFWorker}
    */
   static fromPort(params) {
     if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {


### PR DESCRIPTION
The TypeScript compiler did not infer the return type from the returned instance, defaulting to any. This PR adds an annotation to explicitly define the return type.

Before:
``` ts
static fromPort(params: PDFWorkerParameters): any;
```

After:
``` ts
static fromPort(params: PDFWorkerParameters): PDFWorker;
```