### PR TITLE
Remove the `BasePdfManager.prototype.catalog` getter

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -95,10 +95,6 @@ class BasePdfManager {
     return this._docBaseUrl;
   }
 
-  get catalog() {
-    return this.pdfDocument.catalog;
-  }
-
   ensureDoc(prop, args) {
     return this.ensure(this.pdfDocument, prop, args);
   }

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -118,7 +118,7 @@ class StructTreeRoot {
     pdfManager,
     changes,
   }) {
-    const root = pdfManager.catalog.cloneDict();
+    const root = await pdfManager.ensureCatalog("cloneDict");
     const cache = new RefSetCache();
     cache.put(catalogRef, root);
 


### PR DESCRIPTION
This is only invoked *once* and it can be trivially replaced by the `ensureCatalog`-method, since the code where it's used is already asynchronous.