### PR TITLE
Handle non-integer and out-of-range values correctly in Indexed color spaces

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -429,6 +429,7 @@ class IndexedCS extends ColorSpace {
   constructor(base, highVal, lookup) {
     super("Indexed", 1);
     this.base = base;
+    this.highVal = highVal;
 
     const length = base.numComps * (highVal + 1);
     this.lookup = new Uint8Array(length);
@@ -452,9 +453,10 @@ class IndexedCS extends ColorSpace {
         'IndexedCS.getRgbItem: Unsupported "dest" type.'
       );
     }
-    const numComps = this.base.numComps;
-    const start = src[srcOffset] * numComps;
-    this.base.getRgbBuffer(this.lookup, start, 1, dest, destOffset, 8, 0);
+    const { base, highVal, lookup } = this;
+    const start =
+      MathClamp(Math.round(src[srcOffset]), 0, highVal) * base.numComps;
+    base.getRgbBuffer(lookup, start, 1, dest, destOffset, 8, 0);
   }
 
   getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
@@ -464,13 +466,13 @@ class IndexedCS extends ColorSpace {
         'IndexedCS.getRgbBuffer: Unsupported "dest" type.'
       );
     }
-    const base = this.base;
-    const numComps = base.numComps;
+    const { base, highVal, lookup } = this;
+    const { numComps } = base;
     const outputDelta = base.getOutputLength(numComps, alpha01);
-    const lookup = this.lookup;
 
     for (let i = 0; i < count; ++i) {
-      const lookupPos = src[srcOffset++] * numComps;
+      const lookupPos =
+        MathClamp(Math.round(src[srcOffset++]), 0, highVal) * numComps;
       base.getRgbBuffer(lookup, lookupPos, 1, dest, destOffset, 8, alpha01);
       destOffset += outputDelta;
     }

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -191,6 +191,7 @@
 !rotation.pdf
 !simpletype3font.pdf
 !Type3WordSpacing.pdf
+!IndexedCS_negative_and_high.pdf
 !sizes.pdf
 !javauninstall-7r.pdf
 !file_url_link.pdf

--- a/test/pdfs/IndexedCS_negative_and_high.pdf
+++ b/test/pdfs/IndexedCS_negative_and_high.pdf
@@ -1,0 +1,87 @@
+%PDF-1.7
+%‚„œ”
+
+1 0 obj
+<<
+  /Type   /Catalog
+  /Pages  2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+  /Type   /Pages
+  /Kids   [ 3 0 R ]
+  /Count  1
+>>
+endobj
+
+3 0 obj
+<<
+  /Type     /Page
+  /Parent   2 0 R
+  /MediaBox [ 0 0 500 100 ]
+  /Contents 5 0 R
+  /Resources <<
+    /ColorSpace << /Cs1 4 0 R >>
+  >>
+>>
+endobj
+
+4 0 obj
+[
+  /Indexed /DeviceRGB
+  7                     % "hival"
+  < 008000 FF0000 00FF00 0000FF 00FFFF FF00FF FFFF00 F380FF > % indices 0-7 inclusive
+] 
+endobj
+
+5 0 obj
+<<
+  /Length 1037
+>>
+stream
+  % Reference 
+  0 0.5 0 rg       5  10  20 20 re f % 008000
+  0 0.5 0 rg      30  10  20 20 re f % 008000
+  1 0 0 rg        55  10  20 20 re f % FF0000
+  0 1 0 rg        80  10  20 20 re f % 00FF00
+  0 0 1 rg       105  10  20 20 re f % 0000FF
+  0 1 1 rg       130  10  20 20 re f % 00FFFF
+  1 0 1 rg       155  10  20 20 re f % FF00FF
+  1 1 0 rg       180  10  20 20 re f % FFFF00
+  0.95 0.5 1 rg  205  10  20 20 re f % F380FF
+  0.95 0.5 1 rg  230  10  20 20 re f % F380FF
+  0.95 0.5 1 rg  255  10  20 20 re f % F380FF
+
+  % Test patches
+  /Cs1 cs 
+-17   sc    5  50  20 20 re f % Below 0 --> snap to 0
+  0   sc   30  50  20 20 re f
+  1   sc   55  50  20 20 re f
+  2   sc   80  50  20 20 re f
+  3   sc  105  50  20 20 re f
+  4   sc  130  50  20 20 re f
+  5   sc  155  50  20 20 re f
+  6   sc  180  50  20 20 re f
+  7   sc  205  50  20 20 re f % Same as "Hival" = OK
+  6.5 sc  230  50  20 20 re f % Needs to round up --> snap to "hival"
+ 17   sc  255  50  20 20 re f % Clearly out of range! --> snap to "hival"
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000019 00000 n
+0000000083 00000 n
+0000000162 00000 n
+0000000332 00000 n
+0000000503 00000 n
+trailer
+<<
+  /Root 1 0 R
+  /Size 6
+>>
+startxref
+1600
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2852,6 +2852,14 @@
     "type": "eq"
   },
   {
+    "id": "IndexedCS_negative_and_high",
+    "file": "pdfs/IndexedCS_negative_and_high.pdf",
+    "md5": "3bbf5e6f1cf49acb075fabb0726b5fe4",
+    "link": false,
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue13372",
     "file": "pdfs/issue13372.pdf",
     "md5": "0bc5329623fd554174c5e7653f904e28",


### PR DESCRIPTION
In PDF version 2.0 the handling of Indexed color spaces was clarified as follows:
> The index value should be an integer in the range 0 to hival. If the value is a real number, it shall be rounded to the nearest integer (0.5 values shall be rounded up); if it is outside the range 0 to hival, it shall be adjusted to the nearest value within that range.

Please refer to https://github.com/pdf-association/pdf-differences/tree/main/IndexedColor