### PR TITLE
Let SMask/Mask images fallback to the parent image dimensions (issue 19611)

### DIFF
--- a/test/pdfs/issue19611.pdf.link
+++ b/test/pdfs/issue19611.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/19102190/test.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3914,6 +3914,14 @@
     "type": "eq"
   },
   {
+    "id": "issue19611",
+    "file": "pdfs/issue19611.pdf",
+    "md5": "169dc6df1c43dcb4659b2ddb6a4b39e4",
+    "rounds": 1,
+    "link": true,
+    "type": "eq"
+  },
+  {
     "id": "issue1127-text",
     "file": "pdfs/issue1127.pdf",
     "md5": "4fb2be5ffefeafda4ba977de2a1bb4d8",


### PR DESCRIPTION
One of the images have a corrupt SMask, where the /Height-entry is bogus; see the excerpt below (via https://brendandahl.github.io/pdf.js.utils/browser/).
```
SMask (stream) [id: 17, gen: 0]

    ColorSpace = /DeviceGray
    Height = /Length
    Subtype = /Image
    Filter = /FlateDecode
    Type = /XObject
    Width = 157
    Matte (array)
    BitsPerComponent = 8
    Length = 3893
    <view contents> download
```

Hence we enable SMask/Mask images to fallback to the parent image dimensions, and also add more validation of the width/height to get a better error message when that data is wrong.