### PR TITLE
Fix incorrect rendering of directly adjacent shapes

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -745,6 +745,9 @@ class CanvasGraphics {
     this.ctx.transform(...viewport.transform);
     this.viewportScale = viewport.scale;
 
+    // Offset by half a pixel to prevent anti-aliasing artifacts between adjacent shapes
+    this.ctx.translate(0.5, 0.5);
+    
     this.baseTransform = getCurrentTransform(this.ctx);
   }
 


### PR DESCRIPTION
Closes https://github.com/mozilla/pdf.js/issues/19987 

Appears to be a rendering issue more than a core calculation issue.