### PR TITLE
Fix missing `await` for asynchronous method calls in the integration tests

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -669,7 +669,7 @@ describe("FreeText Editor", () => {
             }
           );
 
-          page.evaluate(() => {
+          await page.evaluate(() => {
             window.PDFViewerApplication.eventBus.dispatch(
               "switchannotationeditorparams",
               {
@@ -1290,7 +1290,7 @@ describe("FreeText Editor", () => {
             ".selectedEditor .internal"
           );
 
-          page.evaluate(() => {
+          await page.evaluate(() => {
             window.PDFViewerApplication.eventBus.dispatch(
               "switchannotationeditorparams",
               {

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -626,7 +626,7 @@ describe("Highlight Editor", () => {
           const { width: prevWidth } = await getRect(page, editorSelector);
 
           value = 24;
-          page.evaluate(val => {
+          await page.evaluate(val => {
             window.PDFViewerApplication.eventBus.dispatch(
               "switchannotationeditorparams",
               {
@@ -763,7 +763,7 @@ describe("Highlight Editor", () => {
 
           const { width: prevWidth } = await getRect(page, editorSelector);
 
-          page.evaluate(val => {
+          await page.evaluate(val => {
             window.PDFViewerApplication.eventBus.dispatch(
               "switchannotationeditorparams",
               {

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -302,7 +302,7 @@ describe("Ink Editor", () => {
           await page.mouse.up();
           await awaitPromise(clickHandle);
 
-          page.mouse.click(rect.x - 10, rect.y + 10);
+          await page.mouse.click(rect.x - 10, rect.y + 10);
           await page.waitForSelector(`${getEditorSelector(0)}.disabled`);
         })
       );
@@ -583,7 +583,7 @@ describe("Ink Editor", () => {
           }
 
           const red = "#ff0000";
-          page.evaluate(value => {
+          await page.evaluate(value => {
             window.PDFViewerApplication.eventBus.dispatch(
               "switchannotationeditorparams",
               {
@@ -763,7 +763,7 @@ describe("Ink Editor", () => {
           await selectEditor(page, pdfjsA);
 
           const red = "#ff0000";
-          page.evaluate(value => {
+          await page.evaluate(value => {
             window.PDFViewerApplication.eventBus.dispatch(
               "switchannotationeditorparams",
               {


### PR DESCRIPTION
The `Page.evaluate()` and `Mouse.click()` APIs in Puppeteer both return a promise; see https://pptr.dev/api/puppeteer.page.evaluate and https://pptr.dev/api/puppeteer.mouse.click, and should therefore be awaited before proceeding in tests to make sure that the test's behavior is deterministic and avoid intermittent failures.

The following command was used to find potential places to fix:
`grep -nEr "[^await|return] page\." test/integration/*`