### PR TITLE
Fix: Add visible focus outlines for PDF viewer interactive elements

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -35,6 +35,9 @@
   --doorhanger-icon-opacity: 0.9;
   --doorhanger-height: 8px;
 
+  /* Accessibility variable for focus rings */
+  --focus-ring-outline: 2px solid #0a84ff;
+
   --main-color: light-dark(rgb(12 12 13), rgb(249 249 250));
   --body-bg-color: light-dark(rgb(212 212 215), rgb(42 42 46));
   --progressBar-color: light-dark(rgb(10 132 255), rgb(0 96 223));
@@ -1058,8 +1061,28 @@ dialog :link {
       height: auto;
     }
   }
-}
+  /* ---- A11Y: strong keyboard focus ring for toolbar controls (WCAG 2.4.7) ---- */
+  .toolbarButton:focus-visible,
+  #secondaryToolbar .toolbarButton:focus-visible,
+  .toolbarField:focus-visible,
+  .dropdownToolbarButton:focus-visible,
+  .toolbarButtonWithContainer > .toolbarButton:focus-visible {
+    outline: var(--focus-ring-outline);
+    outline-offset: 2px;
+    box-shadow: none;
+  }
 
+  /* Windows High Contrast / Forced colors fallback */
+  @media (forced-colors: active) {
+    .toolbarButton:focus-visible,
+    #secondaryToolbar .toolbarButton:focus-visible,
+    .toolbarField:focus-visible,
+    .dropdownToolbarButton:focus-visible,
+    .toolbarButtonWithContainer > .toolbarButton:focus-visible {
+      outline: 2px solid CanvasText;
+    }
+  }
+}
 .toolbarButtonWithContainer {
   height: 100%;
   aspect-ratio: 1;


### PR DESCRIPTION
<img width="1440" height="900" alt="Screenshot 2025-08-12 at 12 53 52 AM" src="https://github.com/user-attachments/assets/a874a03b-05ec-4372-adc4-59a5c33ad4e5" />
<img width="1440" height="900" alt="Screenshot 2025-08-12 at 12 54 47 AM" src="https://github.com/user-attachments/assets/51d2b18b-f377-4112-a9b3-d0382dbd853f" />
<img width="1440" height="900" alt="Screenshot 2025-08-12 at 1 16 21 AM" src="https://github.com/user-attachments/assets/ec2268b7-bfe7-498c-854b-ffab9c3b924b" />

This change ensures that all interactive toolbar elements in the PDF viewer display a visible focus outline when navigated via keyboard.
Previously, the focus ring skipped certain elements, making them inaccessible through keyboard navigation.