### PR TITLE
Run the integration tests in a random order

### DIFF
--- a/test/integration/accessibility_spec.mjs
+++ b/test/integration/accessibility_spec.mjs
@@ -38,11 +38,11 @@ describe("accessibility", () => {
   describe("structure tree", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("structure_simple.pdf", ".structTree");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -107,14 +107,14 @@ describe("accessibility", () => {
   describe("Annotation", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey_a11y.pdf",
         ".textLayer .endOfContent"
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -147,11 +147,11 @@ describe("accessibility", () => {
   describe("Annotations order", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("fields_order.pdf", ".annotationLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -180,11 +180,11 @@ describe("accessibility", () => {
   describe("Stamp annotation accessibility", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tagged_stamp.pdf", ".annotationLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -245,11 +245,11 @@ describe("accessibility", () => {
   describe("Figure in the content stream", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("bug1708040.pdf", ".textLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/annotation_spec.mjs
+++ b/test/integration/annotation_spec.mjs
@@ -25,14 +25,14 @@ describe("Annotation highlight", () => {
   describe("annotation-highlight.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "annotation-highlight.pdf",
         "[data-annotation-id='19R']"
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -62,11 +62,11 @@ describe("Annotation highlight", () => {
   describe("Check that widget annotations are in front of highlight ones", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("bug1883609.pdf", "[data-annotation-id='23R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -87,11 +87,11 @@ describe("Checkbox annotation", () => {
   describe("issue12706.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue12706.pdf", "[data-annotation-id='63R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -123,11 +123,11 @@ describe("Checkbox annotation", () => {
   describe("issue15597.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue15597.pdf", "[data-annotation-id='7R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -148,11 +148,11 @@ describe("Checkbox annotation", () => {
   describe("bug1847733.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("bug1847733.pdf", "[data-annotation-id='18R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -178,11 +178,11 @@ describe("Text widget", () => {
   describe("issue13271.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue13271.pdf", "[data-annotation-id='24R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -207,11 +207,11 @@ describe("Text widget", () => {
   describe("issue16473.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue16473.pdf", "[data-annotation-id='22R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -236,11 +236,11 @@ describe("Annotation and storage", () => {
   describe("issue14023.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue14023.pdf", "[data-annotation-id='64R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -337,11 +337,11 @@ describe("ResetForm action", () => {
   describe("resetform.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("resetform.pdf", "[data-annotation-id='63R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -462,14 +462,14 @@ describe("ResetForm action", () => {
     describe("issue14438.pdf", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "issue14438.pdf",
           "[data-annotation-id='10R']"
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -490,14 +490,14 @@ describe("ResetForm action", () => {
     describe("annotation-caret-ink.pdf", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "annotation-caret-ink.pdf",
           "[data-annotation-id='25R']"
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -525,14 +525,14 @@ describe("ResetForm action", () => {
     describe("bug1844583.pdf", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "bug1844583.pdf",
           "[data-annotation-id='8R']"
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -553,14 +553,14 @@ describe("ResetForm action", () => {
     describe("tagged_stamp.pdf", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "tagged_stamp.pdf",
           "[data-annotation-id='20R']"
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -622,14 +622,14 @@ describe("ResetForm action", () => {
     describe("issue14438.pdf", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "highlights.pdf",
           "[data-annotation-id='693R']"
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -652,14 +652,14 @@ describe("ResetForm action", () => {
     describe("issue14438.pdf", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "rotated_ink.pdf",
           "[data-annotation-id='18R']"
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 

--- a/test/integration/autolinker_spec.mjs
+++ b/test/integration/autolinker_spec.mjs
@@ -63,7 +63,7 @@ describe("autolinker", function () {
   describe("bug1019475_2.pdf", function () {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "bug1019475_2.pdf",
         ".annotationLayer",
@@ -75,7 +75,7 @@ describe("autolinker", function () {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -99,7 +99,7 @@ describe("autolinker", function () {
   describe("bug1019475_1.pdf", function () {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "bug1019475_1.pdf",
         ".annotationLayer",
@@ -111,7 +111,7 @@ describe("autolinker", function () {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -138,14 +138,14 @@ describe("autolinker", function () {
   describe("pr19449.pdf", function () {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("pr19449.pdf", ".annotationLayer", null, null, {
         docBaseUrl: "http://example.com",
         enableAutoLinking: true,
       });
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -172,7 +172,7 @@ describe("autolinker", function () {
   describe("PR 19470", function () {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "bug1019475_2.pdf",
         ".annotationLayer",
@@ -184,7 +184,7 @@ describe("autolinker", function () {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -218,7 +218,7 @@ describe("autolinker", function () {
   describe("when highlighting search results", function () {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "issue3115r.pdf",
         ".annotationLayer",
@@ -228,7 +228,7 @@ describe("autolinker", function () {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/caret_browsing_spec.mjs
+++ b/test/integration/caret_browsing_spec.mjs
@@ -27,11 +27,11 @@ describe("Caret browsing", () => {
   describe("Selection", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".textLayer .endOfContent");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/copy_paste_spec.mjs
+++ b/test/integration/copy_paste_spec.mjs
@@ -40,12 +40,12 @@ describe("Copy and paste", () => {
   describe("all text", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", "#hiddenCopyElement", 100);
       await mockClipboard(pages);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -137,7 +137,7 @@ describe("Copy and paste", () => {
   describe("Copy/paste and ligatures", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "copy_paste_ligatures.pdf",
         "#hiddenCopyElement",
@@ -146,7 +146,7 @@ describe("Copy and paste", () => {
       await mockClipboard(pages);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -28,11 +28,11 @@ describe("find bar", () => {
   describe("highlight all", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("find_all.pdf", ".textLayer", 100);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -89,11 +89,11 @@ describe("find bar", () => {
   describe("highlight all (XFA)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("xfa_imm5257e.pdf", ".xfaLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -130,11 +130,11 @@ describe("find bar", () => {
   describe("issue19207.pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue19207.pdf", ".textLayer", 200);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -431,11 +431,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (multiselection)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("aboutstacks.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -588,11 +588,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (bugs)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -726,7 +726,7 @@ describe("FreeText Editor", () => {
   describe("issue 15789", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue15789.pdf", ".annotationEditorLayer");
       pages = await Promise.all(
         pages.map(async ([browserName, page]) => {
@@ -736,7 +736,7 @@ describe("FreeText Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -817,11 +817,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (move existing)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("freetexts.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -852,11 +852,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (update existing)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("freetexts.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -949,11 +949,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (update existing and popups)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("freetexts.pdf", "[data-annotation-id='32R']");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1004,11 +1004,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (update existing but not empty ones)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue14438.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1027,11 +1027,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (delete existing)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("freetexts.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1088,11 +1088,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (copy/paste existing)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("freetexts.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1116,11 +1116,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (edit existing in double clicking on it)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("freetexts.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1151,14 +1151,14 @@ describe("FreeText Editor", () => {
   describe("FreeText with popup", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "annotation-freetext.pdf",
         ".annotationEditorLayer"
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1233,11 +1233,11 @@ describe("FreeText Editor", () => {
   describe("FreeText rotation", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1333,11 +1333,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (remove)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1397,11 +1397,11 @@ describe("FreeText Editor", () => {
   describe("FreeText (open existing)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue16633.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1522,7 +1522,7 @@ describe("FreeText Editor", () => {
   describe("FreeText (open existing and rotated)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "rotated_freetexts.pdf",
         ".annotationEditorLayer",
@@ -1530,7 +1530,7 @@ describe("FreeText Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1690,11 +1690,11 @@ describe("FreeText Editor", () => {
   describe("Keyboard shortcuts when the editor layer isn't focused", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1897,7 +1897,7 @@ describe("FreeText Editor", () => {
   describe("Focus must go on the current page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -1913,7 +1913,7 @@ describe("FreeText Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1962,11 +1962,11 @@ describe("FreeText Editor", () => {
   describe("Freetext must stay focused after having been moved", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2037,11 +2037,11 @@ describe("FreeText Editor", () => {
   describe("Move several FreeTexts", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2089,7 +2089,7 @@ describe("FreeText Editor", () => {
   describe("Don't unselect all when scrolling", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -2104,7 +2104,7 @@ describe("FreeText Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2152,11 +2152,11 @@ describe("FreeText Editor", () => {
   describe("FreeText on several pages", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2221,11 +2221,11 @@ describe("FreeText Editor", () => {
   describe("Deleted FreeText", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2280,11 +2280,11 @@ describe("FreeText Editor", () => {
   describe("FreeText accessibility", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("bug1823296.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2327,11 +2327,11 @@ describe("FreeText Editor", () => {
   describe("Bug 1854818: mouse events in a selected FreeText editor", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2474,11 +2474,11 @@ describe("FreeText Editor", () => {
   describe("Avoid to steal keyboard events", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2528,11 +2528,11 @@ describe("FreeText Editor", () => {
   describe("Delete a freetext in using the delete button", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2571,11 +2571,11 @@ describe("FreeText Editor", () => {
   describe("Delete two freetexts in using the delete button and the keyboard", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2625,11 +2625,11 @@ describe("FreeText Editor", () => {
   describe("Consecutive white spaces in Freetext without appearance", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("bug1871353.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2656,11 +2656,11 @@ describe("FreeText Editor", () => {
   describe("Consecutive white spaces in Freetext with appearance", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("bug1871353.1.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2687,11 +2687,11 @@ describe("FreeText Editor", () => {
   describe("Freetext with several lines", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2721,11 +2721,11 @@ describe("FreeText Editor", () => {
   describe("Freetext UI when undoing/redoing", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2788,11 +2788,11 @@ describe("FreeText Editor", () => {
   describe("Annotation editor layer visibility", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2822,11 +2822,11 @@ describe("FreeText Editor", () => {
   describe("Delete a freetext and undo it on another page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2872,11 +2872,11 @@ describe("FreeText Editor", () => {
   describe("Delete a freetext, scroll and undo it", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2917,11 +2917,11 @@ describe("FreeText Editor", () => {
   describe("Paste some html", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -3040,14 +3040,14 @@ describe("FreeText Editor", () => {
   describe("Update a freetext and scroll", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey_freetext.pdf",
         ".annotationEditorLayer"
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -3170,11 +3170,11 @@ describe("FreeText Editor", () => {
   describe("Freetext and shift+enter", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -55,11 +55,11 @@ describe("Highlight Editor", () => {
   describe("Editor must be removed without exception", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -101,11 +101,11 @@ describe("Highlight Editor", () => {
   describe("Editor must keep selected", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -145,7 +145,7 @@ describe("Highlight Editor", () => {
   describe("The default color must have the correct value", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -155,7 +155,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -190,7 +190,7 @@ describe("Highlight Editor", () => {
   describe("Invisible editor must change its color", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -200,7 +200,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -278,7 +278,7 @@ describe("Highlight Editor", () => {
   describe("Highlight data serialization", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -288,7 +288,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -335,7 +335,7 @@ describe("Highlight Editor", () => {
   describe("Color picker and keyboard", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -348,7 +348,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -449,7 +449,7 @@ describe("Highlight Editor", () => {
   describe("Text highlights aren't draggable", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -459,7 +459,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -502,11 +502,11 @@ describe("Highlight Editor", () => {
   describe("Color picker and click outside", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -543,11 +543,11 @@ describe("Highlight Editor", () => {
   describe("Color picker can annoy the user when selecting some text", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -580,7 +580,7 @@ describe("Highlight Editor", () => {
   describe("Free highlight thickness can be changed", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "empty.pdf",
         ".annotationEditorLayer",
@@ -590,7 +590,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -660,11 +660,11 @@ describe("Highlight Editor", () => {
   describe("Highlight with the keyboard", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -723,7 +723,7 @@ describe("Highlight Editor", () => {
   describe("Free highlight is drawn at the right place after having been rotated (bug 1879108)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "empty.pdf",
         ".annotationEditorLayer",
@@ -733,7 +733,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -807,7 +807,7 @@ describe("Highlight Editor", () => {
   describe("Highlight links", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "bug1868759.pdf",
         ".annotationEditorLayer",
@@ -817,7 +817,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -852,7 +852,7 @@ describe("Highlight Editor", () => {
   describe("Highlight forms", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "issue12233.pdf",
         ".annotationEditorLayer",
@@ -862,7 +862,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -902,7 +902,7 @@ describe("Highlight Editor", () => {
   describe("Send a message when some text is selected", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         `.page[data-page-number = "1"] .endOfContent`,
@@ -919,7 +919,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -982,7 +982,7 @@ describe("Highlight Editor", () => {
   describe("Highlight and caret browsing", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -1002,16 +1002,6 @@ describe("Highlight Editor", () => {
     });
 
     afterEach(async () => {
-      for (const [, page] of pages) {
-        await page.evaluate(() => {
-          window.uiManager.reset();
-        });
-        // Disable editing mode.
-        await switchToHighlight(page, /* disable */ true);
-      }
-    });
-
-    afterAll(async () => {
       await closePages(pages);
     });
 
@@ -1154,11 +1144,11 @@ describe("Highlight Editor", () => {
   describe("Editor must be removed in using the space key on the delete button", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1189,11 +1179,11 @@ describe("Highlight Editor", () => {
   describe("Thickness must be enabled when there's no selected highlights", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1244,11 +1234,11 @@ describe("Highlight Editor", () => {
   describe("Quadpoints must be correct", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1280,11 +1270,11 @@ describe("Highlight Editor", () => {
   describe("Quadpoints must be correct when they're in a translated page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue18360.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1316,11 +1306,11 @@ describe("Highlight Editor", () => {
   describe("Editor must be unselected when the color picker is Escaped", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1348,11 +1338,11 @@ describe("Highlight Editor", () => {
   describe("Highlight editor mustn't be moved when close to the page limits", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1386,11 +1376,11 @@ describe("Highlight Editor", () => {
   describe("Show/hide all the highlights", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1455,7 +1445,7 @@ describe("Highlight Editor", () => {
   describe("Highlight from floating highlight button", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -1465,7 +1455,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1507,11 +1497,11 @@ describe("Highlight Editor", () => {
   describe("Text layer must have the focus before highlights", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1550,11 +1540,11 @@ describe("Highlight Editor", () => {
   describe("Undo a highlight", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1587,7 +1577,7 @@ describe("Highlight Editor", () => {
   describe("Delete a highlight and undo it an other page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -1600,7 +1590,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1649,7 +1639,7 @@ describe("Highlight Editor", () => {
   describe("Delete a highlight, scroll and undo it", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -1662,7 +1652,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1706,7 +1696,7 @@ describe("Highlight Editor", () => {
   describe("Use a toolbar overlapping an other highlight", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".annotationEditorLayer",
@@ -1719,7 +1709,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1783,11 +1773,11 @@ describe("Highlight Editor", () => {
   describe("Draw a free highlight with the pointer hovering an existing highlight", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1849,11 +1839,11 @@ describe("Highlight Editor", () => {
   describe("Select text with the pointer hovering an existing highlight", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1919,7 +1909,7 @@ describe("Highlight Editor", () => {
   describe("Highlight with the floating button in a pdf containing a FreeText", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "file_pdfjs_test.pdf",
         ".annotationEditorLayer",
@@ -1929,7 +1919,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1961,7 +1951,7 @@ describe("Highlight Editor", () => {
   describe("Highlight (edit existing in double clicking on it)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "highlights.pdf",
         ".annotationEditorLayer",
@@ -1974,7 +1964,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2008,14 +1998,14 @@ describe("Highlight Editor", () => {
   describe("Highlight (delete an existing annotation)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "highlight_popup.pdf",
         ".annotationEditorLayer"
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2052,7 +2042,7 @@ describe("Highlight Editor", () => {
   describe("Free Highlight (edit existing in double clicking on it)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "highlights.pdf",
         ".annotationEditorLayer",
@@ -2065,7 +2055,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2101,14 +2091,14 @@ describe("Highlight Editor", () => {
   describe("Highlight editor mustn't throw when disabled", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "annotation-highlight.pdf",
         ".annotationEditorLayer"
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2134,7 +2124,7 @@ describe("Highlight Editor", () => {
   describe("Free Highlight with an image in the struct tree", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "bug1708040.pdf",
         ".annotationEditorLayer",
@@ -2144,7 +2134,7 @@ describe("Highlight Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2623,11 +2613,11 @@ describe("Highlight Editor", () => {
   describe("Highlight mustn't trigger a scroll when edited", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue18911.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -2678,11 +2668,11 @@ describe("Highlight Editor", () => {
   describe("Highlight must be rotated when existing in the pdf", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue19424.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/jasmine-boot.js
+++ b/test/integration/jasmine-boot.js
@@ -23,7 +23,7 @@ async function runTests(results) {
   jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
   jasmine.loadConfig({
-    random: false,
+    random: true,
     spec_dir: "integration",
     spec_files: [
       "accessibility_spec.mjs",

--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -1197,13 +1197,6 @@ describe("Interaction", () => {
           await page.waitForFunction(
             `${getQuerySelector("27R")}.value === "HEAO "`
           );
-
-          // The typing actions in the first textbox caused sandbox events to be
-          // queued. We don't close the document between tests, so we have to
-          // flush them here, by clicking the second textbox, so they don't leak
-          // through to the following test.
-          await page.click(getSelector("28R"));
-          await waitForSandboxTrip(page);
         })
       );
     });

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -16,7 +16,6 @@
 import {
   applyFunctionToEditor,
   awaitPromise,
-  cleanupEditing,
   clearEditors,
   clearInput,
   closePages,
@@ -31,7 +30,6 @@ import {
   getRect,
   getSerialized,
   isCanvasMonochrome,
-  isVisible,
   kbBigMoveDown,
   kbBigMoveRight,
   kbUndo,
@@ -101,7 +99,7 @@ describe("Stamp Editor", () => {
   describe("Basic operations", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", null, {
         eventBusSetup: eventBus => {
           eventBus.on("annotationeditoruimanager", ({ uiManager }) => {
@@ -112,10 +110,6 @@ describe("Stamp Editor", () => {
     });
 
     afterEach(async () => {
-      await cleanupEditing(pages, switchToStamp);
-    });
-
-    afterAll(async () => {
       await closePages(pages);
     });
 
@@ -203,7 +197,7 @@ describe("Stamp Editor", () => {
   describe("Resize", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", 50, {
         eventBusSetup: eventBus => {
           eventBus.on("annotationeditoruimanager", ({ uiManager }) => {
@@ -213,12 +207,8 @@ describe("Stamp Editor", () => {
       });
     });
 
-    afterAll(async () => {
-      await closePages(pages);
-    });
-
     afterEach(async () => {
-      await cleanupEditing(pages, switchToStamp);
+      await closePages(pages);
     });
 
     it("must check that an added image stay within the page", async () => {
@@ -325,11 +315,11 @@ describe("Stamp Editor", () => {
   describe("Alt text dialog", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", 50);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -500,11 +490,11 @@ describe("Stamp Editor", () => {
   describe("Resize an image with the keyboard", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", 50);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -631,12 +621,12 @@ describe("Stamp Editor", () => {
   describe("Copy/paste from a tab to an other", () => {
     let pages1, pages2;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages1 = await loadAndWait("empty.pdf", ".annotationEditorLayer");
       pages2 = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages1);
       await closePages(pages2);
     });
@@ -665,11 +655,11 @@ describe("Stamp Editor", () => {
   describe("Undo a stamp", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -697,11 +687,11 @@ describe("Stamp Editor", () => {
   describe("Delete a stamp and undo it on another page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -742,11 +732,11 @@ describe("Stamp Editor", () => {
   describe("Delete a stamp, scroll and undo it", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -782,11 +772,11 @@ describe("Stamp Editor", () => {
   describe("Resize a stamp", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -832,7 +822,7 @@ describe("Stamp Editor", () => {
   describe("Add a stamp in odd spread mode", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "empty.pdf",
         ".annotationEditorLayer",
@@ -844,7 +834,7 @@ describe("Stamp Editor", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -873,11 +863,11 @@ describe("Stamp Editor", () => {
   describe("Copy and paste a stamp with an alt text", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -918,7 +908,7 @@ describe("Stamp Editor", () => {
   describe("New alt-text flow", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "empty.pdf",
         ".annotationEditorLayer",
@@ -942,23 +932,6 @@ describe("Stamp Editor", () => {
     });
 
     afterEach(async () => {
-      for (const [, page] of pages) {
-        if (await isVisible(page, "#newAltTextDialog")) {
-          await page.keyboard.press("Escape");
-          await page.waitForSelector("#newAltTextDisclaimer", {
-            visible: false,
-          });
-        }
-        await page.evaluate(() => {
-          window.uiManager.reset();
-          window.telemetry = [];
-        });
-        // Disable editing mode.
-        await switchToStamp(page, /* disable */ true);
-      }
-    });
-
-    afterAll(async () => {
       await closePages(pages);
     });
 
@@ -1296,7 +1269,7 @@ describe("Stamp Editor", () => {
   describe("New alt-text flow (bug 1920515)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "empty.pdf",
         ".annotationEditorLayer",
@@ -1318,22 +1291,6 @@ describe("Stamp Editor", () => {
     });
 
     afterEach(async () => {
-      for (const [, page] of pages) {
-        if (await isVisible(page, "#newAltTextDialog")) {
-          await page.keyboard.press("Escape");
-          await page.waitForSelector("#newAltTextDisclaimer", {
-            visible: false,
-          });
-        }
-        await page.evaluate(() => {
-          window.uiManager.reset();
-        });
-        // Disable editing mode.
-        await switchToStamp(page, /* disable */ true);
-      }
-    });
-
-    afterAll(async () => {
       await closePages(pages);
     });
 
@@ -1364,11 +1321,11 @@ describe("Stamp Editor", () => {
   describe("No auto-resize", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", 67);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1410,11 +1367,11 @@ describe("Stamp Editor", () => {
   describe("A stamp musn't be on top of the secondary toolbar", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer", 600);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1453,11 +1410,11 @@ describe("Stamp Editor", () => {
   describe("Stamp (move existing)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("stamps.pdf", getAnnotationSelector("25R"));
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1491,11 +1448,11 @@ describe("Stamp Editor", () => {
   describe("Stamp (change alt-text)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("stamps.pdf", getAnnotationSelector("58R"));
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1551,11 +1508,11 @@ describe("Stamp Editor", () => {
   describe("Stamp (delete existing and undo)", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("stamps.pdf", getAnnotationSelector("37R"));
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1599,11 +1556,11 @@ describe("Stamp Editor", () => {
   describe("Drag a stamp annotation and click on a touchscreen", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1725,11 +1682,11 @@ describe("Stamp Editor", () => {
   describe("Switch to edit mode a pdf with an existing stamp annotation on an invisible and rendered page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue19239.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1755,11 +1712,11 @@ describe("Stamp Editor", () => {
   describe("Switch to edit mode a pdf with an existing stamp annotation on an invisible and unrendered page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue19239.pdf", ".annotationEditorLayer");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1794,11 +1751,11 @@ describe("Stamp Editor", () => {
 
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue19239.pdf", annotationSelector);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -1825,11 +1782,11 @@ describe("Stamp Editor", () => {
 
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("red_stamp.pdf", annotationSelector, 20);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -137,13 +137,6 @@ function closePages(pages) {
   return Promise.all(pages.map(([_, page]) => closeSinglePage(page)));
 }
 
-function isVisible(page, selector) {
-  return page.evaluate(
-    sel => document.querySelector(sel)?.checkVisibility(),
-    selector
-  );
-}
-
 async function closeSinglePage(page) {
   // Avoid to keep something from a previous test.
   await page.evaluate(async () => {
@@ -861,16 +854,6 @@ function isCanvasMonochrome(page, pageNumber, rectangle, color) {
   );
 }
 
-async function cleanupEditing(pages, switcher) {
-  for (const [, page] of pages) {
-    await page.evaluate(() => {
-      window.uiManager.reset();
-    });
-    // Disable editing mode.
-    await switcher(page, /* disable */ true);
-  }
-}
-
 async function getXY(page, selector) {
   const rect = await getRect(page, selector);
   return `${rect.x}::${rect.y}`;
@@ -902,7 +885,6 @@ async function moveEditor(page, selector, n, pressKey) {
 export {
   applyFunctionToEditor,
   awaitPromise,
-  cleanupEditing,
   clearEditors,
   clearInput,
   closePages,
@@ -927,7 +909,6 @@ export {
   getXY,
   hover,
   isCanvasMonochrome,
-  isVisible,
   kbBigMoveDown,
   kbBigMoveLeft,
   kbBigMoveRight,

--- a/test/integration/text_field_spec.mjs
+++ b/test/integration/text_field_spec.mjs
@@ -19,11 +19,11 @@ describe("Text field", () => {
   describe("Empty text field", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("file_pdfjs_form.pdf", getSelector("7R"));
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 

--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -59,7 +59,7 @@ describe("Text layer", () => {
       };
     }
 
-    beforeAll(() => {
+    beforeEach(() => {
       jasmine.addAsyncMatchers({
         // Check that a page has a selection containing the given text, with
         // some tolerance for extra characters before/after.
@@ -111,13 +111,13 @@ describe("Text layer", () => {
       describe("doesn't jump when hovering on an empty area", () => {
         let pages;
 
-        beforeAll(async () => {
+        beforeEach(async () => {
           pages = await loadAndWait(
             "tracemonkey.pdf",
             `.page[data-page-number = "1"] .endOfContent`
           );
         });
-        afterAll(async () => {
+        afterEach(async () => {
           await closePages(pages);
         });
 
@@ -220,13 +220,13 @@ describe("Text layer", () => {
       describe("doesn't jump when hovering on an empty area, with .markedContent", () => {
         let pages;
 
-        beforeAll(async () => {
+        beforeEach(async () => {
           pages = await loadAndWait(
             "chrome-text-selection-markedContent.pdf",
             `.page[data-page-number = "1"] .endOfContent`
           );
         });
-        afterAll(async () => {
+        afterEach(async () => {
           await closePages(pages);
         });
 
@@ -318,22 +318,15 @@ describe("Text layer", () => {
       describe("when selecting over a link", () => {
         let pages;
 
-        beforeAll(async () => {
+        beforeEach(async () => {
           pages = await loadAndWait(
             "annotation-link-text-popup.pdf",
             `.page[data-page-number = "1"] .endOfContent`
           );
         });
-        afterAll(async () => {
+        afterEach(async () => {
           await closePages(pages);
         });
-        afterEach(() =>
-          Promise.all(
-            pages.map(([_, page]) =>
-              page.evaluate(() => window.getSelection().removeAllRanges())
-            )
-          )
-        );
 
         it("allows selecting within the link", async () => {
           await Promise.all(
@@ -451,7 +444,7 @@ describe("Text layer", () => {
       let browser;
       let page;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         // Chrome does not support simulating caret-based selection, so this
         // test only runs in Firefox.
         browser = await startBrowser({
@@ -472,7 +465,7 @@ describe("Text layer", () => {
           { timeout: 0 }
         );
       });
-      afterAll(async () => {
+      afterEach(async () => {
         await closeSinglePage(page);
         await browser.close();
       });
@@ -542,7 +535,7 @@ describe("Text layer", () => {
     let browser;
     let page;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       // Only testing in Firefox because, while Chrome has a setting similar to
       // font.minimum-size.x-western, it is not exposed through its API.
       browser = await startBrowser({
@@ -561,7 +554,7 @@ describe("Text layer", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closeSinglePage(page);
       await browser.close();
     });

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -28,7 +28,7 @@ describe("PDF viewer", () => {
   describe("Zoom origin", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "tracemonkey.pdf",
         ".textLayer .endOfContent",
@@ -38,7 +38,7 @@ describe("PDF viewer", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -107,11 +107,11 @@ describe("PDF viewer", () => {
   describe("Zoom with the mouse wheel", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("empty.pdf", ".textLayer .endOfContent", 1000);
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -141,11 +141,11 @@ describe("PDF viewer", () => {
   describe("Zoom commands", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("tracemonkey.pdf", ".textLayer .endOfContent");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -191,7 +191,7 @@ describe("PDF viewer", () => {
     describe("forced (maxCanvasPixels: 0)", () => {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "tracemonkey.pdf",
           ".textLayer .endOfContent",
@@ -201,7 +201,7 @@ describe("PDF viewer", () => {
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -257,7 +257,7 @@ describe("PDF viewer", () => {
 
       const MAX_CANVAS_PIXELS = new Map();
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "tracemonkey.pdf",
           ".textLayer .endOfContent",
@@ -271,9 +271,7 @@ describe("PDF viewer", () => {
             return { maxCanvasPixels };
           }
         );
-      });
 
-      beforeEach(async () => {
         await Promise.all(
           pages.map(async ([browserName, page]) => {
             const handle = await waitForPageRendered(page);
@@ -294,7 +292,7 @@ describe("PDF viewer", () => {
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -387,7 +385,7 @@ describe("PDF viewer", () => {
   describe("Canvas fits the page", () => {
     let pages;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait(
         "issue18694.pdf",
         ".textLayer .endOfContent",
@@ -395,7 +393,7 @@ describe("PDF viewer", () => {
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 
@@ -461,7 +459,7 @@ describe("PDF viewer", () => {
     function setupPages(zoom, devicePixelRatio, setups = {}) {
       let pages;
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         pages = await loadAndWait(
           "colors.pdf",
           null,
@@ -480,7 +478,7 @@ describe("PDF viewer", () => {
         );
       });
 
-      afterAll(async () => {
+      afterEach(async () => {
         await closePages(pages);
       });
 
@@ -1121,11 +1119,11 @@ describe("PDF viewer", () => {
       );
     }
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       pages = await loadAndWait("issue18694.pdf", ".textLayer .endOfContent");
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await closePages(pages);
     });
 


### PR DESCRIPTION
Previous PRs for this issue removed the existing dependencies between tests, and this commit series finishes the work by preventing creation of new ones. Closing the viewer between tests also simplifies the code and further reduces room for intermittent failures because viewer state can no longer be retained between tests.

_This PR is easier to review per commit because the isolation and associated cleanup are bundled per suite._

Fixes #19065.