### PR TITLE
Fix a printing issue on Mac (bug 1961423)

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1770,13 +1770,13 @@ class CFFCompiler {
       // In a CID font, the charset is a mapping of CIDs not SIDs so just
       // create an identity mapping.
       // nLeft: Glyphs left in range (excluding first) (see the CFF specs).
-      // Having a wrong value for nLeft induces a print issue on MacOS (see
+      // The first CID must be 1 in order to avoid a print issue on mac (see
       // https://bugzilla.mozilla.org/1961423).
       const nLeft = numGlyphsLessNotDef - 1;
       out = new Uint8Array([
         2, // format
         0, // first CID upper byte
-        0, // first CID lower byte
+        1, // first CID lower byte
         (nLeft >> 8) & 0xff,
         nLeft & 0xff,
       ]);

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -479,7 +479,7 @@ describe("CFFCompiler", function () {
     expect(out).toEqual([
       2, // format
       0, // cid (high)
-      0, // cid (low)
+      1, // cid (low)
       0, // nLeft (high)
       numGlyphs - 2, // nLeft (low)
     ]);


### PR DESCRIPTION
On mac, the pdf backend used when printing is using the cid from the font, so if a char has null cid then it's equivalent to .notdef and some viewers don't display it.