### PR TITLE
Unskip the `must check that date entered by the user is consistent` scripting integration test for Firefox

### DIFF
--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -2463,13 +2463,6 @@ describe("Interaction", () => {
     it("must check that date entered by the user is consistent", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          if (browserName === "firefox") {
-            // Skip the test for Firefox as it doesn't support timezone
-            // emulation for WebDriver BiDi yet.
-            // TODO: Remove this check once bug 1978027 is fixed.
-            return;
-          }
-
           await waitForScripting(page);
 
           await page.emulateTimezone("Pacific/Honolulu");


### PR DESCRIPTION
Bug 1978027 has been fixed upstream 10 days ago, so this integration test can be enabled for Firefox too now that it passed with recent Nightly versions.