### PR TITLE
Support the `maxCanvasPixels` option in the thumbnails code

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -640,8 +640,38 @@ class OutputScale {
     return this.sx !== 1 || this.sy !== 1;
   }
 
+  /**
+   * @type {boolean} Returns `true` when scaling is symmetric,
+   *   `false` otherwise.
+   */
   get symmetric() {
     return this.sx === this.sy;
+  }
+
+  /**
+   * @returns {boolean} Returns `true` if scaling was limited,
+   *   `false` otherwise.
+   */
+  limitCanvas(width, height, maxPixels, maxDim) {
+    let maxAreaScale = Infinity,
+      maxWidthScale = Infinity,
+      maxHeightScale = Infinity;
+
+    if (maxPixels > 0) {
+      maxAreaScale = Math.sqrt(maxPixels / (width * height));
+    }
+    if (maxDim !== -1) {
+      maxWidthScale = maxDim / width;
+      maxHeightScale = maxDim / height;
+    }
+    const maxScale = Math.min(maxAreaScale, maxWidthScale, maxHeightScale);
+
+    if (this.sx > maxScale || this.sy > maxScale) {
+      this.sx = maxScale;
+      this.sy = maxScale;
+      return true;
+    }
+    return false;
   }
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -478,6 +478,7 @@ const PDFViewerApplication = {
         : null;
 
     const enableHWA = AppOptions.get("enableHWA"),
+      maxCanvasPixels = AppOptions.get("maxCanvasPixels"),
       maxCanvasDim = AppOptions.get("maxCanvasDim");
     const pdfViewer = new PDFViewer({
       container,
@@ -506,7 +507,7 @@ const PDFViewerApplication = {
       ),
       imageResourcesPath: AppOptions.get("imageResourcesPath"),
       enablePrintAutoRotate: AppOptions.get("enablePrintAutoRotate"),
-      maxCanvasPixels: AppOptions.get("maxCanvasPixels"),
+      maxCanvasPixels,
       maxCanvasDim,
       enableDetailCanvas: AppOptions.get("enableDetailCanvas"),
       enablePermissions: AppOptions.get("enablePermissions"),
@@ -529,6 +530,7 @@ const PDFViewerApplication = {
         eventBus,
         renderingQueue: pdfRenderingQueue,
         linkService: pdfLinkService,
+        maxCanvasPixels,
         maxCanvasDim,
         pageColors,
         abortSignal,

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -775,28 +775,13 @@ class PDFPageView extends BasePDFPageView {
       outputScale.sx *= invScale;
       outputScale.sy *= invScale;
       this.#needsRestrictedScaling = true;
-    } else if (this.maxCanvasPixels > 0 || this.maxCanvasDim !== -1) {
-      let maxAreaScale = Infinity,
-        maxWidthScale = Infinity,
-        maxHeightScale = Infinity;
-
-      if (this.maxCanvasPixels > 0) {
-        const pixelsInViewport = width * height;
-        maxAreaScale = Math.sqrt(this.maxCanvasPixels / pixelsInViewport);
-      }
-      if (this.maxCanvasDim !== -1) {
-        maxWidthScale = this.maxCanvasDim / width;
-        maxHeightScale = this.maxCanvasDim / height;
-      }
-      const maxScale = Math.min(maxAreaScale, maxWidthScale, maxHeightScale);
-
-      if (outputScale.sx > maxScale || outputScale.sy > maxScale) {
-        outputScale.sx = maxScale;
-        outputScale.sy = maxScale;
-        this.#needsRestrictedScaling = true;
-      } else {
-        this.#needsRestrictedScaling = false;
-      }
+    } else {
+      this.#needsRestrictedScaling = outputScale.limitCanvas(
+        width,
+        height,
+        this.maxCanvasPixels,
+        this.maxCanvasDim
+      );
     }
   }
 

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -39,6 +39,9 @@ const THUMBNAIL_SELECTED_CLASS = "selected";
  * @property {EventBus} eventBus - The application event bus.
  * @property {IPDFLinkService} linkService - The navigation/linking service.
  * @property {PDFRenderingQueue} renderingQueue - The rendering queue object.
+ * @property {number} [maxCanvasPixels] - The maximum supported canvas size in
+ *   total pixels, i.e. width * height. Use `-1` for no limit, or `0` for
+ *   CSS-only zooming. The default value is 4096 * 8192 (32 mega-pixels).
  * @property {number} [maxCanvasDim] - The maximum supported canvas dimension,
  *   in either width or height. Use `-1` for no limit.
  *   The default value is 32767.
@@ -63,6 +66,7 @@ class PDFThumbnailViewer {
     eventBus,
     linkService,
     renderingQueue,
+    maxCanvasPixels,
     maxCanvasDim,
     pageColors,
     abortSignal,
@@ -72,6 +76,7 @@ class PDFThumbnailViewer {
     this.eventBus = eventBus;
     this.linkService = linkService;
     this.renderingQueue = renderingQueue;
+    this.maxCanvasPixels = maxCanvasPixels;
     this.maxCanvasDim = maxCanvasDim;
     this.pageColors = pageColors || null;
     this.enableHWA = enableHWA || false;
@@ -214,6 +219,7 @@ class PDFThumbnailViewer {
             optionalContentConfigPromise,
             linkService: this.linkService,
             renderingQueue: this.renderingQueue,
+            maxCanvasPixels: this.maxCanvasPixels,
             maxCanvasDim: this.maxCanvasDim,
             pageColors: this.pageColors,
             enableHWA: this.enableHWA,


### PR DESCRIPTION
This addresses an inconsistency in the viewer, since the thumbnails don't respect the `maxCanvasPixels` option.
Note that, as far as I know, this has not lead to any bugs since the thumbnails render with a fixed (and small) width, however it really cannot hurt to address this (especially after the introduction of the `maxCanvasDim` option).

To support this a new `OutputScale`-method was added, to avoid having to duplicate code in multiple files.

/cc @nicolo-ribaudo 