### PR TITLE
Catch circular references in /Form XObjects (issue 19800)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -49,6 +49,8 @@ import {
   lookupNormalRect,
   lookupRect,
   numberToString,
+  RESOURCES_KEYS_OPERATOR_LIST,
+  RESOURCES_KEYS_TEXT_CONTENT,
   stringToAsciiOrUTF16BE,
   stringToUTF16String,
 } from "./core_utils.js";
@@ -1196,7 +1198,7 @@ class Annotation {
 
     const appearanceDict = appearance.dict;
     const resources = await this.loadResources(
-      ["ExtGState", "ColorSpace", "Pattern", "Shading", "XObject", "Font"],
+      RESOURCES_KEYS_OPERATOR_LIST,
       appearance
     );
     const bbox = lookupRect(appearanceDict.getArray("BBox"), [0, 0, 1, 1]);
@@ -1257,7 +1259,7 @@ class Annotation {
     }
 
     const resources = await this.loadResources(
-      ["ExtGState", "Font", "Properties", "XObject"],
+      RESOURCES_KEYS_TEXT_CONTENT,
       this.appearance
     );
 

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -32,6 +32,23 @@ const MIN_INT_32 = -(2 ** 31);
 
 const IDENTITY_MATRIX = [1, 0, 0, 1, 0, 0];
 
+const RESOURCES_KEYS_OPERATOR_LIST = [
+  "ColorSpace",
+  "ExtGState",
+  "Font",
+  "Pattern",
+  "Properties",
+  "Shading",
+  "XObject",
+];
+
+const RESOURCES_KEYS_TEXT_CONTENT = [
+  "ExtGState",
+  "Font",
+  "Properties",
+  "XObject",
+];
+
 function getLookupTableFactory(initializer) {
   let lookup;
   return function () {
@@ -745,6 +762,8 @@ export {
   readUint16,
   readUint32,
   recoverJsURL,
+  RESOURCES_KEYS_OPERATOR_LIST,
+  RESOURCES_KEYS_TEXT_CONTENT,
   stringToAsciiOrUTF16BE,
   stringToUTF16HexString,
   stringToUTF16String,

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -206,6 +206,7 @@
 !issue3928.pdf
 !issue8565.pdf
 !clippath.pdf
+!issue19800.pdf
 !issue8795_reduced.pdf
 !bug1755507.pdf
 !close-path-bug.pdf

--- a/test/pdfs/issue19800.pdf
+++ b/test/pdfs/issue19800.pdf
@@ -1,0 +1,90 @@
+%PDF-1.4
+1 0 obj
+<<
+ /Type /Catalog
+ /Outlines 2 0 R
+ /Pages 3 0 R
+>>
+endobj
+2 0 obj
+<<
+ /Type /Outlines
+ /Count 0
+>>
+endobj
+3 0 obj
+<<
+ /Type /Pages
+ /Kids [ 4 0 R ]
+ /Count 1
+>>
+endobj
+4 0 obj
+<<
+ /Type /Page
+ /Parent 3 0 R
+ /MediaBox [ 0 0 500 300 ]
+ /Contents 5 0 R
+ /Resources <<
+  /ProcSet [ /PDF /Text ]
+  /XObject << /X1 6 0 R >>
+ >>
+>>
+endobj
+5 0 obj
+<< /Length 24 >>
+stream
+1 0 0 1 25 25 cm /X1 Do
+endstream
+endobj
+6 0 obj
+<< /Subtype /Form
+   /BBox [0 0 1000 1000]
+   /Length 61
+   /Resources <<
+     /ProcSet [ /PDF /Text ]
+     /Font << /F1 7 0 R >>
+     /XObject << /X0 8 0 R >>
+   >>
+>>
+stream
+BT
+/F1 24 Tf
+(Hello world) Tj
+ET
+0.5 0 0 0.5 25 25 cm /X0 Do
+endstream
+endobj
+7 0 obj
+<<
+ /Type /Font
+ /Subtype /Type1
+ /Name /F1
+ /BaseFont /Helvetica
+ /Encoding /MacRomanEncoding
+>>
+endobj
+8 0 obj
+<< /Subtype /Form
+   /BBox [0 0 1000 1000]
+   /Length 61
+   /Resources <<
+     /ProcSet [ /PDF /Text ]
+     /Font << /F1 7 0 R >>
+     /XObject << /X1 6 0 R >>
+   >>
+>>
+stream
+BT
+/F1 24 Tf
+(Hello world) Tj
+ET
+0.5 0 0 0.5 25 25 cm /X1 Do
+endstream
+endobj
+trailer 
+<<
+ /Size 8
+ /Root 1 0 R
+>>
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6898,6 +6898,20 @@
     "type": "eq"
   },
   {
+    "id": "issue19800-eq",
+    "file": "pdfs/issue19800.pdf",
+    "md5": "92825d3178196bdd01096c4081609efd",
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
+    "id": "issue19800-text",
+    "file": "pdfs/issue19800.pdf",
+    "md5": "92825d3178196bdd01096c4081609efd",
+    "rounds": 1,
+    "type": "text"
+  },
+  {
     "id": "issue3438",
     "file": "pdfs/issue3438.pdf",
     "md5": "5aa3340b0920b65a377f697587668f89",


### PR DESCRIPTION
For simplicity we will abort /Form XObject parsing *immediately* when encountering a circular reference, rather than letting it continue up until some limit (as e.g. PDFium appears to do), which should be fine since there are never any guarantees if/how *corrupt* PDF documents will render.