### PR TITLE
Pass the `XRef`-instance explicitly to the `StructTreeRoot` class, and simplify the `StructElementNode.prototype.role` getter

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -262,7 +262,7 @@ class Catalog {
   get structTreeRoot() {
     let structTree = null;
     try {
-      structTree = this._readStructTreeRoot();
+      structTree = this.#readStructTreeRoot();
     } catch (ex) {
       if (ex instanceof MissingDataException) {
         throw ex;
@@ -272,17 +272,14 @@ class Catalog {
     return shadow(this, "structTreeRoot", structTree);
   }
 
-  /**
-   * @private
-   */
-  _readStructTreeRoot() {
+  #readStructTreeRoot() {
     const rawObj = this._catDict.getRaw("StructTreeRoot");
     const obj = this.xref.fetchIfRef(rawObj);
     if (!(obj instanceof Dict)) {
       return null;
     }
 
-    const root = new StructTreeRoot(obj, rawObj);
+    const root = new StructTreeRoot(this.xref, obj, rawObj);
     root.init();
     return root;
   }

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -551,10 +551,7 @@ class StructElementNode {
     const nameObj = this.dict.get("S");
     const name = nameObj instanceof Name ? nameObj.name : "";
     const { root } = this.tree;
-    if (root.roleMap.has(name)) {
-      return root.roleMap.get(name);
-    }
-    return name;
+    return root.roleMap.get(name) ?? name;
   }
 
   parseKids() {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -558,7 +558,6 @@ class WorkerMessageHandler {
           } else if (
             await _structTreeRoot.canUpdateStructTree({
               pdfManager,
-              xref,
               newAnnotationsByPage,
             })
           ) {


### PR DESCRIPTION
 - **Pass the `XRef`-instance explicitly to the `StructTreeRoot` class**

   This avoids the current situation where we're accessing it through various dictionaries, since that's a somewhat brittle solution given that in the general case a `Dict`-instance may not have the `xref`-field set (see e.g. the empty-Dict).

 - **Simplify the `StructElementNode.prototype.role` getter a tiny bit**

   Given that the `roleMap` only contains `Name`-strings, the lookup can be simplified thanks to modern JavaScript features.