### PR TITLE
[Editor] Cleanup the pages not being fully rendered before switching to editing mode

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1074,6 +1074,10 @@ class PDFPageView extends BasePDFPageView {
         );
       }
     ).then(async () => {
+      if (this.renderingState !== RenderingStates.FINISHED) {
+        // The rendering has been cancelled.
+        return;
+      }
       this.structTreeLayer ||= new StructTreeLayerBuilder(
         pdfPage,
         viewport.rawDims

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2502,6 +2502,8 @@ class PDFViewer {
       if (!isEditing) {
         this.pdfDocument.annotationStorage.resetModifiedIds();
       }
+      // We need to cleanup whatever pages being rendered.
+      this.cleanup();
       for (const pageView of this._pages) {
         pageView.toggleEditingMode(isEditing);
       }


### PR DESCRIPTION
In order to see the issue this patch is fixing:
 - open a pdf with some highlights and a comment on page 1, at page 7
 - open the comment sidebar
 - click on the comment on page 1

Opening at page 7 lets a not fully rendered page which means that when jumping to it with the sidebar, we re-use what we've instead of redrawing it.