### PR TITLE
Store ops bboxes in a linear Uint8Array

### DIFF
--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -478,7 +478,7 @@ class TilingPattern {
     this.baseTransform = baseTransform;
   }
 
-  createPatternCanvas(owner) {
+  createPatternCanvas(owner, opIdx) {
     const {
       bbox,
       operatorList,
@@ -567,7 +567,7 @@ class TilingPattern {
       dimy.size
     );
     const tmpCtx = tmpCanvas.context;
-    const graphics = canvasGraphicsFactory.createCanvasGraphics(tmpCtx);
+    const graphics = canvasGraphicsFactory.createCanvasGraphics(tmpCtx, opIdx);
     graphics.groupLevel = owner.groupLevel;
 
     this.setFillAndStrokeStyleToContext(graphics, paintType, color);
@@ -600,7 +600,7 @@ class TilingPattern {
 
     graphics.endDrawing();
 
-    graphics.dependencyTracker?.restore().recordNestedDependencies?.();
+    graphics.dependencyTracker?.restore();
     tmpCtx.restore();
 
     if (redrawHorizontally || redrawVertically) {
@@ -726,7 +726,7 @@ class TilingPattern {
     return false;
   }
 
-  getPattern(ctx, owner, inverse, pathType) {
+  getPattern(ctx, owner, inverse, pathType, opIdx) {
     // PDF spec 8.7.2 NOTE 1: pattern's matrix is relative to initial matrix.
     let matrix = inverse;
     if (pathType !== PathType.SHADING) {
@@ -736,7 +736,7 @@ class TilingPattern {
       }
     }
 
-    const temporaryPatternCanvas = this.createPatternCanvas(owner);
+    const temporaryPatternCanvas = this.createPatternCanvas(owner, opIdx);
 
     let domMatrix = new DOMMatrix(matrix);
     // Rescale and so that the ctx.createPattern call generates a pattern with

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -541,8 +541,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": true
+    }
   },
   {
     "id": "bug1753983",
@@ -673,8 +672,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": true
+    }
   },
   {
     "id": "bug1473809",
@@ -780,8 +778,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": "Gives slightly different results in Firefox when running in headless mode"
+    }
   },
   {
     "id": "issue2128",
@@ -1556,8 +1553,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": "Gives slightly different results in Firefox when running in headless mode"
+    }
   },
   {
     "id": "bug1811668",
@@ -2904,8 +2900,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": true
+    }
   },
   {
     "id": "bug1245391-text",
@@ -3250,8 +3245,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": true
+    }
   },
   {
     "id": "bug1337429",
@@ -8080,8 +8074,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": "Half pixel rendering at the edge of the image"
+    }
   },
   {
     "id": "issue16454",
@@ -11270,8 +11263,7 @@
       "maxX": 0.5,
       "minY": 0.25,
       "maxY": 0.5
-    },
-    "knownPartialMismatch": "One-bit difference in two pixels at the edge"
+    }
   },
   {
     "id": "issue14724",

--- a/web/base_pdf_page_view.js
+++ b/web/base_pdf_page_view.js
@@ -44,7 +44,7 @@ class BasePDFPageView {
 
   pageColors = null;
 
-  recordedGroups = null;
+  recordedBBoxes = null;
 
   renderingQueue = null;
 
@@ -235,7 +235,7 @@ class BasePDFPageView {
       if (renderTask === this.renderTask) {
         this.renderTask = null;
         if (this.enableOptimizedPartialRendering) {
-          this.recordedGroups ??= renderTask.recordedGroups;
+          this.recordedBBoxes ??= renderTask.recordedBBoxes;
         }
       }
     }

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -934,7 +934,7 @@ class PDFPageView extends BasePDFPageView {
       pageColors: this.pageColors,
       isEditing: this.#isEditing,
       recordOperations:
-        this.enableOptimizedPartialRendering && !this.recordedGroups,
+        this.enableOptimizedPartialRendering && !this.recordedBBoxes,
     };
   }
 


### PR DESCRIPTION
> **Store ops bboxes in a linear Uint8Array**
>
> This PR changes the way we store bounding boxes so that they use less memory and can be more easily shared across threads in the future.
>
> Instead of storing the bounding box and list of dependencies for each operation that renders _something_, we now only store the bounding box of _every_ operation and no dependencies list. The bounding box of each operation covers the bounding box of all the operations affected by it that render something. For example, the bounding box of a `setFont` operation will be the bounding box of all the `showText` operations that use that font.
>
> This affects the debugging experience in pdfBug, since now the bounding box of an operation may be larger than what it renders itself. To help with this, now when hovering on an operation we also highlight (in red) all its dependents. We highlight with white stripes operations that do not affect any part of the page (i.e. with an empty bbox).
>
> To save memory, we now save bounding box x/y coordinates as uint8 rather than float64. This effectively gives us a 256x256 uniform grid that covers the page, which is high enough resolution for the usecase.

Follow up to https://github.com/mozilla/pdf.js/pull/19043.

Due to the more coarse bounding boxes, some tests that previously had a 1-pixel difference on the edge of the partial render now match exactly. We'll need to re-generate the reference images for them.