### PR TITLE
Ensure that "local" /Contents stream-dict /Resources aren't empty (PR 19803 follow-up)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -427,7 +427,7 @@ class Page {
     // available (see issue18894.pdf).
     const localResources = streamDict?.get("Resources");
 
-    if (!(localResources instanceof Dict)) {
+    if (!(localResources instanceof Dict && localResources.size)) {
       return this.resources;
     }
     const objectLoader = new ObjectLoader(localResources, keys, this.xref);


### PR DESCRIPTION
This is a small, and quite possibly pointless, optimization which ensures that any "local" /Resources aren't empty, to avoid needlessly trying to load and merge dictionaries.