### PR TITLE
Support /DefaultGray, /DefaultRGB, and /DefaultCMYK color spaces

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -192,6 +192,9 @@
 !simpletype3font.pdf
 !Type3WordSpacing.pdf
 !IndexedCS_negative_and_high.pdf
+!DefaultRGBColourSpaces.pdf
+!DefaultRGBColourSpaces-inherit.pdf
+!DefaultColourSpaces-230802.pdf
 !sizes.pdf
 !javauninstall-7r.pdf
 !file_url_link.pdf

--- a/test/pdfs/DefaultColourSpaces-230802.pdf
+++ b/test/pdfs/DefaultColourSpaces-230802.pdf
@@ -1,0 +1,1024 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+	<<
+	/Pages 	2 0 R 
+	/Type 	/Catalog 
+>> 
+endobj
+2 0 obj
+	<<
+	/Kids 	[ 3 0 R  ] 
+	/Count 	1 
+	/Type 	/Pages 
+>> 
+endobj
+3 0 obj
+	<<
+	/MediaBox 	[ 0 0 595 842  ] 
+	/Parent 	2 0 R 
+	/Type 	/Page 
+	/Resources 			<<
+		/ExtGState 				<<
+			/GS8 	8 0 R 
+			/GS7 	7 0 R 
+		>> 
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+		/ColorSpace 				<<
+			/DefaultRGB 	10 0 R 
+			/DefaultCMYK 	21 0 R 
+		>> 
+		/XObject 				<<
+			/scNone 	11 0 R 
+			/scNoDef 	12 0 R 
+			/rgNone 	14 0 R 
+			/scNoDefCMYK 	24 0 R 
+			/rgDef 	16 0 R 
+			/kNoDef 	27 0 R 
+			/scDef 	13 0 R 
+			/scDefCMYK 	25 0 R 
+			/rgNoDef 	15 0 R 
+			/scNoneCMYK 	23 0 R 
+			/kNone 	26 0 R 
+			/kDef 	28 0 R 
+		>> 
+	>> 
+	/Contents 	4 0 R 
+>> 
+endobj
+4 0 obj
+	<<
+	/Length 	2207 
+>> 
+stream
+0 G 0 g
+q
+  /FB 14 Tf
+  1 0 0 1 30 800 cm
+  BT
+    (INHERITANCE OF DEFAULT COLOUR SPACES INTO FORM XOBJECTS) Tj
+  ET
+Q
+
+q
+  /F1 11 Tf
+  1 0 0 1 30 740 cm
+  BT
+    (Base page) Tj
+  ET
+Q
+q
+  1 0 0 1 130 660 cm
+  0 0 100 100 re
+  s
+
+  /FB 11 Tf
+  q
+    BT
+      1 0 0 1 20 75 Tm
+      1 0 0 rg
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 20 50 Tm
+      0 1 0 rg
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 20 25 Tm
+      0 0 1 rg
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+q
+  1 0 0 1 330 660 cm
+  0 0 100 100 re
+  s
+
+  /FB 11 Tf
+  q
+    BT
+      1 0 0 1 20 75 Tm
+      1 0 0 0 k
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 20 50 Tm
+      0 1 0 0 k
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 20 25 Tm
+      0 0 1 0 k
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+q
+  130 300 400 300 re
+  230 300 m 230 600 l
+  330 300 m 330 600 l
+  430 300 m 430 600 l
+  130 400 m 530 400 l 
+  130 500 m 530 500 l s
+Q
+q
+  /F1 11 Tf
+  BT
+    1 0 0 1 30 620 Tm
+    (Form Resources) Tj
+  ET
+  BT
+    1 0 0 1 140 620 Tm
+    (Form uses sc) Tj
+  ET
+  BT
+    1 0 0 1 240 620 Tm
+    (Form uses rg) Tj
+  ET
+  BT
+    1 0 0 1 340 620 Tm
+    (Form uses sc) Tj
+  ET
+  BT
+    1 0 0 1 440 620 Tm
+    (Form uses k) Tj
+  ET
+  BT
+    1 0 0 1 30 560 Tm
+    (None) Tj
+  ET
+  BT
+    1 0 0 1 30 460 Tm
+    (Yes) Tj
+    1 0 0 1 30 442 Tm
+    (NO Default space) Tj
+  ET
+  BT
+    1 0 0 1 30 360 Tm
+    (Yes) Tj
+    1 0 0 1 30 342 Tm
+    (with Default space) Tj
+  ET
+Q
+
+q
+  1 1 1 rg
+
+  q
+    1 0 0 1 130 500 cm
+    /scNone Do
+  Q
+  q
+    1 0 0 1 130 400 cm
+    /scNoDef Do
+  Q
+  q
+    1 0 0 1 130 300 cm
+    /scDef Do
+  Q
+  q
+    1 0 0 1 230 500 cm
+    /rgNone Do
+  Q
+  q
+    1 0 0 1 230 400 cm
+    /rgNoDef Do
+  Q
+  q
+    1 0 0 1 230 300 cm
+    /rgDef Do
+  Q
+Q
+
+q
+  0 0 0 1 k
+
+  q
+    1 0 0 1 330 500 cm
+    /scNoneCMYK Do
+  Q
+  q
+    1 0 0 1 330 400 cm
+    /scNoDefCMYK Do
+  Q
+  q
+    1 0 0 1 330 300 cm
+    /scDefCMYK Do
+  Q
+  q
+    1 0 0 1 430 500 cm
+    /kNone Do
+  Q
+  q
+    1 0 0 1 430 400 cm
+    /kNoDef Do
+  Q
+  q
+    1 0 0 1 430 300 cm
+    /kDef Do
+  Q
+Q
+
+endstream
+endobj
+5 0 obj
+	<<
+	/Subtype 	/TrueType 
+	/BaseFont 	/ArialMT 
+	/Name 	/F1 
+	/Widths 	20 0 R 
+	/FontDescriptor 	6 0 R 
+	/Encoding 	/WinAnsiEncoding 
+	/LastChar 	122 
+	/Type 	/Font 
+	/FirstChar 	32 
+>> 
+endobj
+6 0 obj
+	<<
+	/FontName 	/ArialMT 
+	/Ascent 	905 
+	/FontWeight 	400 
+	/ItalicAngle 	0 
+	/XHeight 	250 
+	/AvgWidth 	441 
+	/StemV 	44 
+	/FontBBox 	[ -665 -210 2000 728  ] 
+	/Type 	/FontDescriptor 
+	/Flags 	32 
+	/Descent 	-210 
+	/MaxWidth 	2665 
+	/CapHeight 	728 
+	/Leading 	33 
+>> 
+endobj
+7 0 obj
+	<<
+	/BM 	/Normal 
+	/ca 	1 
+	/Type 	/ExtGState 
+>> 
+endobj
+8 0 obj
+	<<
+	/BM 	/Normal 
+	/CA 	1 
+	/Type 	/ExtGState 
+>> 
+endobj
+9 0 obj
+	<<
+	/CreationDate 	<443A32303233303731363130313030382B303127303027> 
+	/Producer 	<476C6F62616C20477261706869637320736F667477617265204C7464> 
+	/Creator 	<476C6F62616C20477261706869637320736F667477617265204C7464> 
+	/Author 	<4D617274696E42> 
+	/ModDate 	<443A32303233303731363130313030382B303127303027> 
+>> 
+endobj
+10 0 obj
+[ /CalRGB 	<<
+	/WhitePoint 	[ 1.0 1.0 1.0  ] 
+	/Matrix 	[ 0 1 0 1 0 0 0 0 1  ] 
+>>  ] 
+endobj
+11 0 obj
+	<<
+	/FormType 	1 
+	/Type 	/XObject 
+	/BBox 	[ 0 0 101 101  ] 
+	/Length 	382 
+	/Subtype 	/Form 
+>> 
+stream
+q
+%  0 0 0 rg
+  
+q
+  0 0 0 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (A) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 sc
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 sc
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 sc
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+12 0 obj
+	<<
+	/Subtype 	/Form 
+	/FormType 	1 
+	/BBox 	[ 0 0 250 220  ] 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+	>> 
+	/Length 	382 
+	/Type 	/XObject 
+>> 
+stream
+q
+%  0 0 0 rg
+  
+q
+  0 0 0 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (B) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 sc
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 sc
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 sc
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+13 0 obj
+	<<
+	/Subtype 	/Form 
+	/FormType 	1 
+	/BBox 	[ 0 0 250 220  ] 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+		/ColorSpace 				<<
+			/DefaultRGB 	10 0 R 
+		>> 
+	>> 
+	/Length 	382 
+	/Type 	/XObject 
+>> 
+stream
+q
+%  0 0 0 rg
+  
+q
+  0 0 0 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (C) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 sc
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 sc
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 sc
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+14 0 obj
+	<<
+	/FormType 	1 
+	/Type 	/XObject 
+	/BBox 	[ 0 0 101 101  ] 
+	/Length 	368 
+	/Subtype 	/Form 
+>> 
+stream
+q
+0 0 0 rg
+  
+q
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85  Tm
+    (D) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 sc
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 sc
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 sc
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+15 0 obj
+	<<
+	/Subtype 	/Form 
+	/FormType 	1 
+	/BBox 	[ 0 0 250 220  ] 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+	>> 
+	/Length 	367 
+	/Type 	/XObject 
+>> 
+stream
+q
+0 0 0 rg
+  
+q
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (E) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 sc
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 sc
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 sc
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+16 0 obj
+	<<
+	/Subtype 	/Form 
+	/FormType 	1 
+	/BBox 	[ 0 0 250 220  ] 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+		/ColorSpace 				<<
+			/DefaultRGB 	10 0 R 
+		>> 
+	>> 
+	/Length 	365 
+	/Type 	/XObject 
+>> 
+stream
+q
+0 0 0 rg
+
+q
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (F) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 sc
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 sc
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 sc
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+17 0 obj
+	<<
+	/LastChar 	125 
+	/Subtype 	/TrueType 
+	/Name 	/FB 
+	/Widths 	19 0 R 
+	/FontDescriptor 	18 0 R 
+	/Encoding 	/WinAnsiEncoding 
+	/Type 	/Font 
+	/BaseFont 	/Arial#2DBoldMT 
+	/FirstChar 	32 
+>> 
+endobj
+18 0 obj
+	<<
+	/Leading 	33 
+	/Ascent 	905 
+	/AvgWidth 	479 
+	/FontWeight 	700 
+	/ItalicAngle 	0 
+	/XHeight 	250 
+	/StemV 	47 
+	/FontBBox 	[ -628 -210 2000 728  ] 
+	/Flags 	32 
+	/Type 	/FontDescriptor 
+	/Descent 	-210 
+	/MaxWidth 	2628 
+	/FontName 	/Arial#2DBoldMT 
+	/CapHeight 	728 
+>> 
+endobj
+19 0 obj
+[ 278 333 0 0 0 0 0 0 333 333 0 0 278 0 278 278 556 556 556 556 556 556 556 556 556 556 333 333 584 0 584 611 0 722 722 722 722 667 611 778 722 278 556 722 611 833 722 778 667 778 722 667 611 722 667 944 667 667 611 333 278 333 0 0 0 556 611 556 611 556 333 611 611 278 278 556 278 889 611 611 611 611 389 556 333 611 556 778 556 556 500 389 0 389  ] 
+endobj
+20 0 obj
+[ 278 0 0 0 0 0 0 0 333 333 0 0 278 0 278 333 556 556 556 556 556 556 556 556 556 556 278 278 584 0 584 0 0 667 667 722 722 667 611 778 722 278 500 667 556 833 722 778 667 778 722 667 611 722 667 944 667 667 611 0 0 0 0 0 0 556 556 500 556 556 278 556 556 222 222 500 222 833 556 556 556 556 333 500 278 556 500 722 500 500 500 334 0 334  ] 
+endobj
+21 0 obj
+[ /DeviceN [ /Magenta /Cyan /Yellow /Black  ] /DeviceCMYK 22 0 R  ] 
+endobj
+22 0 obj
+	<<
+	/Domain 	[ 0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0  ] 
+	/Range 	[ 0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0  ] 
+	/FunctionType 	4 
+	/Length 	28 
+>> 
+stream
+{ 4 2 roll exch 4 2 roll }
+
+endstream
+endobj
+23 0 obj
+	<<
+	/Subtype 	/Form 
+	/BBox 	[ 0 0 101 101  ] 
+	/Length 	396 
+	/FormType 	1 
+	/Type 	/XObject 
+>> 
+stream
+q
+%  0 0 0 1 k
+  
+q
+  0 0 0 1 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (G) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 0 sc
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 0 sc
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 0 sc
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+24 0 obj
+	<<
+	/FormType 	1 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+	>> 
+	/BBox 	[ 0 0 101 101  ] 
+	/Subtype 	/Form 
+	/Type 	/XObject 
+	/Length 	396 
+>> 
+stream
+q
+%  0 0 0 1 k
+  
+q
+  0 0 0 1 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (H) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 0 sc
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 0 sc
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 0 sc
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+25 0 obj
+	<<
+	/FormType 	1 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+		/ColorSpace 				<<
+			/DefaultCMYK 	21 0 R 
+		>> 
+	>> 
+	/BBox 	[ 0 0 250 220  ] 
+	/Subtype 	/Form 
+	/Type 	/XObject 
+	/Length 	396 
+>> 
+stream
+q
+%  0 0 0 1 k
+  
+q
+  0 0 0 1 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (I) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 0 sc
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 0 sc
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 0 sc
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+26 0 obj
+	<<
+	/Subtype 	/Form 
+	/BBox 	[ 0 0 101 101  ] 
+	/Length 	393 
+	/FormType 	1 
+	/Type 	/XObject 
+>> 
+stream
+q
+0 0 0 1 k
+  
+q
+  0 0 0 1 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (J) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 0 sc
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 0 sc
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 0 sc
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+27 0 obj
+	<<
+	/FormType 	1 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+	>> 
+	/BBox 	[ 0 0 101 101  ] 
+	/Subtype 	/Form 
+	/Type 	/XObject 
+	/Length 	393 
+>> 
+stream
+q
+0 0 0 1 k
+  
+q
+  0 0 0 1 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (K) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 0 sc
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 0 sc
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 0 sc
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+28 0 obj
+	<<
+	/FormType 	1 
+	/Resources 			<<
+		/Font 				<<
+			/F1 	5 0 R 
+			/FB 	17 0 R 
+		>> 
+		/ColorSpace 				<<
+			/DefaultCMYK 	21 0 R 
+		>> 
+	>> 
+	/BBox 	[ 0 0 250 220  ] 
+	/Subtype 	/Form 
+	/Type 	/XObject 
+	/Length 	393 
+>> 
+stream
+q
+0 0 0 1 k
+  
+q
+  0 0 0 1 sc
+  /F1 11 Tf
+  BT
+    1 0 0 1 85 85 Tm
+    (L) Tj
+  ET
+Q
+  
+  /FB 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 75 Tm
+      1 0 0 0 sc
+      (CYAN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 50 Tm
+      0 1 0 0 sc
+      (MAGENTA) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 25 Tm
+      0 0 1 0 sc
+      (YELLOW) Tj
+    ET
+  Q
+Q
+
+endstream
+endobj
+xref
+0 29
+0000000000 65535 f 
+0000000015 00000 n 
+0000000072 00000 n 
+0000000143 00000 n 
+0000000729 00000 n 
+0000002995 00000 n 
+0000003197 00000 n 
+0000003483 00000 n 
+0000003550 00000 n 
+0000003617 00000 n 
+0000003938 00000 n 
+0000004041 00000 n 
+0000004559 00000 n 
+0000005152 00000 n 
+0000005796 00000 n 
+0000006300 00000 n 
+0000006878 00000 n 
+0000007505 00000 n 
+0000007716 00000 n 
+0000008010 00000 n 
+0000008378 00000 n 
+0000008736 00000 n 
+0000008821 00000 n 
+0000009021 00000 n 
+0000009553 00000 n 
+0000010160 00000 n 
+0000010819 00000 n 
+0000011348 00000 n 
+0000011952 00000 n 
+trailer
+	<<
+	/Size 	29 
+	/Root 	1 0 R 
+	/Info 	9 0 R 
+	/ID 	[ <D201E2E8ABC6AF41AC7351B44EFEFD93> <D201E2E8ABC6AF41AC7351B44EFEFD93>  ] 
+>> 
+startxref
+12608
+%%EOF

--- a/test/pdfs/DefaultRGBColourSpaces-inherit.pdf
+++ b/test/pdfs/DefaultRGBColourSpaces-inherit.pdf
@@ -1,0 +1,402 @@
+%PDF-1.3
+%Î¼á¿¦
+
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>> 
+endobj
+
+2 0 obj
+<<
+  /Type /Pages
+  /Kids [ 3 0 R ]
+  /Count 1
+>> 
+endobj
+
+3 0 obj
+<<
+  /MediaBox [ 0 0 1500 220 ]
+  /Parent 2 0 R
+  /Type /Page
+  /Contents  10 0 R
+  /Resources <<
+    /XObject <<
+      /InheritFromPage     11 0 R
+      /LocalFormResources  12 0 R
+      /Uses_SC             13 0 R
+    >>
+    /Font << /F1 4 0 R >>
+    /ColorSpace << /DefaultRGB 5 0 R >>
+  >>
+>> 
+endobj
+
+4 0 obj % Standard 14 font 
+<<
+  /Type /Font
+  /Subtype /Type1
+  /BaseFont /Helvetica
+>>
+endobj
+
+5 0 obj % CalRGB --> G R B
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 1 0 
+                  1 0 0 
+                  0 0 1 ]
+  >>
+]
+endobj
+
+6 0 obj % CalRGB --> B G R
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 0 1 
+                  0 1 0 
+                  1 0 0 ]
+  >>
+]
+endobj
+
+7 0 obj % CalRGB --> R B G
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 1 0 0 
+                  0 0 1 
+                  0 1 0 ]
+  >>
+]
+endobj
+
+8 0 obj % CalRGB --> G B R 
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 1 0 
+                  0 0 1 
+                  1 0 0 ]
+  >>
+]
+endobj
+
+9 0 obj % CalRGB --> B G R 
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 0 1 
+                  0 1 0 
+                  1 0 0 ]
+  >>
+]
+endobj
+
+10 0 obj % Page content stream - all resources in page
+<<
+  /Length 1171
+>> 
+stream
+/F1 11 Tf
+q
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Base page; resources; using rg/RG) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 rg
+      1 0 0 RG
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 rg
+      0 1 0 RG
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 rg
+      0 0 1 RG
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+q
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 250 138 Tm
+      0 G
+      (Base page; resources; using sc/SC) Tj
+    ET
+  Q
+  % Set color space to DeviceRGB via cs/CS operators and then use sc/SC operators
+  /DeviceRGB cs
+  /DeviceRGB CS
+  q
+    BT
+      1 0 0 1 250 116 Tm
+      1 0 0 sc
+      1 0 0 SC
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 93 Tm
+      0 1 0 sc
+      0 1 0 SC
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 71 Tm
+      0 0 1 sc
+      0 0 1 SC
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+q
+  0 0 0 rg % Black using Device RGB operators
+  0 0 0 RG % Black using Device RGB operators
+  q
+    1 0 0 1 500 0 cm
+    /InheritFromPage Do
+  Q
+  q
+    1 0 0 1 750 0 cm
+    /LocalFormResources Do
+  Q
+  q
+    1 0 0 1 1250 0 cm
+    /Uses_SC Do
+  Q
+Q
+endstream
+endobj
+
+11 0 obj % InheritFromPage = no resources in this XObject; use rg/RG operators
+<<
+  /Type /XObject
+  /Subtype /Form
+  /FormType 1
+  /BBox [ 0 0 250 220 ]
+% /Resources << /Font << /F1 4 0 R >> /ColorSpace << /DefaultRGB 7 0 R >> >>
+  /Length 414
+>> 
+stream
+q
+  /F1 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Form; inherit resources from page; rg/RG) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 rg
+      1 0 0 RG
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 rg
+      0 1 0 RG
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 rg
+      0 0 1 RG
+      (BLUE) Tj
+    ET
+  Q
+Q  
+endstream
+endobj
+
+12 0 obj % LocalFormResources (all resources defined in this XObject)
+<<
+  /Type /XObject
+  /Subtype /Form
+  /FormType 1 
+  /BBox [ 0 0 500 220  ]
+  /Resources << 
+     /Font << /F1 4 0 R >> 
+     /ColorSpace << /DefaultRGB 8 0 R >> 
+  >>
+  /Length 898
+>> 
+stream
+q
+  /F1 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Form; with resources, using rg/RG) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 rg
+      1 0 0 RG
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 rg
+      0 1 0 RG
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 rg
+      0 0 1 RG
+      (BLUE) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 138 Tm
+      0 G
+      (Form; with resources, using sc/SC) Tj
+    ET
+  Q
+  % Set color space to DeviceRGB via cs/CS operators and then use sc/SC operators
+  /DeviceRGB cs
+  /DeviceRGB CS
+  q
+    BT
+      1 0 0 1 250 116 Tm
+      1 0 0 sc
+      1 0 0 SC
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 93 Tm
+      0 1 0 sc
+      0 1 0 SC
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 71 Tm
+      0 0 1 sc
+      0 0 1 SC
+      (BLUE) Tj
+    ET
+  Q
+Q
+endstream
+endobj
+
+13 0 obj % Uses_SC, no resources in this Form XObject
+<<
+  /Type /XObject
+  /Subtype /Form
+  /FormType 1
+  /BBox [ 0 0 250 220 ]
+%  /Resources << 
+%   /Font << /F1 4 0 R >>
+%   /ColorSpace << /DefaultRGB 9 0 R >>
+% >>
+  /Length 522
+>> 
+stream
+q
+  /F1 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Form; inherit resources; using sc/SC) Tj
+    ET
+  Q
+  % Set color space to DeviceRGB via cs/CS operators and then use sc/SC operators
+  /DeviceRGB cs
+  /DeviceRGB CS
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 sc
+      1 0 0 SC
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 sc
+      0 1 0 SC
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 sc
+      0 0 1 SC
+      (BLUE) Tj
+    ET
+  Q
+Q
+endstream
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000022 00000 n 
+0000000077 00000 n 
+0000000144 00000 n 
+0000000458 00000 n 
+0000000555 00000 n 
+0000000718 00000 n 
+0000000881 00000 n 
+0000001044 00000 n 
+0000001208 00000 n 
+0000001372 00000 n 
+0000002645 00000 n 
+0000003333 00000 n 
+0000004513 00000 n 
+trailer
+<<
+  /Size 14
+  /Root 1 0 R
+>>
+startxref
+5295
+%%EOF

