### PR TITLE
[Editor] Add the possibility to add a popup to an annotation when saving

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -310,6 +310,12 @@ class Page {
           }
           continue;
         }
+        if (annotation.popup?.deleted) {
+          const popupRef = Ref.fromString(annotation.popupRef);
+          if (popupRef) {
+            deletedAnnotations.put(popupRef, popupRef);
+          }
+        }
         existingAnnotations?.put(ref);
         annotation.ref = ref;
         promises.push(

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1092,6 +1092,9 @@ function isArrayEqual(arr1, arr2) {
 }
 
 function getModificationDate(date = new Date()) {
+  if (!(date instanceof Date)) {
+    date = new Date(date);
+  }
   const buffer = [
     date.getUTCFullYear().toString(),
     (date.getUTCMonth() + 1).toString().padStart(2, "0"),

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -12171,5 +12171,47 @@
     "md5": "9fa985242476c642464d94893528e40f",
     "rounds": 1,
     "type": "eq"
+  },
+  {
+    "id": "highlights-popup",
+    "file": "pdfs/highlights.pdf",
+    "md5": "55c12c918f3e2253b39b42075cb38205",
+    "rounds": 1,
+    "type": "eq",
+    "lastPage": 1,
+    "save": true,
+    "annotations": true,
+    "annotationStorage": {
+      "pdfjs_internal_editor_0": {
+        "annotationType": 9,
+        "popup": {
+          "contents": "Hello PDF.js World"
+        },
+        "pageIndex": 0,
+        "date": "2013-11-12T14:15:16Z",
+        "id": "612R"
+      }
+    }
+  },
+  {
+    "id": "annotation-caret-ink-popup-deleted",
+    "file": "pdfs/annotation-caret-ink.pdf",
+    "md5": "6218ca235580d1975474c979e0128c2d",
+    "rounds": 1,
+    "type": "eq",
+    "lastPage": 1,
+    "save": true,
+    "annotations": true,
+    "annotationStorage": {
+      "pdfjs_internal_editor_0": {
+        "annotationType": 15,
+        "popup": {
+          "deleted": true
+        },
+        "pageIndex": 0,
+        "id": "25R",
+        "popupRef": "27R"
+      }
+    }
   }
 ]

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -247,6 +247,7 @@ describe("util", function () {
     it("should get a correctly formatted date", function () {
       const date = new Date(Date.UTC(3141, 5, 9, 2, 6, 53));
       expect(getModificationDate(date)).toEqual("31410609020653");
+      expect(getModificationDate(date.toString())).toEqual("31410609020653");
     });
   });
 


### PR DESCRIPTION
When saving/printing, only update the properties which are provided and set a default value only when there is no pre-existing one.