### PR TITLE
Do not constantly render the detail canvas on zoom (bug 1952496)

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1868,14 +1868,18 @@ class PDFViewer {
       this._spreadMode !== SpreadMode.NONE &&
       this._scrollMode !== ScrollMode.HORIZONTAL;
 
-    // If we are scrolling and the rendering of a detail view was just
-    // cancelled, it's because the user is scrolling too quickly and so
-    // we constantly need to re-render a different area.
-    // Don't attempt to re-render it: this will be done once the user
-    // stops scrolling.
     const ignoreDetailViews =
-      this.#scrollTimeoutId !== null &&
-      visiblePages.views.some(page => page.detailView?.renderingCancelled);
+      // If we are zooming, do not re-render the detail views. Re-renders on
+      // zoom happen with a delay, and once the rendering happens it will also
+      // trigger rendering of the detail views.
+      this.#scaleTimeoutId !== null ||
+      // If we are scrolling and the rendering of a detail view was just
+      // cancelled, it's because the user is scrolling too quickly and so
+      // we constantly need to re-render a different area.
+      // Don't attempt to re-render it: this will be done once the user
+      // stops scrolling.
+      (this.#scrollTimeoutId !== null &&
+        visiblePages.views.some(page => page.detailView?.renderingCancelled));
 
     const pageView = this.renderingQueue.getHighestPriority(
       visiblePages,


### PR DESCRIPTION
When zooming, we should skip rendering the detail canvas until the zoom is done, similarly to how normal page rendering is delayed. To do so is enough to skip details view while zooming, since the main view rendering that already happens after the delay will also trigger rendering of the detail views.