### PR TITLE
Fix intermittent failure in the viewer alert tests

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -111,8 +111,9 @@ describe("FreeText Editor", () => {
           await waitForSelectedEditor(page, editorSelector);
           await waitForStorageEntries(page, 1);
 
-          const alert = await page.$eval("#viewer-alert", el => el.textContent);
-          expect(alert).toEqual("Text added");
+          await page.waitForFunction(
+            `document.getElementById("viewer-alert").textContent === "Text added"`
+          );
 
           let content = await page.$eval(editorSelector, el =>
             el.innerText.trimEnd()

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -78,8 +78,9 @@ describe("Highlight Editor", () => {
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
 
-          const alert = await page.$eval("#viewer-alert", el => el.textContent);
-          expect(alert).toEqual("Highlight added");
+          await page.waitForFunction(
+            `document.getElementById("viewer-alert").textContent === "Highlight added"`
+          );
 
           const oneToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
             Array.from(new Array(13).keys(), n => 13 - n)

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -84,8 +84,9 @@ describe("Ink Editor", () => {
             await commit(page);
           }
 
-          const alert = await page.$eval("#viewer-alert", el => el.textContent);
-          expect(alert).toEqual("Drawing added");
+          await page.waitForFunction(
+            `document.getElementById("viewer-alert").textContent === "Drawing added"`
+          );
 
           await clearAll(page);
 

--- a/test/integration/signature_editor_spec.mjs
+++ b/test/integration/signature_editor_spec.mjs
@@ -181,8 +181,9 @@ describe("Signature Editor", () => {
             { visible: true }
           );
 
-          const alert = await page.$eval("#viewer-alert", el => el.textContent);
-          expect(alert).toEqual("Signature added");
+          await page.waitForFunction(
+            `document.getElementById("viewer-alert").textContent === "Signature added"`
+          );
 
           // Check the tooltip.
           await page.waitForSelector(

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -125,8 +125,9 @@ describe("Stamp Editor", () => {
           const editorSelector = getEditorSelector(0);
           await waitForImage(page, editorSelector);
 
-          const alert = await page.$eval("#viewer-alert", el => el.textContent);
-          expect(alert).toEqual("Image added");
+          await page.waitForFunction(
+            `document.getElementById("viewer-alert").textContent === "Image added"`
+          );
 
           const { width } = await getEditorDimensions(page, editorSelector);
 


### PR DESCRIPTION
It takes some time for the viewer alert to be updated after the editor is committed, but the current tests don't await that and proceed too fast to the viewer alert string assertion. This commit fixes the issue by waiting for the expected viewer alert string to appear instead.

Fixes #20105.