### PR TITLE
Simplify the `serializeXfaData` method and related code

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1408,7 +1408,7 @@ class PDFDocument {
     this.xfaFactory.appendFonts(pdfFonts, reallyMissingFonts);
   }
 
-  async serializeXfaData(annotationStorage) {
+  serializeXfaData(annotationStorage) {
     return this.xfaFactory
       ? this.xfaFactory.serializeData(annotationStorage)
       : null;

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -127,10 +127,6 @@ class BasePdfManager {
     return this.pdfDocument.loadXfaImages();
   }
 
-  serializeXfaData(annotationStorage) {
-    return this.pdfDocument.serializeXfaData(annotationStorage);
-  }
-
   cleanup(manuallyTriggered = false) {
     return this.pdfDocument.cleanup(manuallyTriggered);
   }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -617,7 +617,9 @@ class WorkerMessageHandler {
         }
 
         if (isPureXfa) {
-          promises.push(pdfManager.serializeXfaData(annotationStorage));
+          promises.push(
+            pdfManager.ensureDoc("serializeXfaData", [annotationStorage])
+          );
         } else {
           for (let pageIndex = 0; pageIndex < numPages; pageIndex++) {
             promises.push(


### PR DESCRIPTION
Rather than having a dedicated `BasePdfManager`-method for this one call-site we can instead change `PDFDocument.prototype.serializeXfaData` to a non-async method, that we invoke via `BasePdfManager.prototype.ensureDoc`.