### PR TITLE
[Editor] Hide the comment sidebar on document change

### DIFF
--- a/web/comment_manager.js
+++ b/web/comment_manager.js
@@ -408,6 +408,7 @@ class CommentManager {
   destroy() {
     this.#uiManager = null;
     this.#finish();
+    this.#sidebar.hide();
   }
 }
 


### PR DESCRIPTION
If the document changes the comment state from the old document should be replaced with that of the new document. To do this the comment manager is destroyed, but the corresponding comment sidebar wasn't destroyed yet, which resulted in the comment state from the old document still being visible for the new document.

This commit fixes the issue by hiding the comment sidebar if the comment manager is destroyed. Note that hiding the comment sidebar effectively destroys all its state, and we already set the annotation mode to "none" on document change so we don't want to keep showing the comment sidebar anyway.

Fixes #20219.