### PR TITLE
Shorten the `PDFDocument.prototype.fieldObjects` getter slightly

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1871,20 +1871,17 @@ class PDFDocument {
         if (!formInfo.hasFields) {
           return null;
         }
-
-        const [annotationGlobals, acroForm] = await Promise.all([
-          this.pdfManager.ensureDoc("annotationGlobals"),
-          this.pdfManager.ensureCatalog("acroForm"),
-        ]);
+        const annotationGlobals = await this.annotationGlobals;
         if (!annotationGlobals) {
           return null;
         }
+        const { acroForm } = annotationGlobals;
 
         const visitedRefs = new RefSet();
         const allFields = Object.create(null);
         const fieldPromises = new Map();
         const orphanFields = new RefSetCache();
-        for (const fieldRef of await acroForm.getAsync("Fields")) {
+        for (const fieldRef of acroForm.get("Fields")) {
           await this.#collectFieldObjects(
             "",
             null,


### PR DESCRIPTION
The effect is probably not even measurable, however this patch ever so slightly reduces the asynchronicity in the `fieldObjects` getter. These changes should be safe since:

 - We're inside of the `PDFDocument`-class and the `annotationGlobals`-getter, which will always return a (shadowed) Promise and won't throw `MissingDataException`s, can be accessed directly without going through the `BasePdfManager`-instance.

 - The `acroForm`-dictionary can be accessed through the `annotationGlobals`-data, removing the need to "manually" look it up and thus the need for using `Promise.all` here.

 - We can also lookup the /Fields-data, in the `acroForm`-dictionary, synchronously since the initial `formInfo.hasFields` check guarantees that it's available.