### PR TITLE
Fix Alpha channel not respected on graphics

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -510,6 +510,27 @@ class PartialEvaluator {
         smask.backdrop = colorSpace.getRgbHex(smask.backdrop, 0);
       }
 
+      // Parse group blend mode from ExtGState if it's in FormX Resources
+      const localResources = dict.get("Resources");
+      if (localResources instanceof Dict) {
+        const extGState = localResources.get("ExtGState");
+        if (extGState instanceof Dict) {
+          for (const val of extGState.getRawValues()) { 
+            if (val instanceof Dict && val.has("BM")) {
+              const blendMode = val.get("BM");
+              if (blendMode != null) {
+                try {
+                  groupOptions.blendMode = normalizeBlendMode(blendMode);
+                  break;
+                } catch (ex) {
+                  console.error(`Invalid blend mode in ExtGState: ${blendMode}`, ex);
+                }
+              }
+            }
+          }
+        }
+      }
+
       operatorList.addOp(OPS.beginGroup, [groupOptions]);
     }
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2464,7 +2464,12 @@ class CanvasGraphics {
         currentMtx,
         dirtyBox
       );
+
+      // Apply the group blend mode and alpha when compositing the group
+      const prevBlendMode = this.pushGroupBlendMode(this.ctx, group.blendMode);
       this.ctx.drawImage(groupCtx.canvas, 0, 0);
+      this.popGroupBlendMode(this.ctx, prevBlendMode);
+
       this.ctx.restore();
       this.compose(dirtyBox);
     }
@@ -3041,6 +3046,22 @@ class CanvasGraphics {
 
     if (saveRestore) {
       ctx.restore();
+    }
+  }
+
+  pushGroupBlendMode(ctx, blendMode) {
+    if (!ctx || !blendMode) {
+      return null;
+    }
+
+    const prev = ctx.globalCompositeOperation;
+    ctx.globalCompositeOperation = blendMode;
+    return prev;
+  }
+
+  popGroupBlendMode(ctx, prev) {
+    if (ctx && prev !== null) {
+      ctx.globalCompositeOperation = prev;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/mozilla/pdf.js/issues/19978

For reference, the structure of the pdf file is the ff: 

```
/BBox [
    167.119995
    261.677
    311.02899
    274.83899
  ]
  /Filter /FlateDecode
  /FormType 1
  /Group <<
    /S /Transparency
    /Type /Group
  >>
  /Length 85
  /Matrix [
    1
    0
    0
    1
    -167.119995
    -261.677
  ]
  /Resources <<
    /ExtGState <<
      /TransGs <<
        /AIS false
        /BM /Multiply
        /CA 1
        /Type /ExtGState
        /ca 1
      >>
    >>
    /ProcSet [
      /PDF
    ]
  >>
  /Subtype /Form
  /Type /XObject
`
```