### PR TITLE
Remove debug code from the integration tests, and skip the "must check that canvas perfectly fits the page whatever the zoom level" integration test in Chrome

### DIFF
--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -1388,15 +1388,10 @@ describe("Stamp Editor", () => {
 
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          const debug = false;
-
           await page.click("#secondaryToolbarToggleButton");
           await page.waitForSelector("#secondaryToolbar", { visible: true });
           const secondary = await page.$("#secondaryToolbar");
-          const png = await secondary.screenshot({
-            type: "png",
-            path: debug ? `foo.png` : "",
-          });
+          const png = await secondary.screenshot({ type: "png" });
           const secondaryImage = PNG.sync.read(Buffer.from(png));
           const buffer = new Uint32Array(secondaryImage.data.buffer);
           expect(buffer.every(x => x === 0xff0000ff))

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -400,6 +400,14 @@ describe("PDF viewer", () => {
     it("must check that canvas perfectly fits the page whatever the zoom level is", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          if (browserName === "chrome") {
+            // Skip the test for Chrome as `scrollIntoView` below hangs since
+            // Puppeteer 24.5.0 and higher.
+            // See https://github.com/mozilla/pdf.js/issues/19811.
+            // TODO: Remove this check once the issue is fixed.
+            return;
+          }
+
           // The pdf has a single page with a red background.
           // We set the viewer background to red, because when screenshoting
           // some part of the viewer background can be visible.

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -400,8 +400,6 @@ describe("PDF viewer", () => {
     it("must check that canvas perfectly fits the page whatever the zoom level is", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          const debug = false;
-
           // The pdf has a single page with a red background.
           // We set the viewer background to red, because when screenshoting
           // some part of the viewer background can be visible.
@@ -426,10 +424,7 @@ describe("PDF viewer", () => {
             await scrollIntoView(page, `.page[data-page-number="1"]`);
 
             const element = await page.$(`.page[data-page-number="1"]`);
-            const png = await element.screenshot({
-              type: "png",
-              path: debug ? `foo${i}.png` : "",
-            });
+            const png = await element.screenshot({ type: "png" });
             const pageImage = PNG.sync.read(Buffer.from(png));
             let buffer = new Uint32Array(pageImage.data.buffer);
 


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Related to #19811.