### PR TITLE
Improve how the PDF.js version/commit information is exposed in the *built* files

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -302,6 +302,12 @@ function createWebpackConfig(
   const licenseHeaderLibre = fs
     .readFileSync("./src/license_header_libre.js")
     .toString();
+  const versionInfoHeader = [
+    "/**",
+    ` * pdfjsVersion = ${versionInfo.version}`,
+    ` * pdfjsBuild = ${versionInfo.commit}`,
+    " */",
+  ].join("\n");
   const enableSourceMaps =
     !bundleDefines.MOZCENTRAL &&
     !bundleDefines.CHROME &&
@@ -335,7 +341,10 @@ function createWebpackConfig(
   const plugins = [];
   if (!disableLicenseHeader) {
     plugins.push(
-      new webpack2.BannerPlugin({ banner: licenseHeaderLibre, raw: true })
+      new webpack2.BannerPlugin({
+        banner: licenseHeaderLibre + "\n" + versionInfoHeader,
+        raw: true,
+      })
     );
   }
   plugins.push({
@@ -389,7 +398,7 @@ function createWebpackConfig(
                   sequences: false,
                 },
                 format: {
-                  comments: /@lic|webpackIgnore|@vite-ignore/i,
+                  comments: /@lic|webpackIgnore|@vite-ignore|pdfjsVersion/i,
                 },
                 keep_classnames: true,
                 keep_fnames: true,

--- a/src/pdf.image_decoders.js
+++ b/src/pdf.image_decoders.js
@@ -22,13 +22,6 @@ import { Jbig2Error, Jbig2Image } from "./core/jbig2.js";
 import { JpegError, JpegImage } from "./core/jpg.js";
 import { JpxError, JpxImage } from "./core/jpx.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 globalThis.pdfjsImageDecoders = {
   getVerbosityLevel,
   Jbig2Error,

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -81,15 +81,8 @@ import { TextLayer } from "./display/text_layer.js";
 import { TouchManager } from "./display/touch_manager.js";
 import { XfaLayer } from "./display/xfa_layer.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING || GENERIC")) {
-  globalThis.pdfjsTestingUtils = {
+  globalThis._pdfjsTestingUtils = {
     HighlightOutliner,
   };
 }

--- a/src/pdf.sandbox.js
+++ b/src/pdf.sandbox.js
@@ -16,11 +16,6 @@
 import ModuleLoader from "../external/quickjs/quickjs-eval.js";
 import { SandboxSupportBase } from "./pdf.sandbox.external.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion = PDFJSDev.eval("BUNDLE_VERSION");
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild = PDFJSDev.eval("BUNDLE_BUILD");
-
 class SandboxSupport extends SandboxSupportBase {
   exportValueToSandbox(val) {
     // The communication with the Quickjs sandbox is based on strings

--- a/src/pdf.scripting.js
+++ b/src/pdf.scripting.js
@@ -15,13 +15,6 @@
 
 import { initSandbox } from "./scripting_api/initialization.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 // To avoid problems with `export` statements in the QuickJS Javascript Engine,
 // we manually expose `pdfjsScripting` globally instead.
 globalThis.pdfjsScripting = { initSandbox };

--- a/src/pdf.worker.js
+++ b/src/pdf.worker.js
@@ -15,13 +15,6 @@
 
 import { WorkerMessageHandler } from "./core/worker.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 globalThis.pdfjsWorker = {
   WorkerMessageHandler,
 };

--- a/test/driver.js
+++ b/test/driver.js
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* globals pdfjsLib, pdfjsTestingUtils, pdfjsViewer */
+/* globals pdfjsLib, _pdfjsTestingUtils, pdfjsViewer */
 
 const {
   AnnotationLayer,
@@ -26,7 +26,7 @@ const {
   TextLayer,
   XfaLayer,
 } = pdfjsLib;
-const { HighlightOutliner } = pdfjsTestingUtils;
+const { HighlightOutliner } = _pdfjsTestingUtils;
 const { GenericL10n, parseQueryString, SimpleLinkService } = pdfjsViewer;
 
 const WAITING_TIME = 100; // ms

--- a/web/pdf_viewer.component.js
+++ b/web/pdf_viewer.component.js
@@ -39,13 +39,6 @@ import { StructTreeLayerBuilder } from "./struct_tree_layer_builder.js";
 import { TextLayerBuilder } from "./text_layer_builder.js";
 import { XfaLayerBuilder } from "./xfa_layer_builder.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 globalThis.pdfjsViewer = {
   AnnotationLayerBuilder,
   DownloadManager,

--- a/web/viewer-geckoview.js
+++ b/web/viewer-geckoview.js
@@ -18,13 +18,6 @@ import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";
 import { PDFViewerApplication } from "./app.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 const AppConstants =
   typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
     ? { LinkTarget, RenderingStates, ScrollMode, SpreadMode }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -18,13 +18,6 @@ import { AppOptions } from "./app_options.js";
 import { LinkTarget } from "./pdf_link_service.js";
 import { PDFViewerApplication } from "./app.js";
 
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsVersion =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_VERSION") : void 0;
-/* eslint-disable-next-line no-unused-vars */
-const pdfjsBuild =
-  typeof PDFJSDev !== "undefined" ? PDFJSDev.eval("BUNDLE_BUILD") : void 0;
-
 const AppConstants =
   typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
     ? { LinkTarget, RenderingStates, ScrollMode, SpreadMode }


### PR DESCRIPTION
To make it easier to tell which PDF.js version/commit that the *built* files correspond to, they have (since many years) included `pdfjsVersion` and `pdfjsBuild` constants with that information.

As currently implemented this has a few shortcomings:
 - It requires manually adding the code, with its preprocessor statements, in all relevant files.

 - It requires ESLint disable statements, since it's obviously unused code.

 - Being unused, this code is removed in the minified builds.

 - This information would be more appropriate as comments, however Babel discards all comments during building.

 - It would be helpful to have this information at the top of the *built* files, however it's being moved during building.

To address all of these issues, we'll instead utilize Webpack to insert the version/commit information as a comment placed just after the license header.