### PR TITLE
[WIP] Implement a delay for mouse clicks in the integration tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -403,6 +403,18 @@ export default [
           message:
             "`waitForTimeout` can cause intermittent failures and should not be used (see issue #17656 for replacements).",
         },
+        {
+          selector:
+            "CallExpression:has(> MemberExpression.callee[object.name='page'][property.name='click'])[arguments.length < 2]",
+          message:
+            "`page.click` without delay can cause intermittent failures; provide `{ delay: CLICK_DELAY }` as options argument instead",
+        },
+        {
+          selector:
+            "CallExpression:has(> MemberExpression.callee[object.object.name='page'][object.property.name='mouse'][property.name='click'])[arguments.length < 3]",
+          message:
+            "`page.mouse.click` without delay can cause intermittent failures; provide `{ delay: CLICK_DELAY }` as options argument instead",
+        },
       ],
     },
   },

--- a/test/integration/accessibility_spec.mjs
+++ b/test/integration/accessibility_spec.mjs
@@ -15,6 +15,7 @@
 
 import {
   awaitPromise,
+  CLICK_DELAY,
   closePages,
   loadAndWait,
   waitForPageRendered,
@@ -96,7 +97,9 @@ describe("accessibility", () => {
               .toBeTrue();
 
             const handle = await waitForPageRendered(page);
-            await page.click(`#zoom${i < 4 ? "In" : "Out"}Button`);
+            await page.click(`#zoom${i < 4 ? "In" : "Out"}Button`, {
+              delay: CLICK_DELAY,
+            });
             await awaitPromise(handle);
           }
         })
