### PR TITLE
[Editor] Don't save the image when updating a stamp annotation

### DIFF
--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -878,8 +878,10 @@ class StampEditor extends AnnotationEditor {
         serialized.accessibilityData.structParent =
           this._initialData.structParent ?? -1;
       }
+      serialized.id = this.annotationElementId;
+      delete serialized.bitmapId;
+      return serialized;
     }
-    serialized.id = this.annotationElementId;
 
     if (context === null) {
       return serialized;


### PR DESCRIPTION
It adds some useless bytes in the file.