### PR TITLE
fix: set Find Controller to `NOT_FOUND` for empty queries

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -992,7 +992,7 @@ class PDFFindController {
     // If there's no query there's no point in searching.
     const query = this.#query;
     if (query.length === 0) {
-      this.#updateUIState(FindState.FOUND);
+      this.#updateUIState(FindState.NOT_FOUND);
       return;
     }
     // If we're waiting on a page, we return since we can't do anything else.


### PR DESCRIPTION
This pull request includes a small change to the `PDFFindController` class in the `web/pdf_find_controller.js` file. The change updates the behavior when the search query is empty, ensuring the UI state is set to `FindState.NOT_FOUND` instead of `FindState.FOUND`.

---
This change might seem insignificant, and the maintainers might disagree with it. If so, please feel free to close the PR. 🙂

However, while adopting the project, I found it counter-intuitive that the `updatefindcontrolstate` event returns `FindState.FOUND` whenever the search field is cleared.

We rely on `updatefindcontrolstate` to get information about state transitions, while using `updatefindmatchescount` to update the counts.

But, it seems that when we clear a search field with results, it triggers `updatefindcontrolstate` with `FindState.NOT_FOUND`, but `updatefindmatchescount` is not triggered.

Returning `NOT_FOUND` seems more appropriate in the circumstance.