### PR TITLE
Simplify `Object.fromEntries` usage a tiny bit in the `web/generic_signature_storage.js` file

### DIFF
--- a/web/generic_signature_storage.js
+++ b/web/generic_signature_storage.js
@@ -36,7 +36,7 @@ class SignatureStorage {
   #save() {
     localStorage.setItem(
       KEY_STORAGE,
-      JSON.stringify(Object.fromEntries(this.#signatures.entries()))
+      JSON.stringify(Object.fromEntries(this.#signatures))
     );
   }
 


### PR DESCRIPTION
As can be seen [at MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries#parameters) the `Object.fromEntries` method accepts a `Map` directly, hence using the `Map.prototype.entries` method is superfluous here.