### PR TITLE
Use the `MathClamp` helper function more (PR 19617 follow-up) 

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -18,6 +18,7 @@ import {
   FormatError,
   IDENTITY_MATRIX,
   info,
+  MathClamp,
   unreachable,
   Util,
   warn,
@@ -843,17 +844,19 @@ class MeshShading extends BaseShading {
       ((figureMaxX - figureMinX) * MeshShading.TRIANGLE_DENSITY) /
         (this.bounds[2] - this.bounds[0])
     );
-    splitXBy = Math.max(
+    splitXBy = MathClamp(
+      splitXBy,
       MeshShading.MIN_SPLIT_PATCH_CHUNKS_AMOUNT,
-      Math.min(MeshShading.MAX_SPLIT_PATCH_CHUNKS_AMOUNT, splitXBy)
+      MeshShading.MAX_SPLIT_PATCH_CHUNKS_AMOUNT
     );
     let splitYBy = Math.ceil(
       ((figureMaxY - figureMinY) * MeshShading.TRIANGLE_DENSITY) /
         (this.bounds[3] - this.bounds[1])
     );
-    splitYBy = Math.max(
+    splitYBy = MathClamp(
+      splitYBy,
       MeshShading.MIN_SPLIT_PATCH_CHUNKS_AMOUNT,
-      Math.min(MeshShading.MAX_SPLIT_PATCH_CHUNKS_AMOUNT, splitYBy)
+      MeshShading.MAX_SPLIT_PATCH_CHUNKS_AMOUNT
     );
 
     const verticesPerRow = splitXBy + 1;

--- a/src/core/xfa/layout.js
+++ b/src/core/xfa/layout.js
@@ -21,6 +21,7 @@ import {
   $isSplittable,
   $isThereMoreWidth,
 } from "./symbol_utils.js";
+import { MathClamp } from "../../shared/util.js";
 import { measureToString } from "./html_utils.js";
 
 // Subform and ExclGroup have a layout so they share these functions.
@@ -141,7 +142,7 @@ function addHTML(node, html, bbox) {
       break;
     }
     case "table": {
-      extra.width = Math.min(availableSpace.width, Math.max(extra.width, w));
+      extra.width = MathClamp(w, extra.width, availableSpace.width);
       extra.height += h;
       extra.children.push(html);
       break;
@@ -150,7 +151,7 @@ function addHTML(node, html, bbox) {
       // Even if the subform can possibly take all the available width,
       // we must compute the final width as it is in order to be able
       // for example to center the subform within its parent.
-      extra.width = Math.min(availableSpace.width, Math.max(extra.width, w));
+      extra.width = MathClamp(w, extra.width, availableSpace.width);
       extra.height += h;
       extra.children.push(html);
       break;

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -81,13 +81,11 @@ const StyleMapping = new Map([
   ["kerning-mode", value => (value === "none" ? "none" : "normal")],
   [
     "xfa-font-horizontal-scale",
-    value =>
-      `scaleX(${Math.max(0, Math.min(parseInt(value) / 100)).toFixed(2)})`,
+    value => `scaleX(${Math.max(0, parseInt(value) / 100).toFixed(2)})`,
   ],
   [
     "xfa-font-vertical-scale",
-    value =>
-      `scaleY(${Math.max(0, Math.min(parseInt(value) / 100)).toFixed(2)})`,
+    value => `scaleY(${Math.max(0, parseInt(value) / 100).toFixed(2)})`,
   ],
   ["xfa-spacerun", ""],
   ["xfa-tab-stops", ""],


### PR DESCRIPTION
 - **Use the `MathClamp` helper function more (PR 19617 follow-up)**

   There's a few spots that I accidentally missed in PR #19617.

 - **Remove pointless `Math.min` usage in the XFA parsing**

   When creating the `StyleMapping` for the "xfa-font-horizontal-scale" and "xfa-font-vertical-scale" properties there's currently pointless `Math.min` usage, since we're not actually comparing with anything.