### PR TITLE
Fix the "must check that canvas perfectly fits the page whatever the zoom level" viewer integration test

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -395,29 +395,13 @@ describe("PDF viewer", () => {
     it("must check that canvas perfectly fits the page whatever the zoom level is", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          if (browserName === "chrome") {
-            // Skip the test for Chrome as `scrollIntoView` below hangs since
-            // Puppeteer 24.5.0 and higher.
-            // See https://github.com/mozilla/pdf.js/issues/19811.
-            // TODO: Remove this check once the issue is fixed.
-            return;
-          }
-
           // The pdf has a single page with a red background.
           // We set the viewer background to red, because when screenshoting
           // some part of the viewer background can be visible.
           // But here we don't care about the viewer background: we only
           // care about the page background and the canvas default color.
-
           await page.evaluate(() => {
             document.body.style.background = "#ff0000";
-            const toolbar = document.querySelector(".toolbar");
-            toolbar.style.display = "none";
-          });
-          await page.waitForSelector(".toolbar", { visible: false });
-          await page.evaluate(() => {
-            const p = document.querySelector(`.page[data-page-number="1"]`);
-            p.style.border = "none";
           });
 
           for (let i = 0; ; i++) {


### PR DESCRIPTION
In order to screenshot the page and assert that it's monochrome, providing a regression test for #18694, the viewer background is configured to match the page background because screenshotting the page always captures a small part of the viewer background as well, and this way we can easily go over all pixels and check that they are all equal.

However, in addition to configuring the viewer background the test also hides the toolbar and removes the page border. Especially the latter makes `scrollIntoView` fail in both Chrome and Firefox with recent Puppeteer versions, for reasons which remain a bit unclear.

Fortunately both hiding the toolbar and removing the page border is not actually necessary (anymore) for the test to work, so we can simply remove those actions to fix the issue and reduce the amount of code. To make sure that the test still covers the original issue correctly we've reverted the changes from #18698 and then test still fails as expected.

Fixes #19811.
Fixes 68332ec2.

Related to #20029.