### PR TITLE
Add regression test for PR 18844

### DIFF
--- a/test/unit/text_layer_spec.js
+++ b/test/unit/text_layer_spec.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
+import { FeatureTest, isNodeJS } from "../../src/shared/util.js";
 import { buildGetDocumentParams } from "./test_utils.js";
 import { getDocument } from "../../src/display/api.js";
-import { isNodeJS } from "../../src/shared/util.js";
 import { TextLayer } from "../../src/display/text_layer.js";
 
 describe("textLayer", function () {
@@ -249,5 +249,22 @@ describe("textLayer", function () {
     expect(transform2).toEqual(serialTransform2);
 
     await loadingTask.destroy();
+  });
+
+  it("should use Calibri and Lucida Console on Windows with Firefox", async function () {
+    spyOnProperty(FeatureTest, "platform", "get").and.returnValue({
+      isWindows: true,
+      isFirefox: true,
+    });
+
+    const fontFamilyMap = TextLayer.fontFamilyMap;
+    const expectedSansSerif = "Calibri, sans-serif";
+    const expectedMonospace = "Lucida Console, monospace";
+
+    const actualSansSerif = fontFamilyMap.get("sans-serif");
+    const actualMonospace = fontFamilyMap.get("monospace");
+
+    expect(actualSansSerif).toBe(expectedSansSerif);
+    expect(actualMonospace).toBe(expectedMonospace);
   });
 });


### PR DESCRIPTION
This test was automatically generated and could serve as a regression test for [PR #18844](https://github.com/mozilla/pdf.js/pull/18844). The added test:
- fails on the codebase prior to the PR
- passes on the codebase after the PR
- still passes against today’s pdf.js master branch

It verifies that sans-serif is correctly mapped to Calibri and monospace to Lucida Console on Windows/Firefox.

This is part of our research at the [ZEST](https://www.ifi.uzh.ch/en/zest.html) group of University of Zurich in collaboration with [Mozilla](https://www.mozilla.org).
If you have any suggestions, questions, or simply want to learn more, feel free to contact us at konstantinos.kitsios@uzh.ch and mcastelluccio@mozilla.com.