### PR TITLE
Fix printing of XFA documents, by calling `XfaLayerBuilder.prototype.render` correctly (issue 19840)

### DIFF
--- a/web/print_utils.js
+++ b/web/print_utils.js
@@ -35,7 +35,7 @@ function getXfaHtmlForPrinting(printContainer, pdfDocument) {
     });
     const viewport = getXfaPageViewport(xfaPage, { scale });
 
-    builder.render(viewport, "print");
+    builder.render({ viewport, intent: "print" });
     page.append(builder.div);
   }
 }


### PR DESCRIPTION
When changing the format of various `render`-methods in PR #19365 I forgot to update the code used to print XFA documents, sorry about that.