### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -41,7 +41,7 @@ const COMMAND_MAP = {
 };
 
 /**
- * CharStrings are encoded following the the CharString Encoding sequence
+ * CharStrings are encoded following the CharString Encoding sequence
  * describe in Chapter 6 of the "Adobe Type1 Font Format" specification.
  * The value in a byte indicates a command, a number, or subsequent bytes
  * that are to be interpreted in a special way.

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -425,7 +425,7 @@ class StampEditor extends AnnotationEditor {
       width > MAX_RATIO * pageWidth ||
       height > MAX_RATIO * pageHeight
     ) {
-      // If the the image is too big compared to the page dimensions
+      // If the image is too big compared to the page dimensions
       // (more than MAX_RATIO) then we scale it down.
       const factor = Math.min(
         (MAX_RATIO * pageWidth) / width,


### PR DESCRIPTION
remove redundant word in comment