### PR TITLE
[api-minor] Replace various `getAll` methods with iterators

### DIFF
--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { objectFromMap, shadow, unreachable } from "../shared/util.js";
+import { shadow, unreachable } from "../shared/util.js";
 import { AnnotationEditor } from "./editor/editor.js";
 import { MurmurHash3_64 } from "../shared/murmurhash3.js";
 
@@ -41,6 +41,17 @@ class AnnotationStorage {
     this.onSetModified = null;
     this.onResetModified = null;
     this.onAnnotationEditor = null;
+
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+      // For testing purposes.
+      Object.defineProperty(this, "_setValues", {
+        value: obj => {
+          for (const [key, val] of Object.entries(obj)) {
+            this.setValue(key, val);
+          }
+        },
+      });
+    }
   }
 
   /**
@@ -126,22 +137,6 @@ class AnnotationStorage {
    */
   has(key) {
     return this.#storage.has(key);
-  }
-
-  /**
-   * @returns {Object | null}
-   */
-  getAll() {
-    return this.#storage.size > 0 ? objectFromMap(this.#storage) : null;
-  }
-
-  /**
-   * @param {Object} obj
-   */
-  setAll(obj) {
-    for (const [key, val] of Object.entries(obj)) {
-      this.setValue(key, val);
-    }
   }
 
   get size() {
@@ -277,6 +272,10 @@ class AnnotationStorage {
       ids: new Set(ids),
       hash: ids.join(","),
     });
+  }
+
+  [Symbol.iterator]() {
+    return this.#storage.entries();
   }
 }
 

--- a/src/display/metadata.js
+++ b/src/display/metadata.js
@@ -13,15 +13,13 @@
  * limitations under the License.
  */
 
-import { objectFromMap } from "../shared/util.js";
-
 class Metadata {
-  #metadataMap;
+  #map;
 
   #data;
 
   constructor({ parsedData, rawData }) {
-    this.#metadataMap = parsedData;
+    this.#map = parsedData;
     this.#data = rawData;
   }
 
@@ -30,15 +28,11 @@ class Metadata {
   }
 
   get(name) {
-    return this.#metadataMap.get(name) ?? null;
+    return this.#map.get(name) ?? null;
   }
 
-  getAll() {
-    return objectFromMap(this.#metadataMap);
-  }
-
-  has(name) {
-    return this.#metadataMap.has(name);
+  [Symbol.iterator]() {
+    return this.#map.entries();
   }
 }
 

--- a/src/display/optional_content_config.js
+++ b/src/display/optional_content_config.js
@@ -15,7 +15,6 @@
 
 import {
   info,
-  objectFromMap,
   RenderingIntentFlag,
   unreachable,
   warn,
@@ -301,10 +300,6 @@ class OptionalContentConfig {
     return [...this.#groups.keys()];
   }
 
-  getGroups() {
-    return this.#groups.size > 0 ? objectFromMap(this.#groups) : null;
-  }
-
   getGroup(id) {
     return this.#groups.get(id) || null;
   }
@@ -319,6 +314,10 @@ class OptionalContentConfig {
       hash.update(`${id}:${group.visible}`);
     }
     return (this.#cachedGetHash = hash.hexdigest());
+  }
+
+  [Symbol.iterator]() {
+    return this.#groups.entries();
   }
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -578,16 +578,6 @@ function objectSize(obj) {
   return Object.keys(obj).length;
 }
 
-// Ensure that the returned Object has a `null` prototype; hence why
-// `Object.fromEntries(...)` is not used.
-function objectFromMap(map) {
-  const obj = Object.create(null);
-  for (const [key, value] of map) {
-    obj[key] = value;
-  }
-  return obj;
-}
-
 // Checks the endianness of the platform.
 function isLittleEndian() {
   const buffer8 = new Uint8Array(4);
@@ -1313,7 +1303,6 @@ export {
   LINE_FACTOR,
   MathClamp,
   normalizeUnicode,
-  objectFromMap,
   objectSize,
   OPS,
   PageActionEventType,

--- a/test/driver.js
+++ b/test/driver.js
@@ -738,7 +738,7 @@ class Driver {
                 await page.getAnnotations({ intent: "display" });
               }
             }
-            doc.annotationStorage.setAll(task.annotationStorage);
+            doc.annotationStorage._setValues(task.annotationStorage);
 
             const data = await doc.saveDocument();
             await loadingTask.destroy();
@@ -919,7 +919,7 @@ class Driver {
               pageColors = null;
 
             if (task.annotationStorage) {
-              task.pdfDoc.annotationStorage.setAll(task.annotationStorage);
+              task.pdfDoc.annotationStorage._setValues(task.annotationStorage);
             }
 
             let textLayerCanvas, annotationLayerCanvas, annotationLayerContext;

--- a/test/unit/annotation_storage_spec.js
+++ b/test/unit/annotation_storage_spec.js
@@ -59,7 +59,7 @@ describe("AnnotationStorage", function () {
     it("should set a new value in the annotation storage", function () {
       const annotationStorage = new AnnotationStorage();
       annotationStorage.setValue("123A", { value: "an other string" });
-      const value = annotationStorage.getAll()["123A"].value;
+      const { value } = annotationStorage.getRawValue("123A");
       expect(value).toEqual("an other string");
     });
 


### PR DESCRIPTION
These `getAll` methods are not used anywhere within the PDF.js code-base, outside of tests, and were mostly added (speculatively) for third-party users.
To still allow access to the same data we instead introduce iterators on these classes, which (slightly) shortens the code and allows us to remove the `objectFromMap` helper function.

A summary of the changes in this patch:
 - Replace the `getAll` methods with iterators in the following classes: `AnnotationStorage`, `Metadata`, and `OptionalContentGroup`.

 - Change, and also re-name, `AnnotationStorage.prototype.setAll` into a test-only method since it's not used elsewhere.

 - Remove the `Metadata.prototype.has` method, since it's only used in tests and can be trivially replaced by calling `Metadata.prototype.get` and checking if the returned value is `null`.