### PR TITLE
Add regression test for PR 19639

### DIFF
--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -423,4 +423,30 @@ describe("evaluator", function () {
       expect(operatorList.length).toEqual(0);
     });
   });
+
+  describe("graphics-state operators", function () {
+    it("should convert negative line width to absolute value in the graphic state", async function () {
+      const gState = new Dict();
+      gState.set("LW", -5);
+      const extGState = new Dict();
+      extGState.set("GSneg", gState);
+
+      const resources = new ResourcesMock();
+      resources.ExtGState = extGState;
+
+      const stream = new StringStream("/GSneg gs");
+      const result = await runOperatorListCheck(
+        partialEvaluator,
+        stream,
+        resources
+      );
+
+      expect(result.fnArray).toEqual([OPS.setGState]);
+
+      const stateEntries = result.argsArray[0][0];
+      const lwEntry = stateEntries.find(([key]) => key === "LW");
+      expect(lwEntry).toBeDefined();
+      expect(lwEntry[1]).toEqual(5);
+    });
+  });
 });


### PR DESCRIPTION
This test was automatically generated and could serve as a regression test for [PR #19639](https://github.com/mozilla/pdf.js/pull/19639). The added test:
- fails on the codebase prior to the PR
- passes on the codebase after the PR
- still passes against today’s pdf.js master branch

It ensures that negative “LW” entries in an ExtGState dictionary are converted to their absolute values when the “gs” operator is processed.

This is part of our research at the [ZEST](https://www.ifi.uzh.ch/en/zest.html) group of University of Zurich in collaboration with [Mozilla](https://www.mozilla.org).
If you have any suggestions, questions, or simply want to learn more, feel free to contact us at konstantinos.kitsios@uzh.ch and mcastelluccio@mozilla.com.