### PR TITLE
[Editor] Don't use a null signal for the comment button

### DIFF
--- a/src/display/editor/comment.js
+++ b/src/display/editor/comment.js
@@ -39,12 +39,17 @@ class Comment {
     if (!this.#editor._uiManager.hasCommentManager()) {
       return null;
     }
+
     const comment = (this.#commentButton = document.createElement("button"));
     comment.className = "comment";
     comment.tabIndex = "0";
     comment.setAttribute("data-l10n-id", "pdfjs-editor-edit-comment-button");
 
     const signal = this.#editor._uiManager._signal;
+    if (!(signal instanceof AbortSignal) || signal.aborted) {
+      return comment;
+    }
+
     comment.addEventListener("contextmenu", noContextMenu, { signal });
     comment.addEventListener("pointerdown", event => event.stopPropagation(), {
       signal,


### PR DESCRIPTION
This removes the following error from the integration test logs:

```
JavaScript error: http://127.0.0.1:59283/build/generic/build/pdf.mjs, line 3879:
TypeError: EventTarget.addEventListener: 'signal' member of AddEventListenerOptions is not an object.
```

Fixes 636ff50.
Extends 63651885.