### PR TITLE
Make horizontal padding relative to device width

### DIFF
--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -149,4 +149,32 @@ describe("find bar", () => {
       );
     });
   });
+
+  describe("scrolls to the search result text for smaller viewports", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait("tracemonkey.pdf", ".textLayer", 100);
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must scroll to the search result text", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // Set a smaller viewport to simulate a mobile device
+          await page.setViewport({ width: 350, height: 600 });
+          await page.click("#viewFindButton");
+          await page.waitForSelector("#findInput", { visible: true });
+          await page.type("#findInput", "productivity");
+
+          const highlight = await page.waitForSelector(".textLayer .highlight");
+
+          expect(await highlight.isIntersectingViewport()).toBeTrue();
+        })
+      );
+    });
+  });
 });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -29,7 +29,6 @@ const FindState = {
 
 const FIND_TIMEOUT = 250; // ms
 const MATCH_SCROLL_OFFSET_TOP = -50; // px
-const MATCH_SCROLL_OFFSET_LEFT = -400; // px
 
 const CHARACTERS_TO_NORMALIZE = {
   "\u2010": "-", // Hyphen
@@ -573,10 +572,9 @@ class PDFFindController {
       return;
     }
     this._scrollMatches = false; // Ensure that scrolling only happens once.
-
     const spot = {
       top: MATCH_SCROLL_OFFSET_TOP,
-      left: selectedLeft + MATCH_SCROLL_OFFSET_LEFT,
+      left: selectedLeft,
     };
     scrollIntoView(element, spot, /* scrollMatches = */ true);
   }

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -120,7 +120,17 @@ function scrollIntoView(element, spot, scrollMatches = false) {
       offsetY += spot.top;
     }
     if (spot.left !== undefined) {
-      offsetX += spot.left;
+      if (scrollMatches) {
+        const elementWidth = element.getBoundingClientRect().width;
+        const padding = MathClamp(
+          (parent.clientWidth - elementWidth) / 2,
+          20,
+          400
+        );
+        offsetX += spot.left - padding;
+      } else {
+        offsetX += spot.left;
+      }
       parent.scrollLeft = offsetX;
     }
   }


### PR DESCRIPTION
The fixed -400px horizontal offset used by
scrollIntoView led to horizontal scroll only moving part-way right on narrow screens. The highlights near the right-edge remained party or completely off screen.

This centres the highlighted match on any viewport width while clamping the left margin to 20-400px. On very narrow screens the scrollbar now moves all the way to the right instead of stopping midway.

This change was previously added in https://github.com/mozilla/pdf.js/pull/20047 and it was reverted because it caused the regression: https://github.com/mozilla/pdf.js/issues/20075 
This fixes the regression and also the horizontal scroll. 

The test added to check for https://github.com/mozilla/pdf.js/issues/20075 only checks for pinch zoom in Chrome since [Firefox doesn't support](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#api.touch) Touch on non-touch devices, so we are just testing it on chrome for now. 

I am open to ideas on better ways of testing this. :)