### PR TITLE
Use `console.warn`/`console.info` where appropriate

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -374,7 +374,7 @@ function getVerbosityLevel() {
 function info(msg) {
   if (verbosity >= VerbosityLevel.INFOS) {
     // eslint-disable-next-line no-console
-    console.log(`Info: ${msg}`);
+    console.info(`Info: ${msg}`);
   }
 }
 
@@ -382,7 +382,7 @@ function info(msg) {
 function warn(msg) {
   if (verbosity >= VerbosityLevel.WARNINGS) {
     // eslint-disable-next-line no-console
-    console.log(`Warning: ${msg}`);
+    console.warn(`Warning: ${msg}`);
   }
 }
 


### PR DESCRIPTION
Why: the practical reason is I have a pdf reader mcp , that uses deno + pdfjs, it works but shows this warning `Warning: Setting up fake worker.`

the problem is that warning is printed to stdout so it breaks the mcp.

By switching to console.warn deno will print to stderr which make it work correctly.

Here is the code btw to make pdfjs work with deno 

```ts
//pdfjs magic
import DOMMatrix from "npm:@thednp/dommatrix@2.0.12";
globalThis.DOMMatrix = DOMMatrix;
globalThis.process = undefined;
Object.defineProperty(navigator, "platform", {
  value: "Linux",
});
const pdfjsLib = await import("npm:pdfjs-dist@5.4.149");
pdfjsLib.GlobalWorkerOptions.workerSrc = import.meta.resolve("npm:pdfjs-dist@5.4.149/build/pdf.worker.mjs");
// pdfjs writes warning to stdout, which breaks mcp, this worksaround it
console.log = console.warn
```

DOMMatrix is expected to land on the next deno version (pr already done)