### PR TITLE
Simplify the `ColorSpaceUtils.singletons` handling (PR 19564 follow-up)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -552,15 +552,15 @@ function getRgbColor(color, defaultColor = new Uint8ClampedArray(3)) {
       return null;
 
     case 1: // Convert grayscale to RGB
-      ColorSpaceUtils.singletons.gray.getRgbItem(color, 0, rgbColor, 0);
+      ColorSpaceUtils.gray.getRgbItem(color, 0, rgbColor, 0);
       return rgbColor;
 
     case 3: // Convert RGB percentages to RGB
-      ColorSpaceUtils.singletons.rgb.getRgbItem(color, 0, rgbColor, 0);
+      ColorSpaceUtils.rgb.getRgbItem(color, 0, rgbColor, 0);
       return rgbColor;
 
     case 4: // Convert CMYK to RGB
-      ColorSpaceUtils.singletons.cmyk.getRgbItem(color, 0, rgbColor, 0);
+      ColorSpaceUtils.cmyk.getRgbItem(color, 0, rgbColor, 0);
       return rgbColor;
 
     default:

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -357,7 +357,7 @@ class Catalog {
         isNumberArray(color, 3) &&
         (color[0] !== 0 || color[1] !== 0 || color[2] !== 0)
       ) {
-        rgbColor = ColorSpaceUtils.singletons.rgb.getRgb(color, 0);
+        rgbColor = ColorSpaceUtils.rgb.getRgb(color, 0);
       }
 
       const outlineItem = {

--- a/src/core/colorspace_utils.js
+++ b/src/core/colorspace_utils.js
@@ -133,15 +133,15 @@ class ColorSpaceUtils {
       switch (cs.name) {
         case "G":
         case "DeviceGray":
-          return this.singletons.gray;
+          return this.gray;
         case "RGB":
         case "DeviceRGB":
-          return this.singletons.rgb;
+          return this.rgb;
         case "DeviceRGBA":
-          return this.singletons.rgba;
+          return this.rgba;
         case "CMYK":
         case "DeviceCMYK":
-          return this.singletons.cmyk;
+          return this.cmyk;
         case "Pattern":
           return new PatternCS(/* baseCS = */ null);
         default:
@@ -160,7 +160,7 @@ class ColorSpaceUtils {
           }
           // Fallback to the default gray color space.
           warn(`Unrecognized ColorSpace: ${cs.name}`);
-          return this.singletons.gray;
+          return this.gray;
       }
     }
     if (Array.isArray(cs)) {
@@ -170,13 +170,13 @@ class ColorSpaceUtils {
       switch (mode) {
         case "G":
         case "DeviceGray":
-          return this.singletons.gray;
+          return this.gray;
         case "RGB":
         case "DeviceRGB":
-          return this.singletons.rgb;
+          return this.rgb;
         case "CMYK":
         case "DeviceCMYK":
-          return this.singletons.cmyk;
+          return this.cmyk;
         case "CalGray":
           params = xref.fetchIfRef(cs[1]);
           whitePoint = params.getArray("WhitePoint");
@@ -229,11 +229,11 @@ class ColorSpaceUtils {
             warn("ICCBased color space: Ignoring incorrect /Alternate entry.");
           }
           if (numComps === 1) {
-            return this.singletons.gray;
+            return this.gray;
           } else if (numComps === 3) {
-            return this.singletons.rgb;
+            return this.rgb;
           } else if (numComps === 4) {
-            return this.singletons.cmyk;
+            return this.cmyk;
           }
           break;
         case "Pattern":
@@ -264,29 +264,28 @@ class ColorSpaceUtils {
         default:
           // Fallback to the default gray color space.
           warn(`Unimplemented ColorSpace object: ${mode}`);
-          return this.singletons.gray;
+          return this.gray;
       }
     }
     // Fallback to the default gray color space.
     warn(`Unrecognized ColorSpace object: ${cs}`);
-    return this.singletons.gray;
+    return this.gray;
   }
 
-  static get singletons() {
-    return shadow(this, "singletons", {
-      get gray() {
-        return shadow(this, "gray", new DeviceGrayCS());
-      },
-      get rgb() {
-        return shadow(this, "rgb", new DeviceRgbCS());
-      },
-      get rgba() {
-        return shadow(this, "rgba", new DeviceRgbaCS());
-      },
-      get cmyk() {
-        return shadow(this, "cmyk", new DeviceCmykCS());
-      },
-    });
+  static get gray() {
+    return shadow(this, "gray", new DeviceGrayCS());
+  }
+
+  static get rgb() {
+    return shadow(this, "rgb", new DeviceRgbCS());
+  }
+
+  static get rgba() {
+    return shadow(this, "rgba", new DeviceRgbaCS());
+  }
+
+  static get cmyk() {
+    return shadow(this, "cmyk", new DeviceCmykCS());
   }
 }
 

--- a/src/core/default_appearance.js
+++ b/src/core/default_appearance.js
@@ -73,28 +73,13 @@ class DefaultAppearanceEvaluator extends EvaluatorPreprocessor {
             }
             break;
           case OPS.setFillRGBColor:
-            ColorSpaceUtils.singletons.rgb.getRgbItem(
-              args,
-              0,
-              result.fontColor,
-              0
-            );
+            ColorSpaceUtils.rgb.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.setFillGray:
-            ColorSpaceUtils.singletons.gray.getRgbItem(
-              args,
-              0,
-              result.fontColor,
-              0
-            );
+            ColorSpaceUtils.gray.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.setFillCMYKColor:
-            ColorSpaceUtils.singletons.cmyk.getRgbItem(
-              args,
-              0,
-              result.fontColor,
-              0
-            );
+            ColorSpaceUtils.cmyk.getRgbItem(args, 0, result.fontColor, 0);
             break;
         }
       }
@@ -132,7 +117,7 @@ class AppearanceStreamEvaluator extends EvaluatorPreprocessor {
       fontSize: 0,
       fontName: "",
       fontColor: /* black = */ new Uint8ClampedArray(3),
-      fillColorSpace: ColorSpaceUtils.singletons.gray,
+      fillColorSpace: ColorSpaceUtils.gray,
     };
     let breakLoop = false;
     const stack = [];
@@ -186,28 +171,13 @@ class AppearanceStreamEvaluator extends EvaluatorPreprocessor {
             cs.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.setFillRGBColor:
-            ColorSpaceUtils.singletons.rgb.getRgbItem(
-              args,
-              0,
-              result.fontColor,
-              0
-            );
+            ColorSpaceUtils.rgb.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.setFillGray:
-            ColorSpaceUtils.singletons.gray.getRgbItem(
-              args,
-              0,
-              result.fontColor,
-              0
-            );
+            ColorSpaceUtils.gray.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.setFillCMYKColor:
-            ColorSpaceUtils.singletons.cmyk.getRgbItem(
-              args,
-              0,
-              result.fontColor,
-              0
-            );
+            ColorSpaceUtils.cmyk.getRgbItem(args, 0, result.fontColor, 0);
             break;
           case OPS.showText:
           case OPS.showSpacedText:

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -501,7 +501,7 @@ class PartialEvaluator {
       }
 
       if (smask?.backdrop) {
-        colorSpace ||= ColorSpaceUtils.singletons.rgb;
+        colorSpace ||= ColorSpaceUtils.rgb;
         smask.backdrop = colorSpace.getRgb(smask.backdrop, 0);
       }
 
@@ -1992,7 +1992,7 @@ class PartialEvaluator {
             next(
               self._handleColorSpace(fillCS).then(colorSpace => {
                 stateManager.state.fillColorSpace =
-                  colorSpace || ColorSpaceUtils.singletons.gray;
+                  colorSpace || ColorSpaceUtils.gray;
               })
             );
             return;
@@ -2011,7 +2011,7 @@ class PartialEvaluator {
             next(
               self._handleColorSpace(strokeCS).then(colorSpace => {
                 stateManager.state.strokeColorSpace =
-                  colorSpace || ColorSpaceUtils.singletons.gray;
+                  colorSpace || ColorSpaceUtils.gray;
               })
             );
             return;
@@ -2027,41 +2027,38 @@ class PartialEvaluator {
             fn = OPS.setStrokeRGBColor;
             break;
           case OPS.setFillGray:
-            stateManager.state.fillColorSpace = ColorSpaceUtils.singletons.gray;
-            args = ColorSpaceUtils.singletons.gray.getRgb(args, 0);
+            stateManager.state.fillColorSpace = ColorSpaceUtils.gray;
+            args = ColorSpaceUtils.gray.getRgb(args, 0);
             fn = OPS.setFillRGBColor;
             break;
           case OPS.setStrokeGray:
-            stateManager.state.strokeColorSpace =
-              ColorSpaceUtils.singletons.gray;
-            args = ColorSpaceUtils.singletons.gray.getRgb(args, 0);
+            stateManager.state.strokeColorSpace = ColorSpaceUtils.gray;
+            args = ColorSpaceUtils.gray.getRgb(args, 0);
             fn = OPS.setStrokeRGBColor;
             break;
           case OPS.setFillCMYKColor:
-            stateManager.state.fillColorSpace = ColorSpaceUtils.singletons.cmyk;
-            args = ColorSpaceUtils.singletons.cmyk.getRgb(args, 0);
+            stateManager.state.fillColorSpace = ColorSpaceUtils.cmyk;
+            args = ColorSpaceUtils.cmyk.getRgb(args, 0);
             fn = OPS.setFillRGBColor;
             break;
           case OPS.setStrokeCMYKColor:
-            stateManager.state.strokeColorSpace =
-              ColorSpaceUtils.singletons.cmyk;
-            args = ColorSpaceUtils.singletons.cmyk.getRgb(args, 0);
+            stateManager.state.strokeColorSpace = ColorSpaceUtils.cmyk;
+            args = ColorSpaceUtils.cmyk.getRgb(args, 0);
             fn = OPS.setStrokeRGBColor;
             break;
           case OPS.setFillRGBColor:
-            stateManager.state.fillColorSpace = ColorSpaceUtils.singletons.rgb;
-            args = ColorSpaceUtils.singletons.rgb.getRgb(args, 0);
+            stateManager.state.fillColorSpace = ColorSpaceUtils.rgb;
+            args = ColorSpaceUtils.rgb.getRgb(args, 0);
             break;
           case OPS.setStrokeRGBColor:
-            stateManager.state.strokeColorSpace =
-              ColorSpaceUtils.singletons.rgb;
-            args = ColorSpaceUtils.singletons.rgb.getRgb(args, 0);
+            stateManager.state.strokeColorSpace = ColorSpaceUtils.rgb;
+            args = ColorSpaceUtils.rgb.getRgb(args, 0);
             break;
           case OPS.setFillColorN:
             cs = stateManager.state.patternFillColorSpace;
             if (!cs) {
               if (isNumberArray(args, null)) {
-                args = ColorSpaceUtils.singletons.gray.getRgb(args, 0);
+                args = ColorSpaceUtils.gray.getRgb(args, 0);
                 fn = OPS.setFillRGBColor;
                 break;
               }
@@ -2093,7 +2090,7 @@ class PartialEvaluator {
             cs = stateManager.state.patternStrokeColorSpace;
             if (!cs) {
               if (isNumberArray(args, null)) {
-                args = ColorSpaceUtils.singletons.gray.getRgb(args, 0);
+                args = ColorSpaceUtils.gray.getRgb(args, 0);
                 fn = OPS.setStrokeRGBColor;
                 break;
               }
@@ -4884,8 +4881,7 @@ class EvalState {
     this.ctm = new Float32Array(IDENTITY_MATRIX);
     this.font = null;
     this.textRenderingMode = TextRenderingMode.FILL;
-    this._fillColorSpace = ColorSpaceUtils.singletons.gray;
-    this._strokeColorSpace = ColorSpaceUtils.singletons.gray;
+    this._fillColorSpace = this._strokeColorSpace = ColorSpaceUtils.gray;
     this.patternFillColorSpace = null;
     this.patternStrokeColorSpace = null;
   }


### PR DESCRIPTION
With the changes in PR #19564 the actual `ColorSpace`-classes where separated from the various static "helper" methods.
Hence it seems that we can now simplify/shorten this old code to instead cache the "standard" ColorSpaces directly on the `ColorSpaceUtils`-class.