### PR TITLE
Don't attempt to use auto-linking in XFA documents (PR 19110 follow-up)

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1064,7 +1064,7 @@ class PDFPageView extends BasePDFPageView {
       if (this.annotationLayer) {
         await this.#renderAnnotationLayer();
 
-        if (this.#enableAutoLinking && this.annotationLayer) {
+        if (this.#enableAutoLinking && this.annotationLayer && this.textLayer) {
           await this.#injectLinkAnnotations(textLayerPromise);
         }
       }


### PR DESCRIPTION
Auto-linking requires a normal textLayer which XFA documents obviously don't have, and currently XFA documents cause "pointless" error messages to be logged in the console.