### PR TITLE
Preserve webpack/vite ignore comments when minifying

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -362,6 +362,9 @@ function createWebpackConfig(
                   // V8 chokes on very long sequences, work around that.
                   sequences: false,
                 },
+                format: {
+                  comments: /@lic|webpackIgnore|@vite-ignore/i,
+                },
                 keep_classnames: true,
                 keep_fnames: true,
                 module: isModule,


### PR DESCRIPTION
> They were removed in the minified build, but the code that made the comments necessary was still there (just minified). This commit updates the Terser config to preserve them.
>
> The default value of Terser's `comments` option is [`/@preserve|@copyright|@lic|@cc_on|^\**!/i`](https://github.com/terser/terser/blob/d528103b7c00735ca7736a2a8ad27188e93c0c90/lib/output.js#L178C12-L178C53), however the only type of comment it was actually matching in our case is `@lic`, for the license header in minified files. Thus the new regexp is `/@lic|webpackIgnore|@vite-ignore/i`.

Found this while investigating https://github.com/mozilla/pdf.js/issues/19921.