### PR TITLE
[api-minor] Attempt to improve support for using the PDF.js builds with Vite

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,7 +76,7 @@ export default [
       globals: {
         ...globals.worker,
         PDFJSDev: "readonly",
-        __non_webpack_import__: "readonly",
+        __raw_import__: "readonly",
       },
 
       ecmaVersion: 2025,

--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -153,17 +153,21 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
           path.replaceWith(t.inherits(t.valueToNode(result), path.node));
         }
 
-        if (t.isIdentifier(node.callee, { name: "__non_webpack_import__" })) {
+        if (t.isIdentifier(node.callee, { name: "__raw_import__" })) {
           if (node.arguments.length !== 1) {
-            throw new Error("Invalid `__non_webpack_import__` usage.");
+            throw new Error("Invalid `__raw_import__` usage.");
           }
-          // Replace it with a standard `import`-call and
-          // ensure that Webpack will leave it alone.
+          // Replace it with a standard `import`-call and attempt to ensure that
+          // various bundlers will leave it alone; this *must* include Webpack.
           const source = node.arguments[0];
           source.leadingComments = [
             {
               type: "CommentBlock",
               value: "webpackIgnore: true",
+            },
+            {
+              type: "CommentBlock",
+              value: "@vite-ignore",
             },
           ];
           path.replaceWith(t.importExpression(source));

--- a/external/builder/fixtures_babel/importalias-expected.js
+++ b/external/builder/fixtures_babel/importalias-expected.js
@@ -1,4 +1,7 @@
 import { Test } from "import-name";
 import { Test2 } from './non-alias';
 export { Test3 } from "import-name";
-await import(/*webpackIgnore: true*/"./non-alias");
+await import(
+/*webpackIgnore: true*/
+/*@vite-ignore*/
+"./non-alias");

--- a/external/builder/fixtures_babel/importalias.js
+++ b/external/builder/fixtures_babel/importalias.js
@@ -1,4 +1,4 @@
 import { Test } from 'import-alias';
 import { Test2 } from './non-alias';
 export { Test3 } from 'import-alias';
-await __non_webpack_import__("./non-alias");
+await __raw_import__("./non-alias");

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -57,7 +57,7 @@ class JpxImage {
     try {
       const mod = await (typeof PDFJSDev === "undefined"
         ? import(path) // eslint-disable-line no-unsanitized/method
-        : __non_webpack_import__(path));
+        : __raw_import__(path));
       instance = mod.default();
     } catch (e) {
       warn(`JpxImage#getJsModule: ${e}`);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2416,7 +2416,7 @@ class PDFWorker {
       const worker =
         typeof PDFJSDev === "undefined"
           ? await import("pdfjs/pdf.worker.js")
-          : await __non_webpack_import__(this.workerSrc);
+          : await __raw_import__(this.workerSrc);
       return worker.WorkerMessageHandler;
     };
 

--- a/web/app.js
+++ b/web/app.js
@@ -286,7 +286,7 @@ const PDFViewerApplication = {
       const { PDFBug } =
         typeof PDFJSDev === "undefined"
           ? await import(AppOptions.get("debuggerSrc")) // eslint-disable-line no-unsanitized/method
-          : await __non_webpack_import__(AppOptions.get("debuggerSrc"));
+          : await __raw_import__(AppOptions.get("debuggerSrc"));
 
       this._PDFBug = PDFBug;
     };
@@ -299,7 +299,7 @@ const PDFViewerApplication = {
         if (typeof PDFJSDev === "undefined") {
           globalThis.pdfjsWorker = await import("pdfjs/pdf.worker.js");
         } else {
-          await __non_webpack_import__(PDFWorker.workerSrc);
+          await __raw_import__(PDFWorker.workerSrc);
         }
       } catch (ex) {
         console.error("_parseHashParams:", ex);

--- a/web/generic_scripting.js
+++ b/web/generic_scripting.js
@@ -39,7 +39,7 @@ class GenericScripting {
       const sandbox =
         typeof PDFJSDev === "undefined"
           ? import(sandboxBundleSrc) // eslint-disable-line no-unsanitized/method
-          : __non_webpack_import__(sandboxBundleSrc);
+          : __raw_import__(sandboxBundleSrc);
       sandbox
         .then(pdfjsSandbox => {
           resolve(pdfjsSandbox.QuickJSSandbox());


### PR DESCRIPTION
Similar to Webpack there's apparently other bundlers that will not leave `import`-calls alone unless magic comments are used. Hence we extend the builder to also append `/* @vite-ignore */` comments to `import`-calls, in order to attempt to improve support for using the PDF.js builds together with Vite.

This patch also renames `__non_webpack_import__` to `__raw_import__` since the functionality is no longer bundler-specific.

***PLEASE NOTE:*** This patch is provided as-is, and it does *not* mean that the PDF.js project can/will provide official support for Vite.