### PR TITLE
Simplify the `getAnnotationStorage` integration-test helper function

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -466,8 +466,8 @@ async function getFirstSerialized(page, filter = undefined) {
 function getAnnotationStorage(page) {
   return page.evaluate(() =>
     Object.fromEntries(
-      window.PDFViewerApplication.pdfDocument.annotationStorage.serializable.map?.entries() ||
-        []
+      window.PDFViewerApplication.pdfDocument.annotationStorage.serializable
+        .map || []
     )
   );
 }


### PR DESCRIPTION
As can be seen [at MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries#parameters) the `Object.fromEntries` method accepts a `Map` directly, hence using the `Map.prototype.entries` method is superfluous here.