### PR TITLE
[Editor] Remove the unused `opacityToHex` helper function (PR 19093 follow-up)

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -43,17 +43,6 @@ function bindEvents(obj, element, names) {
 }
 
 /**
- * Convert a number between 0 and 100 into an hex number between 0 and 255.
- * @param {number} opacity
- * @return {string}
- */
-function opacityToHex(opacity) {
-  return Math.round(Math.min(255, Math.max(1, 255 * opacity)))
-    .toString(16)
-    .padStart(2, "0");
-}
-
-/**
  * Class to create some unique ids for the different editors.
  */
 class IdManager {
@@ -2562,5 +2551,4 @@ export {
   ColorManager,
   CommandManager,
   KeyboardManager,
-  opacityToHex,
 };


### PR DESCRIPTION
The only call-site was removed in PR #19093, hence this is now dead code.