### PR TITLE
Only record bboxes when needed

### DIFF
--- a/web/pdf_page_detail_view.js
+++ b/web/pdf_page_detail_view.js
@@ -187,11 +187,15 @@ class PDFPageDetailView extends BasePDFPageView {
   }
 
   _getRenderingContext(canvas, transform) {
-    const baseContext = this.pageView._getRenderingContext(canvas, transform);
+    const baseContext = this.pageView._getRenderingContext(
+      canvas,
+      transform,
+      false
+    );
     const recordedBBoxes = this.pdfPage.recordedBBoxes;
 
     if (!recordedBBoxes || !this.enableOptimizedPartialRendering) {
-      return { ...baseContext, recordOperations: false };
+      return baseContext;
     }
 
     const {
@@ -211,7 +215,6 @@ class PDFPageDetailView extends BasePDFPageView {
 
     return {
       ...baseContext,
-      recordOperations: false,
       operationsFilter(index) {
         if (recordedBBoxes.isEmpty(index)) {
           return false;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -929,7 +929,7 @@ class PDFPageView extends BasePDFPageView {
     return canvasWrapper;
   }
 
-  _getRenderingContext(canvas, transform) {
+  _getRenderingContext(canvas, transform, recordOperations) {
     return {
       canvas,
       transform,
@@ -939,8 +939,7 @@ class PDFPageView extends BasePDFPageView {
       annotationCanvasMap: this._annotationCanvasMap,
       pageColors: this.pageColors,
       isEditing: this.#isEditing,
-      recordOperations:
-        this.enableOptimizedPartialRendering && !this.recordedBBoxes,
+      recordOperations,
     };
   }
 
@@ -1058,12 +1057,17 @@ class PDFPageView extends BasePDFPageView {
       this.#scaleRoundY = sfy[1];
     }
 
+    const recordBBoxes =
+      this.enableOptimizedPartialRendering &&
+      this.#hasRestrictedScaling &&
+      !this.recordedBBoxes;
+
     // Rendering area
     const transform = outputScale.scaled
       ? [outputScale.sx, 0, 0, outputScale.sy, 0, 0]
       : null;
     const resultPromise = this._drawCanvas(
-      this._getRenderingContext(canvas, transform),
+      this._getRenderingContext(canvas, transform, recordBBoxes),
       () => {
         prevCanvas?.remove();
         this._resetCanvas();


### PR DESCRIPTION
Before this patch, when `enableOptimizedPartialRendering`
is enabled we would record the bounding boxes of the
various operations on the first render.

This patch changes it to happen on the first render that we
know will also need a detail view, so that the performance
cost is not paid for the case when the detail view is not used.