### PR TITLE
Don't focus the viewer at startup (bug 1974863)

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -543,6 +543,14 @@ async function dragAndDrop(page, selector, translations, steps = 1) {
   await page.waitForSelector("#viewer:not(.noUserSelect)");
 }
 
+function waitForPageChanging(page) {
+  return createPromise(page, resolve => {
+    window.PDFViewerApplication.eventBus.on("pagechanging", resolve, {
+      once: true,
+    });
+  });
+}
+
 function waitForAnnotationEditorLayer(page) {
   return createPromise(page, resolve => {
     window.PDFViewerApplication.eventBus.on(
@@ -944,6 +952,7 @@ export {
   waitForEntryInStorage,
   waitForEvent,
   waitForNoElement,
+  waitForPageChanging,
   waitForPageRendered,
   waitForPointerUp,
   waitForSandboxTrip,

--- a/web/app.js
+++ b/web/app.js
@@ -1455,11 +1455,6 @@ const PDFViewerApplication = {
             spreadMode,
           });
           this.eventBus.dispatch("documentinit", { source: this });
-          // Make all navigation keys work on document load,
-          // unless the viewer is embedded in a web page.
-          if (!this.isViewerEmbedded) {
-            pdfViewer.focus();
-          }
 
           // For documents with different page sizes, once all pages are
           // resolved, ensure that the correct location becomes visible on load.


### PR DESCRIPTION
It's useless and it causes screen readers to not always read the document title.