--- a/test/pdfs/DefaultRGBColourSpaces.pdf
+++ b/test/pdfs/DefaultRGBColourSpaces.pdf
@@ -1,0 +1,402 @@
+%PDF-1.7
+%Î¼á¿¦
+
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>> 
+endobj
+
+2 0 obj
+<<
+  /Type /Pages
+  /Kids [ 3 0 R ]
+  /Count 1
+>> 
+endobj
+
+3 0 obj
+<<
+  /MediaBox [ 0 0 1500 220 ]
+  /Parent 2 0 R
+  /Type /Page
+  /Contents  10 0 R
+  /Resources <<
+    /XObject <<
+      /InheritFromPage     11 0 R
+      /LocalFormResources  12 0 R
+      /Uses_SC             13 0 R
+    >>
+    /Font << /F1 4 0 R >>
+    /ColorSpace << /DefaultRGB 5 0 R >>
+  >>
+>> 
+endobj
+
+4 0 obj % Standard 14 font 
+<<
+  /Type /Font
+  /Subtype /Type1
+  /BaseFont /Helvetica
+>>
+endobj
+
+5 0 obj % CalRGB --> G R B
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 1 0 
+                  1 0 0 
+                  0 0 1 ]
+  >>
+]
+endobj
+
+6 0 obj % CalRGB --> B G R
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 0 1 
+                  0 1 0 
+                  1 0 0 ]
+  >>
+]
+endobj
+
+7 0 obj % CalRGB --> R B G
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 1 0 0 
+                  0 0 1 
+                  0 1 0 ]
+  >>
+]
+endobj
+
+8 0 obj % CalRGB --> G B R 
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 1 0 
+                  0 0 1 
+                  1 0 0 ]
+  >>
+]
+endobj
+
+9 0 obj % CalRGB --> B G R 
+[ /CalRGB <<
+    /WhitePoint [ 1.0 1.0 1.0 ]
+    /Matrix     [ 0 0 1 
+                  0 1 0 
+                  1 0 0 ]
+  >>
+]
+endobj
+
+10 0 obj % Page content stream - all resources in page
+<<
+  /Length 1171
+>> 
+stream
+/F1 11 Tf
+q
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Base page; resources; using rg/RG) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 rg
+      1 0 0 RG
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 rg
+      0 1 0 RG
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 rg
+      0 0 1 RG
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+q
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 250 138 Tm
+      0 G
+      (Base page; resources; using sc/SC) Tj
+    ET
+  Q
+  % Set color space to DeviceRGB via cs/CS operators and then use sc/SC operators
+  /DeviceRGB cs
+  /DeviceRGB CS
+  q
+    BT
+      1 0 0 1 250 116 Tm
+      1 0 0 sc
+      1 0 0 SC
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 93 Tm
+      0 1 0 sc
+      0 1 0 SC
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 71 Tm
+      0 0 1 sc
+      0 0 1 SC
+      (BLUE) Tj
+    ET
+  Q
+Q
+
+q
+  0 0 0 rg % Black using Device RGB operators
+  0 0 0 RG % Black using Device RGB operators
+  q
+    1 0 0 1 500 0 cm
+    /InheritFromPage Do
+  Q
+  q
+    1 0 0 1 750 0 cm
+    /LocalFormResources Do
+  Q
+  q
+    1 0 0 1 1250 0 cm
+    /Uses_SC Do
+  Q
+Q
+endstream
+endobj
+
+11 0 obj % InheritFromPage: all resources in this XObject; use rg/RG operators
+<<
+  /Type /XObject
+  /Subtype /Form
+  /FormType 1
+  /BBox [ 0 0 250 220 ]
+  /Resources << /Font << /F1 4 0 R >> /ColorSpace << /DefaultRGB 7 0 R >> >>
+  /Length 414
+>> 
+stream
+q
+  /F1 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Form; all resources local; rg/RG) Tj        
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 rg
+      1 0 0 RG
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 rg
+      0 1 0 RG
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 rg
+      0 0 1 RG
+      (BLUE) Tj
+    ET
+  Q
+Q  
+endstream
+endobj
+
+12 0 obj % LocalFormResources (all resources defined in this XObject)
+<<
+  /Type /XObject
+  /Subtype /Form
+  /FormType 1 
+  /BBox [ 0 0 500 220  ]
+  /Resources << 
+     /Font << /F1 4 0 R >> 
+     /ColorSpace << /DefaultRGB 8 0 R >> 
+  >>
+  /Length 898
+>> 
+stream
+q
+  /F1 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Form; with resources, using rg/RG) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 rg
+      1 0 0 RG
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 rg
+      0 1 0 RG
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 rg
+      0 0 1 RG
+      (BLUE) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 138 Tm
+      0 G
+      (Form; with resources, using sc/SC) Tj
+    ET
+  Q
+  % Set color space to DeviceRGB via cs/CS operators and then use sc/SC operators
+  /DeviceRGB cs
+  /DeviceRGB CS
+  q
+    BT
+      1 0 0 1 250 116 Tm
+      1 0 0 sc
+      1 0 0 SC
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 93 Tm
+      0 1 0 sc
+      0 1 0 SC
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 250 71 Tm
+      0 0 1 sc
+      0 0 1 SC
+      (BLUE) Tj
+    ET
+  Q
+Q
+endstream
+endobj
+
+13 0 obj % Uses_SC all resources in this Form XObject
+<<
+  /Type /XObject
+  /Subtype /Form
+  /FormType 1
+  /BBox [ 0 0 250 220 ]
+   /Resources << 
+    /Font << /F1 4 0 R >>
+    /ColorSpace << /DefaultRGB 9 0 R >>
+  >>
+  /Length 522
+>> 
+stream
+q
+  /F1 11 Tf
+  1 0 0 1 30 0 cm
+  q
+    BT
+      1 0 0 1 0 138 Tm
+      0 G
+      (Form; local resources; using sc/SC) Tj  
+    ET
+  Q
+  % Set color space to DeviceRGB via cs/CS operators and then use sc/SC operators
+  /DeviceRGB cs
+  /DeviceRGB CS
+  q
+    BT
+      1 0 0 1 0 116 Tm
+      1 0 0 sc
+      1 0 0 SC
+      (RED) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 93 Tm
+      0 1 0 sc
+      0 1 0 SC
+      (GREEN) Tj
+    ET
+  Q
+  q
+    BT
+      1 0 0 1 0 71 Tm
+      0 0 1 sc
+      0 0 1 SC
+      (BLUE) Tj
+    ET
+  Q
+Q
+endstream
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000022 00000 n 
+0000000077 00000 n 
+0000000144 00000 n 
+0000000458 00000 n 
+0000000555 00000 n 
+0000000718 00000 n 
+0000000881 00000 n 
+0000001044 00000 n 
+0000001208 00000 n 
+0000001372 00000 n 
+0000002645 00000 n 
+0000003333 00000 n 
+0000004513 00000 n 
+trailer
+<<
+  /Size 14
+  /Root 1 0 R
+>>
+startxref
+5295
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2860,6 +2860,30 @@
     "type": "eq"
   },
   {
+    "id": "DefaultRGBColourSpaces",
+    "file": "pdfs/DefaultRGBColourSpaces.pdf",
+    "md5": "43549c004e6be3f64d9323c0b9d99638",
+    "link": false,
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
+    "id": "DefaultRGBColourSpaces-inherit",
+    "file": "pdfs/DefaultRGBColourSpaces-inherit.pdf",
+    "md5": "87a7d71c31e29e8b4bc60de80042847d",
+    "link": false,
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
+    "id": "DefaultColourSpaces-230802",
+    "file": "pdfs/DefaultColourSpaces-230802.pdf",
+    "md5": "8e0f4a0552d69d9f6bb55d7fd8f83f0a",
+    "link": false,
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue13372",
     "file": "pdfs/issue13372.pdf",
     "md5": "0bc5329623fd554174c5e7653f904e28",

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -43,6 +43,7 @@ import {
 import { Dict, Name, Ref, RefSetCache } from "../../src/core/primitives.js";
 import { Lexer, Parser } from "../../src/core/parser.js";
 import { FlateStream } from "../../src/core/flate_stream.js";
+import { GlobalColorSpaceCache } from "../../src/core/image_utils.js";
 import { PartialEvaluator } from "../../src/core/evaluator.js";
 import { StringStream } from "../../src/core/stream.js";
 import { WorkerTask } from "../../src/core/worker.js";
@@ -136,6 +137,7 @@ describe("annotation", function () {
       fontCache: new RefSetCache(),
       builtInCMapCache,
       standardFontDataCache: new Map(),
+      globalColorSpaceCache: new GlobalColorSpaceCache(),
       systemFontCache: new Map(),
     });
   });


### PR DESCRIPTION
Currently we don't support default color spaces at all, despite that having been included in the PDF specification for a long time; see https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G7.1852999

Please also refer to https://github.com/pdf-association/pdf-differences/tree/main/DefaultColorSpaces