### PR TITLE
Improve serif fallback font name matching

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -989,10 +989,14 @@ class Font {
     // Fallback to checking the font name, in order to improve text-selection,
     // since the /Flags-entry is often wrong (fixes issue13845.pdf).
     if (!isSerifFont && !properties.isSimulatedFlags) {
-      const baseName = name.replaceAll(/[,_]/g, "-").split("-", 1)[0],
+      const stdFontMap = getStdFontMap(),
+        nonStdFontMap = getNonStdFontMap(),
         serifFonts = getSerifFonts();
-      for (const namePart of baseName.split("+")) {
-        if (serifFonts[namePart]) {
+      for (const namePart of name.split("+")) {
+        let fontName = namePart.replaceAll(/[,_]/g, "-");
+        fontName = stdFontMap[fontName] || nonStdFontMap[fontName] || fontName;
+        fontName = fontName.split("-", 1)[0];
+        if (serifFonts[fontName]) {
           isSerifFont = true;
           break;
         }


### PR DESCRIPTION
Extends on #14064, which was added to fix #13845.

While the initial implementation worked for some font names, `getSerifFonts` uses the mapped names, eg `Times`. If you have a font name such as `AAAAAC+TimesNewRomanPSMT` (as used in the added test) or `TimesNewRomanPS-BoldMT` (observed in other files), then the fallback serif logic wouldn't work. This PR changes the logic to be more similar to `fallbackToSystemFont` which maps the passed-in font name through `getStdFontMap`/`getNonStdFontMap`.

Before:

<img width="1008" height="578" alt="image" src="https://github.com/user-attachments/assets/a2aa2f26-05eb-411b-b3f0-a7378cfe4293" />


After:

<img width="1002" height="557" alt="image" src="https://github.com/user-attachments/assets/1af0729b-3c7c-41e0-932c-2e842209de49" />
