### PR TITLE
Fix the rendering of XFA rich text in popup annotations

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -2494,7 +2494,7 @@ class PopupElement {
     renderRichText(
       {
         html: this.#html || this.#contentsObj.str,
-        dir: this.#contentsObj.dir,
+        dir: this.#contentsObj?.dir,
         className: "popupContent",
       },
       popup


### PR DESCRIPTION
Before the introduction of the `renderRichText` helper function we exclusively used `this.#html` for XFA rich text and exclusively used `this.#contentsObj` for plain text. However, after the refactoring we tried to access `this.#contentsObj.dir` in both cases, which fails for XFA rich text because `this.#contentsObj` is `null` in that case.

This commit fixes the issue by using optional chaining to make sure we don't try to access non-existent `this.#contentsObj` properties, which makes the `must update an existing annotation and show the right popup` freetext integration pass again.

Fixes #20237.
Fixes 35c90984.