### PR TITLE
Improve `addSignatureDescription`/`editSignatureDescription` handling (issue 19683)

### DIFF
--- a/web/signature_manager.js
+++ b/web/signature_manager.js
@@ -187,10 +187,10 @@ class SignatureManager {
       },
       { passive: true }
     );
-    description.addEventListener(
+    this.#description.addEventListener(
       "input",
       () => {
-        this.#clearDescription.disabled = description.value === "";
+        this.#clearDescription.disabled = this.#description.value === "";
       },
       { passive: true }
     );

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -716,9 +716,9 @@ See https://github.com/adobe-type-tools/cmap-resources
               <div id="addSignatureControls">
                 <div id="horizontalContainer">
                   <div id="addSignatureDescriptionContainer">
-                    <label for="addSignatureDescription" data-l10n-id="pdfjs-editor-add-signature-description-label"></span></label>
+                    <label for="addSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
                     <span id="addSignatureDescription" class="inputWithClearButton">
-                      <input type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0"></input>
+                      <input id="addSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0"></input>
                       <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
                     </span>
                   </div>
@@ -755,9 +755,9 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
           <div id="editSignatureDescriptionAndView">
             <div id="editSignatureDescriptionContainer">
-              <label for="editSignatureDescription" data-l10n-id="pdfjs-editor-add-signature-description-label"></span></label>
+              <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
               <span id="editSignatureDescription" class="inputWithClearButton">
-                <input type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0"></input>
+                <input id="editSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0"></input>
                 <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
               </span>
             </div>


### PR DESCRIPTION
 - Point the `addSignatureDescription` respectively `editSignatureDescription` labels to their actual `input`-elements (this way clicking the label will actually focus the input).

 - Add the event listener to the `addSignatureDescription`-input, rather than its `span`-element (this is consistent with the `editSignatureDescription` case).

 - Correctly check if the `addSignatureDescription`-input is empty, since we're accidentally comparing with its `span`-element.

 - Remove unbalanced, and likely accidentally added, `</span>` tags.