### PR TITLE
In HCM, invert colors when hovering an annotation with a popup

### DIFF
--- a/web/annotation_layer_builder.css
+++ b/web/annotation_layer_builder.css
@@ -366,6 +366,10 @@
 
   .popupTriggerArea {
     cursor: pointer;
+
+    &:hover {
+      backdrop-filter: var(--hcm-highlight-filter);
+    }
   }
 
   section svg {


### PR DESCRIPTION
It can be tested on Windows in HCM with freetexts.pdf.

<img width="958" height="313" alt="image" src="https://github.com/user-attachments/assets/134f4a7a-6eb5-4f9f-aaf8-9b16a65fac6e" />
