### PR TITLE
Add a "supportsPrinting" viewer-option (bug 1957401)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -875,7 +875,12 @@ const PDFViewerApplication = {
   },
 
   get supportsPrinting() {
-    return PDFPrintServiceFactory.supportsPrinting;
+    return shadow(
+      this,
+      "supportsPrinting",
+      AppOptions.get("supportsPrinting") &&
+        PDFPrintServiceFactory.supportsPrinting
+    );
   },
 
   get supportsFullscreen() {

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -136,6 +136,11 @@ const defaultOptions = {
     value: true,
     kind: OptionKind.BROWSER,
   },
+  supportsPrinting: {
+    /** @type {boolean} */
+    value: true,
+    kind: OptionKind.BROWSER,
+  },
   toolbarDensity: {
     /** @type {number} */
     value: 0, // 0 = "normal", 1 = "compact", 2 = "touch"


### PR DESCRIPTION
This will allow us to respect the `print.enabled` Firefox preference, by extending [this method](https://searchfox.org/mozilla-central/rev/56117379696ea0cffb94cd09c14cd022a8c5e4e8/toolkit/components/pdfjs/content/PdfStreamConverter.sys.mjs#426-453), which will hide the toolbar and secondaryToolbar print-buttons.