### PR TITLE
Ensure that each canvas is a separate compositing layer

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -94,6 +94,7 @@
       width: 100%;
       height: 100%;
       contain: content;
+      will-change: transform;
 
       .structTree {
         contain: strict;


### PR DESCRIPTION
I’ve been investigating an issue in Safari where a code editor displayed next to a PDF exhibits increasing amounts of lag as the PDF gets more zoomed in.

Here’s a [demo](https://aeaton-pdfjssafaridemo.web.val.run/) (the PDF is on the right, but just looks white as it’s at the maximum zoom level; only Safari is affected). In PDF.js v5.2.133, dragging a selection across the text in the editor shows a lag in Safari 18.4 on macOS 15.4.

The fix I’ve found for this is to suggest a separate composition layer for each `canvas` element by setting `will-change: transform`. This is working in our application now, but I thought it might also be useful to other users of the PDF viewer library.

before:

https://github.com/user-attachments/assets/e89496b4-fecc-4cd5-90ab-99be878a3b4f

after:

https://github.com/user-attachments/assets/7343ae2a-7fd3-4d7e-89a2-786791231e69