### PR TITLE
Lazy initialize FinalizationRegistry used by IccColorSpace.#finalizer

### DIFF
--- a/src/core/icc_colorspace.js
+++ b/src/core/icc_colorspace.js
@@ -48,9 +48,7 @@ class IccColorSpace extends ColorSpace {
 
   static #wasmUrl = null;
 
-  static #finalizer = new FinalizationRegistry(transformer => {
-    qcms_drop_transformer(transformer);
-  });
+  static #finalizer = null;
 
   constructor(iccProfile, name, numComps) {
     if (!IccColorSpace.isUsable) {
@@ -100,6 +98,9 @@ class IccColorSpace extends ColorSpace {
     if (!this.#transformer) {
       throw new Error("Failed to create ICC color space");
     }
+    IccColorSpace.#finalizer ||= new FinalizationRegistry(transformer => {
+      qcms_drop_transformer(transformer);
+    });
     IccColorSpace.#finalizer.register(this, this.#transformer);
   }
 


### PR DESCRIPTION
FinalizationRegistry is [Safari 14.1+](https://caniuse.com/?search=FinalizationRegistry) and cannot be polyfilled. This change would allow custom legacy browser-compatible builds to still work.

I initially thought of adding the same check as [elsewhere](https://github.com/mozilla/pdf.js/blob/e9a483014d5e57e7244340967affc55cec86c8f4/src/scripting_api/app.js#L55) in the codebase, but I found since the `IccColorSpace` usage is always guarded by `IccColorSpace.isUsable`, simply deferring intialization of `IccColorSpace.#finalizer` should suffice. 