### PR TITLE
Slightly re-factor how we pre-load fonts and images in XFA documents

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -115,14 +115,6 @@ class BasePdfManager {
     return this.pdfDocument.fontFallback(id, handler);
   }
 
-  loadXfaFonts(handler, task) {
-    return this.pdfDocument.loadXfaFonts(handler, task);
-  }
-
-  loadXfaImages() {
-    return this.pdfDocument.loadXfaImages();
-  }
-
   cleanup(manuallyTriggered = false) {
     return this.pdfDocument.cleanup(manuallyTriggered);
   }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -170,18 +170,11 @@ class WorkerMessageHandler {
 
       const isPureXfa = await pdfManager.ensureDoc("isPureXfa");
       if (isPureXfa) {
-        const task = new WorkerTask("loadXfaFonts");
+        const task = new WorkerTask("loadXfaResources");
         startWorkerTask(task);
 
-        await Promise.all([
-          pdfManager
-            .loadXfaFonts(handler, task)
-            .catch(reason => {
-              // Ignore errors, to allow the document to load.
-            })
-            .then(() => finishWorkerTask(task)),
-          pdfManager.loadXfaImages(),
-        ]);
+        await pdfManager.ensureDoc("loadXfaResources", [handler, task]);
+        finishWorkerTask(task);
       }
 
       const [numPages, fingerprints] = await Promise.all([

--- a/src/core/xfa/factory.js
+++ b/src/core/xfa/factory.js
@@ -43,7 +43,7 @@ class XFAFactory {
   }
 
   isValid() {
-    return this.root && this.form;
+    return !!(this.root && this.form);
   }
 
   /**


### PR DESCRIPTION
 - **Ensure that `XFAFactory.prototype.isValid` returns a boolean value**

   Considering the name of the method, and how it's actually being used, you'd expect it to return a boolean value.
   Given how it's currently being used this inconsistency doesn't cause any issues, however we should still fix this.

 - **Reduce duplication when parsing fonts in `loadXfaFonts`**

   Currently we repeat virtually the same code when calling the `PartialEvaluator.prototype.handleSetFont` method, which we can avoid by introducing an inline helper function.

 - **Slightly re-factor how we pre-load fonts and images in XFA documents**

   Rather than "manually" invoking the methods from the `src/core/worker.js` file we introduce a single `PDFDocument`-method that handles this for us, and make the current methods private.
   Since this code is only invoked at most *once* per document, and only for XFA documents, we can use `BasePdfManager.prototype.ensureDoc` directly rather than needing a stand-alone method.