### PR TITLE
Tweak the Node.js version listed in "engines", to ensure that `process.getBuiltinModule` is available

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2333,7 +2333,7 @@ function packageJson() {
       url: `git+${DIST_GIT_URL}`,
     },
     engines: {
-      node: ">=20",
+      node: ">=20.16.0",
     },
     scripts: {},
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.16.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "url": "git://github.com/mozilla/pdf.js.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.16.0"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
In order to use the PDF.js library in Node.js environments the `process.getBuiltinModule` functionality must be available, which was released in [version `20.16.0`](https://nodejs.org/en/blog/release/v20.16.0), however we've seen repeated issues filed by users on older `20.x` versions.