### PR TITLE
Don't close the `secondaryToolbar` when clicking inside it (PR 18385 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2683,18 +2683,19 @@ function onWheel(evt) {
   }
 }
 
-function closeSecondaryToolbar(evt) {
+function closeSecondaryToolbar({ target }) {
   if (!this.secondaryToolbar?.isOpen) {
     return;
   }
-  const appConfig = this.appConfig;
+  const { toolbar, secondaryToolbar } = this.appConfig;
   if (
-    this.pdfViewer.containsElement(evt.target) ||
-    (appConfig.toolbar?.container.contains(evt.target) &&
+    this.pdfViewer.containsElement(target) ||
+    (toolbar?.container.contains(target) &&
+      !secondaryToolbar?.toolbar.contains(target) &&
       // TODO: change the `contains` for an equality check when the bug:
       //  https://bugzilla.mozilla.org/show_bug.cgi?id=1921984
       // is fixed.
-      !appConfig.secondaryToolbar?.toggleButton.contains(evt.target))
+      !secondaryToolbar?.toggleButton.contains(target))
   ) {
     this.secondaryToolbar.close();
   }


### PR DESCRIPTION
When the DOM structure of the viewer was updated in PR #18385 it caused the `secondaryToolbar` to accidentally start closing when clicking inside of it, since the `secondaryToolbar` now reside *under* the `toolbar` in the DOM.

**Steps to reproduce:**
 - Open the viewer.
 - Open the `secondaryToolbar`.
 - Try to change document rotation at least *twice*.

**Expected behaviour:**
 The document rotation can be changed an arbitrary number of times.

**Actual results:**
 The `secondaryToolbar` closes after changing rotation just once.