### PR TITLE
Write string-data into the `.error`-file created for broken test-manifest links (issue 19579)

### DIFF
--- a/test/downloadutils.mjs
+++ b/test/downloadutils.mjs
@@ -88,7 +88,7 @@ async function downloadManifestFiles(manifest) {
     } catch (ex) {
       console.error(`Error during downloading of ${url}:`, ex);
       fs.writeFileSync(file, ""); // making it empty file
-      fs.writeFileSync(`${file}.error`, ex);
+      fs.writeFileSync(`${file}.error`, ex.toString());
     }
   }
 }


### PR DESCRIPTION
This appears to have broken in PR #17431, since prior to that the `downloadFile` function returned a string (via a callback) on failure and now we're instead rejecting with an Error.