### PR TITLE
Try reducing flakiness of CSS-only zoom test

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -568,16 +568,24 @@ function waitForAnnotationModeChanged(page) {
   });
 }
 
-function waitForPageRendered(page) {
-  return createPromise(page, resolve => {
-    const { eventBus } = window.PDFViewerApplication;
-    eventBus.on("pagerendered", function handler(e) {
-      if (!e.isDetailView) {
-        resolve();
-        eventBus.off("pagerendered", handler);
-      }
-    });
-  });
+function waitForPageRendered(page, pageNumber) {
+  return page.evaluateHandle(
+    number => [
+      new Promise(resolve => {
+        const { eventBus } = window.PDFViewerApplication;
+        eventBus.on("pagerendered", function handler(e) {
+          if (
+            !e.isDetailView &&
+            (number === undefined || e.pageNumber === number)
+          ) {
+            resolve();
+            eventBus.off("pagerendered", handler);
+          }
+        });
+      }),
+    ],
+    pageNumber
+  );
 }
 
 function waitForEditorMovedInDOM(page) {

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -328,7 +328,7 @@ describe("PDF viewer", () => {
             const originalCanvasSize = await getCanvasSize(page);
             const factor = 2;
 
-            const handle = await waitForPageRendered(page);
+            const handle = await waitForPageRendered(page, 1);
             await page.evaluate(scaleFactor => {
               window.PDFViewerApplication.pdfViewer.increaseScale({
                 drawingDelay: 0,
@@ -356,7 +356,7 @@ describe("PDF viewer", () => {
             const originalCanvasSize = await getCanvasSize(page);
             const factor = 4;
 
-            const handle = await waitForPageRendered(page);
+            const handle = await waitForPageRendered(page, 1);
             await page.evaluate(scaleFactor => {
               window.PDFViewerApplication.pdfViewer.increaseScale({
                 drawingDelay: 0,


### PR DESCRIPTION
> Update the test to wait for the `pagerendered`` event of a specific
> page (1), so that the `pagerendered`` event of other pages from a
> previously running render doesn't resolve the `waitForPageRendered`
> promise.

Testing if what I wrote in https://github.com/mozilla/pdf.js/pull/19128#issuecomment-2675486800 is correct.

The failure seems to be frequent enough that if it passes for 5 times in a row it's hopefully fixed.