### PR TITLE
Be sure to consume responses in case of error in downloading test files (issue 19580)

### DIFF
--- a/test/downloadutils.mjs
+++ b/test/downloadutils.mjs
@@ -42,6 +42,7 @@ function downloadFile(file, url, redirects = 0) {
       .get(url, async function (response) {
         if ([301, 302, 307, 308].includes(response.statusCode)) {
           if (redirects > 10) {
+            response.resume();
             reject(new Error("Too many redirects"));
             return;
           }
@@ -50,12 +51,14 @@ function downloadFile(file, url, redirects = 0) {
             await downloadFile(file, redirectTo, ++redirects);
             resolve();
           } catch (ex) {
+            response.resume();
             reject(ex);
           }
           return;
         }
 
         if (response.statusCode !== 200) {
+          response.resume();
           reject(new Error(`HTTP ${response.statusCode}`));
           return;
         }


### PR DESCRIPTION
As mentioned in https://nodejs.org/docs/latest-v20.x/api/http.html#httpgeturl-options-callback if a request results in an error, you still need to consume the data, or call `response.resume()`, or your code will hang waiting for the request to close.

Fixes #19580.