### PR TITLE
Don't overwrite the global alpha when switching to smask mode (bug 1764587)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1323,8 +1323,7 @@ class CanvasGraphics {
           this.current.strokeAlpha = value;
           break;
         case "ca":
-          this.current.fillAlpha = value;
-          this.ctx.globalAlpha = value;
+          this.ctx.globalAlpha = this.current.fillAlpha = value;
           break;
         case "BM":
           this.ctx.globalCompositeOperation = value;
@@ -1378,17 +1377,12 @@ class CanvasGraphics {
       drawnHeight
     );
     this.suspendedCtx = this.ctx;
-    this.ctx = scratchCanvas.context;
-    const ctx = this.ctx;
+    const ctx = (this.ctx = scratchCanvas.context);
     ctx.setTransform(this.suspendedCtx.getTransform());
     copyCtxState(this.suspendedCtx, ctx);
     mirrorContextOperations(ctx, this.suspendedCtx);
 
-    this.setGState([
-      ["BM", "source-over"],
-      ["ca", 1],
-      ["CA", 1],
-    ]);
+    this.setGState([["BM", "source-over"]]);
   }
 
   endSMaskMode() {

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -5821,8 +5821,7 @@
     "file": "pdfs/issue16287.pdf",
     "md5": "cd3e0859140465ae8b8bde0c95cb4929",
     "rounds": 1,
-    "type": "eq",
-    "about": "Please note that this file currently renders incorrectly."
+    "type": "eq"
   },
   {
     "id": "issue2006",


### PR DESCRIPTION
It fixes #issue16287.