### PR TITLE
Avoid to redraw a pdf with automatic zoom when switching to an empty tab

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2099,11 +2099,6 @@ const PDFViewerApplication = {
     window.addEventListener("keydown", onKeyDown.bind(this), { signal });
     window.addEventListener("keyup", onKeyUp.bind(this), { signal });
     window.addEventListener(
-      "resize",
-      () => eventBus.dispatch("resize", { source: window }),
-      { signal }
-    );
-    window.addEventListener(
       "hashchange",
       () => {
         eventBus.dispatch("hashchange", {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -297,6 +297,7 @@ class PDFViewer {
       }
     }
     this.#resizeObserver.observe(this.container);
+    this.#resizeObserver.observe(this.viewer);
 
     this.eventBus = options.eventBus;
     this.linkService = options.linkService || new SimpleLinkService();
@@ -2322,13 +2323,16 @@ class PDFViewer {
   }
 
   #resizeObserverCallback(entries) {
-    for (const entry of entries) {
-      if (entry.target === this.container) {
-        this.#updateContainerHeightCss(
-          Math.floor(entry.borderBoxSize[0].blockSize)
-        );
+    for (const { target, borderBoxSize } of entries) {
+      if (target === this.viewer) {
+        this.eventBus.dispatch("resize", {
+          source: window,
+        });
+        continue;
+      }
+      if (target === this.container) {
+        this.#updateContainerHeightCss(Math.floor(borderBoxSize[0].blockSize));
         this.#containerTopLeft = null;
-        break;
       }
     }
   }


### PR DESCRIPTION
The pdf "wuppertal_2012.pdf" in automatic zoom si redrawn each time we switch to an empty tab. It's because of the scrollbars which are removed.
So instead of relying on the windows resize event we now rely on the viewer itself being resized.