### PR TITLE
Replace a few simple regular expressions in the XFA-code with string parsing

### DIFF
--- a/src/core/xfa/config.js
+++ b/src/core/xfa/config.js
@@ -956,8 +956,7 @@ class Range extends ContentObject {
 
   [$finalize]() {
     this[$content] = this[$content]
-      .trim()
-      .split(/\s*,\s*/, 2)
+      .split(",", 2)
       .map(range => range.split("-").map(x => parseInt(x.trim(), 10)))
       .filter(range => range.every(x => !isNaN(x)))
       .map(range => {
@@ -1308,10 +1307,7 @@ class Window extends ContentObject {
   }
 
   [$finalize]() {
-    const pair = this[$content]
-      .trim()
-      .split(/\s*,\s*/, 2)
-      .map(x => parseInt(x, 10));
+    const pair = this[$content].split(",", 2).map(x => parseInt(x.trim(), 10));
     if (pair.some(x => isNaN(x))) {
       this[$content] = [0, 0];
       return;

--- a/src/core/xfa/utils.js
+++ b/src/core/xfa/utils.js
@@ -106,9 +106,8 @@ function getRatio(data) {
     return { num: 1, den: 1 };
   }
   const ratio = data
-    .trim()
-    .split(/\s*:\s*/)
-    .map(x => parseFloat(x))
+    .split(":", 2)
+    .map(x => parseFloat(x.trim()))
     .filter(x => !isNaN(x));
   if (ratio.length === 1) {
     ratio.push(1);
@@ -141,8 +140,7 @@ function getColor(data, def = [0, 0, 0]) {
     return { r, g, b };
   }
   const color = data
-    .trim()
-    .split(/\s*,\s*/)
+    .split(",", 3)
     .map(c => MathClamp(parseInt(c.trim(), 10), 0, 255))
     .map(c => (isNaN(c) ? 0 : c));
 
@@ -159,10 +157,8 @@ function getBBox(data) {
   if (!data) {
     return { x: def, y: def, width: def, height: def };
   }
-  const bbox = data
-    .trim()
-    .split(/\s*,\s*/)
-    .map(m => getMeasurement(m, "-1"));
+  const bbox = data.split(",", 4).map(m => getMeasurement(m.trim(), "-1"));
+
   if (bbox.length < 4 || bbox[2] < 0 || bbox[3] < 0) {
     return { x: def, y: def, width: def, height: def };
   }

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -191,10 +191,9 @@ function checkStyle(node) {
 
   // Remove any non-allowed keys.
   return node.style
-    .trim()
-    .split(/\s*;\s*/)
-    .filter(s => !!s)
-    .map(s => s.split(/\s*:\s*/, 2))
+    .split(";")
+    .filter(s => !!s.trim())
+    .map(s => s.split(":", 2).map(t => t.trim()))
     .filter(([key, value]) => {
       if (key === "font-family") {
         node[$globalData].usedTypefaces.add(value);


### PR DESCRIPTION
 - Add a couple of `limit` parameters in cases where those were "missing", for `String.prototype.split()` calls, to avoid unnecessary parsing.

 - Remove some "pointless" initial trimming of leading/trailing spaces, since that's already done at a later parsing step in many cases.