### PR TITLE
Improve text-selection for Type3 fonts, using `d0` operators, with empty /FontBBox-entries (issue 19624)

### DIFF
--- a/test/pdfs/issue19624.pdf.link
+++ b/test/pdfs/issue19624.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/19126771/okm2500682934750615600.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -3922,6 +3922,15 @@
     "type": "eq"
   },
   {
+    "id": "issue19624-text",
+    "file": "pdfs/issue19624.pdf",
+    "md5": "087ac2141dbfa218be833efcc143925a",
+    "rounds": 1,
+    "link": true,
+    "firstPage": 2,
+    "type": "text"
+  },
+  {
     "id": "issue1127-text",
     "file": "pdfs/issue1127.pdf",
     "md5": "4fb2be5ffefeafda4ba977de2a1bb4d8",


### PR DESCRIPTION
For Type3 glyphs with `d1` operators it's easy to compute a fallback bounding box, however for `d0` the situation is more difficult.
Given that we nowadays compute the min/max of basic path-rendering operators on the worker-thread, we can utilize that by parsing these Type3 operatorLists to guess a more suitable fallback bounding box.