### PR TITLE
Fix the MD5 computation in the `src/core/writer.js` file

### DIFF
--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -189,7 +189,7 @@ function computeMD5(filesize, xrefInfo) {
     writeString(str, offset, array);
     offset += str.length;
   }
-  return bytesToString(calculateMD5(array));
+  return bytesToString(calculateMD5(array, 0, array.length));
 }
 
 function writeXFADataForAcroform(str, changes) {

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -19,6 +19,15 @@ import { bytesToString } from "../../src/shared/util.js";
 import { StringStream } from "../../src/core/stream.js";
 
 describe("Writer", function () {
+  beforeAll(function () {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(0));
+  });
+
+  afterAll(function () {
+    jasmine.clock().uninstall();
+  });
+
   describe("Incremental update", function () {
     it("should update a file with new objects", async function () {
       const originalData = new Uint8Array();
@@ -50,7 +59,7 @@ describe("Writer", function () {
         "defg\n" +
         "789 0 obj\n" +
         "<< /Prev 314 /Size 790 /Type /XRef /Index [123 1 456 1 789 1] " +
-        "/W [1 1 1] /ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)] " +
+        "/W [1 1 1] /ID [(id) (\xeb\x4b\x2a\xe7\x31\x36\xf0\xcd\x83\x35\x94\x2a\x36\xcf\xaa\xb0)] " +
         "/Length 9>> stream\n" +
         "\x01\x01\x2d" +
         "\x01\x05\x4e" +
@@ -83,7 +92,7 @@ describe("Writer", function () {
         "0000000010 00000 n\r\n" +
         "trailer\n" +
         "<< /Prev 314 /Size 789 " +
-        "/ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)]>>\n" +
+        "/ID [(id) (\xeb\x4b\x2a\xe7\x31\x36\xf0\xcd\x83\x35\x94\x2a\x36\xcf\xaa\xb0)]>>\n" +
         "startxref\n" +
         "10\n" +
         "%%EOF\n";
@@ -279,7 +288,7 @@ describe("Writer", function () {
       "\nabc\n" +
       "789 0 obj\n" +
       "<< /Prev 314 /Size 790 /Type /XRef /Index [123 1 456 1 789 1] " +
-      "/W [1 1 1] /ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)] " +
+      "/W [1 1 1] /ID [(id) (\x5f\xd1\x43\x8e\xf8\x62\x79\x80\xbb\xd6\xf7\xb6\xd2\xb5\x6f\xd8)] " +
       "/Length 9>> stream\n" +
       "\x00\x00\x2e" +
       "\x01\x01\x4e" +
@@ -311,7 +320,7 @@ describe("Writer", function () {
       "0000000005 00000 n\r\n" +
       "trailer\n" +
       "<< /Prev 314 /Size 789 " +
-      "/ID [(id) (\x01#Eg\x89\xab\xcd\xef\xfe\xdc\xba\x98vT2\x10)]>>\n" +
+      "/ID [(id) (\x5f\xd1\x43\x8e\xf8\x62\x79\x80\xbb\xd6\xf7\xb6\xd2\xb5\x6f\xd8)]>>\n" +
       "startxref\n" +
       "5\n" +
       "%%EOF\n";


### PR DESCRIPTION
Currently the MD5 computation doesn't actually work (at all?), since we're invoking the `calculateMD5` function without providing all of the necessary parameters and the PDF-data thus isn't taken into account.

Fixing this caused unit-tests to fail, which isn't that surprising since the current date/time is used in the MD5 computation, and we thus utilize Jasmine to work-around that.