### PR TITLE
Offload rendering to a worker

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -543,6 +543,18 @@ function createWorkerBundle(defines) {
     .pipe(webpack2Stream(workerFileConfig));
 }
 
+function createRendererWorkerBundle(defines) {
+  const rendererWorkerFileConfig = createWebpackConfig(defines, {
+    filename: defines.MINIFIED ? "pdf.renderer.min.mjs" : "pdf.renderer.mjs",
+    library: {
+      type: "module",
+    },
+  });
+  return gulp
+    .src("./src/pdf.renderer.js", { encoding: false })
+    .pipe(webpack2Stream(rendererWorkerFileConfig));
+}
+
 function createWebBundle(defines, options) {
   const viewerFileConfig = createWebpackConfig(defines, {
     filename: "viewer.mjs",
@@ -1055,6 +1067,7 @@ function buildGeneric(defines, dir) {
   return ordered([
     createMainBundle(defines).pipe(gulp.dest(dir + "build")),
     createWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
+    createRendererWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
     createSandboxBundle(defines).pipe(gulp.dest(dir + "build")),
     createWebBundle(defines).pipe(gulp.dest(dir + "web")),
     gulp
@@ -1215,6 +1228,7 @@ function buildMinified(defines, dir) {
   return ordered([
     createMainBundle(defines).pipe(gulp.dest(dir + "build")),
     createWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
+    createRendererWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
     createSandboxBundle(defines).pipe(gulp.dest(dir + "build")),
     createImageDecodersBundle({ ...defines, IMAGE_DECODERS: true }).pipe(
       gulp.dest(dir + "image_decoders")
@@ -1344,6 +1358,9 @@ gulp.task(
         createWorkerBundle(defines).pipe(
           gulp.dest(MOZCENTRAL_CONTENT_DIR + "build")
         ),
+        createRendererWorkerBundle(defines).pipe(
+          gulp.dest(MOZCENTRAL_CONTENT_DIR + "build")
+        ),
         createWebBundle(defines).pipe(
           gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")
         ),
@@ -1447,6 +1464,9 @@ gulp.task(
           gulp.dest(CHROME_BUILD_CONTENT_DIR + "build")
         ),
         createWorkerBundle(defines).pipe(
+          gulp.dest(CHROME_BUILD_CONTENT_DIR + "build")
+        ),
+        createRendererWorkerBundle(defines).pipe(
           gulp.dest(CHROME_BUILD_CONTENT_DIR + "build")
         ),
         createSandboxBundle(defines).pipe(

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -128,11 +128,10 @@ class Page {
     };
   }
 
-  #createPartialEvaluator(handler, rendererHandler) {
+  #createPartialEvaluator(handler) {
     return new PartialEvaluator({
       xref: this.xref,
       handler,
-      rendererHandler,
       pageIndex: this.pageIndex,
       idFactory: this._localIdFactory,
       fontCache: this.fontCache,
@@ -473,10 +472,7 @@ class Page {
     const contentStreamPromise = this.getContentStream();
     const resourcesPromise = this.loadResources(RESOURCES_KEYS_OPERATOR_LIST);
 
-    const partialEvaluator = this.#createPartialEvaluator(
-      handler,
-      rendererHandler
-    );
+    const partialEvaluator = this.#createPartialEvaluator(handler);
 
     const newAnnotsByPage = !this.xfaFactory
       ? getNewAnnotationsMap(annotationStorage)
@@ -1315,7 +1311,7 @@ class PDFDocument {
     this.xfaFactory.setImages(xfaImages);
   }
 
-  async #loadXfaFonts(handler, task, rendererHandler) {
+  async #loadXfaFonts(handler, task) {
     const acroForm = await this.pdfManager.ensureCatalog("acroForm");
     if (!acroForm) {
       return;
@@ -1341,7 +1337,6 @@ class PDFDocument {
     const partialEvaluator = new PartialEvaluator({
       xref: this.xref,
       handler,
-      rendererHandler,
       pageIndex: -1,
       idFactory: this._globalIdFactory,
       fontCache,
@@ -1454,9 +1449,9 @@ class PDFDocument {
     this.xfaFactory.appendFonts(pdfFonts, reallyMissingFonts);
   }
 
-  loadXfaResources(handler, task, rendererHandler) {
+  loadXfaResources(handler, task) {
     return Promise.all([
-      this.#loadXfaFonts(handler, task, rendererHandler).catch(() => {
+      this.#loadXfaFonts(handler, task).catch(() => {
         // Ignore errors, to allow the document to load.
       }),
       this.#loadXfaImages(),

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -128,10 +128,11 @@ class Page {
     };
   }
 
-  #createPartialEvaluator(handler) {
+  #createPartialEvaluator(handler, rendererHandler) {
     return new PartialEvaluator({
       xref: this.xref,
       handler,
+      rendererHandler,
       pageIndex: this.pageIndex,
       idFactory: this._localIdFactory,
       fontCache: this.fontCache,
@@ -459,6 +460,7 @@ class Page {
 
   async getOperatorList({
     handler,
+    rendererHandler,
     sink,
     task,
     intent,
@@ -471,7 +473,10 @@ class Page {
     const contentStreamPromise = this.getContentStream();
     const resourcesPromise = this.loadResources(RESOURCES_KEYS_OPERATOR_LIST);
 
-    const partialEvaluator = this.#createPartialEvaluator(handler);
+    const partialEvaluator = this.#createPartialEvaluator(
+      handler,
+      rendererHandler
+    );
 
     const newAnnotsByPage = !this.xfaFactory
       ? getNewAnnotationsMap(annotationStorage)
@@ -1310,7 +1315,7 @@ class PDFDocument {
     this.xfaFactory.setImages(xfaImages);
   }
 
-  async #loadXfaFonts(handler, task) {
+  async #loadXfaFonts(handler, task, rendererHandler) {
     const acroForm = await this.pdfManager.ensureCatalog("acroForm");
     if (!acroForm) {
       return;
@@ -1336,6 +1341,7 @@ class PDFDocument {
     const partialEvaluator = new PartialEvaluator({
       xref: this.xref,
       handler,
+      rendererHandler,
       pageIndex: -1,
       idFactory: this._globalIdFactory,
       fontCache,
@@ -1448,9 +1454,9 @@ class PDFDocument {
     this.xfaFactory.appendFonts(pdfFonts, reallyMissingFonts);
   }
 
-  loadXfaResources(handler, task) {
+  loadXfaResources(handler, task, rendererHandler) {
     return Promise.all([
-      this.#loadXfaFonts(handler, task).catch(() => {
+      this.#loadXfaFonts(handler, task, rendererHandler).catch(() => {
         // Ignore errors, to allow the document to load.
       }),
       this.#loadXfaImages(),

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -67,6 +67,7 @@ import { Catalog } from "./catalog.js";
 import { clearGlobalCaches } from "./cleanup_helper.js";
 import { DatasetReader } from "./dataset_reader.js";
 import { Intersector } from "./intersector.js";
+import { isPDFFunction } from "./function.js";
 import { Linearization } from "./parser.js";
 import { ObjectLoader } from "./object_loader.js";
 import { OperatorList } from "./operator_list.js";
@@ -128,10 +129,11 @@ class Page {
     };
   }
 
-  #createPartialEvaluator(handler) {
+  #createPartialEvaluator(handler, rendererHandler = null) {
     return new PartialEvaluator({
       xref: this.xref,
       handler,
+      rendererHandler,
       pageIndex: this.pageIndex,
       idFactory: this._localIdFactory,
       fontCache: this.fontCache,
@@ -359,11 +361,21 @@ class Page {
     await Promise.all(promises);
   }
 
-  async saveNewAnnotations(handler, task, annotations, imagePromises, changes) {
+  async saveNewAnnotations(
+    handler,
+    task,
+    annotations,
+    imagePromises,
+    changes,
+    rendererHandler = null
+  ) {
     if (this.xfaFactory) {
       throw new Error("XFA: Cannot save new annotations.");
     }
-    const partialEvaluator = this.#createPartialEvaluator(handler);
+    const partialEvaluator = this.#createPartialEvaluator(
+      handler,
+      rendererHandler
+    );
 
     const deletedAnnotations = new RefSetCache();
     const existingAnnotations = new RefSet();
@@ -405,8 +417,17 @@ class Page {
     }
   }
 
-  async save(handler, task, annotationStorage, changes) {
-    const partialEvaluator = this.#createPartialEvaluator(handler);
+  async save(
+    handler,
+    task,
+    annotationStorage,
+    changes,
+    rendererHandler = null
+  ) {
+    const partialEvaluator = this.#createPartialEvaluator(
+      handler,
+      rendererHandler
+    );
 
     // Fetch the page's annotations and save the content
     // in case of interactive form fields.
@@ -459,7 +480,7 @@ class Page {
 
   async getOperatorList({
     handler,
-    rendererHandler,
+    rendererHandler = null,
     sink,
     task,
     intent,
@@ -472,7 +493,10 @@ class Page {
     const contentStreamPromise = this.getContentStream();
     const resourcesPromise = this.loadResources(RESOURCES_KEYS_OPERATOR_LIST);
 
-    const partialEvaluator = this.#createPartialEvaluator(handler);
+    const partialEvaluator = this.#createPartialEvaluator(
+      handler,
+      rendererHandler
+    );
 
     const newAnnotsByPage = !this.xfaFactory
       ? getNewAnnotationsMap(annotationStorage)
@@ -551,12 +575,49 @@ class Page {
         RESOURCES_KEYS_OPERATOR_LIST
       );
       const opList = new OperatorList(intent, sink);
+
+      let hasFilterOps = false;
+      const extGState = resources.get("ExtGState");
+      if (extGState instanceof Dict) {
+        for (const [, gState] of extGState) {
+          if (!(gState instanceof Dict)) {
+            continue;
+          }
+
+          const tr = gState.get("TR");
+          if (tr !== undefined) {
+            if (Array.isArray(tr)) {
+              const trArray = gState.getArray("TR") || tr;
+              if (!trArray.every(entry => isName(entry, "Identity"))) {
+                hasFilterOps = true;
+                break;
+              }
+            } else if (!isName(tr, "Identity")) {
+              hasFilterOps = true;
+              break;
+            }
+          }
+
+          const sMask = gState.get("SMask");
+          if (!sMask || isName(sMask, "None") || !(sMask instanceof Dict)) {
+            continue;
+          }
+          const sMaskType = sMask.get("S");
+          const sMaskTR = sMask.get("TR");
+          if (isName(sMaskType, "Luminosity") || isPDFFunction(sMaskTR)) {
+            hasFilterOps = true;
+            break;
+          }
+        }
+      }
+
       handler.send("StartRenderPage", {
         transparency: partialEvaluator.hasBlendModes(
           resources,
           this.nonBlendModesSet
         ),
         pageIndex,
+        hasFilterOps,
         cacheKey,
       });
 
@@ -660,6 +721,7 @@ class Page {
 
   async extractTextContent({
     handler,
+    rendererHandler = null,
     task,
     includeMarkedContent,
     disableNormalization,
@@ -680,7 +742,10 @@ class Page {
       RESOURCES_KEYS_TEXT_CONTENT
     );
 
-    const partialEvaluator = this.#createPartialEvaluator(handler);
+    const partialEvaluator = this.#createPartialEvaluator(
+      handler,
+      rendererHandler
+    );
 
     return partialEvaluator.getTextContent({
       stream: contentStream,
@@ -727,7 +792,7 @@ class Page {
     return tree;
   }
 
-  async getAnnotationsData(handler, task, intent) {
+  async getAnnotationsData(handler, task, intent, rendererHandler = null) {
     const annotations = await this._parsedAnnotations;
     if (annotations.length === 0) {
       return annotations;
@@ -752,7 +817,10 @@ class Page {
       }
 
       if (annotation.hasTextContent && isVisible) {
-        partialEvaluator ??= this.#createPartialEvaluator(handler);
+        partialEvaluator ??= this.#createPartialEvaluator(
+          handler,
+          rendererHandler
+        );
 
         textContentPromises.push(
           annotation
@@ -778,6 +846,7 @@ class Page {
       textContentPromises.push(
         this.extractTextContent({
           handler,
+          rendererHandler,
           task,
           includeMarkedContent: false,
           disableNormalization: false,
@@ -883,7 +952,8 @@ class Page {
     task,
     types,
     promises,
-    annotationGlobals
+    annotationGlobals,
+    rendererHandler = null
   ) {
     const { pageIndex } = this;
 
@@ -917,7 +987,10 @@ class Page {
             }
             annotation.data.pageIndex = pageIndex;
             if (annotation.hasTextContent && annotation.viewable) {
-              const partialEvaluator = this.#createPartialEvaluator(handler);
+              const partialEvaluator = this.#createPartialEvaluator(
+                handler,
+                rendererHandler
+              );
               await annotation.extractTextContent(partialEvaluator, task, [
                 -Infinity,
                 -Infinity,
@@ -1311,7 +1384,7 @@ class PDFDocument {
     this.xfaFactory.setImages(xfaImages);
   }
 
-  async #loadXfaFonts(handler, task) {
+  async #loadXfaFonts(handler, task, rendererHandler = null) {
     const acroForm = await this.pdfManager.ensureCatalog("acroForm");
     if (!acroForm) {
       return;
@@ -1337,6 +1410,7 @@ class PDFDocument {
     const partialEvaluator = new PartialEvaluator({
       xref: this.xref,
       handler,
+      rendererHandler,
       pageIndex: -1,
       idFactory: this._globalIdFactory,
       fontCache,
@@ -1449,9 +1523,9 @@ class PDFDocument {
     this.xfaFactory.appendFonts(pdfFonts, reallyMissingFonts);
   }
 
-  loadXfaResources(handler, task) {
+  loadXfaResources(handler, task, rendererHandler = null) {
     return Promise.all([
-      this.#loadXfaFonts(handler, task).catch(() => {
+      this.#loadXfaFonts(handler, task, rendererHandler).catch(() => {
         // Ignore errors, to allow the document to load.
       }),
       this.#loadXfaImages(),
@@ -1817,12 +1891,16 @@ class PDFDocument {
     }
   }
 
-  async fontFallback(id, handler) {
+  async fontFallback(id, handler, rendererHandler = null) {
     const { catalog, pdfManager } = this;
 
     for (const translatedFont of await Promise.all(catalog.fontCache)) {
       if (translatedFont.loadedName === id) {
-        translatedFont.fallback(handler, pdfManager.evaluatorOptions);
+        translatedFont.fallback(
+          handler,
+          pdfManager.evaluatorOptions,
+          rendererHandler
+        );
         return;
       }
     }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -226,7 +226,6 @@ class PartialEvaluator {
   constructor({
     xref,
     handler,
-    rendererHandler,
     pageIndex,
     idFactory,
     fontCache,
@@ -239,7 +238,6 @@ class PartialEvaluator {
   }) {
     this.xref = xref;
     this.handler = handler;
-    this.rendererHandler = rendererHandler;
     this.pageIndex = pageIndex;
     this.idFactory = idFactory;
     this.fontCache = fontCache;
@@ -559,19 +557,13 @@ class PartialEvaluator {
     const transfers = imgData ? [imgData.bitmap || imgData.data.buffer] : null;
 
     if (this.parsingType3Font || cacheGlobally) {
-      this.handler.send("commonobj", [objId, "Image", imgData], transfers);
-      return this.rendererHandler.send(
+      return this.handler.send(
         "commonobj",
         [objId, "Image", imgData],
         transfers
       );
     }
-    this.handler.send(
-      "obj",
-      [objId, this.pageIndex, "Image", imgData],
-      transfers
-    );
-    return this.rendererHandler.send(
+    return this.handler.send(
       "obj",
       [objId, this.pageIndex, "Image", imgData],
       transfers
@@ -799,10 +791,11 @@ class PartialEvaluator {
       // globally, check if the image is still cached locally on the main-thread
       // to avoid having to re-parse the image (since that can be slow).
       if (w * h > 250000 || hasMask) {
-        const localLength = await this.rendererHandler.sendWithPromise(
-          "commonobj",
-          [objId, "CopyLocalImage", { imageRef }]
-        );
+        const localLength = await this.sendWithPromise("commonobj", [
+          objId,
+          "CopyLocalImage",
+          { imageRef },
+        ]);
 
         if (localLength) {
           this.globalImageCache.setData(imageRef, globalCacheData);
@@ -1032,7 +1025,6 @@ class PartialEvaluator {
 
     state.font = translated.font;
     translated.send(this.handler);
-    translated.send(this.rendererHandler);
     return translated.loadedName;
   }
 
@@ -1053,7 +1045,7 @@ class PartialEvaluator {
         PartialEvaluator.buildFontPaths(
           font,
           glyphs,
-          this.rendererHandler,
+          this.handler,
           this.options
         );
       }
@@ -1534,19 +1526,8 @@ class PartialEvaluator {
       const patternBuffer = PatternInfo.write(patternIR);
       transfers.push(patternBuffer);
       this.handler.send("commonobj", [id, "Pattern", patternBuffer], transfers);
-      this.rendererHandler.send(
-        "commonobj",
-        [id, "Pattern", patternBuffer],
-        transfers
-      );
     } else {
       this.handler.send("obj", [id, this.pageIndex, "Pattern", patternIR]);
-      this.rendererHandler.send("obj", [
-        id,
-        this.pageIndex,
-        "Pattern",
-        patternIR,
-      ]);
     }
     return id;
   }

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -226,6 +226,7 @@ class PartialEvaluator {
   constructor({
     xref,
     handler,
+    rendererHandler = null,
     pageIndex,
     idFactory,
     fontCache,
@@ -238,6 +239,7 @@ class PartialEvaluator {
   }) {
     this.xref = xref;
     this.handler = handler;
+    this.rendererHandler = rendererHandler;
     this.pageIndex = pageIndex;
     this.idFactory = idFactory;
     this.fontCache = fontCache;
@@ -554,20 +556,31 @@ class PartialEvaluator {
     ) {
       assert(Number.isInteger(imgData.dataLen), "Expected dataLen to be set.");
     }
-    const transfers = imgData ? [imgData.bitmap || imgData.data.buffer] : null;
 
-    if (this.parsingType3Font || cacheGlobally) {
-      return this.handler.send(
-        "commonobj",
-        [objId, "Image", imgData],
-        transfers
+    const action = this.parsingType3Font || cacheGlobally ? "commonobj" : "obj";
+
+    const buildArgs = data =>
+      action === "commonobj"
+        ? [objId, "Image", data]
+        : [objId, this.pageIndex, "Image", data];
+
+    const getTransfers = data => {
+      if (!data) {
+        return null;
+      }
+      const transferable = data.bitmap || data.data?.buffer;
+      return transferable ? [transferable] : null;
+    };
+
+    if (this.rendererHandler) {
+      const clonedData = imgData ? structuredClone(imgData) : imgData;
+      this.rendererHandler.send(
+        action,
+        buildArgs(clonedData),
+        getTransfers(clonedData)
       );
     }
-    return this.handler.send(
-      "obj",
-      [objId, this.pageIndex, "Image", imgData],
-      transfers
-    );
+    this.handler.send(action, buildArgs(imgData), getTransfers(imgData));
   }
 
   async buildPaintImageXObject({
@@ -791,7 +804,7 @@ class PartialEvaluator {
       // globally, check if the image is still cached locally on the main-thread
       // to avoid having to re-parse the image (since that can be slow).
       if (w * h > 250000 || hasMask) {
-        const localLength = await this.sendWithPromise("commonobj", [
+        const localLength = await this.handler.sendWithPromise("commonobj", [
           objId,
           "CopyLocalImage",
           { imageRef },
@@ -801,6 +814,21 @@ class PartialEvaluator {
           this.globalImageCache.setData(imageRef, globalCacheData);
           this.globalImageCache.addByteSize(imageRef, localLength);
           return;
+        }
+
+        // ImageRef not found on main thread - check renderer worker if
+        // it exists
+        if (this.rendererHandler) {
+          const rendererLength = await this.rendererHandler.sendWithPromise(
+            "commonobj",
+            [objId, "CopyLocalImage", { imageRef }]
+          );
+
+          if (rendererLength) {
+            this.globalImageCache.setData(imageRef, globalCacheData);
+            this.globalImageCache.addByteSize(imageRef, rendererLength);
+            return;
+          }
         }
       }
     }
@@ -1024,7 +1052,7 @@ class PartialEvaluator {
     }
 
     state.font = translated.font;
-    translated.send(this.handler);
+    translated.send(this.handler, this.rendererHandler);
     return translated.loadedName;
   }
 
@@ -1046,7 +1074,8 @@ class PartialEvaluator {
           font,
           glyphs,
           this.handler,
-          this.options
+          this.options,
+          this.rendererHandler
         );
       }
     }
@@ -1520,15 +1549,28 @@ class PartialEvaluator {
       id = `${this.idFactory.getDocId()}_type3_${id}`;
     }
     localShadingPatternCache.set(shading, id);
-
-    if (this.parsingType3Font) {
-      const transfers = [];
-      const patternBuffer = PatternInfo.write(patternIR);
-      transfers.push(patternBuffer);
-      this.handler.send("commonobj", [id, "Pattern", patternBuffer], transfers);
-    } else {
-      this.handler.send("obj", [id, this.pageIndex, "Pattern", patternIR]);
+    const patternBuffer = PatternInfo.write(patternIR);
+    const action = this.parsingType3Font ? "commonobj" : "obj";
+    if (this.rendererHandler) {
+      const clonedBuffer = patternBuffer.slice(0);
+      const clonedTransfers = clonedBuffer ? [clonedBuffer] : [];
+      this.rendererHandler.send(
+        action,
+        action === "commonobj"
+          ? [id, "Pattern", clonedBuffer]
+          : [id, this.pageIndex, "Pattern", clonedBuffer],
+        clonedTransfers
+      );
     }
+
+    const transfers = patternBuffer ? [patternBuffer] : [];
+    this.handler.send(
+      action,
+      action === "commonobj"
+        ? [id, "Pattern", patternBuffer]
+        : [id, this.pageIndex, "Pattern", patternBuffer],
+      transfers
+    );
     return id;
   }
 
@@ -4728,7 +4770,13 @@ class PartialEvaluator {
     return new Font(fontName.name, fontFile, newProperties, this.options);
   }
 
-  static buildFontPaths(font, glyphs, handler, evaluatorOptions) {
+  static buildFontPaths(
+    font,
+    glyphs,
+    handler,
+    evaluatorOptions,
+    rendererHandler = null
+  ) {
     function buildPath(fontChar) {
       const glyphName = `${font.loadedName}_path_${fontChar}`;
       try {
@@ -4736,6 +4784,14 @@ class PartialEvaluator {
           return;
         }
         const buffer = FontPathInfo.write(font.renderer.getPathJs(fontChar));
+        if (rendererHandler) {
+          const clonedBuffer = buffer.slice(0);
+          rendererHandler.send(
+            "commonobj",
+            [glyphName, "FontPath", clonedBuffer],
+            [clonedBuffer]
+          );
+        }
         handler.send("commonobj", [glyphName, "FontPath", buffer], [buffer]);
       } catch (reason) {
         if (evaluatorOptions.ignoreErrors) {
@@ -4781,7 +4837,7 @@ class TranslatedFont {
     this.type3Dependencies = font.isType3Font ? new Set() : null;
   }
 
-  send(handler) {
+  send(handler, rendererHandler = null) {
     if (this.#sent) {
       return;
     }
@@ -4795,6 +4851,18 @@ class TranslatedFont {
       fontData.data = FontInfo.write(fontData.data);
       transfer.push(fontData.data);
     }
+    if (rendererHandler) {
+      const clonedFontData = structuredClone(fontData);
+      const clonedTransfer = [];
+      if (clonedFontData.data) {
+        clonedTransfer.push(clonedFontData.data);
+      }
+      rendererHandler.send(
+        "commonobj",
+        [this.loadedName, "Font", clonedFontData],
+        clonedTransfer
+      );
+    }
     handler.send("commonobj", [this.loadedName, "Font", fontData], transfer);
     // future path: switch to a SharedArrayBuffer
     // const sab = new SharedArrayBuffer(data.byteLength);
@@ -4803,7 +4871,7 @@ class TranslatedFont {
     // handler.send("commonobj", [this.loadedName, "Font", sab]);
   }
 
-  fallback(handler, evaluatorOptions) {
+  fallback(handler, evaluatorOptions, rendererHandler = null) {
     if (!this.font.data) {
       return;
     }
@@ -4819,7 +4887,8 @@ class TranslatedFont {
       this.font,
       /* glyphs = */ this.font.glyphCacheValues,
       handler,
-      evaluatorOptions
+      evaluatorOptions,
+      rendererHandler
     );
   }
 

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1636,6 +1636,8 @@ class PartialEvaluator {
             localShadingPatternCache,
           });
           if (objId) {
+            // Ensure that the Pattern is resolved before it's used
+            operatorList.addDependency(objId);
             const matrix = lookupMatrix(dict.getArray("Matrix"), null);
             operatorList.addOp(fn, ["Shading", objId, matrix]);
           }
@@ -2190,6 +2192,7 @@ class PartialEvaluator {
             if (!patternId) {
               continue;
             }
+            operatorList.addDependency(patternId);
             args = [patternId];
             fn = OPS.shadingFill;
             break;

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -113,8 +113,8 @@ class BasePdfManager {
     return this.pdfDocument.getPage(pageIndex);
   }
 
-  fontFallback(id, handler) {
-    return this.pdfDocument.fontFallback(id, handler);
+  fontFallback(id, handler, rendererHandler = null) {
+    return this.pdfDocument.fontFallback(id, handler, rendererHandler);
   }
 
   cleanup(manuallyTriggered = false) {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -964,6 +964,10 @@ class WorkerMessageHandler {
         .then(page => pdfManager.ensure(page, "getStructTree"));
     });
 
+    handler.on("FontFallback", function (data) {
+      return pdfManager.fontFallback(data.id, handler);
+    });
+
     rendererHandler.on("FontFallback", function (data) {
       return pdfManager.fontFallback(data.id, rendererHandler);
     });

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -83,6 +83,8 @@ class WorkerMessageHandler {
 
   static setup(handler, port) {
     let testMessageProcessed = false;
+    let rendererHandler = null;
+
     handler.on("test", data => {
       if (testMessageProcessed) {
         return; // we already processed 'test' message once
@@ -95,12 +97,19 @@ class WorkerMessageHandler {
 
     handler.on("configure", data => {
       setVerbosityLevel(data.verbosity);
+      rendererHandler = new MessageHandler(
+        "worker-channel",
+        "renderer-channel",
+        data.channelPort
+      );
     });
 
-    handler.on("GetDocRequest", data => this.createDocumentHandler(data, port));
+    handler.on("GetDocRequest", data =>
+      this.createDocumentHandler(data, port, rendererHandler)
+    );
   }
 
-  static createDocumentHandler(docParams, port) {
+  static createDocumentHandler(docParams, port, rendererHandler) {
     // This context is actually holds references on pdfManager and handler,
     // until the latter is destroyed.
     let pdfManager;
@@ -174,7 +183,11 @@ class WorkerMessageHandler {
         const task = new WorkerTask("loadXfaResources");
         startWorkerTask(task);
 
-        await pdfManager.ensureDoc("loadXfaResources", [handler, task]);
+        await pdfManager.ensureDoc("loadXfaResources", [
+          handler,
+          task,
+          rendererHandler,
+        ]);
         finishWorkerTask(task);
       }
 
@@ -865,6 +878,7 @@ class WorkerMessageHandler {
         page
           .getOperatorList({
             handler,
+            rendererHandler,
             sink,
             task,
             intent: data.intent,
@@ -950,8 +964,8 @@ class WorkerMessageHandler {
         .then(page => pdfManager.ensure(page, "getStructTree"));
     });
 
-    handler.on("FontFallback", function (data) {
-      return pdfManager.fontFallback(data.id, handler);
+    rendererHandler.on("FontFallback", function (data) {
+      return pdfManager.fontFallback(data.id, rendererHandler);
     });
 
     handler.on("Cleanup", function (data) {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -1267,6 +1267,9 @@ class TextAnnotationElement extends AnnotationElement {
       "data-l10n-args",
       JSON.stringify({ type: this.data.name })
     );
+    if (this.data.name !== "NoIcon" || this.data.hasOwnCanvas) {
+      this.hasOwnCommentButton = true;
+    }
 
     if (!this.data.popupRef && this.hasPopupData) {
       this.hasOwnCommentButton = true;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2427,9 +2427,14 @@ class RendererWorker {
   #handler;
 
   constructor(channelPort, enableHWA) {
-    this.#worker = new Worker("../src/display/renderer_worker.js", {
-      type: "module",
-    });
+    const src =
+      // eslint-disable-next-line no-nested-ternary
+      typeof PDFJSDev === "undefined"
+        ? "../src/pdf.worker.js"
+        : PDFJSDev.test("MOZCENTRAL")
+          ? "resource://pdf.js/build/pdf.worker.mjs"
+          : "../build/pdf.worker.mjs";
+    this.#worker = new Worker(src, { type: "module" });
     this.#handler = new MessageHandler("main", "renderer", this.#worker);
     this.#handler.send("configure", { channelPort, enableHWA }, [channelPort]);
     this.#handler.on("ready", () => {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1912,6 +1912,16 @@ class PDFPageProxy {
     this._intentStates.clear();
     this.objs.clear();
     this.#pendingCleanup = false;
+
+    if (this._transport.rendererHandler) {
+      try {
+        this._transport.rendererHandler.send("cleanupPage", {
+          pageIndex: this._pageIndex,
+        });
+      } catch {
+        // Ignore errors if the renderer worker has been destroyed.
+      }
+    }
     return true;
   }
 
@@ -3442,25 +3452,43 @@ class InternalRenderTask {
           },
           configurable: true,
         });
-        this.rendererHandler.send(
-          "init",
-          {
-            pageIndex: this._pageIndex,
-            canvas: offscreen,
-            map: this.annotationCanvasMap,
-            colors: this.pageColors,
-            taskID: this.taskID,
-            transform,
-            viewport,
-            transparency,
-            background,
-            renderingIntent,
-            optionalContentConfig: optionalContentConfigData,
-            optionalContentConfigState,
-            dependencyTracker,
-          },
-          [offscreen]
-        );
+        const initTransfers = [offscreen];
+        const initParams = {
+          pageIndex: this._pageIndex,
+          canvas: offscreen,
+          colors: this.pageColors,
+          taskID: this.taskID,
+          transform,
+          viewport,
+          transparency,
+          background,
+          renderingIntent,
+          optionalContentConfig: optionalContentConfigData,
+          optionalContentConfigState,
+          dependencyTracker,
+        };
+
+        if (this.annotationCanvasMap) {
+          const annotationCanvases = [];
+          for (const [id, canvas] of this.annotationCanvasMap) {
+            try {
+              const annotationCanvas = canvas.transferControlToOffscreen();
+              annotationCanvases.push([id, annotationCanvas]);
+              initTransfers.push(annotationCanvas);
+            } catch (ex) {
+              warn(
+                `Failed to transfer annotation canvas to worker: ${ex.message}. `
+              );
+            }
+          }
+          if (annotationCanvases.length > 0) {
+            initParams.annotationCanvases = annotationCanvases;
+          } else {
+            initParams.map = new Map();
+          }
+        }
+
+        this.rendererHandler.send("init", initParams, initTransfers);
       } catch (ex) {
         // If transferControlToOffscreen fails (e.g., canvas already
         // has a context), fall back to main thread rendering

--- a/src/display/canvas_factory.js
+++ b/src/display/canvas_factory.js
@@ -89,4 +89,14 @@ class DOMCanvasFactory extends BaseCanvasFactory {
   }
 }
 
-export { BaseCanvasFactory, DOMCanvasFactory };
+class OffscreenCanvasFactory extends BaseCanvasFactory {
+  constructor({ enableHWA = false }) {
+    super({ enableHWA });
+  }
+
+  _createCanvas(width, height) {
+    return new OffscreenCanvas(width, height);
+  }
+}
+
+export { BaseCanvasFactory, DOMCanvasFactory, OffscreenCanvasFactory };

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -1034,6 +1034,114 @@ function makePathFromDrawOPS(data) {
   }
   return path;
 }
+const INITIAL_DATA = Symbol("INITIAL_DATA");
+
+/**
+ * A PDF document and page is built of many objects. E.g. there are objects for
+ * fonts, images, rendering code, etc. These objects may get processed inside of
+ * a worker. This class implements some basic methods to manage these objects.
+ */
+class PDFObjects {
+  #objs = Object.create(null);
+
+  /**
+   * Ensures there is an object defined for `objId`.
+   *
+   * @param {string} objId
+   * @returns {Object}
+   */
+  #ensureObj(objId) {
+    return (this.#objs[objId] ||= {
+      ...Promise.withResolvers(),
+      data: INITIAL_DATA,
+    });
+  }
+
+  /**
+   * If called *without* callback, this returns the data of `objId` but the
+   * object needs to be resolved. If it isn't, this method throws.
+   *
+   * If called *with* a callback, the callback is called with the data of the
+   * object once the object is resolved. That means, if you call this method
+   * and the object is already resolved, the callback gets called right away.
+   *
+   * @param {string} objId
+   * @param {function} [callback]
+   * @returns {any}
+   */
+  get(objId, callback = null) {
+    // If there is a callback, then the get can be async and the object is
+    // not required to be resolved right now.
+    if (callback) {
+      const obj = this.#ensureObj(objId);
+      obj.promise.then(() => callback(obj.data));
+      return null;
+    }
+    // If there isn't a callback, the user expects to get the resolved data
+    // directly.
+    const obj = this.#objs[objId];
+    // If there isn't an object yet or the object isn't resolved, then the
+    // data isn't ready yet!
+    if (!obj || obj.data === INITIAL_DATA) {
+      throw new Error(`Requesting object that isn't resolved yet ${objId}.`);
+    }
+    return obj.data;
+  }
+
+  /**
+   * @param {string} objId
+   * @returns {boolean}
+   */
+  has(objId) {
+    const obj = this.#objs[objId];
+    return !!obj && obj.data !== INITIAL_DATA;
+  }
+
+  /**
+   * @param {string} objId
+   * @returns {boolean}
+   */
+  delete(objId) {
+    const obj = this.#objs[objId];
+    if (!obj || obj.data === INITIAL_DATA) {
+      // Only allow removing the object *after* it's been resolved.
+      return false;
+    }
+    delete this.#objs[objId];
+    return true;
+  }
+
+  /**
+   * Resolves the object `objId` with optional `data`.
+   *
+   * @param {string} objId
+   * @param {any} [data]
+   */
+  resolve(objId, data = null) {
+    const obj = this.#ensureObj(objId);
+    obj.data = data;
+    obj.resolve();
+  }
+
+  clear() {
+    for (const objId in this.#objs) {
+      const { data } = this.#objs[objId];
+      data?.bitmap?.close(); // Release any `ImageBitmap` data.
+    }
+    this.#objs = Object.create(null);
+  }
+
+  *[Symbol.iterator]() {
+    for (const objId in this.#objs) {
+      const { data } = this.#objs[objId];
+
+      if (data === INITIAL_DATA) {
+        continue;
+      }
+      yield [objId, data];
+    }
+  }
+}
 
 /**
  * Maps between page IDs and page numbers, allowing bidirectional conversion
@@ -1278,6 +1386,7 @@ export {
   PagesMapper,
   PageViewport,
   PDFDateString,
+  PDFObjects,
   PixelsPerInch,
   RenderingCancelledException,
   renderRichText,

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -1034,114 +1034,6 @@ function makePathFromDrawOPS(data) {
   }
   return path;
 }
-const INITIAL_DATA = Symbol("INITIAL_DATA");
-
-/**
- * A PDF document and page is built of many objects. E.g. there are objects for
- * fonts, images, rendering code, etc. These objects may get processed inside of
- * a worker. This class implements some basic methods to manage these objects.
- */
-class PDFObjects {
-  #objs = Object.create(null);
-
-  /**
-   * Ensures there is an object defined for `objId`.
-   *
-   * @param {string} objId
-   * @returns {Object}
-   */
-  #ensureObj(objId) {
-    return (this.#objs[objId] ||= {
-      ...Promise.withResolvers(),
-      data: INITIAL_DATA,
-    });
-  }
-
-  /**
-   * If called *without* callback, this returns the data of `objId` but the
-   * object needs to be resolved. If it isn't, this method throws.
-   *
-   * If called *with* a callback, the callback is called with the data of the
-   * object once the object is resolved. That means, if you call this method
-   * and the object is already resolved, the callback gets called right away.
-   *
-   * @param {string} objId
-   * @param {function} [callback]
-   * @returns {any}
-   */
-  get(objId, callback = null) {
-    // If there is a callback, then the get can be async and the object is
-    // not required to be resolved right now.
-    if (callback) {
-      const obj = this.#ensureObj(objId);
-      obj.promise.then(() => callback(obj.data));
-      return null;
-    }
-    // If there isn't a callback, the user expects to get the resolved data
-    // directly.
-    const obj = this.#objs[objId];
-    // If there isn't an object yet or the object isn't resolved, then the
-    // data isn't ready yet!
-    if (!obj || obj.data === INITIAL_DATA) {
-      throw new Error(`Requesting object that isn't resolved yet ${objId}.`);
-    }
-    return obj.data;
-  }
-
-  /**
-   * @param {string} objId
-   * @returns {boolean}
-   */
-  has(objId) {
-    const obj = this.#objs[objId];
-    return !!obj && obj.data !== INITIAL_DATA;
-  }
-
-  /**
-   * @param {string} objId
-   * @returns {boolean}
-   */
-  delete(objId) {
-    const obj = this.#objs[objId];
-    if (!obj || obj.data === INITIAL_DATA) {
-      // Only allow removing the object *after* it's been resolved.
-      return false;
-    }
-    delete this.#objs[objId];
-    return true;
-  }
-
-  /**
-   * Resolves the object `objId` with optional `data`.
-   *
-   * @param {string} objId
-   * @param {any} [data]
-   */
-  resolve(objId, data = null) {
-    const obj = this.#ensureObj(objId);
-    obj.data = data;
-    obj.resolve();
-  }
-
-  clear() {
-    for (const objId in this.#objs) {
-      const { data } = this.#objs[objId];
-      data?.bitmap?.close(); // Release any `ImageBitmap` data.
-    }
-    this.#objs = Object.create(null);
-  }
-
-  *[Symbol.iterator]() {
-    for (const objId in this.#objs) {
-      const { data } = this.#objs[objId];
-
-      if (data === INITIAL_DATA) {
-        continue;
-      }
-      yield [objId, data];
-    }
-  }
-}
 
 /**
  * Maps between page IDs and page numbers, allowing bidirectional conversion
@@ -1386,7 +1278,6 @@ export {
   PagesMapper,
   PageViewport,
   PDFDateString,
-  PDFObjects,
   PixelsPerInch,
   RenderingCancelledException,
   renderRichText,

--- a/src/display/filter_factory.js
+++ b/src/display/filter_factory.js
@@ -49,6 +49,8 @@ class BaseFilterFactory {
   destroy(keepHCM = false) {}
 }
 
+class WorkerFilterFactory extends BaseFilterFactory {}
+
 /**
  * FilterFactory aims to create some SVG filters we can use when drawing an
  * image (or whatever) on a canvas.
@@ -506,4 +508,4 @@ class DOMFilterFactory extends BaseFilterFactory {
   }
 }
 
-export { BaseFilterFactory, DOMFilterFactory };
+export { BaseFilterFactory, DOMFilterFactory, WorkerFilterFactory };

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -1,0 +1,243 @@
+import { assert, warn } from "../shared/util.js";
+import { FontFaceObject, FontLoader } from "./font_loader.js";
+import { CanvasGraphics } from "./canvas.js";
+import { DOMFilterFactory } from "./filter_factory.js";
+import { MessageHandler } from "../shared/message_handler.js";
+import { OffscreenCanvasFactory } from "./canvas_factory.js";
+import { PDFObjects } from "./display_utils.js";
+
+class RendererMessageHandler {
+  static #commonObjs = new PDFObjects();
+
+  static #objsMap = new Map();
+
+  static #tasks = new Map();
+
+  static #fontLoader = new FontLoader({
+    ownerDocument: self,
+  });
+
+  static #canvasFactory;
+
+  static #filterFactory;
+
+  static #enableHWA = false;
+
+  static {
+    this.initializeFromPort(self);
+  }
+
+  static pageObjs(pageIndex) {
+    let objs = this.#objsMap.get(pageIndex);
+    if (!objs) {
+      objs = new PDFObjects();
+      this.#objsMap.set(pageIndex, objs);
+    }
+    return objs;
+  }
+
+  static initializeFromPort(port) {
+    let terminated = false;
+    let mainHandler = new MessageHandler("renderer", "main", port);
+    mainHandler.send("ready", null);
+    mainHandler.on("Ready", function () {
+      // DO NOTHING
+    });
+
+    mainHandler.on("configure", ({ channelPort, enableHWA }) => {
+      this.#enableHWA = enableHWA;
+      const workerHandler = new MessageHandler(
+        "renderer-channel",
+        "worker-channel",
+        channelPort
+      );
+      this.#canvasFactory = new OffscreenCanvasFactory({
+        enableHWA,
+      });
+      this.#filterFactory = new DOMFilterFactory({});
+
+      workerHandler.on("commonobj", ([id, type, data]) => {
+        if (terminated) {
+          throw new Error("Renderer worker has been terminated.");
+        }
+        this.handleCommonObj(id, type, data, workerHandler);
+      });
+
+      workerHandler.on("obj", ([id, pageIndex, type, data]) => {
+        if (terminated) {
+          throw new Error("Renderer worker has been terminated.");
+        }
+        this.handleObj(pageIndex, id, type, data);
+      });
+    });
+
+    mainHandler.on(
+      "init",
+      ({
+        pageIndex,
+        canvas,
+        map,
+        colors,
+        taskID,
+        transform,
+        viewport,
+        transparency,
+        background,
+        optionalContentConfig,
+      }) => {
+        assert(!this.#tasks.has(taskID), "Task already initialized");
+        const ctx = canvas.getContext("2d", {
+          alpha: false,
+          willReadFrequently: this.#enableHWA,
+        });
+        const objs = this.pageObjs(pageIndex);
+        const gfx = new CanvasGraphics(
+          ctx,
+          this.#commonObjs,
+          objs,
+          this.#canvasFactory,
+          this.#filterFactory,
+          { optionalContentConfig },
+          map,
+          colors
+        );
+        gfx.beginDrawing({ transform, viewport, transparency, background });
+        this.#tasks.set(taskID, { canvas, gfx });
+      }
+    );
+
+    mainHandler.on(
+      "execute",
+      async ({ operatorList, operatorListIdx, taskID }) => {
+        if (terminated) {
+          throw new Error("Renderer worker has been terminated.");
+        }
+        const task = this.#tasks.get(taskID);
+        assert(task !== undefined, "Task not initialized");
+        return task.gfx.executeOperatorList(
+          operatorList,
+          operatorListIdx,
+          arg => mainHandler.send("continue", { taskID, arg })
+        );
+      }
+    );
+
+    mainHandler.on("end", ({ taskID }) => {
+      if (terminated) {
+        throw new Error("Renderer worker has been terminated.");
+      }
+      const task = this.#tasks.get(taskID);
+      assert(task !== undefined, "Task not initialized");
+      task.gfx.endDrawing();
+    });
+
+    mainHandler.on("resetCanvas", ({ taskID }) => {
+      if (terminated) {
+        throw new Error("Renderer worker has been terminated.");
+      }
+      const task = this.#tasks.get(taskID);
+      assert(task !== undefined, "Task not initialized");
+      const canvas = task.canvas;
+      canvas.width = canvas.height = 0;
+    });
+
+    mainHandler.on("Terminate", async () => {
+      terminated = true;
+      this.#commonObjs.clear();
+      for (const objs of this.#objsMap.values()) {
+        objs.clear();
+      }
+      this.#objsMap.clear();
+      this.#tasks.clear();
+      this.#fontLoader.clear();
+      mainHandler.destroy();
+      mainHandler = null;
+    });
+  }
+
+  static handleCommonObj(id, type, exportedData, handler) {
+    if (this.#commonObjs.has(id)) {
+      return null;
+    }
+
+    switch (type) {
+      case "Font":
+        if ("error" in exportedData) {
+          const exportedError = exportedData.error;
+          warn(`Error during font loading: ${exportedError}`);
+          this.#commonObjs.resolve(id, exportedError);
+          break;
+        }
+
+        // TODO: Make FontInspector work again.
+        const inspectFont = null;
+        // this._params.pdfBug && globalThis.FontInspector?.enabled
+        //   ? (font, url) => globalThis.FontInspector.fontAdded(font, url)
+        // : null;
+        const font = new FontFaceObject(exportedData, inspectFont);
+
+        this.#fontLoader
+          .bind(font)
+          .catch(() => handler.sendWithPromise("FontFallback", { id }))
+          .finally(() => {
+            if (!font.fontExtraProperties && font.data) {
+              // Immediately release the `font.data` property once the font
+              // has been attached to the DOM, since it's no longer needed,
+              // rather than waiting for a `PDFDocumentProxy.cleanup` call.
+              // Since `font.data` could be very large, e.g. in some cases
+              // multiple megabytes, this will help reduce memory usage.
+              font.data = null;
+            }
+            this.#commonObjs.resolve(id, font);
+          });
+        break;
+      case "CopyLocalImage":
+        const { imageRef } = exportedData;
+        assert(imageRef, "The imageRef must be defined.");
+
+        for (const objs of this.#objsMap.values()) {
+          for (const [, data] of objs) {
+            if (data?.ref !== imageRef) {
+              continue;
+            }
+            if (!data.dataLen) {
+              return null;
+            }
+            this.#commonObjs.resolve(id, structuredClone(data));
+            return data.dataLen;
+          }
+        }
+        break;
+      case "FontPath":
+      case "Image":
+      case "Pattern":
+        this.#commonObjs.resolve(id, exportedData);
+        break;
+      default:
+        throw new Error(`Got unknown common object type ${type}`);
+    }
+
+    return null;
+  }
+
+  static handleObj(pageIndex, id, type, exportedData) {
+    const objs = this.pageObjs(pageIndex);
+
+    if (objs.has(id)) {
+      return;
+    }
+
+    switch (type) {
+      case "Image":
+      case "Pattern":
+        objs.resolve(id, exportedData);
+        break;
+      default:
+        throw new Error(
+          `Got unknown object type ${type} id ${id} for page ${pageIndex} data ${JSON.stringify(exportedData)}`
+        );
+    }
+  }
+}
+
+export { RendererMessageHandler };

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -69,7 +69,7 @@ class RendererMessageHandler {
       ({
         pageIndex,
         canvas,
-        map,
+        annotationCanvasMap,
         colors,
         taskID,
         transform,
@@ -102,7 +102,7 @@ class RendererMessageHandler {
           this.#canvasFactory,
           this.#filterFactory,
           { optionalContentConfig },
-          map,
+          annotationCanvasMap,
           colors
         );
         gfx.beginDrawing({ transform, viewport, transparency, background });
@@ -188,6 +188,19 @@ class RendererMessageHandler {
         return newOperatorListIdx;
       }
     );
+
+    mainHandler.on("cleanupPage", ({ pageIndex }) => {
+      if (terminated) {
+        throw new Error("Renderer worker has been terminated.");
+      }
+
+      const objs = this.#objsMap.get(pageIndex);
+      if (!objs) {
+        return;
+      }
+      objs.clear();
+      this.#objsMap.delete(pageIndex);
+    });
 
     mainHandler.on("end", ({ taskID }) => {
       if (terminated) {

--- a/src/display/worker_options.js
+++ b/src/display/worker_options.js
@@ -18,6 +18,8 @@ class GlobalWorkerOptions {
 
   static #src = "";
 
+  static #rendererSrc = "";
+
   /**
    * @type {Worker | null}
    */
@@ -58,6 +60,27 @@ class GlobalWorkerOptions {
       throw new Error("Invalid `workerSrc` type.");
     }
     this.#src = val;
+  }
+
+  /**
+   * @type {string}
+   */
+  static get rendererSrc() {
+    return this.#rendererSrc;
+  }
+
+  /**
+   * @param {string} rendererSrc - A string containing the path and filename of
+   *   the renderer worker file.
+   *
+   *   NOTE: The `rendererSrc` option should always be set, in order to prevent
+   *         any issues when using the PDF.js library with worker rendering.
+   */
+  static set rendererSrc(val) {
+    if (typeof val !== "string") {
+      throw new Error("Invalid `rendererSrc` type.");
+    }
+    this.#rendererSrc = val;
   }
 }
 

--- a/src/pdf.renderer.js
+++ b/src/pdf.renderer.js
@@ -1,0 +1,18 @@
+/* Copyright 2025 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RendererMessageHandler } from "./display/renderer_worker.js";
+
+export { RendererMessageHandler };

--- a/src/shared/handle_objs.js
+++ b/src/shared/handle_objs.js
@@ -1,0 +1,116 @@
+import { assert, warn } from "../shared/util.js";
+import {
+  FontInfo,
+  FontPathInfo,
+  PatternInfo,
+} from "../shared/obj-bin-transform.js";
+import { FontFaceObject } from "../display/font_loader.js";
+
+function setupHandler(handler, destroyed, commonObjs, pages, fontLoader) {
+  handler.on("commonobj", ([id, type, exportedData]) => {
+    if (destroyed) {
+      return null; // Ignore any pending requests if the worker was terminated.
+    }
+
+    if (commonObjs.has(id)) {
+      return null;
+    }
+
+    switch (type) {
+      case "Font":
+        if ("error" in exportedData) {
+          const exportedError = exportedData.error;
+          warn(`Error during font loading: ${exportedError}`);
+          commonObjs.resolve(id, exportedError);
+          break;
+        }
+
+        const fontData = new FontInfo(exportedData);
+        const inspectFont =
+          this._params.pdfBug && globalThis.FontInspector?.enabled
+            ? (font, url) => globalThis.FontInspector.fontAdded(font, url)
+            : null;
+        const font = new FontFaceObject(
+          fontData,
+          inspectFont,
+          exportedData.extra,
+          exportedData.charProcOperatorList
+        );
+
+        fontLoader
+          .bind(font)
+          .catch(() => handler.sendWithPromise("FontFallback", { id }))
+          .finally(() => {
+            if (!font.fontExtraProperties && font.data) {
+              // Immediately release the `font.data` property once the font
+              // has been attached to the DOM, since it's no longer needed,
+              // rather than waiting for a `PDFDocumentProxy.cleanup` call.
+              // Since `font.data` could be very large, e.g. in some cases
+              // multiple megabytes, this will help reduce memory usage.
+              font.clearData();
+            }
+            commonObjs.resolve(id, font);
+          });
+        break;
+      case "CopyLocalImage":
+        const { imageRef } = exportedData;
+        assert(imageRef, "The imageRef must be defined.");
+
+        for (const page of pages.values()) {
+          for (const [, data] of page.objs) {
+            if (data?.ref !== imageRef) {
+              continue;
+            }
+            if (!data.dataLen) {
+              return null;
+            }
+            commonObjs.resolve(id, structuredClone(data));
+            return data.dataLen;
+          }
+        }
+        break;
+      case "FontPath":
+        commonObjs.resolve(id, new FontPathInfo(exportedData));
+        break;
+      case "Image":
+        commonObjs.resolve(id, exportedData);
+        break;
+      case "Pattern":
+        const pattern = new PatternInfo(exportedData);
+        commonObjs.resolve(id, pattern.getIR());
+        break;
+      default:
+        throw new Error(`Got unknown common object type ${type}`);
+    }
+
+    return null;
+  });
+
+  handler.on("obj", ([id, pageIndex, type, imageData]) => {
+    if (destroyed) {
+      // Ignore any pending requests if the worker was terminated.
+      return;
+    }
+
+    const page = pages.get(pageIndex);
+    if (page.objs.has(id)) {
+      return;
+    }
+    // Don't store data *after* cleanup has successfully run, see bug 1854145.
+    if (page._intentStates.size === 0) {
+      imageData?.bitmap?.close(); // Release any `ImageBitmap` data.
+      return;
+    }
+
+    switch (type) {
+      case "Image":
+      case "Pattern":
+        page.objs.resolve(id, imageData);
+        break;
+      default:
+        throw new Error(`Got unknown object type ${type}`);
+    }
+  });
+}
+
+export { setupHandler };

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -90,6 +90,7 @@ class MessageHandler {
     comObj.addEventListener("message", this.#onMessage.bind(this), {
       signal: this.#messageAC.signal,
     });
+    comObj.start?.();
   }
 
   #onMessage({ data }) {

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -111,6 +111,8 @@ async function initializePDFJS(callback) {
   }
   // Configure the worker.
   GlobalWorkerOptions.workerSrc = "../../build/generic/build/pdf.worker.mjs";
+  GlobalWorkerOptions.rendererSrc =
+    "../../build/generic/build/pdf.renderer.mjs";
 
   callback();
 }

--- a/web/base_pdf_page_view.js
+++ b/web/base_pdf_page_view.js
@@ -48,6 +48,12 @@ class BasePDFPageView extends RenderableView {
 
   renderingQueue = null;
 
+  renderTask = null;
+
+  renderTaskID = null;
+
+  resume = null;
+
   constructor(options) {
     super();
     this.eventBus = options.eventBus;
@@ -159,7 +165,7 @@ class BasePDFPageView extends RenderableView {
 
       if (prevCanvas) {
         prevCanvas.replaceWith(canvas);
-        prevCanvas.width = prevCanvas.height = 0;
+        this.pdfPage.resetCanvas(this.renderTaskID);
       } else {
         onShow(canvas);
       }
@@ -187,7 +193,7 @@ class BasePDFPageView extends RenderableView {
       return;
     }
     canvas.remove();
-    canvas.width = canvas.height = 0;
+    this.pdfPage.resetCanvas(this.renderTaskID);
     this.canvas = null;
     this.#resetTempCanvas();
   }
@@ -208,6 +214,8 @@ class BasePDFPageView extends RenderableView {
         this.#renderError = null;
       }
     };
+
+    this.renderTaskID = renderTask.taskID;
 
     let error = null;
     try {

--- a/web/pdf_page_detail_view.js
+++ b/web/pdf_page_detail_view.js
@@ -293,7 +293,12 @@ class PDFPageDetailView extends BasePDFPageView {
       this._getRenderingContext(canvas, transform),
       () => {
         // If the rendering is cancelled, keep the old canvas visible.
-        this.canvas?.remove();
+        const discardedCanvas = this.canvas;
+        const resetWorkerCanvas = discardedCanvas?.resetWorkerCanvas;
+        if (typeof resetWorkerCanvas === "function") {
+          resetWorkerCanvas();
+        }
+        discardedCanvas?.remove();
         this.canvas = prevCanvas;
       },
       () => {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1091,6 +1091,10 @@ class PDFPageView extends BasePDFPageView {
     const resultPromise = this._drawCanvas(
       this._getRenderingContext(canvas, transform, recordBBoxes),
       () => {
+        const resetWorkerCanvas = prevCanvas?.resetWorkerCanvas;
+        if (typeof resetWorkerCanvas === "function") {
+          resetWorkerCanvas();
+        }
         prevCanvas?.remove();
         this._resetCanvas();
       },

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -319,6 +319,7 @@ class PDFThumbnailView extends RenderableView {
       await renderTask.promise;
     } catch (e) {
       if (e instanceof RenderingCancelledException) {
+        pdfPage.resetCanvas(renderTask.taskID);
         return;
       }
       error = e;
@@ -332,7 +333,8 @@ class PDFThumbnailView extends RenderableView {
     }
     this.renderingState = RenderingStates.FINISHED;
 
-    await this.#convertCanvasToImage(canvas);
+    this.#convertCanvasToImage(canvas);
+    pdfPage.resetCanvas(renderTask.taskID);
 
     this.eventBus.dispatch("thumbnailrendered", {
       source: this,


### PR DESCRIPTION
This change works on top of #20016 to move `CanvasGraphics` operations to a new/different worker thread, thus offloading the heavy page renders and freeing up the main thread.