### PR TITLE
Replace `PDFWorker.fromPort` with a generic `PDFWorker.create` method

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1082,7 +1082,7 @@ describe("api", function () {
           getDocument(tracemonkeyGetDocumentParams);
         }).toThrow(
           new Error(
-            "PDFWorker.fromPort - the worker is being destroyed.\n" +
+            "PDFWorker.create - the worker is being destroyed.\n" +
               "Please remember to await `PDFDocumentLoadingTask.destroy()`-calls."
           )
         );


### PR DESCRIPTION
 - **Replace `PDFWorker.fromPort` with a generic `PDFWorker.create` method**

   This allows us to simply invoke `PDFWorker.create` unconditionally from the `getDocument` function, without having to manually check if a global `workerPort` is available first.

 - **Utilize private fields and methods more in the `PDFWorker` class**

   This replaces, wherever possible, the old semi-private fields and methods with actually private ones.