### PR TITLE
Isolate the "create editor with keyboard" freetext editor integration tests

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -2340,20 +2340,19 @@ describe("FreeText Editor", () => {
   describe("Create editor with keyboard", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
-    it("must create an editor from the toolbar", async () => {
+    it("must create an editor, using Enter/Space keys, with focused toolbar button", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await page.focus("#editorFreeTextButton");
           await page.keyboard.press("Enter");
-
           let editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector, { visible: true });
 
@@ -2394,11 +2393,14 @@ describe("FreeText Editor", () => {
       );
     });
 
-    it("must create an editor with keyboard", async () => {
+    it("must create an editor, using Enter/Space keys, with focused page", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          await switchToFreeText(page);
+
+          await page.focus(".annotationEditorLayer");
           await page.keyboard.press("Enter");
-          let editorSelector = getEditorSelector(2);
+          let editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 10, () => kbBigMoveLeft(page));
@@ -2417,7 +2419,7 @@ describe("FreeText Editor", () => {
           expect(content).withContext(`In ${browserName}`).toEqual(data);
 
           await page.keyboard.press(" ");
-          editorSelector = getEditorSelector(3);
+          editorSelector = getEditorSelector(1);
           await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 10, () =>


### PR DESCRIPTION
This commit reduces the number of freetext editor integration test suite failures, in full isolation, from 6 to 5 by fixing the following issues in the "create editor with keyboard" block:

- The second test relied on the first test to enable freetext editing mode and put focus on the page (annotation layer). For isolation we now do that explicitly in the second test.
- The second test relied on the first test for the editor numbering. For isolation we change the editor numbering to the one after initial document load.

Moreover, the test names have been updated to clarify with scenario is being tested, which came up during comparison of the changes against commit ea5eafa to make sure that we are still testing the originally intended scenarios (confirmed by disabling the relevant code from the commit per scenario and noticing the corresponding test failing).

Fixes a part of #19065.

_Note that this should also reduce the number of test failures in case of intermittent failures. If the first test failed previously, the second test would automatically fail too, whereas now the second test can pass because it's run independently of the first test. This should avoid the double failures as seen in e.g. http://54.241.84.105:8877/be83f9ee48219b6/output.txt._