### PR TITLE
Pass the /Info-strings as a `Map` to the `src/core/writer.js` code

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -674,12 +674,12 @@ class WorkerMessageHandler {
         let newXrefInfo = Object.create(null);
         if (xref.trailer) {
           // Get string info from Info in order to compute fileId.
-          const infoObj = Object.create(null);
+          const infoMap = new Map();
           const xrefInfo = xref.trailer.get("Info") || null;
           if (xrefInfo instanceof Dict) {
             for (const [key, value] of xrefInfo) {
               if (typeof value === "string") {
-                infoObj[key] = stringToPDFString(value);
+                infoMap.set(key, stringToPDFString(value));
               }
             }
           }
@@ -689,7 +689,7 @@ class WorkerMessageHandler {
             encryptRef: xref.trailer.getRaw("Encrypt") || null,
             newRef: xref.getNewTemporaryRef(),
             infoRef: xref.trailer.getRaw("Info") || null,
-            info: infoObj,
+            infoMap,
             fileIds: xref.trailer.get("ID") || null,
             startXRef: linearization
               ? startXRef

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -182,7 +182,7 @@ function computeMD5(filesize, xrefInfo) {
     time.toString(),
     filename,
     filesize.toString(),
-    ...Object.values(xrefInfo.info),
+    ...xrefInfo.infoMap.values(),
   ];
   const md5BufferLen = Math.sumPrecise(md5Buffer.map(str => str.length));
 

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -42,7 +42,7 @@ describe("Writer", function () {
         infoRef: null,
         encryptRef: null,
         filename: "foo.pdf",
-        info: {},
+        infoMap: new Map(),
       };
 
       let data = await incrementalUpdate({
@@ -111,7 +111,7 @@ describe("Writer", function () {
         infoRef: null,
         encryptRef: null,
         filename: "foo.pdf",
-        info: {},
+        infoMap: new Map(),
       };
 
       let data = await incrementalUpdate({
@@ -218,7 +218,7 @@ describe("Writer", function () {
         infoRef: null,
         encryptRef: null,
         filename: "foo.pdf",
-        info: {},
+        infoMap: new Map(),
       };
 
       let data = await incrementalUpdate({
@@ -272,7 +272,7 @@ describe("Writer", function () {
       infoRef: null,
       encryptRef: null,
       filename: "foo.pdf",
-      info: {},
+      infoMap: new Map(),
     };
 
     let data = await incrementalUpdate({


### PR DESCRIPTION
We want to iterate through the data in the `computeMD5` function, and `Map`s have "nicer" support for that than generic objects.
(Somewhat recently `Map` performance was improved in Firefox, however this also isn't really performance sensitive code.)