### PR TITLE
Enable the `no-array-reduce` ESLint plugin rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -127,6 +127,7 @@ export default [
       "perfectionist/sort-named-exports": "error",
       "unicorn/no-abusive-eslint-disable": "error",
       "unicorn/no-array-push-push": "error",
+      "unicorn/no-array-reduce": ["error", { allowSimpleOperations: true }],
       "unicorn/no-console-spaces": "error",
       "unicorn/no-instanceof-builtins": "error",
       "unicorn/no-invalid-remove-event-listener": "error",

--- a/test/stats/statcmp.js
+++ b/test/stats/statcmp.js
@@ -76,10 +76,7 @@ function pad(s, length, dir /* default: 'right' */) {
 }
 
 function mean(array) {
-  function add(a, b) {
-    return a + b;
-  }
-  return array.reduce(add, 0) / array.length;
+  return array.reduce((a, b) => a + b, 0) / array.length;
 }
 
 /* Comparator for row key sorting. */


### PR DESCRIPTION
Please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-reduce.md

Note that this still allows "simple" usage of `Array.prototype.reduce`, however most of those cases will be possible to replace with `Math.sumPrecise` once that becomes generally available (currently not supported in Node.js or QuickJS).