### PR TITLE
Minify the js code when building for Firefox (bug 1965003)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -491,7 +491,8 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefs) {
 
 function createMainBundle(defines) {
   const mainFileConfig = createWebpackConfig(defines, {
-    filename: defines.MINIFIED ? "pdf.min.mjs" : "pdf.mjs",
+    filename:
+      defines.MINIFIED && !defines.MOZCENTRAL ? "pdf.min.mjs" : "pdf.mjs",
     library: {
       type: "module",
     },
@@ -571,7 +572,10 @@ function createSandboxBundle(defines, extraOptions = undefined) {
 
 function createWorkerBundle(defines) {
   const workerFileConfig = createWebpackConfig(defines, {
-    filename: defines.MINIFIED ? "pdf.worker.min.mjs" : "pdf.worker.mjs",
+    filename:
+      defines.MINIFIED && !defines.MOZCENTRAL
+        ? "pdf.worker.min.mjs"
+        : "pdf.worker.mjs",
     library: {
       type: "module",
     },
@@ -1388,7 +1392,7 @@ gulp.task(
   gulp.series(
     createBuildNumber,
     function scriptingMozcentral() {
-      const defines = { ...DEFINES, MOZCENTRAL: true };
+      const defines = { ...DEFINES, MOZCENTRAL: true, MINIFIED: true };
       return buildDefaultPreferences(defines, "mozcentral/");
     },
     async function prefsMozcentral() {
@@ -1397,7 +1401,7 @@ gulp.task(
     function createMozcentral() {
       console.log();
       console.log("### Building mozilla-central extension");
-      const defines = { ...DEFINES, MOZCENTRAL: true };
+      const defines = { ...DEFINES, MOZCENTRAL: true, MINIFIED: true };
       const gvDefines = { ...defines, GECKOVIEW: true };
 
       const MOZCENTRAL_DIR = BUILD_DIR + "mozcentral/",


### PR DESCRIPTION
It helps to improve the loading time in the worker by around 25% on Windows, Mac and Android.