### PR TITLE
[Editor] Allow to change the editor mode when selecting the corresponding editor (bug 1975538)

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -730,6 +730,7 @@ class AnnotationElement {
         source: this,
         mode,
         editId,
+        mustEnterInEditMode: true,
       });
     });
   }

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -205,6 +205,10 @@ class AnnotationEditor {
     return Object.getPrototypeOf(this).constructor._type;
   }
 
+  get mode() {
+    return Object.getPrototypeOf(this).constructor._editorType;
+  }
+
   static get isDrawer() {
     return false;
   }

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1684,8 +1684,15 @@ class AnnotationEditorUIManager {
    * @param {string|null} editId
    * @param {boolean} [isFromKeyboard] - true if the mode change is due to a
    *   keyboard action.
+   * @param {boolean} [mustEnterInEditMode] - true if the editor must enter in
+   *   edit mode.
    */
-  async updateMode(mode, editId = null, isFromKeyboard = false) {
+  async updateMode(
+    mode,
+    editId = null,
+    isFromKeyboard = false,
+    mustEnterInEditMode = false
+  ) {
     if (this.#mode === mode) {
       return;
     }
@@ -1732,7 +1739,9 @@ class AnnotationEditorUIManager {
     for (const editor of this.#allEditors.values()) {
       if (editor.annotationElementId === editId || editor.id === editId) {
         this.setSelected(editor);
-        editor.enterInEditMode();
+        if (mustEnterInEditMode) {
+          editor.enterInEditMode();
+        }
       } else {
         editor.unselect();
       }
@@ -2036,6 +2045,11 @@ class AnnotationEditorUIManager {
    * @param {AnnotationEditor} editor
    */
   setSelected(editor) {
+    this.updateToolbar({
+      mode: editor.mode,
+      editId: editor.id,
+    });
+
     this.#currentDrawingSession?.commitOrRemove();
     for (const ed of this.#selectedEditors) {
       if (ed !== editor) {

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2401,12 +2401,19 @@ class PDFViewer {
    * @property {string|null} [editId] - ID of the existing annotation to edit.
    * @property {boolean} [isFromKeyboard] - True if the mode change is due to a
    *   keyboard action.
+   * @property {boolean} [mustEnterInEditMode] - True if the editor must enter
+   *   edit mode.
    */
 
   /**
    * @param {AnnotationEditorModeOptions} options
    */
-  set annotationEditorMode({ mode, editId = null, isFromKeyboard = false }) {
+  set annotationEditorMode({
+    mode,
+    editId = null,
+    isFromKeyboard = false,
+    mustEnterInEditMode = false,
+  }) {
     if (!this.#annotationEditorUIManager) {
       throw new Error(`The AnnotationEditor is not enabled.`);
     }
@@ -2428,7 +2435,8 @@ class PDFViewer {
       await this.#annotationEditorUIManager.updateMode(
         mode,
         editId,
-        isFromKeyboard
+        isFromKeyboard,
+        mustEnterInEditMode
       );
       if (
         mode !== this.#annotationEditorMode ||


### PR DESCRIPTION
For example, selecting an ink editor just after having created a freetext will switch to ink mode.