### PR TITLE
Don't get ICC color space files if required API options are missing

### DIFF
--- a/src/core/colorspace_utils.js
+++ b/src/core/colorspace_utils.js
@@ -289,7 +289,7 @@ class ColorSpaceUtils {
   }
 
   static get cmyk() {
-    if (IccColorSpace.isUsable) {
+    if (CmykICCBasedCS.isUsable) {
       try {
         return shadow(this, "cmyk", new CmykICCBasedCS());
       } catch {

--- a/src/core/icc_colorspace.js
+++ b/src/core/icc_colorspace.js
@@ -130,11 +130,15 @@ class IccColorSpace extends ColorSpace {
   static get isUsable() {
     let isUsable = false;
     if (this.#useWasm) {
-      try {
-        this._module = QCMS._module = this.#load();
-        isUsable = !!this._module;
-      } catch (e) {
-        warn(`ICCBased color space: "${e}".`);
+      if (this.#wasmUrl) {
+        try {
+          this._module = QCMS._module = this.#load();
+          isUsable = !!this._module;
+        } catch (e) {
+          warn(`ICCBased color space: "${e}".`);
+        }
+      } else {
+        warn("No ICC color space support due to missing `wasmUrl` API option");
       }
     }
 
@@ -168,6 +172,19 @@ class CmykICCBasedCS extends IccColorSpace {
 
   static setOptions({ iccUrl }) {
     this.#iccUrl = iccUrl;
+  }
+
+  static get isUsable() {
+    let isUsable = false;
+    if (IccColorSpace.isUsable) {
+      if (this.#iccUrl) {
+        isUsable = true;
+      } else {
+        warn("No CMYK ICC profile support due to missing `iccUrl` API option");
+      }
+    }
+
+    return shadow(this, "isUsable", isUsable);
   }
 }
 


### PR DESCRIPTION
This commit improves validation of the API options for the ICC color space logic. If `useWasm` is `true` but the corresponding `wasmUrl` or `iccUrl` API options are not provided we can avoid requesting files with `null` URLs which always results in a 404 response.

Fixes #19668.

_The diff is slightly shorter with `?w=1`; see https://github.com/mozilla/pdf.js/pull/19669/files?w=1._