### PR TITLE
Add margin to separate radio buttons and checkboxes from their labels

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -1321,7 +1321,7 @@ class CheckButton extends XFAObject {
   [$toHTML](availableSpace) {
     // TODO: border, shape and mark.
 
-    const style = toStyle("margin");
+    const style = toStyle(this, "margin");
     const size = measureToString(this.size);
 
     style.width = style.height = size;

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -157,6 +157,14 @@
   max-height: 100%;
 }
 
+:is(.xfaRight) > :is(.xfaRadio, .xfaCheckbox) {
+  margin-right: 4px;
+}
+
+:is(.xfaLeft) > :is(.xfaRadio, .xfaCheckbox) {
+  margin-left: 4px;
+}
+
 .xfaTop {
   display: flex;
   flex-direction: column;

--- a/web/xfa_layer_builder.css
+++ b/web/xfa_layer_builder.css
@@ -157,12 +157,12 @@
   max-height: 100%;
 }
 
-:is(.xfaRight) > :is(.xfaRadio, .xfaCheckbox) {
-  margin-right: 4px;
+.xfaRight > :is(.xfaRadio, .xfaCheckbox) {
+  margin-right: 2.5px;
 }
 
-:is(.xfaLeft) > :is(.xfaRadio, .xfaCheckbox) {
-  margin-left: 4px;
+.xfaLeft > :is(.xfaRadio, .xfaCheckbox) {
+  margin-left: 2.5px;
 }
 
 .xfaTop {


### PR DESCRIPTION
This PR addresses [bug 1716806](https://bugzilla.mozilla.org/show_bug.cgi?id=1716806) by adding a 4px margin to the right of checkboxes and radio buttons for `.xfaRight` elements, or to the left for `.xfaLeft` elements.