### PR TITLE
Remove few useless beginPaths

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1768,7 +1768,6 @@ class CanvasGraphics {
     const paths = this.pendingTextPaths;
     const ctx = this.ctx;
     if (paths === undefined) {
-      ctx.beginPath();
       return;
     }
 
@@ -1785,7 +1784,6 @@ class CanvasGraphics {
     }
 
     ctx.clip(newPath);
-    ctx.beginPath();
     delete this.pendingTextPaths;
   }
 
@@ -2292,8 +2290,9 @@ class CanvasGraphics {
   }
 
   setCharWidthAndBounds(xWidth, yWidth, llx, lly, urx, ury) {
-    this.ctx.rect(llx, lly, urx - llx, ury - lly);
-    this.ctx.clip();
+    const clip = new Path2D();
+    clip.rect(llx, lly, urx - llx, ury - lly);
+    this.ctx.clip(clip);
     this.endPath();
   }
 
@@ -2436,11 +2435,11 @@ class CanvasGraphics {
     this.baseTransform = getCurrentTransform(this.ctx);
 
     if (bbox) {
-      const width = bbox[2] - bbox[0];
-      const height = bbox[3] - bbox[1];
-      this.ctx.rect(bbox[0], bbox[1], width, height);
       this.current.updateRectMinMax(getCurrentTransform(this.ctx), bbox);
-      this.clip();
+      const [x0, y0, x1, y1] = bbox;
+      const clip = new Path2D();
+      clip.rect(x0, y0, x1 - x0, y1 - y0);
+      this.ctx.clip(clip);
       this.endPath();
     }
   }
@@ -2668,9 +2667,9 @@ class CanvasGraphics {
         // Consume a potential path before clipping.
         this.endPath();
 
-        this.ctx.rect(rect[0], rect[1], width, height);
-        this.ctx.clip();
-        this.ctx.beginPath();
+        const clip = new Path2D();
+        clip.rect(rect[0], rect[1], width, height);
+        this.ctx.clip(clip);
       }
     }
 
@@ -3079,7 +3078,6 @@ class CanvasGraphics {
       this.pendingClip = null;
     }
     this.current.startNewPathAndClipBox(this.current.clipBox);
-    ctx.beginPath();
   }
 
   getSinglePixelWidth() {


### PR DESCRIPTION
The ctx current path is no more changed since we use some Path2D when we want to fill/stroke them.
It makes calling ctx.beginPath useless.