### PR TITLE
Limit the maximum thumbnail canvas width/height, similar to pages (PR 19604 follow-up)

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -215,9 +215,21 @@ class PDFThumbnailView {
       willReadFrequently: !enableHWA,
     });
     const outputScale = new OutputScale();
+    const width = upscaleFactor * this.canvasWidth,
+      height = upscaleFactor * this.canvasHeight;
 
-    canvas.width = (upscaleFactor * this.canvasWidth * outputScale.sx) | 0;
-    canvas.height = (upscaleFactor * this.canvasHeight * outputScale.sy) | 0;
+    if (this.maxCanvasDim !== -1) {
+      const maxScale = Math.min(
+        this.maxCanvasDim / width,
+        this.maxCanvasDim / height
+      );
+      if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
+        outputScale.sx = maxScale;
+        outputScale.sy = maxScale;
+      }
+    }
+    canvas.width = (width * outputScale.sx) | 0;
+    canvas.height = (height * outputScale.sy) | 0;
 
     const transform = outputScale.scaled
       ? [outputScale.sx, 0, 0, outputScale.sy, 0, 0]


### PR DESCRIPTION
The changes in PR #19604 weren't enough for thumbnail canvases in some cases, see e.g. https://web.archive.org/web/20231204152348if_/https://user.informatik.uni-bremen.de/cabo/rfc9000.pdf#pagemode=thumbs