### PR TITLE
Add regression test for PR 19184

### DIFF
--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -46,6 +46,7 @@
     "struct_tree_spec.js",
     "svg_factory_spec.js",
     "text_layer_spec.js",
+    "to_unicode_map_spec.js",
     "type1_parser_spec.js",
     "ui_utils_spec.js",
     "unicode_spec.js",

--- a/test/unit/to_unicode_map_spec.js
+++ b/test/unit/to_unicode_map_spec.js
@@ -1,0 +1,33 @@
+/* Copyright 2025 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ToUnicodeMap } from "../../src/core/to_unicode_map.js";
+
+describe("ToUnicodeMap", () => {
+  it("should correctly map Extension B characters using codePointAt", () => {
+    const cmap = { 0x20: "\uD840\uDC00" }; // Example Extension B character
+    const toUnicodeMap = new ToUnicodeMap(cmap);
+
+    const expected = 0x20000; // Unicode code point for the character
+    let actual;
+    toUnicodeMap.forEach((charCode, unicode) => {
+      if (charCode === (0x20).toString()) {
+        actual = unicode;
+      }
+    });
+
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
This test was automatically generated and could serve as a regression test for [PR #19184](https://github.com/mozilla/pdf.js/pull/19184). The added test:
- fails on the codebase prior to the PR
- passes on the codebase after the PR
- still passes against today’s pdf.js master branch

It verifies that ToUnicodeMap correctly maps Extension B characters (surrogate pairs) to their full Unicode code points using codePointAt.

This is part of our research at the [ZEST](https://www.ifi.uzh.ch/en/zest.html) group of University of Zurich in collaboration with [Mozilla](https://www.mozilla.org).
If you have any suggestions, questions, or simply want to learn more, feel free to contact us at konstantinos.kitsios@uzh.ch and mcastelluccio@mozilla.com.