### PR TITLE
Implement a delay for Chrome protocol calls in the integration tests, and skip the "must check that an existing highlight is ignored on hovering" integration test on Windows

### DIFF
--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1853,6 +1853,12 @@ describe("Highlight Editor", () => {
     it("must check that an existing highlight is ignored on hovering", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          if (navigator.platform.includes("Win")) {
+            // Skip the test on Windows because it permafails.
+            // TODO: Remove this check once #20136 is fixed.
+            return;
+          }
+
           await switchToHighlight(page);
 
           const rect = await getSpanRectFromText(

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -910,6 +910,14 @@ async function startBrowser({
     // crashes with timeouts or OOM if WebDriver BiDi is used (issue #17961).
     options.protocol = "cdp";
 
+    // Slow down protocol calls by the given number of milliseconds. In Chrome
+    // protocol calls are faster than in Firefox and thus trigger in quicker
+    // succession. This can cause intermittent failures because new protocol
+    // calls can run before events triggered by the previous protocol calls had
+    // a chance to be processed (essentially causing events to get lost). This
+    // value gives Chrome a more similar execution speed as Firefox.
+    options.slowMo = 5;
+
     // avoid crash
     options.args = ["--no-sandbox", "--disable-setuid-sandbox"];
     // silent printing in a pdf


### PR DESCRIPTION
The commit messages contain more information about the individual changes. The changes combined should fix the intermittent failures we experienced.