### PR TITLE
Simplify the `loadXfaImages` method and related code

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1062,11 +1062,13 @@ class Catalog {
     if (obj instanceof Dict && obj.has("XFAImages")) {
       const nameTree = new NameTree(obj.getRaw("XFAImages"), this.xref);
       for (const [key, value] of nameTree.getAll()) {
-        xfaImages ??= new Dict(this.xref);
-        xfaImages.set(
-          stringToPDFString(key, /* keepEscapeSequence = */ true),
-          value
-        );
+        if (value instanceof BaseStream) {
+          xfaImages ??= new Map();
+          xfaImages.set(
+            stringToPDFString(key, /* keepEscapeSequence = */ true),
+            value.getBytes()
+          );
+        }
       }
     }
     return shadow(this, "xfaImages", xfaImages);

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1238,23 +1238,10 @@ class PDFDocument {
   }
 
   async loadXfaImages() {
-    const xfaImagesDict = await this.pdfManager.ensureCatalog("xfaImages");
-    if (!xfaImagesDict) {
+    const xfaImages = await this.pdfManager.ensureCatalog("xfaImages");
+    if (!xfaImages) {
       return;
     }
-
-    const keys = xfaImagesDict.getKeys();
-    const objectLoader = new ObjectLoader(xfaImagesDict, keys, this.xref);
-    await objectLoader.load();
-
-    const xfaImages = new Map();
-    for (const key of keys) {
-      const stream = xfaImagesDict.get(key);
-      if (stream instanceof BaseStream) {
-        xfaImages.set(key, stream.getBytes());
-      }
-    }
-
     this.xfaFactory.setImages(xfaImages);
   }
 

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -3412,8 +3412,7 @@ class Image extends StringObject {
       return HTMLResult.EMPTY;
     }
 
-    let buffer =
-      this[$globalData].images && this[$globalData].images.get(this.href);
+    let buffer = this[$globalData].images?.get(this.href);
     if (!buffer && (this.href || !this[$content])) {
       // In general, we don't get remote data and use what we have
       // in the pdf itself, so no picture for non null href.


### PR DESCRIPTION
Currently we create an intermediate `Dict` during parsing, however that seems unnecessary since (note especially the second point):
 - The `NameOrNumberTree.prototype.getAll` method will already resolve any references, as needed, during parsing.
 - The `Catalog.prototype.xfaImages` getter is invoked, via the `BasePdfManager`-instance, such that any `MissingDataException`s are already handled correctly.