### PR TITLE
Fix the "Signature Editor Basic operations must check copy and paste" integration test

### DIFF
--- a/test/integration/signature_editor_spec.mjs
+++ b/test/integration/signature_editor_spec.mjs
@@ -339,45 +339,44 @@ describe("Signature Editor", () => {
     });
 
     it("must check copy and paste", async () => {
-      await Promise.all(
-        pages.map(async ([browserName, page]) => {
-          await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+      // Run sequentially to avoid clipboard issues.
+      for (const [browserName, page] of pages) {
+        await switchToSignature(page);
+        await page.click("#editorSignatureAddSignature");
 
-          await page.waitForSelector("#addSignatureDialog", {
-            visible: true,
-          });
-          await page.type("#addSignatureTypeInput", "Hello");
-          await page.waitForSelector(`${addButtonSelector}:not(:disabled)`);
-          await page.click("#addSignatureAddButton");
+        await page.waitForSelector("#addSignatureDialog", {
+          visible: true,
+        });
+        await page.type("#addSignatureTypeInput", "Hello");
+        await page.waitForSelector(`${addButtonSelector}:not(:disabled)`);
+        await page.click("#addSignatureAddButton");
 
-          const editorSelector = getEditorSelector(0);
-          await page.waitForSelector(editorSelector, { visible: true });
-          const originalRect = await getRect(page, editorSelector);
-          const originalDescription = await page.$eval(
-            `${editorSelector} .altText.editDescription`,
-            el => el.title
-          );
+        const editorSelector = getEditorSelector(0);
+        await page.waitForSelector(editorSelector, { visible: true });
+        const originalRect = await getRect(page, editorSelector);
+        const originalDescription = await page.$eval(
+          `${editorSelector} .altText.editDescription`,
+          el => el.title
+        );
 
-          await copy(page);
-          await paste(page);
+        await copy(page);
+        await paste(page);
 
-          const pastedEditorSelector = getEditorSelector(1);
-          await page.waitForSelector(pastedEditorSelector, { visible: true });
-          const pastedRect = await getRect(page, pastedEditorSelector);
-          const pastedDescription = await page.$eval(
-            `${pastedEditorSelector} .altText.editDescription`,
-            el => el.title
-          );
+        const pastedEditorSelector = getEditorSelector(1);
+        await page.waitForSelector(pastedEditorSelector, { visible: true });
+        const pastedRect = await getRect(page, pastedEditorSelector);
+        const pastedDescription = await page.$eval(
+          `${pastedEditorSelector} .altText.editDescription`,
+          el => el.title
+        );
 
-          expect(pastedRect)
-            .withContext(`In ${browserName}`)
-            .not.toEqual(originalRect);
-          expect(pastedDescription)
-            .withContext(`In ${browserName}`)
-            .toEqual(originalDescription);
-        })
-      );
+        expect(pastedRect)
+          .withContext(`In ${browserName}`)
+          .not.toEqual(originalRect);
+        expect(pastedDescription)
+          .withContext(`In ${browserName}`)
+          .toEqual(originalDescription);
+      }
     });
   });
 


### PR DESCRIPTION
This integration test fails intermittently because of concurrent clipboard access due to running the test in parallel in both browsers. It can be reproduced by introducing `await waitForTimeout(1000)` between the copy and paste operations.

This commit fixes the issue by running the test sequentially instead, mirroring the change from commit 0e94f2bd.

Fixes #19670.

_The diff is much smaller with the `?w=1` flag applied; see https://github.com/mozilla/pdf.js/pull/19671/files?w=1._