### PR TITLE
Add a basic `navigator` polyfill for older Node.js versions

### DIFF
--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -67,6 +67,13 @@ if (isNodeJS) {
         warn("Cannot polyfill `Path2D`, rendering may be broken.");
       }
     }
+    if (!globalThis.navigator?.language) {
+      globalThis.navigator = {
+        language: "en-US",
+        platform: "",
+        userAgent: "",
+      };
+    }
   }
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -643,30 +643,16 @@ class FeatureTest {
   }
 
   static get platform() {
-    if (
-      (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-      (typeof navigator !== "undefined" &&
-        typeof navigator?.platform === "string" &&
-        typeof navigator?.userAgent === "string")
-    ) {
-      const { platform, userAgent } = navigator;
+    const { platform, userAgent } = navigator;
 
-      return shadow(this, "platform", {
-        isAndroid: userAgent.includes("Android"),
-        isLinux: platform.includes("Linux"),
-        isMac: platform.includes("Mac"),
-        isWindows: platform.includes("Win"),
-        isFirefox:
-          (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-          userAgent.includes("Firefox"),
-      });
-    }
     return shadow(this, "platform", {
-      isAndroid: false,
-      isLinux: false,
-      isMac: false,
-      isWindows: false,
-      isFirefox: false,
+      isAndroid: userAgent.includes("Android"),
+      isLinux: platform.includes("Linux"),
+      isMac: platform.includes("Mac"),
+      isWindows: platform.includes("Win"),
+      isFirefox:
+        (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
+        userAgent.includes("Firefox"),
     });
   }
 

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -19,13 +19,16 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   if (
     typeof PDFJSDev !== "undefined" &&
     PDFJSDev.test("LIB") &&
-    typeof navigator === "undefined"
+    !globalThis.navigator?.language
   ) {
-    globalThis.navigator = Object.create(null);
+    globalThis.navigator = {
+      language: "en-US",
+      maxTouchPoints: 1,
+      platform: "",
+      userAgent: "",
+    };
   }
-  const userAgent = navigator.userAgent || "";
-  const platform = navigator.platform || "";
-  const maxTouchPoints = navigator.maxTouchPoints || 1;
+  const { maxTouchPoints, platform, userAgent } = navigator;
 
   const isAndroid = /Android/.test(userAgent);
   const isIOS =


### PR DESCRIPTION
Modern Node.js versions now include a `navigator` implementation, with a few basic properties, that's actually enough for the PDF.js use-cases; please see https://nodejs.org/api/globals.html#navigator
Unfortunately we still support Node.js version `20`, hence we add a basic polyfill since that allows simplifying the code slightly.

*Smaller diff with https://github.com/mozilla/pdf.js/pull/19876/files?w=1*