### PR TITLE
Pre-load Annotation and FieldObject data before parsing it

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3508,6 +3508,27 @@ describe("api", function () {
       await loadingTask.destroy();
     });
 
+    it("gets all annotations with `disableAutoFetch` set", async function () {
+      if (isNodeJS) {
+        pending("Linked test-cases are not supported in Node.js.");
+      }
+
+      const loadingTask = getDocument(
+        buildGetDocumentParams("pdf.pdf", {
+          disableRange: false,
+          disableStream: true,
+          disableAutoFetch: true,
+        })
+      );
+      const pdfDoc = await loadingTask.promise;
+      const pdfPage = await pdfDoc.getPage(5);
+      const annotations = await pdfPage.getAnnotations();
+
+      expect(annotations.length).toEqual(33);
+
+      await loadingTask.destroy();
+    });
+
     it("gets text content", async function () {
       const { items, styles, lang } = await page.getTextContent();
 


### PR DESCRIPTION
By utilizing the `ObjectLoader` for this data we're able to invoke `AnnotationFactory.create` without having to handle the data-lookup potentially throwing `MissingDataException`s.
This could obviously lead to slightly more data being requested earlier than before[1], however it should be overall more efficient since we'll no longer risk needing to abort and re-parse annotations halfway through.

This patch also changes the `ObjectLoader`-class a little bit, to handle the /Annots-data, and it now supports the initial object being either a Dictionary or an Array.

---
[1] Note that `ObjectLoader.prototype.load` already has a fast-path, which avoids any lookup/parsing if the entire PDF document is already loaded.