### PR TITLE
Fix intermittent failure in the find integration tests

### DIFF
--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -41,7 +41,7 @@ describe("find bar", () => {
         pages.map(async ([browserName, page]) => {
           // Highlight all occurrences of the letter A (case insensitive).
           await page.click("#viewFindButton");
-          await page.waitForSelector("#viewFindButton", { hidden: false });
+          await page.waitForSelector("#findInput", { visible: true });
           await page.type("#findInput", "a");
           await page.click("#findHighlightAll + label");
           await page.waitForSelector(".textLayer .highlight");
@@ -101,7 +101,7 @@ describe("find bar", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await page.click("#viewFindButton");
-          await page.waitForSelector("#viewFindButton", { hidden: false });
+          await page.waitForSelector("#findInput", { visible: true });
           await page.type("#findInput", "preferences");
           await page.waitForSelector("#findInput[data-status='']");
           await page.waitForSelector(".xfaLayer .highlight");
@@ -139,7 +139,7 @@ describe("find bar", () => {
         pages.map(async ([browserName, page]) => {
           // Search for "40"
           await page.click("#viewFindButton");
-          await page.waitForSelector("#viewFindButton", { hidden: false });
+          await page.waitForSelector("#findInput", { visible: true });
           await page.type("#findInput", "40");
 
           const highlight = await page.waitForSelector(".textLayer .highlight");


### PR DESCRIPTION
After clicking the find button we need to wait for the input field to appear before we try to type in it, but instead we were waiting for the button to appear. However, the button is always present, so the current `waitForSelector` call is basically a no-op, and this can cause the integration tests to fail intermittently if we continue before the input field is actually visible.
    
This appears to be due a typo first introduced in commit d10da907dac86c103b787127110a59aed82c7aaa that has been copy/pasted.
    
This commit fixes the issue by waiting for the input field to be visible before we continue typing in it.

Fixes #19999.