### PR TITLE
[Editor] Pointer type initialization only when the user changes the mode

### DIFF
--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -824,7 +824,6 @@ class DrawingEditor extends AnnotationEditor {
       this._currentParent = null;
       DrawingEditor.#currentDraw = null;
       DrawingEditor.#currentDrawingOptions = null;
-      CurrentPointers.clearPointerType();
       CurrentPointers.clearTimeStamp();
     }
 

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1923,6 +1923,8 @@ class AnnotationEditorUIManager {
    * Change the editor mode (None, FreeText, Ink, ...)
    * @param {number} mode
    * @param {string|null} editId
+   * @param {boolean} [isFromUser] - true if the mode change is due to a
+   *   user action.
    * @param {boolean} [isFromKeyboard] - true if the mode change is due to a
    *   keyboard action.
    * @param {boolean} [mustEnterInEditMode] - true if the editor must enter in
@@ -1933,6 +1935,7 @@ class AnnotationEditorUIManager {
   async updateMode(
     mode,
     editId = null,
+    isFromUser = false,
     isFromKeyboard = false,
     mustEnterInEditMode = false,
     editComment = false
@@ -1978,6 +1981,11 @@ class AnnotationEditorUIManager {
 
     if (mode === AnnotationEditorType.SIGNATURE) {
       await this.#signatureManager?.loadSignatures();
+    }
+
+    if (isFromUser) {
+      // reinitialize the pointer type when the mode is changed by the user
+      CurrentPointers.clearPointerType();
     }
 
     this.setEditingState(true);

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2501,6 +2501,7 @@ class PDFViewer {
       await this.#annotationEditorUIManager.updateMode(
         mode,
         editId,
+        /* isFromUser = */ true,
         isFromKeyboard,
         mustEnterInEditMode,
         editComment


### PR DESCRIPTION
It clears the pointer type of ``CurrentPointers`` outside of the ``DrawingEditor`` to always keep the same, until the user changes the mode.
One of the goal is to keep the same pointer type in case of a refresh of the page or if the user changes the pdf document.