### PR TITLE
Tweak the Node.js version listed in "engines", to ensure that process.getBuiltinModule is available

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2315,7 +2315,7 @@ function packageJson() {
       url: `git+${DIST_GIT_URL}`,
     },
     engines: {
-      node: ">=20.16.0",
+      node: ">=20.16.0 || >=22.3.0",
     },
     scripts: {},
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": ">=20.16.0"
+        "node": ">=20.16.0 || >=22.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "url": "git://github.com/mozilla/pdf.js.git"
   },
   "engines": {
-    "node": ">=20.16.0"
+    "node": ">=20.16.0 || >=22.3.0"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Actually, `process.getBuiltinModule(id)` was added in v22.3.0 and v20.16.0. When I ran `example/node/pdf2png.mjs` using Node 22.1, I encountered an error #19857  `process.getBuiltinModule is not a function`.

https://nodejs.org/docs/latest/api/process.html#processgetbuiltinmoduleid