### PR TITLE
Improve error handling when parsing page-structTrees

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -707,10 +707,18 @@ class Page {
     // Ensure that the structTree will contain the page's annotations.
     await this._parsedAnnotations;
 
-    const structTree = await this.pdfManager.ensure(this, "_parseStructTree", [
-      structTreeRoot,
-    ]);
-    return this.pdfManager.ensure(structTree, "serializable");
+    try {
+      const structTree = await this.pdfManager.ensure(
+        this,
+        "_parseStructTree",
+        [structTreeRoot]
+      );
+      const data = await this.pdfManager.ensure(structTree, "serializable");
+      return data;
+    } catch (ex) {
+      warn(`getStructTree: "${ex}".`);
+      return null;
+    }
   }
 
   /**

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -757,7 +757,10 @@ class StructTreePage {
 
     const parent = dict.get("P");
 
-    if (!parent || isName(parent.get("Type"), "StructTreeRoot")) {
+    if (
+      !(parent instanceof Dict) ||
+      isName(parent.get("Type"), "StructTreeRoot")
+    ) {
       if (!this.addTopLevelNode(dict, element)) {
         map.delete(dict);
       }


### PR DESCRIPTION
 - **Catch, and ignore, errors during `Page.prototype.getStructTree`**

   This way any errors thrown during parsing of the page-structTree will not be forwarded to the viewer.

 - **Ensure that the /P-entry is actually a dictionary in `StructTreePage.prototype.addNode`**

   This may fix issue #19822, but without a test-case it's simply impossible to know for sure.