### PR TITLE
Fix the debugger CSS when using the dark theme (PR 19819 follow-up)

### DIFF
--- a/web/debugger.css
+++ b/web/debugger.css
@@ -22,7 +22,10 @@
   font: message-box;
 }
 #PDFBug {
-  background-color: rgb(255 255 255);
+  color-scheme: only light;
+
+  background-color: white;
+  color: black;
   border: 1px solid rgb(102 102 102);
   position: fixed;
   top: 32px;


### PR DESCRIPTION
Perhaps we should update the debugger CSS to properly account for the light/dark theme, however since that's not UI that end-users ever see we simply force using the light theme for now.