### PR TITLE
Initialize the `isOffscreenCanvasSupported` option, in the `OperatorList` class, once per document

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -726,8 +726,6 @@ class PartialEvaluator {
           /* forceRGBA = */ true,
           /* isOffscreenCanvasSupported = */ false
         );
-        operatorList.isOffscreenCanvasSupported =
-          this.options.isOffscreenCanvasSupported;
         operatorList.addImageOps(
           OPS.paintInlineImageXObject,
           [imgData],

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -567,15 +567,10 @@ class QueueOptimizer extends NullOptimizer {
       iCurr: 0,
       fnArray: queue.fnArray,
       argsArray: queue.argsArray,
-      isOffscreenCanvasSupported: false,
+      isOffscreenCanvasSupported: OperatorList.isOffscreenCanvasSupported,
     };
     this.match = null;
     this.lastProcessed = 0;
-  }
-
-  // eslint-disable-next-line accessor-pairs
-  set isOffscreenCanvasSupported(value) {
-    this.context.isOffscreenCanvasSupported = value;
   }
 
   _optimize() {
@@ -656,6 +651,8 @@ class OperatorList {
   // Close to chunk size.
   static CHUNK_SIZE_ABOUT = this.CHUNK_SIZE - 5;
 
+  static isOffscreenCanvasSupported = false;
+
   constructor(intent = 0, streamSink) {
     this._streamSink = streamSink;
     this.fnArray = [];
@@ -670,9 +667,8 @@ class OperatorList {
     this._resolved = streamSink ? null : Promise.resolve();
   }
 
-  // eslint-disable-next-line accessor-pairs
-  set isOffscreenCanvasSupported(value) {
-    this.optimizer.isOffscreenCanvasSupported = value;
+  static setOptions({ isOffscreenCanvasSupported }) {
+    this.isOffscreenCanvasSupported = isOffscreenCanvasSupported;
   }
 
   get length() {

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -25,6 +25,7 @@ import { ImageResizer } from "./image_resizer.js";
 import { JpegStream } from "./jpeg_stream.js";
 import { JpxImage } from "./jpx.js";
 import { MissingDataException } from "./core_utils.js";
+import { OperatorList } from "./operator_list.js";
 import { PDFDocument } from "./document.js";
 import { Stream } from "./stream.js";
 
@@ -74,6 +75,7 @@ class BasePdfManager {
     // Initialize image-options once per document.
     ImageResizer.setOptions(evaluatorOptions);
     JpegStream.setOptions(evaluatorOptions);
+    OperatorList.setOptions(evaluatorOptions);
 
     const options = { ...evaluatorOptions, handler };
     JpxImage.setOptions(options);


### PR DESCRIPTION
Currently we're setting this option for each small inline image, which seems unnecessary since it should suffice to do that once per document.