### PR TITLE
Reduce background canvas resolution

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -363,12 +363,16 @@ describe("PDF viewer", () => {
               .toBeLessThan(originalCanvasSize * factor ** 2);
 
             expect(canvasSize)
-              .withContext(`In ${browserName}, <= MAX_CANVAS_PIXELS`)
-              .toBeLessThanOrEqual(MAX_CANVAS_PIXELS.get(browserName));
+              .withContext(`In ${browserName}, <= MAX_CANVAS_PIXELS / 100`)
+              .toBeLessThanOrEqual(MAX_CANVAS_PIXELS.get(browserName) / 100);
 
             expect(canvasSize)
-              .withContext(`In ${browserName}, > MAX_CANVAS_PIXELS * 0.99`)
-              .toBeGreaterThan(MAX_CANVAS_PIXELS.get(browserName) * 0.99);
+              .withContext(
+                `In ${browserName}, > MAX_CANVAS_PIXELS / 100 * 0.95`
+              )
+              .toBeGreaterThan(
+                (MAX_CANVAS_PIXELS.get(browserName) / 100) * 0.95
+              );
           })
         );
       });
@@ -565,10 +569,10 @@ describe("PDF viewer", () => {
                 .toBe(2);
               expect(after[0].width)
                 .withContext(`In ${browserName}`)
-                .toBe(582 * pixelRatio);
+                .toBe(Math.floor(58.2 * pixelRatio));
               expect(after[0].height)
                 .withContext(`In ${browserName}`)
-                .toBe(823 * pixelRatio);
+                .toBe(Math.floor(82.3 * pixelRatio));
 
               // The dimensions of the detail canvas are capped to 800x600 but
               // it depends on the visible area which depends itself of the

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -798,6 +798,12 @@ class PDFPageView extends BasePDFPageView {
         this.maxCanvasDim,
         this.capCanvasAreaFactor
       );
+      if (this.#needsRestrictedScaling && this.enableDetailCanvas) {
+        // If we are going to have a high-res detail view, further reduce
+        // the canvas resolution to improve rendering performance.
+        outputScale.sx /= 10;
+        outputScale.sy /= 10;
+      }
     }
   }
 


### PR DESCRIPTION
The size of the canvas has significant impact on the rendering performance. If we are going to render a high-res detail view on top of the full-page canvas, we can further reduce the full-page canvas resolution to improve
rendering time without affecting the resolution seen by the user.

Users will se the lower resolution when quickly scrolling around the page, but it will then be replaced with the high-res detail view.