### PR TITLE
Avoid to create any subarrays when optimizing 'save, transform, constructPath, restore' (bug 1961107)

### DIFF
--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -745,12 +745,9 @@ class Commands {
 
   add(cmd, args) {
     if (args) {
-      const [a, b, c, d, e, f] = this.currentTransform;
+      const { currentTransform } = this;
       for (let i = 0, ii = args.length; i < ii; i += 2) {
-        const x = args[i];
-        const y = args[i + 1];
-        args[i] = a * x + c * y + e;
-        args[i + 1] = b * x + d * y + f;
+        Util.applyTransform(args, currentTransform, i);
       }
       this.cmds.push(`${cmd}${args.join(" ")}`);
     } else {

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -524,11 +524,11 @@ addState(
       switch (buffer[k++]) {
         case DrawOPS.moveTo:
         case DrawOPS.lineTo:
-          Util.applyTransform(buffer.subarray(k), transform);
+          Util.applyTransform(buffer, transform, k);
           k += 2;
           break;
         case DrawOPS.curveTo:
-          Util.applyTransformToBezier(buffer.subarray(k), transform);
+          Util.applyTransformToBezier(buffer, transform, k);
           k += 6;
           break;
       }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -730,15 +730,14 @@ class Util {
   }
 
   // For 2d affine transforms
-  static applyTransform(p, m) {
-    const p0 = p[0];
-    const p1 = p[1];
-    p[0] = p0 * m[0] + p1 * m[2] + m[4];
-    p[1] = p0 * m[1] + p1 * m[3] + m[5];
+  static applyTransform(p, m, pos = 0) {
+    const p0 = p[pos];
+    const p1 = p[pos + 1];
+    p[pos] = p0 * m[0] + p1 * m[2] + m[4];
+    p[pos + 1] = p0 * m[1] + p1 * m[3] + m[5];
   }
 
-  // For 2d affine transforms
-  static applyTransformToBezier(p, transform) {
+  static applyTransformToBezier(p, transform, pos = 0) {
     const m0 = transform[0];
     const m1 = transform[1];
     const m2 = transform[2];
@@ -746,10 +745,10 @@ class Util {
     const m4 = transform[4];
     const m5 = transform[5];
     for (let i = 0; i < 6; i += 2) {
-      const pI = p[i];
-      const pI1 = p[i + 1];
-      p[i] = pI * m0 + pI1 * m2 + m4;
-      p[i + 1] = pI * m1 + pI1 * m3 + m5;
+      const pI = p[pos + i];
+      const pI1 = p[pos + i + 1];
+      p[pos + i] = pI * m0 + pI1 * m2 + m4;
+      p[pos + i + 1] = pI * m1 + pI1 * m3 + m5;
     }
   }
 


### PR DESCRIPTION
Removing those `subarray`calls helps to improve performance by a factor 6 on Linux and by a factor of 3
on Windows 11.