### PR TITLE
Remove `Array.prototype.reduce` usage from the `src/core/xfa/template.js` file

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -5721,12 +5721,7 @@ class Text extends ContentObject {
     if (typeof this[$content] === "string") {
       return this[$content]
         .split(/[\u2029\u2028\n]/)
-        .reduce((acc, line) => {
-          if (line) {
-            acc.push(line);
-          }
-          return acc;
-        }, [])
+        .filter(line => !!line)
         .join("\n");
     }
     return this[$content][$text]();
@@ -5748,18 +5743,15 @@ class Text extends ContentObject {
           .map(para =>
             // Convert a paragraph into a set of <span> (for lines)
             // separated by <br>.
-            para.split(/[\u2028\n]/).reduce((acc, line) => {
-              acc.push(
-                {
-                  name: "span",
-                  value: line,
-                },
-                {
-                  name: "br",
-                }
-              );
-              return acc;
-            }, [])
+            para.split(/[\u2028\n]/).flatMap(line => [
+              {
+                name: "span",
+                value: line,
+              },
+              {
+                name: "br",
+              },
+            ])
           )
           .forEach(lines => {
             html.children.push({


### PR DESCRIPTION
Using `Array.prototype.reduce` often leads to less readable code, and in these cases we can replace that with other Array-methods instead.