### PR TITLE
Replace the `setValues` function with `Array.prototype.fill()` in the `src/core/bidi.js` file

### DIFF
--- a/src/core/bidi.js
+++ b/src/core/bidi.js
@@ -91,12 +91,6 @@ function findUnequal(arr, start, value) {
   return j;
 }
 
-function setValues(arr, start, end, value) {
-  for (let j = start; j < end; ++j) {
-    arr[j] = value;
-  }
-}
-
 function reverseValues(arr, start, end) {
   for (let i = start, j = end - 1; i < j; ++i, --j) {
     const temp = arr[i];
@@ -323,7 +317,7 @@ function bidi(str, startLevel = -1, vertical = false) {
         after = "R";
       }
       if (before === after) {
-        setValues(types, i, end, before);
+        types.fill(before, i, end);
       }
       i = end - 1; // reset to end (-1 so next iteration is ok)
     }


### PR DESCRIPTION
This code is originally from 2012, see PR #1218, and the Array-method wasn't available until Firefox 31 (released on 2014-07-22).