### PR TITLE
Reduce duplication when computing the maximum canvas pixels

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -665,13 +665,7 @@ class OutputScale {
       maxWidthScale = Infinity,
       maxHeightScale = Infinity;
 
-    if (capAreaFactor >= 0) {
-      const cappedWindowArea = OutputScale.getCappedWindowArea(capAreaFactor);
-      maxPixels =
-        maxPixels > 0
-          ? Math.min(maxPixels, cappedWindowArea)
-          : cappedWindowArea;
-    }
+    maxPixels = OutputScale.capPixels(maxPixels, capAreaFactor);
     if (maxPixels > 0) {
       maxAreaScale = Math.sqrt(maxPixels / (width * height));
     }
@@ -693,21 +687,18 @@ class OutputScale {
     return globalThis.devicePixelRatio || 1;
   }
 
-  static getCappedWindowArea(capAreaFactor) {
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")) {
-      return Math.ceil(
-        window.innerWidth *
-          window.innerHeight *
+  static capPixels(maxPixels, capAreaFactor) {
+    if (capAreaFactor >= 0) {
+      const winPixels = Math.ceil(
+        (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING")
+          ? window.innerWidth * window.innerHeight
+          : window.screen.availWidth * window.screen.availHeight) *
           this.pixelRatio ** 2 *
           (1 + capAreaFactor / 100)
       );
+      return maxPixels > 0 ? Math.min(maxPixels, winPixels) : winPixels;
     }
-    return Math.ceil(
-      window.screen.availWidth *
-        window.screen.availHeight *
-        this.pixelRatio ** 2 *
-        (1 + capAreaFactor / 100)
-    );
+    return maxPixels;
   }
 }
 

--- a/web/pdf_page_detail_view.js
+++ b/web/pdf_page_detail_view.js
@@ -140,18 +140,10 @@ class PDFPageDetailView extends BasePDFPageView {
       return;
     }
 
-    const { viewport, capCanvasAreaFactor } = this.pageView;
+    const { viewport, maxCanvasPixels, capCanvasAreaFactor } = this.pageView;
 
     const visibleWidth = visibleArea.maxX - visibleArea.minX;
     const visibleHeight = visibleArea.maxY - visibleArea.minY;
-    let { maxCanvasPixels } = this.pageView;
-
-    if (capCanvasAreaFactor >= 0) {
-      maxCanvasPixels = Math.min(
-        maxCanvasPixels,
-        OutputScale.getCappedWindowArea(capCanvasAreaFactor)
-      );
-    }
 
     // "overflowScale" represents which percentage of the width and of the
     // height the detail area extends outside of the visible area. We want to
@@ -164,7 +156,8 @@ class PDFPageDetailView extends BasePDFPageView {
     const visiblePixels =
       visibleWidth * visibleHeight * OutputScale.pixelRatio ** 2;
     const maxDetailToVisibleLinearRatio = Math.sqrt(
-      maxCanvasPixels / visiblePixels
+      OutputScale.capPixels(maxCanvasPixels, capCanvasAreaFactor) /
+        visiblePixels
     );
     const maxOverflowScale = (maxDetailToVisibleLinearRatio - 1) / 2;
     let overflowScale = Math.min(1, maxOverflowScale);


### PR DESCRIPTION
*This is something that occurred to me when reviewing the latest PDF.js update in mozilla-central.*

Currently we duplicate essentially the same code in both the `OutputScale.prototype.limitCanvas` and `PDFPageDetailView.prototype.update` methods, which seems unnecessary, and to avoid that we introduce a new `OutputScale.capPixels` method that is used to compute the maximum canvas pixels.