### PR TITLE
[api-minor] Enable `enableAutoLinking` by default

### DIFF
--- a/extensions/chromium/preferences_schema.json
+++ b/extensions/chromium/preferences_schema.json
@@ -228,7 +228,7 @@
     "enableAutoLinking": {
       "description": "Enable creation of hyperlinks from text that look like URLs.",
       "type": "boolean",
-      "default": false
+      "default": true
     }
   }
 }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -202,7 +202,7 @@ const defaultOptions = {
   },
   enableAutoLinking: {
     /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("MOZCENTRAL"),
+    value: true,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableDetailCanvas: {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -95,7 +95,7 @@ import { XfaLayerBuilder } from "./xfa_layer_builder.js";
  * @property {boolean} [enableHWA] - Enables hardware acceleration for
  *   rendering. The default value is `false`.
  * @property {boolean} [enableAutoLinking] - Enable creation of hyperlinks from
- *   text that look like URLs. The default value is `false`.
+ *   text that look like URLs. The default value is `true`.
  */
 
 const DEFAULT_LAYER_PROPERTIES =
@@ -130,7 +130,7 @@ class PDFPageView extends BasePDFPageView {
 
   #canvasWrapper = null;
 
-  #enableAutoLinking = false;
+  #enableAutoLinking = true;
 
   #hasRestrictedScaling = false;
 
@@ -188,7 +188,7 @@ class PDFPageView extends BasePDFPageView {
     this.maxCanvasPixels =
       options.maxCanvasPixels ?? AppOptions.get("maxCanvasPixels");
     this.maxCanvasDim = options.maxCanvasDim || AppOptions.get("maxCanvasDim");
-    this.#enableAutoLinking = options.enableAutoLinking || false;
+    this.#enableAutoLinking = options.enableAutoLinking !== false;
 
     this.l10n = options.l10n;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -137,7 +137,7 @@ function isValidAnnotationEditorMode(mode) {
  * @property {boolean} [supportsPinchToZoom] - Enable zooming on pinch gesture.
  *   The default value is `true`.
  * @property {boolean} [enableAutoLinking] - Enable creation of hyperlinks from
- *   text that look like URLs. The default value is `false`.
+ *   text that look like URLs. The default value is `true`.
  */
 
 class PDFPageViewBuffer {
@@ -238,7 +238,7 @@ class PDFViewer {
 
   #enableNewAltTextWhenAddingImage = false;
 
-  #enableAutoLinking = false;
+  #enableAutoLinking = true;
 
   #eventAbortController = null;
 
@@ -340,7 +340,7 @@ class PDFViewer {
     this.#mlManager = options.mlManager || null;
     this.#enableHWA = options.enableHWA || false;
     this.#supportsPinchToZoom = options.supportsPinchToZoom !== false;
-    this.#enableAutoLinking = options.enableAutoLinking || false;
+    this.#enableAutoLinking = options.enableAutoLinking !== false;
 
     this.defaultRenderingQueue = !options.renderingQueue;
     if (


### PR DESCRIPTION
It's already enabled by default in Firefox, and since there's no open issues regarding auto-linking I suppose that we can attempt to enable it unconditionally.