### PR TITLE
Assert that `numberToString` is called with a number (issue 19877)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -632,6 +632,13 @@ function recoverJsURL(str) {
 }
 
 function numberToString(value) {
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+    assert(
+      typeof value === "number",
+      `numberToString - the value (${value}) should be a number.`
+    );
+  }
+
   if (Number.isInteger(value)) {
     return value.toString();
   }


### PR DESCRIPTION
*NOTE:* Given that this is an *internal* function, used only in the worker-thread, it's not clear to me that this is an entirely "necessary" change.