### PR TITLE
Replace semi-private fields/methods with actual private ones in `src/core/catalog.js`

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -665,7 +665,7 @@ class Catalog {
   }
 
   get numPages() {
-    return this.hasActualNumPages ? this.#actualNumPages : this._pagesCount;
+    return this.#actualNumPages ?? this._pagesCount;
   }
 
   get destinations() {


### PR DESCRIPTION
Additionally, move a couple of "public" fields out of the class constructor and initialize them directly instead.