### PR TITLE
Show the op dispatched by constructPath in the debugger

### DIFF
--- a/web/debugger.mjs
+++ b/web/debugger.mjs
@@ -374,6 +374,14 @@ class Stepper {
         table.classList.add("showText");
         decArgs.append(table);
         table.append(charCodeRow, fontCharRow, unicodeRow);
+      } else if (fn === "constructPath") {
+        const [op, [path], minMax] = args;
+        decArgs = this.#c("td");
+        decArgs.append(JSON.stringify(this.#simplifyArgs(path)));
+        decArgs.append(this.#c("br"));
+        decArgs.append(`minMax: ${JSON.stringify(this.#simplifyArgs(minMax))}`);
+        decArgs.append(this.#c("br"));
+        decArgs.append(`→ ${opMap[op]}`);
       } else if (fn === "restore" && this.indentLevel > 0) {
         this.indentLevel--;
       }


### PR DESCRIPTION
> Show the op dispatched by constructPath in the debugger
>
> The `constructPath` op receives as arguments not only the information to construct the path, but also the op to apply the path to (such as "fill", or "stroke").
>
> This commit updates the Stepper tool in the debugger to decode that op, showing its name rather than just its numeric ID.

I was picking up https://github.com/mozilla/pdf.js/pull/19043 again, and I think the internal representation of `constructPath` changed since when I first started working on it, making it more difficult to see what is going on in the debugger.

Before (and you would have to know that 22 means "fill"):
![image](https://github.com/user-attachments/assets/57e0562f-3e1b-4848-8c09-f35d68711697)

After:
![image](https://github.com/user-attachments/assets/ed365f20-6759-435a-a139-d01e1498b640)
