### PR TITLE
Fix arguments in `toStyle` call in `CheckButton`

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -1321,7 +1321,7 @@ class CheckButton extends XFAObject {
   [$toHTML](availableSpace) {
     // TODO: border, shape and mark.
 
-    const style = toStyle("margin");
+    const style = toStyle(this, "margin");
     const size = measureToString(this.size);
 
     style.width = style.height = size;


### PR DESCRIPTION
Just one fix - passes `this` as the first argument to `toStyle` in `CheckButton.prototype.[$toHTML]`.