### PR TITLE
Improve the selection check in the "doesn't jump when moving selection" integration test

### DIFF
--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -509,7 +509,7 @@ describe("Text layer", () => {
 
         await expectAsync(page)
           .withContext(`second selection`)
-          .toHaveRoughlySelected(/frequently .* We call such a se/s);
+          .toHaveRoughlySelected(/frequently .* We call such a s/s);
 
         await page.mouse.down();
         await moveInSteps(page, intermediateCaretPos, finalCaretPos, 20);
@@ -517,7 +517,7 @@ describe("Text layer", () => {
 
         await expectAsync(page)
           .withContext(`third selection`)
-          .toHaveRoughlySelected(/frequently .* We call such a se/s);
+          .toHaveRoughlySelected(/frequently .* We call such a s/s);
       });
     });
   });


### PR DESCRIPTION
Locally, on Arch Linux, this integration test permafails:

```
1) Text layer Text selection using selection carets doesn't jump when moving selection
  Message:
    second selection:
        Expected '(frequently executed) bytecode sequences, records
        them, and compiles them to fast native code. We call such a s' to roughly match /frequently .* We call such a se/s.
  Stack:
        at <Jasmine>
        at UserContext.<anonymous> (file:///home/timvandermeij/Documenten/Ontwikkeling/pdf.js/Code/test/integration/text_layer_spec.mjs:521:12)
  Message:
    third selection:
        Expected '(frequently executed) bytecode sequences, records
        them, and compiles them to fast native code. We call such a s' to roughly match /frequently .* We call such a se/s.
  Stack:
        at <Jasmine>
        at UserContext.<anonymous> (file:///home/timvandermeij/Documenten/Ontwikkeling/pdf.js/Code/test/integration/text_layer_spec.mjs:529:12
```

The exact selection can differ a bit per OS/browser. In this case the last character was consistently not selected while on other platforms it is, so this commit fixes the issue by relaxing the regex to not consider the final character so that the test passes if the rest matches.

_For reference, this is the selection that the test makes on Arch Linux (note the final 'e' not being selected):_

<img width="306" height="90" alt="Selection" src="https://github.com/user-attachments/assets/5cdd90e3-678c-46f8-8a52-bbe0b63e51dc" />
