### PR TITLE
Use the canvas context from mozPrintCallback when printing a pdf from the Firefox viewer

### DIFF
--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -72,7 +72,8 @@ function composePage(
           currentRenderTask = null;
         }
         const renderContext = {
-          canvas: ctx.canvas,
+          canvasContext: ctx,
+          canvas: null,
           transform: [PRINT_UNITS, 0, 0, PRINT_UNITS, 0, 0],
           viewport: pdfPage.getViewport({ scale: 1, rotation: size.rotation }),
           intent: "print",


### PR DESCRIPTION
The context is specific to the callback and cannot be created from the canvas itself.