### PR TITLE
Remove documentation for unused l10n variable (PR 18492 follow-up)

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -480,7 +480,6 @@ pdfjs-editor-new-alt-text-error-close-button = Close
 # Variables:
 #   $totalSize (Number) - the total size (in MB) of the AI model.
 #   $downloadedSize (Number) - the downloaded size (in MB) of the AI model.
-#   $percent (Number) - the percentage of the downloaded size.
 pdfjs-editor-new-alt-text-ai-model-downloading-progress = Downloading alt text AI model ({ $downloadedSize } of { $totalSize } MB)
     .aria-valuetext = Downloading alt text AI model ({ $downloadedSize } of { $totalSize } MB)
 


### PR DESCRIPTION
Looking at PR #18492 it doesn't seem that the `$percent` variable, for the `pdfjs-editor-new-alt-text-ai-model-downloading-progress` l10n-string, was ever used.