### PR TITLE
Support Type3 fonts with an incomplete /FontDescriptor dictionary (issue 19954)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4420,7 +4420,13 @@ class PartialEvaluator {
 
     const fontNameStr = fontName?.name;
     const baseFontStr = baseFont?.name;
-    if (!isType3Font && fontNameStr !== baseFontStr) {
+    if (isType3Font) {
+      if (!fontNameStr) {
+        // The Type3 font has a /FontDescriptor, however it's incomplete, hence
+        // why we didn't create a barbebones one above (fixes issue19954.pdf).
+        fontName = Name.get(type);
+      }
+    } else if (fontNameStr !== baseFontStr) {
       info(
         `The FontDescriptor's FontName is "${fontNameStr}" but ` +
           `should be the same as the Font's BaseFont "${baseFontStr}".`

--- a/test/pdfs/issue19954.pdf.link
+++ b/test/pdfs/issue19954.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/20281525/Capital.Bancorp.Inc.Corporate.Responsibility.2025509.SD000000003063823863-1-2.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -2860,6 +2860,15 @@
     "type": "eq"
   },
   {
+    "id": "issue19954",
+    "file": "pdfs/issue19954.pdf",
+    "md5": "9742309bb321691b53b96069dfc1099b",
+    "link": true,
+    "rounds": 1,
+    "lastPage": 1,
+    "type": "text"
+  },
+  {
     "id": "IndexedCS_negative_and_high",
     "file": "pdfs/IndexedCS_negative_and_high.pdf",
     "md5": "3bbf5e6f1cf49acb075fabb0726b5fe4",


### PR DESCRIPTION
We have a fallback for the common case of Type3 fonts without a /FontDescriptor dictionary, however we also need to handle the case where it's present but lacking the required /FontName entry.