### PR TITLE
Replace a loop with `TypedArray.prototype.fill()` in the `RunLengthStream` class

### DIFF
--- a/src/core/run_length_stream.js
+++ b/src/core/run_length_stream.js
@@ -48,11 +48,9 @@ class RunLengthStream extends DecodeStream {
       }
     } else {
       n = 257 - n;
-      const b = repeatHeader[1];
       buffer = this.ensureBuffer(bufferLength + n + 1);
-      for (let i = 0; i < n; i++) {
-        buffer[bufferLength++] = b;
-      }
+      buffer.fill(repeatHeader[1], bufferLength, bufferLength + n);
+      bufferLength += n;
     }
     this.bufferLength = bufferLength;
   }


### PR DESCRIPTION
This is a tiny bit shorter, which cannot hurt.