@@ -193,7 +196,7 @@ describe("accessibility", () => {
         pages.map(async ([browserName, page]) => {
           await page.waitForSelector(".annotationLayer");
           const stampId = "pdfjs_internal_id_20R";
-          await page.click(`#${stampId}`);
+          await page.click(`#${stampId}`, { delay: CLICK_DELAY });
 
           const controlledId = await page.$eval(
             "#pdfjs_internal_id_21R",

--- a/test/integration/annotation_spec.mjs
+++ b/test/integration/annotation_spec.mjs
@@ -14,6 +14,7 @@
  */
 
 import {
+  CLICK_DELAY,
   closePages,
   getQuerySelector,
   getRect,
@@ -89,7 +90,9 @@ describe("Annotation highlight", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           for (const i of [23, 22, 14]) {
-            await page.click(`[data-annotation-id='${i}R']`);
+            await page.click(`[data-annotation-id='${i}R']`, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector(`#pdfjs_internal_id_${i}R:focus`);
           }
         })
@@ -115,7 +118,7 @@ describe("Checkbox annotation", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           for (const selector of selectors) {
-            await page.click(selector);
+            await page.click(selector, { delay: CLICK_DELAY });
             await page.waitForFunction(
               `document.querySelector("${selector} > :first-child").checked`
             );
@@ -150,7 +153,7 @@ describe("Checkbox annotation", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const selector = "[data-annotation-id='7R']";
-          await page.click(selector);
+          await page.click(selector, { delay: CLICK_DELAY });
           await page.waitForFunction(
             `document.querySelector("${selector} > :first-child").checked`
           );
@@ -178,7 +181,7 @@ describe("Checkbox annotation", () => {
             id => `[data-annotation-id='${id}R']`
           );
           for (const selector of selectors) {
-            await page.click(selector);
+            await page.click(selector, { delay: CLICK_DELAY });
             await page.waitForFunction(
               `document.querySelector("${selector} > :first-child").checked`
             );
@@ -272,7 +275,7 @@ describe("Link annotations with internal destinations", () => {
           expect(linkTitle)
             .withContext(`In ${browserName}`)
             .toEqual("Go to the last page");
-          await page.click(linkSelector);
+          await page.click(linkSelector, { delay: CLICK_DELAY });
           const pageSixTextLayerSelector =
             ".page[data-page-number='6'] .textLayer";
           await page.waitForSelector(pageSixTextLayerSelector, {
@@ -312,9 +315,13 @@ describe("Annotation and storage", () => {
           // Text field.
           await page.type(getSelector("64R"), text1);
           // Checkbox.
-          await page.click("[data-annotation-id='65R']");
+          await page.click("[data-annotation-id='65R']", {
+            delay: CLICK_DELAY,
+          });
           // Radio.
-          await page.click("[data-annotation-id='67R']");
+          await page.click("[data-annotation-id='67R']", {
+            delay: CLICK_DELAY,
+          });
 
           for (const [pageNumber, textId, checkId, radio1Id, radio2Id] of [
             [2, "18R", "19R", "21R", "20R"],
@@ -351,9 +358,13 @@ describe("Annotation and storage", () => {
           // Text field.
           await page.type(getSelector("23R"), text2);
           // Checkbox.
-          await page.click("[data-annotation-id='24R']");
+          await page.click("[data-annotation-id='24R']", {
+            delay: CLICK_DELAY,
+          });
           // Radio.
-          await page.click("[data-annotation-id='25R']");
+          await page.click("[data-annotation-id='25R']", {
+            delay: CLICK_DELAY,
+          });
 
           for (const [pageNumber, textId, checkId, radio1Id, radio2Id] of [
             [1, "64R", "65R", "67R", "68R"],
@@ -417,13 +428,15 @@ describe("ResetForm action", () => {
             n => `[data-annotation-id='${n}R']`
           );
           for (const selector of selectors) {
-            await page.click(selector);
+            await page.click(selector, { delay: CLICK_DELAY });
           }
 
           await page.select(getSelector("78R"), "b");
           await page.select(getSelector("81R"), "f");
 
-          await page.click("[data-annotation-id='82R']");
+          await page.click("[data-annotation-id='82R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(`${getQuerySelector("63R")}.value === ""`);
 
           for (let i = 63; i <= 68; i++) {
@@ -467,13 +480,15 @@ describe("ResetForm action", () => {
             n => `[data-annotation-id='${n}R']`
           );
           for (const selector of selectors) {
-            await page.click(selector);
+            await page.click(selector, { delay: CLICK_DELAY });
           }
 
           await page.select(getSelector("78R"), "b");
           await page.select(getSelector("81R"), "f");
 
-          await page.click("[data-annotation-id='84R']");
+          await page.click("[data-annotation-id='84R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(`${getQuerySelector("63R")}.value === ""`);
 
           for (let i = 63; i <= 68; i++) {
@@ -536,7 +551,9 @@ describe("ResetForm action", () => {
       it("must check that the FreeText annotation has a popup", async () => {
         await Promise.all(
           pages.map(async ([browserName, page]) => {
-            await page.click("[data-annotation-id='10R']");
+            await page.click("[data-annotation-id='10R']", {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `document.querySelector("[data-annotation-id='10R']").hidden === false`
             );
@@ -567,11 +584,11 @@ describe("ResetForm action", () => {
             await page.waitForFunction(
               `document.querySelector("[data-annotation-id='25R']").hidden === false`
             );
-            await page.click("#editorFreeText");
+            await page.click("#editorFreeText", { delay: CLICK_DELAY });
             await page.waitForFunction(
               `document.querySelector("[data-annotation-id='25R']").hidden === true`
             );
-            await page.click("#editorFreeText");
+            await page.click("#editorFreeText", { delay: CLICK_DELAY });
             await page.waitForFunction(
               `document.querySelector("[data-annotation-id='25R']").hidden === false`
             );

--- a/test/integration/autolinker_spec.mjs
+++ b/test/integration/autolinker_spec.mjs
@@ -15,6 +15,7 @@
 
 import {
   awaitPromise,
+  CLICK_DELAY,
   closePages,
   createPromise,
   loadAndWait,
@@ -240,7 +241,7 @@ describe("autolinker", function () {
           const linkAnnotationsPromise = await waitForLinkAnnotations(page, 36);
 
           // Search for "rich.edu"
-          await page.click("#viewFindButton");
+          await page.click("#viewFindButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#viewFindButton", { hidden: false });
           await page.type("#findInput", "rich.edu");
           await page.waitForSelector(".textLayer .highlight");

--- a/test/integration/caret_browsing_spec.mjs
+++ b/test/integration/caret_browsing_spec.mjs
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 
-import { closePages, getRect, loadAndWait } from "./test_utils.mjs";
+import {
+  CLICK_DELAY,
+  closePages,
+  getRect,
+  loadAndWait,
+} from "./test_utils.mjs";
 
 const waitForSelectionChange = (page, selection) =>
   page.waitForFunction(
@@ -45,7 +50,7 @@ describe("Caret browsing", () => {
           await page.mouse.click(
             spanRect.x + 1,
             spanRect.y + spanRect.height / 2,
-            { count: 2 }
+            { count: 2, delay: CLICK_DELAY }
           );
           await page.keyboard.down("Shift");
           for (let i = 0; i < 6; i++) {

--- a/test/integration/document_properties_spec.mjs
+++ b/test/integration/document_properties_spec.mjs
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { closePages, FSI, loadAndWait, PDI } from "./test_utils.mjs";
+import {
+  CLICK_DELAY,
+  closePages,
+  FSI,
+  loadAndWait,
+  PDI,
+} from "./test_utils.mjs";
 
 const FIELDS = [
   "fileName",
@@ -61,10 +67,12 @@ describe("PDFDocumentProperties", () => {
     it("must check that the document properties dialog has the correct information", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("#secondaryToolbarToggleButton");
+          await page.click("#secondaryToolbarToggleButton", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#secondaryToolbar", { hidden: false });
 
-          await page.click("#documentProperties");
+          await page.click("#documentProperties", { delay: CLICK_DELAY });
           await page.waitForSelector("#documentPropertiesDialog", {
             hidden: false,
           });

--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { closePages, FSI, loadAndWait, PDI } from "./test_utils.mjs";
+import {
+  CLICK_DELAY,
+  closePages,
+  FSI,
+  loadAndWait,
+  PDI,
+} from "./test_utils.mjs";
 
 function fuzzyMatch(a, b, browserName, pixelFuzz = 3) {
   expect(a)
@@ -40,10 +46,10 @@ describe("find bar", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           // Highlight all occurrences of the letter A (case insensitive).
-          await page.click("#viewFindButton");
+          await page.click("#viewFindButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#findInput", { visible: true });
           await page.type("#findInput", "a");
-          await page.click("#findHighlightAll + label");
+          await page.click("#findHighlightAll + label", { delay: CLICK_DELAY });
           await page.waitForSelector(".textLayer .highlight");
 
           // The PDF file contains the text 'AB BA' in a monospace font on a
@@ -100,7 +106,7 @@ describe("find bar", () => {
     it("must search xfa correctly", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("#viewFindButton");
+          await page.click("#viewFindButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#findInput", { visible: true });
           await page.type("#findInput", "preferences");
           await page.waitForSelector("#findInput[data-status='']");
@@ -138,7 +144,7 @@ describe("find bar", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           // Search for "40"
-          await page.click("#viewFindButton");
+          await page.click("#viewFindButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#findInput", { visible: true });
           await page.type("#findInput", "40");
 

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -16,6 +16,7 @@
 import {
   awaitPromise,
   clearEditors,
+  CLICK_DELAY,
   closePages,
   copy,
   copyToClipboard,
@@ -103,7 +104,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -143,7 +146,9 @@ describe("FreeText Editor", () => {
         const rect = await getRect(page, ".annotationEditorLayer");
         const firstEditorSelector = getEditorSelector(0);
         const data = "Hello PDF.js World !!";
-        await page.mouse.click(rect.x + 100, rect.y + 100);
+        await page.mouse.click(rect.x + 100, rect.y + 100, {
+          delay: CLICK_DELAY,
+        });
         await page.waitForSelector(firstEditorSelector, { visible: true });
         await page.type(`${firstEditorSelector} .internal`, data);
         await commit(page);
@@ -188,7 +193,9 @@ describe("FreeText Editor", () => {
           for (const n of [0, 1, 2]) {
             const editorSelector = getEditorSelector(n);
             const data = "Hello PDF.js World !!";
-            await page.mouse.click(rect.x + 100 * n, rect.y + 100 * n);
+            await page.mouse.click(rect.x + 100 * n, rect.y + 100 * n, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
@@ -223,7 +230,9 @@ describe("FreeText Editor", () => {
         const rect = await getRect(page, ".annotationEditorLayer");
         let editorSelector = getEditorSelector(0);
         const data = "Hello PDF.js World !!";
-        await page.mouse.click(rect.x + 100, rect.y + 100);
+        await page.mouse.click(rect.x + 100, rect.y + 100, {
+          delay: CLICK_DELAY,
+        });
         await page.waitForSelector(editorSelector, { visible: true });
         await page.type(`${editorSelector} .internal`, data);
         await commit(page);
@@ -285,7 +294,8 @@ describe("FreeText Editor", () => {
           const data = "Hello PDF.js World !!";
           await page.mouse.click(
             stacksRect.x + stacksRect.width + 1,
-            stacksRect.y + stacksRect.height / 2
+            stacksRect.y + stacksRect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
@@ -312,7 +322,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -342,7 +354,7 @@ describe("FreeText Editor", () => {
           /* await page.mouse.click(
             editorRect.x + editorRect.width / 2,
             editorRect.y + editorRect.height / 2,
-            { button: "right" }
+            { button: "right", delay: CLICK_DELAY }
           ); */
         })
       );
@@ -355,7 +367,9 @@ describe("FreeText Editor", () => {
 
         const rect = await getRect(page, ".annotationEditorLayer");
         const editorSelector = getEditorSelector(0);
-        await page.mouse.click(rect.x + 200, rect.y + 100);
+        await page.mouse.click(rect.x + 200, rect.y + 100, {
+          delay: CLICK_DELAY,
+        });
         await page.waitForSelector(editorSelector, { visible: true });
 
         for (let i = 0; i < 5; i++) {
@@ -455,7 +469,9 @@ describe("FreeText Editor", () => {
         for (let i = 0; i < 4; i++) {
           const editorSelector = getEditorSelector(i);
           const data = `FreeText ${i}`;
-          await page.mouse.click(lastX, rect.y + rect.height / 10);
+          await page.mouse.click(lastX, rect.y + rect.height / 10, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -476,21 +492,27 @@ describe("FreeText Editor", () => {
 
         // Unselect the editor.
         await kbModifierDown(page);
-        await page.mouse.click(editorCenters[1].x, editorCenters[1].y);
+        await page.mouse.click(editorCenters[1].x, editorCenters[1].y, {
+          delay: CLICK_DELAY,
+        });
         await waitForUnselectedEditor(page, getEditorSelector(1));
 
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 2, 3]);
 
-        await page.mouse.click(editorCenters[2].x, editorCenters[2].y);
+        await page.mouse.click(editorCenters[2].x, editorCenters[2].y, {
+          delay: CLICK_DELAY,
+        });
         await waitForUnselectedEditor(page, getEditorSelector(2));
 
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([0, 3]);
 
-        await page.mouse.click(editorCenters[1].x, editorCenters[1].y);
+        await page.mouse.click(editorCenters[1].x, editorCenters[1].y, {
+          delay: CLICK_DELAY,
+        });
         await kbModifierUp(page);
         await waitForSelectedEditor(page, getEditorSelector(1));
 
@@ -508,13 +530,17 @@ describe("FreeText Editor", () => {
           .toEqual([4, 5, 6]);
 
         // No ctrl here, hence all are unselected and 2 is selected.
-        await page.mouse.click(editorCenters[2].x, editorCenters[2].y);
+        await page.mouse.click(editorCenters[2].x, editorCenters[2].y, {
+          delay: CLICK_DELAY,
+        });
         await waitForSelectedEditor(page, getEditorSelector(2));
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
           .toEqual([2]);
 
-        await page.mouse.click(editorCenters[1].x, editorCenters[1].y);
+        await page.mouse.click(editorCenters[1].x, editorCenters[1].y, {
+          delay: CLICK_DELAY,
+        });
         await waitForSelectedEditor(page, getEditorSelector(1));
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
@@ -522,7 +548,9 @@ describe("FreeText Editor", () => {
 
         await kbModifierDown(page);
 
-        await page.mouse.click(editorCenters[3].x, editorCenters[3].y);
+        await page.mouse.click(editorCenters[3].x, editorCenters[3].y, {
+          delay: CLICK_DELAY,
+        });
         await waitForSelectedEditor(page, getEditorSelector(3));
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
@@ -547,7 +575,8 @@ describe("FreeText Editor", () => {
         // Create an empty editor.
         await page.mouse.click(
           rect.x + (rect.width / 10) * 7,
-          rect.y + rect.height / 10
+          rect.y + rect.height / 10,
+          { delay: CLICK_DELAY }
         );
         await page.waitForSelector(getEditorSelector(7), { visible: true });
         expect(await getEditors(page, "selected"))
@@ -555,7 +584,9 @@ describe("FreeText Editor", () => {
           .toEqual([7]);
 
         // Set the focus to 2 and check that only 2 is selected.
-        await page.mouse.click(editorCenters[2].x, editorCenters[2].y);
+        await page.mouse.click(editorCenters[2].x, editorCenters[2].y, {
+          delay: CLICK_DELAY,
+        });
         await waitForSelectedEditor(page, getEditorSelector(2));
         expect(await getEditors(page, "selected"))
           .withContext(`In ${browserName}`)
@@ -564,7 +595,8 @@ describe("FreeText Editor", () => {
         // Create an empty editor.
         await page.mouse.click(
           rect.x + (rect.width / 10) * 8,
-          rect.y + rect.height / 10
+          rect.y + rect.height / 10,
+          { delay: CLICK_DELAY }
         );
         await page.waitForSelector(getEditorSelector(8), { visible: true });
         expect(await getEditors(page, "selected"))
@@ -625,7 +657,9 @@ describe("FreeText Editor", () => {
             const editorSelector = getEditorSelector(currentId);
             const data = `Hello PDF.js World !! on page ${pageNumber}`;
             expected.push(data);
-            await page.mouse.click(rect.x + 100, rect.y + 100);
+            await page.mouse.click(rect.x + 100, rect.y + 100, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
@@ -757,7 +791,7 @@ describe("FreeText Editor", () => {
             const data = `Hello ${step}`;
             const x = Math.max(rect.x + 0.1 * rect.width, 10);
             const y = Math.max(rect.y + 0.1 * rect.height, 10);
-            await page.mouse.click(x, y);
+            await page.mouse.click(x, y, { delay: CLICK_DELAY });
             await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
@@ -965,7 +999,9 @@ describe("FreeText Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           // Show the popup on "Hello World from Firefox"
-          await page.click("[data-annotation-id='32R']");
+          await page.click("[data-annotation-id='32R']", {
+            delay: CLICK_DELAY,
+          });
           const popupSelector = "[data-annotation-id='popup_32R']";
           await page.waitForSelector(popupSelector, { visible: true });
 
@@ -1091,7 +1127,9 @@ describe("FreeText Editor", () => {
     it("must delete an existing annotation with a popup", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("[data-annotation-id='26R']");
+          await page.click("[data-annotation-id='26R']", {
+            delay: CLICK_DELAY,
+          });
           // Wait for the popup to be displayed.
           const popupSelector = "[data-annotation-id='popup_26R'] .popup";
           await page.waitForSelector(popupSelector, { visible: true });
@@ -1136,7 +1174,9 @@ describe("FreeText Editor", () => {
           const popupAreaSelector =
             "[data-annotation-id='26R'].popupTriggerArea";
           await page.waitForSelector(popupAreaSelector, { visible: true });
-          await page.click("[data-annotation-id='26R']");
+          await page.click("[data-annotation-id='26R']", {
+            delay: CLICK_DELAY,
+          });
           // Wait for the popup to be displayed.
           await page.waitForSelector(popupSelector, { visible: true });
         })
@@ -1187,7 +1227,10 @@ describe("FreeText Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const modeChangedHandle = await waitForAnnotationModeChanged(page);
-          await page.click("[data-annotation-id='26R']", { count: 2 });
+          await page.click("[data-annotation-id='26R']", {
+            count: 2,
+            delay: CLICK_DELAY,
+          });
           await awaitPromise(modeChangedHandle);
           await page.waitForSelector(`${getEditorSelector(0)}-editor`);
 
@@ -1240,7 +1283,9 @@ describe("FreeText Editor", () => {
     it("must hide the popup when editing", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("[data-annotation-id='20R']");
+          await page.click("[data-annotation-id='20R']", {
+            delay: CLICK_DELAY,
+          });
           // Wait for the popup to be displayed.
           await page.waitForFunction(
             () =>
@@ -1296,7 +1341,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -1405,7 +1452,9 @@ describe("FreeText Editor", () => {
             const rect = await getRect(page, annotationLayerSelector);
             const editorSelector = getEditorSelector(currentId);
             const data = `Hello PDF.js World !! on page ${pageNumber}`;
-            await page.mouse.click(rect.x + 100, rect.y + 100);
+            await page.mouse.click(rect.x + 100, rect.y + 100, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
@@ -1747,7 +1796,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -1792,7 +1843,9 @@ describe("FreeText Editor", () => {
 
           const data = "Hello PDF.js World !!";
           const editorSelector = getEditorSelector(0);
-          await page.mouse.click(rect.x + 200, rect.y + 200);
+          await page.mouse.click(rect.x + 200, rect.y + 200, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -1854,7 +1907,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
           const editorSelector = getEditorSelector(0);
-          await page.mouse.click(rect.x + 200, rect.y + 200);
+          await page.mouse.click(rect.x + 200, rect.y + 200, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -1892,7 +1947,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
           let editorSelector = getEditorSelector(0);
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -1901,7 +1958,9 @@ describe("FreeText Editor", () => {
 
           await clearAll(page);
           editorSelector = getEditorSelector(1);
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
 
           await moveEditor(page, editorSelector, 20, () =>
@@ -1966,7 +2025,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await cancelFocusIn(page, editorSelector);
@@ -2019,7 +2080,9 @@ describe("FreeText Editor", () => {
           let rect = await getRect(page, ".annotationEditorLayer");
 
           const firstEditorSelector = getEditorSelector(0);
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(firstEditorSelector, { visible: true });
           await page.type(`${firstEditorSelector} .internal`, "A");
           await commit(page);
@@ -2029,7 +2092,8 @@ describe("FreeText Editor", () => {
           const secondEditorSelector = getEditorSelector(1);
           await page.mouse.click(
             rect.x + 5 * rect.width,
-            rect.y + 5 * rect.height
+            rect.y + 5 * rect.height,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(secondEditorSelector, { visible: true });
           await page.type(`${secondEditorSelector} .internal`, "B");
@@ -2097,7 +2161,9 @@ describe("FreeText Editor", () => {
 
           for (let i = 0; i < 10; i++) {
             const editorSelector = getEditorSelector(i);
-            await page.mouse.click(rect.x + 10 + 30 * i, rect.y + 100 + 5 * i);
+            await page.mouse.click(rect.x + 10 + 30 * i, rect.y + 100 + 5 * i, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector(editorSelector, { visible: true });
             await page.type(
               `${editorSelector} .internal`,
@@ -2157,7 +2223,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await cancelFocusIn(page, editorSelector);
@@ -2209,7 +2277,9 @@ describe("FreeText Editor", () => {
           const page1Selector = `.page[data-page-number = "1"] > .annotationEditorLayer.freetextEditing`;
           let rect = await getRect(page, page1Selector);
           const firstEditorSelector = getEditorSelector(0);
-          await page.mouse.click(rect.x + 10, rect.y + 10);
+          await page.mouse.click(rect.x + 10, rect.y + 10, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(firstEditorSelector, { visible: true });
           await page.type(`${firstEditorSelector} .internal`, "Hello");
           await cancelFocusIn(page, firstEditorSelector);
@@ -2232,7 +2302,9 @@ describe("FreeText Editor", () => {
 
           rect = await getRect(page, page14Selector);
           const secondEditorSelector = getEditorSelector(1);
-          await page.mouse.click(rect.x + 10, rect.y + 10);
+          await page.mouse.click(rect.x + 10, rect.y + 10, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(secondEditorSelector, { visible: true });
           await page.type(`${secondEditorSelector} .internal`, "World");
           await commit(page);
@@ -2278,7 +2350,9 @@ describe("FreeText Editor", () => {
           const page1Selector = `.page[data-page-number = "1"] > .annotationEditorLayer.freetextEditing`;
           const rect = await getRect(page, page1Selector);
           const editorSelector = getEditorSelector(0);
-          await page.mouse.click(rect.x + 10, rect.y + 10);
+          await page.mouse.click(rect.x + 10, rect.y + 10, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, "Hello");
           await cancelFocusIn(page, editorSelector);
@@ -2350,7 +2424,8 @@ describe("FreeText Editor", () => {
           }, parentId);
           await page.mouse.click(
             rect.x + rect.width + 5,
-            rect.y + rect.height / 2
+            rect.y + rect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, "Hello Wolrd");
@@ -2384,18 +2459,21 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           const internalEditorSelector = `${editorSelector} .internal`;
           await page.type(internalEditorSelector, data);
           await commit(page);
 
-          await page.click(editorSelector, { count: 2 });
+          await page.click(editorSelector, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(
             `${editorSelector} .overlay:not(.enabled)`
           );
           await page.click(internalEditorSelector, {
             count: 3,
+            delay: CLICK_DELAY,
           });
           const selection = await page.evaluate(() =>
             document.getSelection().toString()
@@ -2531,7 +2609,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -2541,7 +2621,7 @@ describe("FreeText Editor", () => {
               once: true,
             });
           });
-          await page.click("#pageNumber");
+          await page.click("#pageNumber", { delay: CLICK_DELAY });
           await awaitPromise(handle);
 
           handle = await createPromise(page, resolve => {
@@ -2585,13 +2665,17 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
 
           // Delete it in using the button.
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             sel => !document.querySelector(sel),
             {},
@@ -2631,7 +2715,9 @@ describe("FreeText Editor", () => {
 
           for (let i = 1; i <= 2; i++) {
             const editorSelector = getEditorSelector(i - 1);
-            await page.mouse.click(rect.x + i * 100, rect.y + i * 100);
+            await page.mouse.click(rect.x + i * 100, rect.y + i * 100, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector(editorSelector, { visible: true });
             await page.type(`${editorSelector} .internal`, data);
             await commit(page);
@@ -2680,7 +2766,7 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const editorSelector = getEditorSelector(0);
-          await page.click(editorSelector, { count: 2 });
+          await page.click(editorSelector, { count: 2, delay: CLICK_DELAY });
           await page.type(`${editorSelector} .internal`, "C");
 
           await switchToFreeText(page, /* disable = */ true);
@@ -2711,7 +2797,7 @@ describe("FreeText Editor", () => {
           await switchToFreeText(page);
 
           const editorSelector = getEditorSelector(0);
-          await page.click(editorSelector, { count: 2 });
+          await page.click(editorSelector, { count: 2, delay: CLICK_DELAY });
           await page.type(`${editorSelector} .internal`, "Z");
 
           await switchToFreeText(page, /* disable = */ true);
@@ -2744,7 +2830,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello\nPDF.js\nWorld\n!!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -2778,7 +2866,9 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -2879,14 +2969,18 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           const twoToFourteen = Array.from(new Array(13).keys(), n => n + 2);
@@ -2929,14 +3023,18 @@ describe("FreeText Editor", () => {
           const rect = await getRect(page, ".annotationEditorLayer");
           const editorSelector = getEditorSelector(0);
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           const twoToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
@@ -2975,7 +3073,9 @@ describe("FreeText Editor", () => {
 
         let editorSelector = getEditorSelector(0);
         const data = "Hello PDF.js World !!";
-        await page.mouse.click(rect.x + 100, rect.y + 100);
+        await page.mouse.click(rect.x + 100, rect.y + 100, {
+          delay: CLICK_DELAY,
+        });
         await page.waitForSelector(editorSelector, { visible: true });
         await page.type(`${editorSelector} .internal`, data);
         await commit(page);
@@ -3061,7 +3161,9 @@ describe("FreeText Editor", () => {
         await commit(page);
 
         editorSelector = getEditorSelector(1);
-        await page.mouse.click(rect.x + 200, rect.y + 200);
+        await page.mouse.click(rect.x + 200, rect.y + 200, {
+          delay: CLICK_DELAY,
+        });
         await page.waitForSelector(editorSelector, { visible: true });
 
         const fooBar = "Foo\nBar\nOof";
@@ -3228,7 +3330,9 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
 
           const data = "Hello\nPDF.js\nWorld\n!!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           for (const line of data.split("\n")) {
             await page.type(`${editorSelector} .internal`, line);
@@ -3265,21 +3369,25 @@ describe("FreeText Editor", () => {
 
           const rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           await page.waitForSelector("#editorUndoBarUndoButton", {
             visible: true,
           });
-          await page.click("#editorUndoBarUndoButton");
+          await page.click("#editorUndoBarUndoButton", { delay: CLICK_DELAY });
           await waitForSerialized(page, 1);
           await page.waitForSelector(editorSelector);
         })
@@ -3293,14 +3401,18 @@ describe("FreeText Editor", () => {
 
           const rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await page.waitForFunction(() => {
@@ -3326,21 +3438,27 @@ describe("FreeText Editor", () => {
 
           let rect = await getRect(page, ".annotationEditorLayer");
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await page.waitForSelector("#editorUndoBar", { visible: true });
           rect = await getRect(page, ".annotationEditorLayer");
           const secondEditorSelector = getEditorSelector(1);
           const newData = "This is a new text box!";
-          await page.mouse.click(rect.x + 150, rect.y + 150);
+          await page.mouse.click(rect.x + 150, rect.y + 150, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(secondEditorSelector, { visible: true });
           await page.type(`${secondEditorSelector} .internal`, newData);
           await commit(page);
@@ -3371,7 +3489,9 @@ describe("FreeText Editor", () => {
           const editorSelector = getEditorSelector(0);
 
           const data = "Hello PDF.js World !!";
-          await page.mouse.click(rect.x + 100, rect.y + 100);
+          await page.mouse.click(rect.x + 100, rect.y + 100, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
           await commit(page);
@@ -3383,9 +3503,11 @@ describe("FreeText Editor", () => {
           );
           expect(alignment).withContext(`In ${browserName}`).toEqual("start");
 
-          await page.click("#secondaryToolbarToggleButton");
+          await page.click("#secondaryToolbarToggleButton", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#secondaryToolbar", { visible: true });
-          await page.click("#spreadOdd");
+          await page.click("#spreadOdd", { delay: CLICK_DELAY });
           await page.waitForSelector("#secondaryToolbar", { visible: false });
           await page.waitForSelector(".spread");
 
@@ -3421,7 +3543,8 @@ describe("FreeText Editor", () => {
           const data = "Hello PDF.js World !!";
           await page.mouse.click(
             rect.x + rect.width / 2,
-            rect.y + rect.height / 2
+            rect.y + rect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
@@ -3441,7 +3564,7 @@ describe("FreeText Editor", () => {
           await page.mouse.click(
             editorRect.x + editorRect.width / 2,
             editorRect.y + editorRect.height / 2,
-            { count: 2 }
+            { count: 2, delay: CLICK_DELAY }
           );
 
           await page.waitForSelector(".annotationEditorLayer.freetextEditing");
@@ -3461,7 +3584,8 @@ describe("FreeText Editor", () => {
           const data = "Hello PDF.js World !!";
           await page.mouse.click(
             rect.x + rect.width / 2,
-            rect.y + rect.height / 2
+            rect.y + rect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);
@@ -3495,7 +3619,8 @@ describe("FreeText Editor", () => {
           const editorRect = await getRect(page, editorSelector);
           await page.mouse.click(
             editorRect.x + editorRect.width / 2,
-            editorRect.y + editorRect.height / 2
+            editorRect.y + editorRect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(".annotationEditorLayer.freetextEditing");
           await awaitPromise(modeChangedHandle);
@@ -3525,7 +3650,8 @@ describe("FreeText Editor", () => {
           const data = "Hello PDF.js World !!";
           await page.mouse.click(
             rect.x + rect.width / 2,
-            rect.y + rect.height / 2
+            rect.y + rect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(editorSelector, { visible: true });
           await page.type(`${editorSelector} .internal`, data);

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -15,6 +15,7 @@
 
 import {
   awaitPromise,
+  CLICK_DELAY,
   closePages,
   getEditorSelector,
   getFirstSerialized,
@@ -70,11 +71,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          // Here and elsewhere, we add a small delay between press and release
-          // to make sure that a pointerup event is triggered after
-          // selectionchange.
-          // It works with a value of 1ms, but we use 100ms to be sure.
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
 
@@ -120,7 +117,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
           await page.waitForSelector(
@@ -170,7 +167,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
           await page.waitForSelector(
@@ -215,7 +212,7 @@ describe("Highlight Editor", () => {
           let rect = await getSpanRectFromText(page, 1, "Abstract");
           let x = rect.x + rect.width / 2;
           let y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
           await page.waitForSelector(
@@ -238,7 +235,7 @@ describe("Highlight Editor", () => {
           rect = await getSpanRectFromText(page, 14, "References");
           x = rect.x + rect.width / 2;
           y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(1);
           await page.waitForSelector(editorSelector);
@@ -249,12 +246,16 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(
             `${editorSelector} .editToolbar button.colorPicker`
           );
-          await page.click(`${editorSelector} .editToolbar button.colorPicker`);
+          await page.click(
+            `${editorSelector} .editToolbar button.colorPicker`,
+            { delay: CLICK_DELAY }
+          );
           await page.waitForSelector(
             `${editorSelector} .editToolbar button[title = "Green"]`
           );
           await page.click(
-            `${editorSelector} .editToolbar button[title = "Green"]`
+            `${editorSelector} .editToolbar button[title = "Green"]`,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(
             `.page[data-page-number = "14"] svg.highlight[fill = "#53FFBC"]`
@@ -303,7 +304,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
           await page.waitForSelector(
@@ -364,7 +365,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(sel);
           await page.waitForSelector(
@@ -372,11 +373,15 @@ describe("Highlight Editor", () => {
           );
 
           await page.waitForSelector(`${sel} .editToolbar button.colorPicker`);
-          await page.click(`${sel} .editToolbar button.colorPicker`);
+          await page.click(`${sel} .editToolbar button.colorPicker`, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(
             `${sel} .editToolbar button[title = "Red"]`
           );
-          await page.click(`${sel} .editToolbar button[title = "Red"]`);
+          await page.click(`${sel} .editToolbar button[title = "Red"]`, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(
             `.page[data-page-number = "1"] svg.highlight[fill = "#FF0000"]`
           );
@@ -474,7 +479,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
@@ -522,7 +527,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(sel);
           await page.waitForSelector(
@@ -530,11 +535,13 @@ describe("Highlight Editor", () => {
           );
 
           await page.waitForSelector(`${sel} .editToolbar button.colorPicker`);
-          await page.click(`${sel} .editToolbar button.colorPicker`);
+          await page.click(`${sel} .editToolbar button.colorPicker`, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(
             `${sel} .editToolbar button[title = "Red"]`
           );
-          await page.mouse.click(x, y - rect.height);
+          await page.mouse.click(x, y - rect.height, { delay: CLICK_DELAY });
           await page.waitForSelector(
             `${sel} .editToolbar button.colorPicker .dropdown.hidden`
           );
@@ -563,7 +570,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(sel);
           await page.waitForSelector(
@@ -571,7 +578,7 @@ describe("Highlight Editor", () => {
           );
 
           await page.waitForSelector(`${sel} .editToolbar button.colorPicker`);
-          await page.mouse.click(x, y - rect.height);
+          await page.mouse.click(x, y - rect.height, { delay: CLICK_DELAY });
           await page.waitForSelector(
             `.page[data-page-number = "1"] svg.highlightOutline:not(.selected)`
           );
@@ -685,7 +692,7 @@ describe("Highlight Editor", () => {
           await page.mouse.click(
             spanRect.x + 1,
             spanRect.y + spanRect.height / 2,
-            { count: 2 }
+            { count: 2, delay: CLICK_DELAY }
           );
           for (let i = 0; i < 6; i++) {
             await page.keyboard.press("ArrowRight");
@@ -836,7 +843,7 @@ describe("Highlight Editor", () => {
           );
           const x = rect.x + 0.75 * rect.width;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(`${getEditorSelector(0)}`);
           const usedColor = await page.evaluate(() => {
@@ -932,7 +939,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForFunction(() => window.editingEvents.length > 0);
 
           let editingEvent = await page.evaluate(() => {
@@ -948,7 +955,9 @@ describe("Highlight Editor", () => {
             .toBe(true);
 
           // Click somewhere to unselect the current selection.
-          await page.mouse.click(rect.x + rect.width + 10, y, { count: 1 });
+          await page.mouse.click(rect.x + rect.width + 10, y, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(() => window.editingEvents.length > 0);
           editingEvent = await page.evaluate(() => {
             const e = window.editingEvents[0];
@@ -959,7 +968,7 @@ describe("Highlight Editor", () => {
             .withContext(`In ${browserName}`)
             .toBe(false);
 
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForFunction(() => window.editingEvents.length > 0);
 
           await page.evaluate(() => {
@@ -1016,7 +1025,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
@@ -1084,7 +1093,9 @@ describe("Highlight Editor", () => {
             1,
             "Dynamic languages such as JavaScript are more difﬁcult to com-"
           );
-          await page.mouse.click(rect.x + 5, rect.y + rect.height / 2);
+          await page.mouse.click(rect.x + 5, rect.y + rect.height / 2, {
+            delay: CLICK_DELAY,
+          });
           await page.keyboard.down("Shift");
           for (let i = 0; i < 10; i++) {
             await page.keyboard.press("ArrowRight");
@@ -1115,7 +1126,8 @@ describe("Highlight Editor", () => {
           );
           await page.mouse.click(
             rect.x + rect.width / 2,
-            rect.y + rect.height / 2
+            rect.y + rect.height / 2,
+            { delay: CLICK_DELAY }
           );
           await page.keyboard.down("Shift");
           for (let i = 0; i < 10; i++) {
@@ -1163,7 +1175,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
@@ -1199,7 +1211,7 @@ describe("Highlight Editor", () => {
           await page.mouse.click(
             rect.x + rect.width / 2,
             rect.y + rect.height / 2,
-            { count: 2, delay: 100 }
+            { count: 2, delay: CLICK_DELAY }
           );
 
           const editorSelector = getEditorSelector(0);
@@ -1219,7 +1231,7 @@ describe("Highlight Editor", () => {
             "#editorFreeHighlightThickness:not([disabled])"
           );
 
-          await page.click(editorSelector);
+          await page.click(editorSelector, { delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await page.waitForSelector("#editorFreeHighlightThickness[disabled]");
 
@@ -1254,7 +1266,7 @@ describe("Highlight Editor", () => {
           await page.mouse.click(
             rect.x + rect.width / 2,
             rect.y + rect.height / 2,
-            { count: 2, delay: 100 }
+            { count: 2, delay: CLICK_DELAY }
           );
 
           await page.waitForSelector(getEditorSelector(0));
@@ -1290,7 +1302,7 @@ describe("Highlight Editor", () => {
           await page.mouse.click(
             rect.x + rect.width / 4,
             rect.y + rect.height / 2,
-            { count: 2, delay: 100 }
+            { count: 2, delay: CLICK_DELAY }
           );
 
           await page.waitForSelector(getEditorSelector(0));
@@ -1325,7 +1337,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
@@ -1407,21 +1419,21 @@ describe("Highlight Editor", () => {
           await page.mouse.click(
             rect.x + rect.width / 2,
             rect.y + rect.height / 2,
-            { count: 2, delay: 100 }
+            { count: 2, delay: CLICK_DELAY }
           );
 
           const secondEditorSelector = getEditorSelector(1);
           await page.waitForSelector(secondEditorSelector);
 
-          await page.click("#editorHighlightShowAll");
+          await page.click("#editorHighlightShowAll", { delay: CLICK_DELAY });
           await page.waitForSelector(`${firstEditorSelector}.hidden`);
           await page.waitForSelector(`${secondEditorSelector}.hidden`);
 
-          await page.click("#editorHighlightShowAll");
+          await page.click("#editorHighlightShowAll", { delay: CLICK_DELAY });
           await page.waitForSelector(`${firstEditorSelector}:not(.hidden)`);
           await page.waitForSelector(`${secondEditorSelector}:not(.hidden)`);
 
-          await page.click("#editorHighlightShowAll");
+          await page.click("#editorHighlightShowAll", { delay: CLICK_DELAY });
           await page.waitForSelector(`${firstEditorSelector}.hidden`);
           await page.waitForSelector(`${secondEditorSelector}.hidden`);
 
@@ -1434,7 +1446,9 @@ describe("Highlight Editor", () => {
               `.page[data-page-number = "${pageNumber}"]`
             );
             if (pageNumber === 14) {
-              await page.click("#editorHighlightShowAll");
+              await page.click("#editorHighlightShowAll", {
+                delay: CLICK_DELAY,
+              });
             }
           }
 
@@ -1469,10 +1483,12 @@ describe("Highlight Editor", () => {
             const rect = await getSpanRectFromText(page, 1, text);
             const x = rect.x + rect.width / 2;
             const y = rect.y + rect.height / 2;
-            await page.mouse.click(x, y, { count: 2, delay: 100 });
+            await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
             await page.waitForSelector(".textLayer .highlightButton");
-            await page.click(".textLayer .highlightButton");
+            await page.click(".textLayer .highlightButton", {
+              delay: CLICK_DELAY,
+            });
 
             await page.waitForSelector(getEditorSelector(editorId));
             const usedColor = await page.evaluate(() => {
@@ -1516,13 +1532,13 @@ describe("Highlight Editor", () => {
           let rect = await getSpanRectFromText(page, 1, "Abstract");
           let x = rect.x + rect.width / 2;
           let y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(getEditorSelector(0));
 
           rect = await getSpanRectFromText(page, 1, "Languages");
           x = rect.x + rect.width / 2;
           y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(1);
           await page.waitForSelector(editorSelector);
@@ -1559,14 +1575,16 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await kbUndo(page);
@@ -1605,14 +1623,16 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           const twoToFourteen = Array.from(new Array(13).keys(), n => n + 2);
@@ -1667,14 +1687,16 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           const twoToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
@@ -1752,18 +1774,22 @@ describe("Highlight Editor", () => {
           const rect = await getRect(page, editorSelector);
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y);
+          await page.mouse.click(x, y, { delay: CLICK_DELAY });
 
           await page.waitForSelector(
             `${editorSelector} .editToolbar button.colorPicker`
           );
 
-          await page.click(`${editorSelector} .editToolbar button.colorPicker`);
+          await page.click(
+            `${editorSelector} .editToolbar button.colorPicker`,
+            { delay: CLICK_DELAY }
+          );
           await page.waitForSelector(
             `${editorSelector} .editToolbar button[title = "Green"]`
           );
           await page.click(
-            `${editorSelector} .editToolbar button[title = "Green"]`
+            `${editorSelector} .editToolbar button[title = "Green"]`,
+            { delay: CLICK_DELAY }
           );
           await page.waitForSelector(
             `.page[data-page-number = "1"] svg.highlight[fill = "#00FF00"]`
@@ -1793,7 +1819,7 @@ describe("Highlight Editor", () => {
           const editorSelector = getEditorSelector(0);
           const x = rect.x + rect.width / 2;
           let y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
           await unselectEditor(page, editorSelector);
@@ -1863,7 +1889,7 @@ describe("Highlight Editor", () => {
           const editorSelector = getEditorSelector(0);
           const x = Math.round(rect.x + rect.width / 2);
           let y = Math.round(rect.y + rect.height / 2);
-          await page.mouse.click(x, y, { count: 3, delay: 100 });
+          await page.mouse.click(x, y, { count: 3, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
           await unselectEditor(page, editorSelector);
@@ -1932,10 +1958,12 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "In production");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 3, delay: 100 });
+          await page.mouse.click(x, y, { count: 3, delay: CLICK_DELAY });
 
           await page.waitForSelector(".textLayer .highlightButton");
-          await page.click(".textLayer .highlightButton");
+          await page.click(".textLayer .highlightButton", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector(getEditorSelector(0));
           const usedColor = await page.evaluate(() => {
@@ -2023,7 +2051,9 @@ describe("Highlight Editor", () => {
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 1);
 
           const serialized = await getSerialized(page);
@@ -2066,7 +2096,10 @@ describe("Highlight Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const modeChangedHandle = await waitForAnnotationModeChanged(page);
-          await page.click("[data-annotation-id='693R']", { count: 2 });
+          await page.click("[data-annotation-id='693R']", {
+            count: 2,
+            delay: CLICK_DELAY,
+          });
           await awaitPromise(modeChangedHandle);
           await page.waitForSelector("#highlightParamsToolbarContainer");
 
@@ -2200,19 +2233,21 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           await page.waitForSelector("#editorUndoBarUndoButton", {
             visible: true,
           });
-          await page.click("#editorUndoBarUndoButton");
+          await page.click("#editorUndoBarUndoButton", { delay: CLICK_DELAY });
           await waitForSerialized(page, 1);
           await page.waitForSelector(editorSelector);
           await page.waitForSelector(
@@ -2230,19 +2265,21 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           await page.waitForSelector("#editorUndoBarUndoButton", {
             visible: true,
           });
-          await page.click("#editorUndoBarUndoButton");
+          await page.click("#editorUndoBarUndoButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#editorUndoBar", { hidden: true });
         })
       );
@@ -2256,19 +2293,21 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           await page.waitForSelector("#editorUndoBarCloseButton", {
             visible: true,
           });
-          await page.click("#editorUndoBarCloseButton");
+          await page.click("#editorUndoBarCloseButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#editorUndoBar", { hidden: true });
         })
       );
@@ -2282,19 +2321,21 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           const newRect = await getSpanRectFromText(page, 1, "Introduction");
           const newX = newRect.x + newRect.width / 2;
           const newY = newRect.y + newRect.height / 2;
-          await page.mouse.click(newX, newY, { count: 2, delay: 100 });
+          await page.mouse.click(newX, newY, { count: 2, delay: CLICK_DELAY });
 
           await page.waitForSelector(getEditorSelector(1));
           await page.waitForSelector("#editorUndoBar", { hidden: true });
@@ -2310,12 +2351,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -2333,16 +2376,18 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
-          await page.click("#printButton");
+          await page.click("#printButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#editorUndoBar", { hidden: true });
         })
       );
@@ -2356,12 +2401,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -2379,17 +2426,21 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
-          await page.click("#secondaryToolbarToggleButton");
-          await page.click("#lastPage");
+          await page.click("#secondaryToolbarToggleButton", {
+            delay: CLICK_DELAY,
+          });
+          await page.click("#lastPage", { delay: CLICK_DELAY });
           await page.waitForSelector("#editorUndoBar", { hidden: true });
         })
       );
@@ -2403,12 +2454,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -2426,12 +2479,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
           const pdfPath = path.join(__dirname, "../pdfs/basicapi.pdf");
@@ -2486,12 +2541,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await page.waitForFunction(() => {
@@ -2519,18 +2576,20 @@ describe("Highlight Editor", () => {
           let rect = await getSpanRectFromText(page, 1, "Abstract");
           let x = rect.x + rect.width / 2;
           let y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
 
           rect = await getSpanRectFromText(page, 1, "Languages");
           x = rect.x + rect.width / 2;
           y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(getEditorSelector(1));
 
           await selectAll(page);
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await page.waitForFunction(() => {
@@ -2563,12 +2622,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -2584,7 +2645,9 @@ describe("Highlight Editor", () => {
           );
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -2610,12 +2673,14 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           await page.waitForSelector(editorSelector);
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -2737,12 +2802,13 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
           const highlightSelector = `.page[data-page-number = "1"] .canvasWrapper > svg.highlight`;
           await page.waitForSelector(`${highlightSelector}[fill = "#AB0000"]`);
 
           await page.click(
-            "#editorHighlightColorPicker button[title = 'Blue']"
+            "#editorHighlightColorPicker button[title = 'Blue']",
+            { delay: CLICK_DELAY }
           );
 
           await page.waitForSelector(`${highlightSelector}[fill = "#0000AB"]`);
@@ -2781,7 +2847,7 @@ describe("Highlight Editor", () => {
           const rect = await getSpanRectFromText(page, 1, "Abstract");
           const x = rect.x + rect.width / 2;
           const y = rect.y + rect.height / 2;
-          await page.mouse.click(x, y, { count: 2, delay: 100 });
+          await page.mouse.click(x, y, { count: 2, delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector);

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -16,6 +16,7 @@
 import {
   awaitPromise,
   clearEditors,
+  CLICK_DELAY,
   closePages,
   dragAndDrop,
   getAnnotationSelector,
@@ -306,7 +307,9 @@ describe("Ink Editor", () => {
           await page.mouse.up();
           await awaitPromise(clickHandle);
 
-          await page.mouse.click(rect.x - 10, rect.y + 10);
+          await page.mouse.click(rect.x - 10, rect.y + 10, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector(`${getEditorSelector(0)}.disabled`);
         })
       );
@@ -346,7 +349,9 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await kbUndo(page);
@@ -390,7 +395,9 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           const twoToFourteen = Array.from(new Array(13).keys(), n => n + 2);
@@ -447,7 +454,9 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           const twoToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
@@ -842,7 +851,7 @@ describe("Ink Editor", () => {
           await page.mouse.click(
             inkRect.x + inkRect.width / 2,
             inkRect.y + inkRect.height / 2,
-            { count: 2 }
+            { count: 2, delay: CLICK_DELAY }
           );
           await awaitPromise(modeChangedHandle);
           const edgeB = getEditorSelector(10);
@@ -898,14 +907,16 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           await page.waitForSelector("#editorUndoBarUndoButton", {
             visible: true,
           });
-          await page.click("#editorUndoBarUndoButton");
+          await page.click("#editorUndoBarUndoButton", { delay: CLICK_DELAY });
           await waitForSerialized(page, 1);
           await page.waitForSelector(editorSelector);
         })
@@ -932,7 +943,9 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await page.waitForFunction(() => {
@@ -971,7 +984,9 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
@@ -1102,14 +1117,16 @@ describe("Ink Editor", () => {
           await waitForSerialized(page, 2);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 1);
           await page.waitForSelector("#editorUndoBar", { visible: true });
 
           await page.waitForSelector("#editorUndoBarUndoButton", {
             visible: true,
           });
-          await page.click("#editorUndoBarUndoButton");
+          await page.click("#editorUndoBarUndoButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#editorUndoBar", { hidden: true });
 
           editorSelector = getEditorSelector(0);
@@ -1269,7 +1286,8 @@ describe("Should switch from an editor and mode to others by double clicking", (
         const data = "Hello PDF.js World !!";
         await page.mouse.click(
           editorLayerRect.x + 200,
-          editorLayerRect.y + 200
+          editorLayerRect.y + 200,
+          { delay: CLICK_DELAY }
         );
         await page.waitForSelector(freeTextSelector, { visible: true });
         await page.type(`${freeTextSelector} .internal`, data);

--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -16,6 +16,7 @@
 import {
   awaitPromise,
   clearInput,
+  CLICK_DELAY,
   closePages,
   closeSinglePage,
   getAnnotationStorage,
@@ -111,7 +112,7 @@ describe("Interaction", () => {
           expect(visibility).withContext(`In ${browserName}`).toEqual("hidden");
 
           await page.type(getSelector("416R"), "3.14159");
-          await page.click(getSelector("419R"));
+          await page.click(getSelector("419R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             `${getComputedStyleSelector("427R")}.visibility !== "hidden"`
@@ -128,7 +129,7 @@ describe("Interaction", () => {
           // Clear the textfield
           await clearInput(page, getSelector("416R"));
           // and leave it
-          await page.click(getSelector("419R"));
+          await page.click(getSelector("419R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             `${getComputedStyleSelector("427R")}.visibility !== "visible"`
@@ -149,7 +150,7 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           await page.type(getSelector("416R"), "3.14159");
-          await page.click(getSelector("419R"));
+          await page.click(getSelector("419R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("416R")}.value === "3,14"`
           );
@@ -166,12 +167,12 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           await page.type(getSelector("448R"), "61803");
-          await page.click(getSelector("419R"));
+          await page.click(getSelector("419R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("448R")}.value === "61.803,00"`
           );
 
-          await page.click(getSelector("448R"));
+          await page.click(getSelector("448R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("448R")}.value === "61803"`
           );
@@ -180,7 +181,7 @@ describe("Interaction", () => {
           await clearInput(page, getSelector("448R"));
 
           await page.type(getSelector("448R"), "1.61803");
-          await page.click(getSelector("419R"));
+          await page.click(getSelector("419R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("448R")}.value === "1,62"`
           );
@@ -245,7 +246,9 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           // click on a radio button
-          await page.click("[data-annotation-id='449R']");
+          await page.click("[data-annotation-id='449R']", {
+            delay: CLICK_DELAY,
+          });
 
           // this field has no actions but it must be cleared on reset
           await page.type(getSelector("405R"), "employee");
@@ -254,7 +257,9 @@ describe("Interaction", () => {
           expect(checked).toEqual(true);
 
           // click on reset button
-          await page.click("[data-annotation-id='402R']");
+          await page.click("[data-annotation-id='402R']", {
+            delay: CLICK_DELAY,
+          });
 
           await Promise.all(
             ["416R", "422R", "419R", "405R"].map(id => {
@@ -314,7 +319,7 @@ describe("Interaction", () => {
             // Clear the textfield
             await clearInput(page, getSelector("80R"));
 
-            await page.click(getSelector(id));
+            await page.click(getSelector(id), { delay: CLICK_DELAY });
             await page.waitForFunction(
               `${getQuerySelector("80R")}.value !== ""`
             );
@@ -344,7 +349,7 @@ describe("Interaction", () => {
             // Clear the textfield
             await clearInput(page, getSelector("80R"));
 
-            await page.click(getSelector(id));
+            await page.click(getSelector(id), { delay: CLICK_DELAY });
             await page.waitForFunction(
               `${getQuerySelector("80R")}.value !== ""`
             );
@@ -371,7 +376,7 @@ describe("Interaction", () => {
             // Clear the textfield
             await clearInput(page, getSelector("80R"));
 
-            await page.click(getSelector(id));
+            await page.click(getSelector(id), { delay: CLICK_DELAY });
             await page.waitForFunction(
               `${getQuerySelector("80R")}.value !== ""`
             );
@@ -400,10 +405,12 @@ describe("Interaction", () => {
             await clearInput(page, getSelector("80R"));
 
             if (id) {
-              await page.click(getSelector(id));
+              await page.click(getSelector(id), { delay: CLICK_DELAY });
             }
 
-            await page.click("[data-annotation-id='97R']");
+            await page.click("[data-annotation-id='97R']", {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `${getQuerySelector("80R")}.value !== ""`
             );
@@ -442,7 +449,7 @@ describe("Interaction", () => {
             page,
             getSelector("47R"),
             async () => {
-              await page.click("#printButton");
+              await page.click("#printButton", { delay: CLICK_DELAY });
             }
           );
           expect(text).withContext(`In ${browserName}`).toEqual("WillPrint");
@@ -489,7 +496,7 @@ describe("Interaction", () => {
             page,
             getSelector("47R"),
             async () => {
-              await page.click("#downloadButton");
+              await page.click("#downloadButton", { delay: CLICK_DELAY });
             }
           );
           expect(text).withContext(`In ${browserName}`).toEqual("WillSave");
@@ -580,7 +587,9 @@ describe("Interaction", () => {
             page,
             getSelector("25R"),
             async () => {
-              await page.click("[data-annotation-id='26R']");
+              await page.click("[data-annotation-id='26R']", {
+                delay: CLICK_DELAY,
+              });
             }
           );
           expect(text)
@@ -609,7 +618,9 @@ describe("Interaction", () => {
 
           for (const num of [7, 6, 4, 3, 2, 1]) {
             await clearInput(page, getSelector("33R"));
-            await page.click(`option[value=Export${num}]`);
+            await page.click(`option[value=Export${num}]`, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `${getQuerySelector("33R")}.value !== ""`
             );
@@ -628,20 +639,26 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           // Click on ClearItems button.
-          await page.click("[data-annotation-id='34R']");
+          await page.click("[data-annotation-id='34R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `${getQuerySelector("30R")}.children.length === 0`
           );
 
           // Click on Restore button.
-          await page.click("[data-annotation-id='37R']");
+          await page.click("[data-annotation-id='37R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `${getQuerySelector("30R")}.children.length !== 0`
           );
 
           for (const num of [7, 6, 4, 3, 2, 1]) {
             await clearInput(page, getSelector("33R"));
-            await page.click(`option[value=Export${num}]`);
+            await page.click(`option[value=Export${num}]`, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `${getQuerySelector("33R")}.value !== ""`
             );
@@ -670,7 +687,9 @@ describe("Interaction", () => {
             );
 
             // Click on AddItem button.
-            await page.click("[data-annotation-id='38R']");
+            await page.click("[data-annotation-id='38R']", {
+              delay: CLICK_DELAY,
+            });
 
             await page.waitForFunction(
               `${getQuerySelector("30R")}.children.length === ${len}`
@@ -699,7 +718,9 @@ describe("Interaction", () => {
           let len = 6;
           // Click on Restore button.
           await clearInput(page, getSelector("33R"));
-          await page.click("[data-annotation-id='37R']");
+          await page.click("[data-annotation-id='37R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `${getQuerySelector("30R")}.children.length === ${len}`
           );
@@ -710,7 +731,9 @@ describe("Interaction", () => {
             await page.type(getSelector("39R"), `${num}`);
 
             // Click on DeleteItem button.
-            await page.click("[data-annotation-id='36R']");
+            await page.click("[data-annotation-id='36R']", {
+              delay: CLICK_DELAY,
+            });
 
             await page.waitForFunction(
               `${getQuerySelector("30R")}.children.length === ${len}`
@@ -719,7 +742,9 @@ describe("Interaction", () => {
 
           for (const num of [6, 4, 2, 1]) {
             await clearInput(page, getSelector("33R"));
-            await page.click(`option[value=Export${num}]`);
+            await page.click(`option[value=Export${num}]`, {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `${getQuerySelector("33R")}.value !== ""`
             );
@@ -781,7 +806,9 @@ describe("Interaction", () => {
                 propName
               );
 
-              await page.click(`[data-annotation-id='${id}R']`);
+              await page.click(`[data-annotation-id='${id}R']`, {
+                delay: CLICK_DELAY,
+              });
               await page.waitForFunction(
                 `${getComputedStyleSelector(
                   ref
@@ -891,7 +918,9 @@ describe("Interaction", () => {
           );
 
           // Click on execute button to eval the above code.
-          await page.click("[data-annotation-id='57R']");
+          await page.click("[data-annotation-id='57R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(`${getQuerySelector("56R")}.value !== ""`);
 
           const text = await page.$eval(getSelector("56R"), el => el.value);
@@ -922,7 +951,9 @@ describe("Interaction", () => {
               `this.getField("Text2").display = display.${type};`
             );
 
-            await page.click("[data-annotation-id='57R']");
+            await page.click("[data-annotation-id='57R']", {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `${getComputedStyleSelector(
                 "56R"
@@ -995,7 +1026,9 @@ describe("Interaction", () => {
             page,
             getSelector("25R"),
             async () => {
-              await page.click("[data-annotation-id='26R']");
+              await page.click("[data-annotation-id='26R']", {
+                delay: CLICK_DELAY,
+              });
             }
           );
           expect(text).withContext(`In ${browserName}`).toEqual("Standard");
@@ -1032,13 +1065,13 @@ describe("Interaction", () => {
 
         await page.focus(getSelector("29R"));
         await typeAndWaitForSandbox(page, getSelector("29R"), "34");
-        await page.click("[data-annotation-id='30R']");
+        await page.click("[data-annotation-id='30R']", { delay: CLICK_DELAY });
         await waitForSandboxTrip(page);
         await page.waitForFunction(`${getQuerySelector("29R")}.value === ""`);
 
         await page.focus(getSelector("29R"));
         await typeAndWaitForSandbox(page, getSelector("29R"), "12345");
-        await page.click("[data-annotation-id='30R']");
+        await page.click("[data-annotation-id='30R']", { delay: CLICK_DELAY });
         await waitForSandboxTrip(page);
         await page.waitForFunction(
           `${getQuerySelector("29R")}.value === "12345"`
@@ -1077,13 +1110,13 @@ describe("Interaction", () => {
 
         await page.focus(getSelector("30R"));
         await typeAndWaitForSandbox(page, getSelector("30R"), "-789");
-        await page.click("[data-annotation-id='29R']");
+        await page.click("[data-annotation-id='29R']", { delay: CLICK_DELAY });
         await waitForSandboxTrip(page);
         await page.waitForFunction(`${getQuerySelector("30R")}.value === ""`);
 
         await page.focus(getSelector("30R"));
         await typeAndWaitForSandbox(page, getSelector("30R"), "(123) 456-7890");
-        await page.click("[data-annotation-id='29R']");
+        await page.click("[data-annotation-id='29R']", { delay: CLICK_DELAY });
         await waitForSandboxTrip(page);
         await page.waitForFunction(
           `${getQuerySelector("30R")}.value === "(123) 456-7890"`
@@ -1122,13 +1155,13 @@ describe("Interaction", () => {
 
         await page.focus(getSelector("30R"));
         await typeAndWaitForSandbox(page, getSelector("30R"), "-456");
-        await page.click("[data-annotation-id='29R']");
+        await page.click("[data-annotation-id='29R']", { delay: CLICK_DELAY });
         await waitForSandboxTrip(page);
         await page.waitForFunction(`${getQuerySelector("30R")}.value === ""`);
 
         await page.focus(getSelector("30R"));
         await typeAndWaitForSandbox(page, getSelector("30R"), "123-4567");
-        await page.click("[data-annotation-id='29R']");
+        await page.click("[data-annotation-id='29R']", { delay: CLICK_DELAY });
         await waitForSandboxTrip(page);
         await page.waitForFunction(
           `${getQuerySelector("30R")}.value === "123-4567"`
@@ -1206,7 +1239,7 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page]) => {
           await waitForScripting(page);
 
-          await page.click(getSelector("28R"));
+          await page.click(getSelector("28R"), { delay: CLICK_DELAY });
           await page.keyboard.press("Home");
           await page.type(getSelector("28R"), "Hello");
           await page.waitForFunction(
@@ -1216,7 +1249,9 @@ describe("Interaction", () => {
           // The action triggers a `calculateNow` which in turn triggers a
           // `resetForm (inducing a `calculateNow`) and a `calculateNow`.
           // Without infinite loop prevention the field would be empty.
-          await page.click("[data-annotation-id='31R']");
+          await page.click("[data-annotation-id='31R']", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `${getQuerySelector("28R")}.value === "123"`
           );
@@ -1247,7 +1282,7 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           await page.type(getSelector("29R"), "Hello World");
-          await page.click(getSelector("27R"));
+          await page.click(getSelector("27R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             `${getQuerySelector("29R")}.value !== "Hello World"`
@@ -1256,7 +1291,7 @@ describe("Interaction", () => {
           let text = await page.$eval(getSelector("29R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("checked");
 
-          await page.click(getSelector("27R"));
+          await page.click(getSelector("27R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             `${getQuerySelector("29R")}.value !== "checked"`
@@ -1333,7 +1368,7 @@ describe("Interaction", () => {
             .withContext(`In ${browserName}`)
             .toEqual("visible");
 
-          await page.click(getSelector("44R"));
+          await page.click(getSelector("44R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `document.querySelector("[data-annotation-id='35R']").style.visibility === "hidden"`
           );
@@ -1393,7 +1428,7 @@ describe("Interaction", () => {
               );
             }
             base += 90;
-            await page.click(getSelector("48R"));
+            await page.click(getSelector("48R"), { delay: CLICK_DELAY });
           }
         })
       );
@@ -1422,7 +1457,7 @@ describe("Interaction", () => {
           await clearInput(page, getSelector("42R"));
           await typeAndWaitForSandbox(page, getSelector("42R"), "456");
 
-          await page.click(getSelector("45R"));
+          await page.click(getSelector("45R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             `${getQuerySelector("43R")}.value === "579.00"`
@@ -1458,7 +1493,7 @@ describe("Interaction", () => {
           );
 
           // Increase the charLimit to 1 (this truncates the existing text).
-          await page.click(getSelector("9R"));
+          await page.click(getSelector("9R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
           await page.waitForFunction(`${getQuerySelector("7R")}.value === "a"`);
 
@@ -1467,7 +1502,7 @@ describe("Interaction", () => {
           await page.waitForFunction(`${getQuerySelector("7R")}.value === "x"`);
 
           // Increase the charLimit to 2.
-          await page.click(getSelector("9R"));
+          await page.click(getSelector("9R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           await clearInput(page, getSelector("7R"));
@@ -1497,10 +1532,10 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           await typeAndWaitForSandbox(page, getSelector("30R"), "123");
-          await page.click(getSelector("31R"));
+          await page.click(getSelector("31R"), { delay: CLICK_DELAY });
           await page.type(getSelector("31R"), "456");
-          await page.click(getSelector("26R"));
-          await page.click(getSelector("27R"));
+          await page.click(getSelector("26R"), { delay: CLICK_DELAY });
+          await page.click(getSelector("27R"), { delay: CLICK_DELAY });
           await page.waitForFunction(`${getQuerySelector("26R")}.value !== ""`);
 
           const value = await page.$eval(getSelector("26R"), el => el.value);
@@ -1592,7 +1627,9 @@ describe("Interaction", () => {
           for (const exportValue of ["x3", "x2", "x1"]) {
             await clearInput(page, getSelector("27R"));
             await page.type(getSelector("27R"), exportValue);
-            await page.click("[data-annotation-id='28R']");
+            await page.click("[data-annotation-id='28R']", {
+              delay: CLICK_DELAY,
+            });
             await page.waitForFunction(
               `${getQuerySelector("24R")}.value === "${exportValue}"`
             );
@@ -1716,13 +1753,13 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page]) => {
           await waitForScripting(page);
 
-          await page.click(getSelector("25R"));
+          await page.click(getSelector("25R"), { delay: CLICK_DELAY });
           await page.type(getSelector("25R"), "00000000123");
 
           let text = await page.$eval(getSelector("25R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("00000000123");
 
-          await page.click(getSelector("26R"));
+          await page.click(getSelector("26R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           text = await page.$eval(getSelector("25R"), el => el.value);
@@ -1754,13 +1791,13 @@ describe("Interaction", () => {
           await page.$eval(getSelector("31R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("5,25");
 
-          await page.click(getSelector("22R"));
+          await page.click(getSelector("22R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           text = await page.$eval(getSelector("22R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("5,25");
 
-          await page.click(getSelector("31R"));
+          await page.click(getSelector("31R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("31R")}.value !== "5,25"`
           );
@@ -1828,7 +1865,7 @@ describe("Interaction", () => {
             .withContext(`In ${browserName}`)
             .toEqual("ABCDEFGHIJKLMN");
 
-          await page.click(getSelector("23R"));
+          await page.click(getSelector("23R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("23R")}.value !== "ABCDEFGHIJKLMN"`
           );
@@ -1847,11 +1884,11 @@ describe("Interaction", () => {
           let text = await page.$eval(getSelector("26R"), el => el.value);
           expect(text).withContext(`In ${browserName}`).toEqual("");
 
-          await page.click(getSelector("26R"));
+          await page.click(getSelector("26R"), { delay: CLICK_DELAY });
           await page.type(getSelector("26R"), "abcde");
-          await page.click(getSelector("23R"));
+          await page.click(getSelector("23R"), { delay: CLICK_DELAY });
           await clearInput(page, getSelector("26R"));
-          await page.click(getSelector("23R"));
+          await page.click(getSelector("23R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           text = await page.$eval(getSelector("26R"), el => el.value);
@@ -1891,7 +1928,7 @@ describe("Interaction", () => {
           );
           expect(hasHiddenInput).withContext(`In ${browserName}`).toEqual(true);
 
-          await page.click(getSelector("12R"));
+          await page.click(getSelector("12R"), { delay: CLICK_DELAY });
           await page.waitForSelector(
             `[data-annotation-id="9R"] > canvas[hidden]`
           );
@@ -1947,7 +1984,7 @@ describe("Interaction", () => {
           );
           expect(visibility).withContext(`In ${browserName}`).toEqual("hidden");
 
-          await page.click(getSelector("11R"));
+          await page.click(getSelector("11R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             `${getComputedStyleSelector("7R")}.visibility !== "hidden"`
@@ -1996,17 +2033,17 @@ describe("Interaction", () => {
             el => el.disabled
           );
           expect(readonly).withContext(`In ${browserName}`).toEqual(true);
-          await page.click(getSelector("334R"));
+          await page.click(getSelector("334R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           readonly = await page.$eval(getSelector("353R"), el => el.disabled);
           expect(readonly).withContext(`In ${browserName}`).toEqual(true);
-          await page.click(getSelector("351R"));
+          await page.click(getSelector("351R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           readonly = await page.$eval(getSelector("353R"), el => el.disabled);
           expect(readonly).withContext(`In ${browserName}`).toEqual(true);
-          await page.click(getSelector("352R"));
+          await page.click(getSelector("352R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("353R")}.disabled !== true`
           );
@@ -2014,14 +2051,14 @@ describe("Interaction", () => {
           readonly = await page.$eval(getSelector("353R"), el => el.disabled);
           expect(readonly).withContext(`In ${browserName}`).toEqual(false);
 
-          await page.click(getSelector("353R"));
+          await page.click(getSelector("353R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("353R")}.checked !== false`
           );
 
           let checked = await page.$eval(getSelector("353R"), el => el.checked);
           expect(checked).withContext(`In ${browserName}`).toEqual(true);
-          await page.click(getSelector("334R"));
+          await page.click(getSelector("334R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("353R")}.disabled !== false`
           );
@@ -2061,11 +2098,11 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page], i) => {
           await waitForScripting(page);
 
-          await page.click(getSelector("55R"));
+          await page.click(getSelector("55R"), { delay: CLICK_DELAY });
           await page.type(getSelector("55R"), "Hello");
-          await page.click(getSelector("56R"));
+          await page.click(getSelector("56R"), { delay: CLICK_DELAY });
 
-          await page.click(getSelector("55R"));
+          await page.click(getSelector("55R"), { delay: CLICK_DELAY });
           await page.type(getSelector("55R"), " World");
 
           await otherPages[i].bringToFront();
@@ -2098,8 +2135,8 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page], i) => {
           await waitForScripting(page);
 
-          await page.click(getSelector("25R"));
-          await page.click(getSelector("26R"));
+          await page.click(getSelector("25R"), { delay: CLICK_DELAY });
+          await page.click(getSelector("26R"), { delay: CLICK_DELAY });
 
           await page.waitForFunction(
             sel => document.querySelector(sel).value !== "",
@@ -2131,7 +2168,7 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           await scrollIntoView(page, getSelector("22R"));
-          await page.click(getSelector("25R"));
+          await page.click(getSelector("25R"), { delay: CLICK_DELAY });
           await waitForEntryInStorage(page, "25R", { value: true });
 
           let storage = await getAnnotationStorage(page);
@@ -2149,7 +2186,7 @@ describe("Interaction", () => {
               "22R": { value: false },
             });
 
-          await page.click(getSelector("22R"));
+          await page.click(getSelector("22R"), { delay: CLICK_DELAY });
           await waitForEntryInStorage(page, "22R", { value: true });
 
           storage = await getAnnotationStorage(page);
@@ -2187,7 +2224,7 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page], i) => {
           await waitForScripting(page);
 
-          await page.click(getSelector("15R"));
+          await page.click(getSelector("15R"), { delay: CLICK_DELAY });
           await page.type(getSelector("15R"), "3");
           await page.keyboard.press("Enter");
 
@@ -2220,7 +2257,7 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page], i) => {
           await waitForScripting(page);
 
-          await page.click(getSelector("24R"));
+          await page.click(getSelector("24R"), { delay: CLICK_DELAY });
           await typeAndWaitForSandbox(page, getSelector("24R"), "01234");
           await page.keyboard.press("Tab");
           await waitForSandboxTrip(page);
@@ -2328,9 +2365,9 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           const inputSelector = getSelector("34R");
-          await page.click(inputSelector);
+          await page.click(inputSelector, { delay: CLICK_DELAY });
           await page.type(inputSelector, "123");
-          await page.click(getSelector("28R"));
+          await page.click(getSelector("28R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("36R")}.value !== "0"`
           );
@@ -2365,9 +2402,9 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           const inputSelector = getSelector("24R");
-          await page.click(inputSelector);
+          await page.click(inputSelector, { delay: CLICK_DELAY });
           await page.type(inputSelector, "123");
-          await page.click(getSelector("25R"));
+          await page.click(getSelector("25R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("28R")}.value === "12300"`
           );
@@ -2393,9 +2430,9 @@ describe("Interaction", () => {
           await waitForScripting(page);
 
           const inputSelector = getSelector("33R");
-          await page.click(inputSelector);
+          await page.click(inputSelector, { delay: CLICK_DELAY });
           await page.type(inputSelector, "7");
-          await page.click(getSelector("34R"));
+          await page.click(getSelector("34R"), { delay: CLICK_DELAY });
           await page.waitForFunction(
             `${getQuerySelector("35R")}.value === "324,00"`
           );
@@ -2433,14 +2470,22 @@ describe("Interaction", () => {
             }
           };
           await checkColor([255, 0, 0]);
-          await page.click("[data-annotation-id='44R']");
+          await page.click("[data-annotation-id='44R']", {
+            delay: CLICK_DELAY,
+          });
           await checkColor([0, 0, 255]);
-          await page.click("[data-annotation-id='44R']");
+          await page.click("[data-annotation-id='44R']", {
+            delay: CLICK_DELAY,
+          });
           await checkColor([255, 0, 0]);
 
-          await page.click("[data-annotation-id='43R']");
+          await page.click("[data-annotation-id='43R']", {
+            delay: CLICK_DELAY,
+          });
           await waitForSandboxTrip(page);
-          await page.click("[data-annotation-id='44R']");
+          await page.click("[data-annotation-id='44R']", {
+            delay: CLICK_DELAY,
+          });
           await checkColor([0, 0, 255]);
         })
       );
@@ -2475,7 +2520,7 @@ describe("Interaction", () => {
 
           const expectedDate = "02/01/2000";
           await page.type(getSelector("24R"), expectedDate);
-          await page.click(getSelector("25R"));
+          await page.click(getSelector("25R"), { delay: CLICK_DELAY });
           await waitForSandboxTrip(page);
 
           const date = await page.$eval(getSelector("24R"), el => el.value);

--- a/test/integration/signature_editor_spec.mjs
+++ b/test/integration/signature_editor_spec.mjs
@@ -15,6 +15,7 @@
 
 import {
   awaitPromise,
+  CLICK_DELAY,
   closePages,
   copy,
   FSI,
@@ -54,7 +55,9 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([_, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
@@ -64,7 +67,7 @@ describe("Signature Editor", () => {
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector, { visible: false });
 
-          await page.click("#addSignatureCancelButton");
+          await page.click("#addSignatureCancelButton", { delay: CLICK_DELAY });
 
           // The editor should have been removed.
           await page.waitForSelector(`:not(${editorSelector})`);
@@ -76,7 +79,9 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
@@ -85,7 +90,7 @@ describe("Signature Editor", () => {
           await page.waitForSelector(
             "#addSignatureTypeButton[aria-selected=true]"
           );
-          await page.click("#addSignatureTypeInput");
+          await page.click("#addSignatureTypeInput", { delay: CLICK_DELAY });
           await page.waitForSelector(
             "#addSignatureSaveContainer > input:disabled"
           );
@@ -118,13 +123,15 @@ describe("Signature Editor", () => {
           expect(description).withContext(browserName).toEqual("PDF.js");
 
           // Clear the description.
-          await page.click("#addSignatureDescription > button");
+          await page.click("#addSignatureDescription > button", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `document.querySelector("${descriptionInputSelector}").value === ""`
           );
 
           // Clear the text for the signature.
-          await page.click("#clearSignatureButton");
+          await page.click("#clearSignatureButton", { delay: CLICK_DELAY });
           await page.waitForFunction(
             `document.querySelector("#addSignatureTypeInput").value === ""`
           );
@@ -140,7 +147,7 @@ describe("Signature Editor", () => {
           );
 
           // Clearing the signature type should clear the description.
-          await page.click("#clearSignatureButton");
+          await page.click("#clearSignatureButton", { delay: CLICK_DELAY });
           await page.waitForFunction(
             `document.querySelector("#addSignatureTypeInput").value === ""`
           );
@@ -153,7 +160,9 @@ describe("Signature Editor", () => {
           await page.waitForFunction(
             `document.querySelector("${descriptionInputSelector}").value !== ""`
           );
-          await page.click("#addSignatureDescription > button");
+          await page.click("#addSignatureDescription > button", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `document.querySelector("${descriptionInputSelector}").value === ""`
           );
@@ -169,7 +178,7 @@ describe("Signature Editor", () => {
           );
           expect(description).withContext(browserName).toEqual("Hello World");
 
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureDialog", {
             visible: false,
           });
@@ -196,7 +205,7 @@ describe("Signature Editor", () => {
           );
 
           // Edit the description.
-          await page.click(`.altText.editDescription`);
+          await page.click(".altText.editDescription", { delay: CLICK_DELAY });
 
           await page.waitForSelector("#editSignatureDescriptionDialog", {
             visible: true,
@@ -208,7 +217,9 @@ describe("Signature Editor", () => {
           const editDescriptionInput = "#editSignatureDescription > input";
           description = await page.$eval(editDescriptionInput, el => el.value);
           expect(description).withContext(browserName).toEqual("Hello World");
-          await page.click("#editSignatureDescription > button");
+          await page.click("#editSignatureDescription > button", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForFunction(
             `document.querySelector("${editDescriptionInput}").value === ""`
           );
@@ -220,7 +231,9 @@ describe("Signature Editor", () => {
             "#editSignatureUpdateButton:not(:disabled)"
           );
 
-          await page.click("#editSignatureUpdateButton");
+          await page.click("#editSignatureUpdateButton", {
+            delay: CLICK_DELAY,
+          });
 
           // Check the tooltip.
           await page.waitForSelector(
@@ -234,13 +247,15 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
 
-          await page.click("#addSignatureDrawButton");
+          await page.click("#addSignatureDrawButton", { delay: CLICK_DELAY });
           const drawSelector = "#addSignatureDraw";
           await page.waitForSelector(drawSelector, { visible: true });
 
@@ -276,7 +291,7 @@ describe("Signature Editor", () => {
           );
           expect(description).withContext(browserName).toEqual("Signature");
 
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureDialog", {
             visible: false,
           });
@@ -292,13 +307,15 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
 
-          await page.click("#addSignatureImageButton");
+          await page.click("#addSignatureImageButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureImagePlaceholder", {
             visible: true,
           });
@@ -334,7 +351,7 @@ describe("Signature Editor", () => {
             .withContext(browserName)
             .toEqual("firefox_logo.png");
 
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureDialog", {
             visible: false,
           });
@@ -350,14 +367,16 @@ describe("Signature Editor", () => {
       // Run sequentially to avoid clipboard issues.
       for (const [browserName, page] of pages) {
         await switchToSignature(page);
-        await page.click("#editorSignatureAddSignature");
+        await page.click("#editorSignatureAddSignature", {
+          delay: CLICK_DELAY,
+        });
 
         await page.waitForSelector("#addSignatureDialog", {
           visible: true,
         });
         await page.type("#addSignatureTypeInput", "Hello");
         await page.waitForSelector(`${addButtonSelector}:not(:disabled)`);
-        await page.click("#addSignatureAddButton");
+        await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
 
         const editorSelector = getEditorSelector(0);
         await page.waitForSelector(editorSelector, { visible: true });
@@ -412,7 +431,9 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([_, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
@@ -422,7 +443,7 @@ describe("Signature Editor", () => {
             "[18:50:03] asset pdf.scripting.mjs 105 KiB [emitted] [javascript module] (name: main)"
           );
           await page.waitForSelector(`${addButtonSelector}:not(:disabled)`);
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector, { visible: true });
@@ -454,12 +475,14 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([_, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
-          await page.click("#addSignatureImageButton");
+          await page.click("#addSignatureImageButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureImagePlaceholder", {
             visible: true,
           });
@@ -468,7 +491,9 @@ describe("Signature Editor", () => {
             `${path.join(__dirname, "./signature_editor_spec.mjs")}`
           );
           await page.waitForSelector("#addSignatureError", { visible: true });
-          await page.click("#addSignatureErrorCloseButton");
+          await page.click("#addSignatureErrorCloseButton", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#addSignatureError", { visible: false });
 
           await input.uploadFile(
@@ -476,12 +501,12 @@ describe("Signature Editor", () => {
           );
           await page.waitForSelector("#addSignatureError", { visible: true });
 
-          await page.click("#addSignatureTypeButton");
+          await page.click("#addSignatureTypeButton", { delay: CLICK_DELAY });
           await page.waitForSelector(
             "#addSignatureTypeButton[aria-selected=true]"
           );
           await page.waitForSelector("#addSignatureError", { visible: false });
-          await page.click("#addSignatureCancelButton");
+          await page.click("#addSignatureCancelButton", { delay: CLICK_DELAY });
         })
       );
     });
@@ -515,14 +540,16 @@ describe("Signature Editor", () => {
           expect(colorTheme).toEqual("light");
 
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
           await page.type("#addSignatureTypeInput", "Should be black.");
           await page.waitForSelector(`${addButtonSelector}:not(:disabled)`);
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector, { visible: true });
@@ -571,14 +598,16 @@ describe("Signature Editor", () => {
           expect(colorTheme).toEqual("dark");
 
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
           await page.type("#addSignatureTypeInput", "Should be black.");
           await page.waitForSelector(`${addButtonSelector}:not(:disabled)`);
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
 
           const editorSelector = getEditorSelector(0);
           await page.waitForSelector(editorSelector, { visible: true });
@@ -644,13 +673,15 @@ describe("Signature Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToSignature(page);
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
 
-          await page.click("#addSignatureImageButton");
+          await page.click("#addSignatureImageButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureImagePlaceholder", {
             visible: true,
           });
@@ -666,7 +697,7 @@ describe("Signature Editor", () => {
           await page.waitForSelector(
             "#addSignatureSaveContainer > input:not(:disabled)"
           );
-          await page.click("#addSignatureAddButton");
+          await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureDialog", {
             visible: false,
           });
@@ -702,11 +733,13 @@ describe("Signature Editor", () => {
           await switchToSignature(page);
 
           for (let i = 0; i < 6; i++) {
-            await page.click("#editorSignatureAddSignature");
+            await page.click("#editorSignatureAddSignature", {
+              delay: CLICK_DELAY,
+            });
             await page.waitForSelector("#addSignatureDialog", {
               visible: true,
             });
-            await page.click("#addSignatureTypeInput");
+            await page.click("#addSignatureTypeInput", { delay: CLICK_DELAY });
             await page.type("#addSignatureTypeInput", `PDF.js ${i}`);
             if (i === 5) {
               await page.waitForSelector(
@@ -719,7 +752,7 @@ describe("Signature Editor", () => {
                 "#addSignatureSaveCheckbox:not(:disabled)"
               );
             }
-            await page.click("#addSignatureAddButton");
+            await page.click("#addSignatureAddButton", { delay: CLICK_DELAY });
             await page.waitForSelector("#addSignatureDialog", {
               visible: false,
             });
@@ -745,12 +778,14 @@ describe("Signature Editor", () => {
         pages.map(async ([_, page]) => {
           await switchToSignature(page);
 
-          await page.click("#editorSignatureAddSignature");
+          await page.click("#editorSignatureAddSignature", {
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForSelector("#addSignatureDialog", {
             visible: true,
           });
-          await page.click("#addSignatureImageButton");
+          await page.click("#addSignatureImageButton", { delay: CLICK_DELAY });
           await page.waitForSelector("#addSignatureImagePlaceholder", {
             visible: true,
           });
@@ -765,7 +800,9 @@ describe("Signature Editor", () => {
           await page.waitForSelector(
             "#addSignatureErrorDescription[data-l10n-id='pdfjs-editor-add-signature-image-no-data-error-description']"
           );
-          await page.click("#addSignatureErrorCloseButton");
+          await page.click("#addSignatureErrorCloseButton", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#addSignatureError", { visible: false });
         })
       );

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -18,6 +18,7 @@ import {
   awaitPromise,
   clearEditors,
   clearInput,
+  CLICK_DELAY,
   closePages,
   copy,
   copyToClipboard,
@@ -116,7 +117,7 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
-          await page.click("#editorStampAddImage");
+          await page.click("#editorStampAddImage", { delay: CLICK_DELAY });
 
           const input = await page.$("#stampEditorFileInput");
           await input.uploadFile(
@@ -146,7 +147,7 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
-          await page.click("#editorStampAddImage");
+          await page.click("#editorStampAddImage", { delay: CLICK_DELAY });
           const input = await page.$("#stampEditorFileInput");
           await input.uploadFile(
             `${path.join(__dirname, "../images/firefox_logo.svg")}`
@@ -174,7 +175,7 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
-          await page.click("#editorStampAddImage");
+          await page.click("#editorStampAddImage", { delay: CLICK_DELAY });
           const input = await page.$("#stampEditorFileInput");
           await input.uploadFile(
             `${path.join(__dirname, "../images/firefox_logo.svg")}`
@@ -184,7 +185,9 @@ describe("Stamp Editor", () => {
           await waitForSerialized(page, 1);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
           await waitForSerialized(page, 0);
 
           await kbUndo(page);
@@ -225,7 +228,7 @@ describe("Stamp Editor", () => {
               await clearAll(page);
             }
 
-            await page.click("#editorStampAddImage");
+            await page.click("#editorStampAddImage", { delay: CLICK_DELAY });
             const input = await page.$("#stampEditorFileInput");
             await input.uploadFile(
               `${path.join(__dirname, "../images/firefox_logo.png")}`
@@ -281,7 +284,7 @@ describe("Stamp Editor", () => {
         pages.map(async ([browserName, page]) => {
           await switchToStamp(page);
 
-          await page.click("#editorStampAddImage");
+          await page.click("#editorStampAddImage", { delay: CLICK_DELAY });
           const input = await page.$("#stampEditorFileInput");
           await input.uploadFile(
             `${path.join(__dirname, "../images/firefox_logo.png")}`
@@ -339,19 +342,19 @@ describe("Stamp Editor", () => {
         await page.waitForSelector(buttonSelector);
 
         // Click on the alt-text button.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
 
         // Wait for the alt-text dialog to be visible.
         await page.waitForSelector("#altTextDialog", { visible: true });
 
         // Click on the alt-text editor.
         const textareaSelector = "#altTextDialog textarea";
-        await page.click(textareaSelector);
+        await page.click(textareaSelector, { delay: CLICK_DELAY });
         await page.type(textareaSelector, "Hello World");
 
         // Click on save button.
         const saveButtonSelector = "#altTextDialog #altTextSave";
-        await page.click(saveButtonSelector);
+        await page.click(saveButtonSelector, { delay: CLICK_DELAY });
 
         // Check that the canvas has an aria-describedby attribute.
         await page.waitForSelector(`${editorSelector}[aria-describedby]`);
@@ -374,14 +377,14 @@ describe("Stamp Editor", () => {
 
         // Now we change the alt-text and check that the tooltip is updated.
         const longString = "a".repeat(512);
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#altTextDialog", { visible: true });
         await page.evaluate(sel => {
           document.querySelector(`${sel}`).value = "";
         }, textareaSelector);
-        await page.click(textareaSelector);
+        await page.click(textareaSelector, { delay: CLICK_DELAY });
         await page.type(textareaSelector, longString);
-        await page.click(saveButtonSelector);
+        await page.click(saveButtonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(`${buttonSelector}.done`);
         await page.hover(buttonSelector);
         await page.waitForSelector(tooltipSelector, { visible: true });
@@ -399,15 +402,15 @@ describe("Stamp Editor", () => {
         expect(dims.width / dims.height).toBeLessThan(2);
 
         // Now we just check that cancel didn't change anything.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#altTextDialog", { visible: true });
         await page.evaluate(sel => {
           document.querySelector(`${sel}`).value = "";
         }, textareaSelector);
-        await page.click(textareaSelector);
+        await page.click(textareaSelector, { delay: CLICK_DELAY });
         await page.type(textareaSelector, "Hello PDF.js");
         const cancelButtonSelector = "#altTextDialog #altTextCancel";
-        await page.click(cancelButtonSelector);
+        await page.click(cancelButtonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(`${buttonSelector}.done`);
         await page.hover(buttonSelector);
         await page.waitForSelector(tooltipSelector, { visible: true });
@@ -419,13 +422,13 @@ describe("Stamp Editor", () => {
         expect(tooltipText).toEqual(longString);
 
         // Now we switch to decorative.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#altTextDialog", { visible: true });
         const decorativeSelector = "#altTextDialog #decorativeButton";
-        await page.click(decorativeSelector);
-        await page.click(saveButtonSelector);
+        await page.click(decorativeSelector, { delay: CLICK_DELAY });
+        await page.click(saveButtonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(`${buttonSelector}.done`);
-        await page.hover(buttonSelector);
+        await page.hover(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(tooltipSelector, { visible: true });
         tooltipText = await page.evaluate(
           sel => document.querySelector(`${sel}`).innerText,
@@ -434,13 +437,13 @@ describe("Stamp Editor", () => {
         expect(tooltipText).toEqual("Marked as decorative");
 
         // Now we switch back to non-decorative.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#altTextDialog", { visible: true });
         const descriptionSelector = "#altTextDialog #descriptionButton";
-        await page.click(descriptionSelector);
-        await page.click(saveButtonSelector);
+        await page.click(descriptionSelector, { delay: CLICK_DELAY });
+        await page.click(saveButtonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(`${buttonSelector}.done`);
-        await page.hover(buttonSelector);
+        await page.hover(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(tooltipSelector, { visible: true });
         tooltipText = await page.evaluate(
           sel => document.querySelector(`${sel}`).innerText,
@@ -449,12 +452,12 @@ describe("Stamp Editor", () => {
         expect(tooltipText).toEqual(longString);
 
         // Now we remove the alt-text and check that the tooltip is removed.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#altTextDialog", { visible: true });
         await page.evaluate(sel => {
           document.querySelector(`${sel}`).value = "";
         }, textareaSelector);
-        await page.click(saveButtonSelector);
+        await page.click(saveButtonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector(`${buttonSelector}:not(.done)`);
         await page.hover(buttonSelector);
         await page.evaluate(
@@ -678,7 +681,9 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 1);
 
         await page.waitForSelector(`${editorSelector} button.delete`);
-        await page.click(`${editorSelector} button.delete`);
+        await page.click(`${editorSelector} button.delete`, {
+          delay: CLICK_DELAY,
+        });
         await waitForSerialized(page, 0);
 
         await kbUndo(page);
@@ -710,7 +715,9 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 1);
 
         await page.waitForSelector(`${editorSelector} button.delete`);
-        await page.click(`${editorSelector} button.delete`);
+        await page.click(`${editorSelector} button.delete`, {
+          delay: CLICK_DELAY,
+        });
         await waitForSerialized(page, 0);
 
         const twoToFourteen = Array.from(new Array(13).keys(), n => n + 2);
@@ -755,7 +762,9 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 1);
 
         await page.waitForSelector(`${editorSelector} button.delete`);
-        await page.click(`${editorSelector} button.delete`);
+        await page.click(`${editorSelector} button.delete`, {
+          delay: CLICK_DELAY,
+        });
         await waitForSerialized(page, 0);
 
         const twoToOne = Array.from(new Array(13).keys(), n => n + 2).concat(
@@ -999,7 +1008,7 @@ describe("Stamp Editor", () => {
         await page.waitForSelector("#newAltTextDisclaimer", { visible: false });
 
         // Click on the Not Now button.
-        await page.click("#newAltTextNotNow");
+        await page.click("#newAltTextNotNow", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
         await waitForSelectedEditor(page, editorSelector);
 
@@ -1034,7 +1043,7 @@ describe("Stamp Editor", () => {
         await page.waitForSelector(".noAltTextBadge", { visible: false });
 
         // Click on the Review button.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: true });
 
         // Check that the dialog has the correct title: "Edit..."
@@ -1043,7 +1052,9 @@ describe("Stamp Editor", () => {
         );
 
         // Click on create automatically toggle button.
-        await page.click("#newAltTextCreateAutomaticallyButton");
+        await page.click("#newAltTextCreateAutomaticallyButton", {
+          delay: CLICK_DELAY,
+        });
         await clearInput(
           page,
           "#newAltTextDescriptionTextarea",
@@ -1051,7 +1062,7 @@ describe("Stamp Editor", () => {
         );
 
         // Save the empty text.
-        await page.click("#newAltTextSave");
+        await page.click("#newAltTextSave", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
         await waitForSelectedEditor(page, editorSelector);
         await page.waitForSelector(buttonSelector, { visible: true });
@@ -1082,7 +1093,7 @@ describe("Stamp Editor", () => {
         await page.waitForSelector(".noAltTextBadge", { visible: false });
 
         // Click on the Review button.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: true });
 
         await page.waitForFunction(
@@ -1095,7 +1106,7 @@ describe("Stamp Editor", () => {
         );
 
         // Click on the Save button.
-        await page.click("#newAltTextSave");
+        await page.click("#newAltTextSave", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
 
         await waitForTranslation(page);
@@ -1125,10 +1136,12 @@ describe("Stamp Editor", () => {
         expect(tooltipText).toEqual("Hello World");
 
         // Click on the Review button.
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: true });
-        await page.click("#newAltTextCreateAutomaticallyButton");
-        await page.click("#newAltTextCancel");
+        await page.click("#newAltTextCreateAutomaticallyButton", {
+          delay: CLICK_DELAY,
+        });
+        await page.click("#newAltTextCancel", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
       }
     });
@@ -1154,7 +1167,9 @@ describe("Stamp Editor", () => {
         await page.waitForSelector("#newAltTextDisclaimer", { visible: true });
 
         // Click in the textarea in order to stop the guessing.
-        await page.click("#newAltTextDescriptionTextarea");
+        await page.click("#newAltTextDescriptionTextarea", {
+          delay: CLICK_DELAY,
+        });
         await page.waitForFunction(() =>
           document
             .getElementById("newAltTextTitle")
@@ -1165,7 +1180,7 @@ describe("Stamp Editor", () => {
         await page.waitForSelector("#newAltTextDisclaimer", { visible: false });
 
         // Click on the Not Now button.
-        await page.click("#newAltTextNotNow");
+        await page.click("#newAltTextNotNow", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
       }
     });
@@ -1222,7 +1237,7 @@ describe("Stamp Editor", () => {
           /* waitForInputEvent = */ true
         );
         // Save the empty text.
-        await page.click("#newAltTextSave");
+        await page.click("#newAltTextSave", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
 
         // Get the telemetry data and clean.
@@ -1245,14 +1260,14 @@ describe("Stamp Editor", () => {
         // Click on the Review button.
         const buttonSelector = `${editorSelector} button.altText.new`;
         await page.waitForSelector(buttonSelector, { visible: true });
-        await page.click(buttonSelector);
+        await page.click(buttonSelector, { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: true });
 
         // Add a new alt text and check that the title changes to "Edit..."
         await page.type("#newAltTextDescriptionTextarea", "Fake text alt foo.");
 
         // Save the empty text.
-        await page.click("#newAltTextSave");
+        await page.click("#newAltTextSave", { delay: CLICK_DELAY });
         await page.waitForSelector("#newAltTextDialog", { visible: false });
 
         telemetry = await page.evaluate(() => window.telemetry);
@@ -1392,7 +1407,9 @@ describe("Stamp Editor", () => {
 
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("#secondaryToolbarToggleButton");
+          await page.click("#secondaryToolbarToggleButton", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#secondaryToolbar", { visible: true });
           const secondary = await page.$("#secondaryToolbar");
           const png = await secondary.screenshot({ type: "png" });
@@ -1421,7 +1438,10 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const modeChangedHandle = await waitForAnnotationModeChanged(page);
-          await page.click(getAnnotationSelector("25R"), { count: 2 });
+          await page.click(getAnnotationSelector("25R"), {
+            count: 2,
+            delay: CLICK_DELAY,
+          });
           await awaitPromise(modeChangedHandle);
           const editorSelector = getEditorSelector(0);
           await waitForSelectedEditor(page, editorSelector);
@@ -1459,7 +1479,10 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const modeChangedHandle = await waitForAnnotationModeChanged(page);
-          await page.click(getAnnotationSelector("58R"), { count: 2 });
+          await page.click(getAnnotationSelector("58R"), {
+            count: 2,
+            delay: CLICK_DELAY,
+          });
           await awaitPromise(modeChangedHandle);
           const editorSelector = getEditorSelector(4);
           await waitForSelectedEditor(page, editorSelector);
@@ -1467,7 +1490,9 @@ describe("Stamp Editor", () => {
           const editorIds = await getEditors(page, "stamp");
           expect(editorIds.length).withContext(`In ${browserName}`).toEqual(5);
 
-          await page.click(`${editorSelector} button.altText`);
+          await page.click(`${editorSelector} button.altText`, {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#altTextDialog", { visible: true });
 
           const textareaSelector = "#altTextDialog textarea";
@@ -1487,7 +1512,7 @@ describe("Stamp Editor", () => {
             document.querySelector(sel).value = "";
           }, textareaSelector);
 
-          await page.click(textareaSelector);
+          await page.click(textareaSelector, { delay: CLICK_DELAY });
           await page.type(textareaSelector, "Hello World");
 
           // All the current annotations should be serialized as null objects
@@ -1496,7 +1521,7 @@ describe("Stamp Editor", () => {
           expect(serialized).withContext(`In ${browserName}`).toEqual([]);
 
           const saveButtonSelector = "#altTextDialog #altTextSave";
-          await page.click(saveButtonSelector);
+          await page.click(saveButtonSelector, { delay: CLICK_DELAY });
 
           await waitForSerialized(page, 1);
         })
@@ -1519,7 +1544,10 @@ describe("Stamp Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const modeChangedHandle = await waitForAnnotationModeChanged(page);
-          await page.click(getAnnotationSelector("37R"), { count: 2 });
+          await page.click(getAnnotationSelector("37R"), {
+            count: 2,
+            delay: CLICK_DELAY,
+          });
           await awaitPromise(modeChangedHandle);
           const editorSelector = getEditorSelector(2);
           await waitForSelectedEditor(page, editorSelector);
@@ -1533,7 +1561,9 @@ describe("Stamp Editor", () => {
           expect(serialized).withContext(`In ${browserName}`).toEqual([]);
 
           await page.waitForSelector(`${editorSelector} button.delete`);
-          await page.click(`${editorSelector} button.delete`);
+          await page.click(`${editorSelector} button.delete`, {
+            delay: CLICK_DELAY,
+          });
 
           await waitForSerialized(page, 1);
           serialized = await getSerialized(page);
@@ -1607,14 +1637,16 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 1);
 
         await page.waitForSelector(`${editorSelector} button.delete`);
-        await page.click(`${editorSelector} button.delete`);
+        await page.click(`${editorSelector} button.delete`, {
+          delay: CLICK_DELAY,
+        });
         await waitForSerialized(page, 0);
         await page.waitForSelector("#editorUndoBar", { visible: true });
 
         await page.waitForSelector("#editorUndoBarUndoButton", {
           visible: true,
         });
-        await page.click("#editorUndoBarUndoButton");
+        await page.click("#editorUndoBarUndoButton", { delay: CLICK_DELAY });
         await waitForSerialized(page, 1);
         await page.waitForSelector(editorSelector);
         await page.waitForSelector(`${editorSelector} canvas`);
@@ -1632,7 +1664,9 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 1);
 
         await page.waitForSelector(`${editorSelector} button.delete`);
-        await page.click(`${editorSelector} button.delete`);
+        await page.click(`${editorSelector} button.delete`, {
+          delay: CLICK_DELAY,
+        });
         await waitForSerialized(page, 0);
 
         await page.waitForFunction(() => {
@@ -1658,11 +1692,13 @@ describe("Stamp Editor", () => {
         await waitForSerialized(page, 1);
 
         await page.waitForSelector(`${editorSelector} button.delete`);
-        await page.click(`${editorSelector} button.delete`);
+        await page.click(`${editorSelector} button.delete`, {
+          delay: CLICK_DELAY,
+        });
         await waitForSerialized(page, 0);
 
         await page.waitForSelector("#editorUndoBar", { visible: true });
-        await page.click("#editorStampAddImage");
+        await page.click("#editorStampAddImage", { delay: CLICK_DELAY });
         const newInput = await page.$("#stampEditorFileInput");
         await newInput.uploadFile(
           `${path.join(__dirname, "../images/firefox_logo.png")}`
@@ -1760,7 +1796,10 @@ describe("Stamp Editor", () => {
           await page.waitForSelector(annotationSelector);
           await scrollIntoView(page, annotationSelector);
 
-          await page.click(annotationSelector, { count: 2 });
+          await page.click(annotationSelector, {
+            count: 2,
+            delay: CLICK_DELAY,
+          });
 
           await page.waitForFunction(() =>
             document

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -15,6 +15,14 @@
 
 import os from "os";
 
+// The time, in milliseconds, between `mousedown`/`mouseup` events in human
+// interaction. By default Puppeteer doesn't delay mouse clicks, making them
+// unrealistically fast and causing intermittent failures because the events
+// fire too fast in succession for the event listeners to process in time.
+// Note that this particular value is also used in Firefox; please see
+// https://github.com/mozilla-firefox/firefox/blob/main/modules/libpref/init/StaticPrefList.yaml#L19136-L19140.
+const CLICK_DELAY = 40;
+
 const isMac = os.platform() === "darwin";
 
 function loadAndWait(filename, selector, zoom, setups, options, viewport) {
@@ -176,7 +184,7 @@ function waitForTimeout(milliseconds) {
 
 async function clearInput(page, selector, waitForInputEvent = false) {
   const action = async () => {
-    await page.click(selector);
+    await page.click(selector, { delay: CLICK_DELAY });
     await kbSelectAll(page);
     await page.keyboard.press("Backspace");
     await page.waitForFunction(
@@ -195,6 +203,7 @@ async function clearInput(page, selector, waitForInputEvent = false) {
 
 async function waitAndClick(page, selector, clickOptions = {}) {
   await page.waitForSelector(selector, { visible: true });
+  clickOptions.delay = CLICK_DELAY;
   await page.click(selector, clickOptions);
 }
 
@@ -357,7 +366,7 @@ async function selectEditor(page, selector, count = 1) {
   await page.mouse.click(
     editorRect.x + editorRect.width / 2,
     editorRect.y + editorRect.height / 2,
-    { count }
+    { count, delay: CLICK_DELAY }
   );
   await waitForSelectedEditor(page, selector);
 }
@@ -806,7 +815,7 @@ async function switchToEditor(name, page, disable = false) {
       { once: true }
     );
   });
-  await page.click(`#editor${name}Button`);
+  await page.click(`#editor${name}Button`, { delay: CLICK_DELAY });
   name = name.toLowerCase();
   await page.waitForSelector(
     ".annotationEditorLayer" +
@@ -896,6 +905,7 @@ export {
   awaitPromise,
   clearEditors,
   clearInput,
+  CLICK_DELAY,
   closePages,
   closeSinglePage,
   copy,

--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -14,6 +14,7 @@
  */
 
 import {
+  CLICK_DELAY,
   closePages,
   closeSinglePage,
   getSpanRectFromText,
@@ -390,7 +391,10 @@ describe("Text layer", () => {
               await waitForEvent({
                 page,
                 eventName: "click",
-                action: () => page.mouse.click(positionEnd.x, positionEnd.y),
+                action: () =>
+                  page.mouse.click(positionEnd.x, positionEnd.y, {
+                    delay: CLICK_DELAY,
+                  }),
                 selector: "#pdfjs_internal_id_8R",
                 validator: e => {
                   // Don't navigate to the link destination: the `click` event
@@ -425,7 +429,10 @@ describe("Text layer", () => {
               await waitForEvent({
                 page,
                 eventName: "click",
-                action: () => page.mouse.click(positionEnd.x, positionEnd.y),
+                action: () =>
+                  page.mouse.click(positionEnd.x, positionEnd.y, {
+                    delay: CLICK_DELAY,
+                  }),
                 selector: "#pdfjs_internal_id_8R",
                 validator: e => {
                   // Don't navigate to the link destination: the `click` event

--- a/test/integration/thumbnail_view_spec.mjs
+++ b/test/integration/thumbnail_view_spec.mjs
@@ -1,4 +1,4 @@
-import { closePages, loadAndWait } from "./test_utils.mjs";
+import { CLICK_DELAY, closePages, loadAndWait } from "./test_utils.mjs";
 
 describe("PDF Thumbnail View", () => {
   describe("Works without errors", () => {
@@ -15,7 +15,7 @@ describe("PDF Thumbnail View", () => {
     it("should render thumbnails without errors", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("#sidebarToggleButton");
+          await page.click("#sidebarToggleButton", { delay: CLICK_DELAY });
 
           const thumbSelector = "#thumbnailView .thumbnailImage";
           await page.waitForSelector(thumbSelector, { visible: true });

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -15,6 +15,7 @@
 
 import {
   awaitPromise,
+  CLICK_DELAY,
   closePages,
   createPromise,
   getSpanRectFromText,
@@ -1177,7 +1178,9 @@ describe("PDF viewer", () => {
     it("must check that the SecondaryToolbar doesn't close between rotations", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await page.click("#secondaryToolbarToggleButton");
+          await page.click("#secondaryToolbarToggleButton", {
+            delay: CLICK_DELAY,
+          });
           await page.waitForSelector("#secondaryToolbar", { hidden: false });
 
           for (let i = 1; i <= 4; i++) {
@@ -1191,7 +1194,7 @@ describe("PDF viewer", () => {
             const rotation = i * 90;
             const handle = await waitForRotationChanging(page, rotation);
 
-            await page.click("#pageRotateCw");
+            await page.click("#pageRotateCw", { delay: CLICK_DELAY });
             await awaitPromise(handle);
 
             const pagesRotation = await page.evaluate(


### PR DESCRIPTION
By default Puppeteer mouse clicks are unrealistically fast because there is no delay between the `mousedown` and `mouseup` events. This doesn't match human user behavior and leads to intermittent failures because the event listeners aren't able to process events in time that are fired so fast in succession.

This commit fixes the issue by giving all mouse clicks, via the `page.click` (for DOM elements) and `page.mouse.click` (for coordinates) APIs, a delay that matches human user interaction more closely.

_This PR should fix the `must select/unselect several editors and check copy, paste and delete operations` and `must check that text change can be undone/redone` tests, and possibly other lesser occurring intermittents, because I can't reproduce their failures anymore with this change applied, even though before this patch that was relatively easy to do. It could bring other existing intermittents most closely to the surface too, which hopefully makes fixing those in a follow-up easier if they become less flaky._