### PR TITLE
Fix intermittent failure in the "must check that the computed value is correct" scripting integration test

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -2392,9 +2392,7 @@ describe("Interaction", () => {
         pages.map(async ([browserName, page], i) => {
           await waitForScripting(page);
 
-          const inputSelector = getSelector("33R");
-          await page.click(inputSelector);
-          await page.type(inputSelector, "7");
+          await typeAndWaitForSandbox(page, getSelector("33R"), "7");
           await page.click(getSelector("34R"));
           await page.waitForFunction(
             `${getQuerySelector("35R")}.value === "324,00"`


### PR DESCRIPTION
Typing in the text field causes a sandbox event to trigger, which we should await to avoid continuing to the next part of the test before the sandbox event is fully processed.

Fixes #20133.