### PR TITLE
Check for ASCII control characters in the getCharUnicodeCategory method

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1027,6 +1027,17 @@ class PartialEvaluator {
     const font = state.font;
     const glyphs = font.charsToGlyphs(chars);
 
+    // Filter out invisible format marks
+    const filteredGlyphs = [];
+    for (let i = 0, ii = glyphs.length; i < ii; i++) {
+      const glyph = glyphs[i];
+      const { category } = glyph;
+      if (category.isInvisibleFormatMark) {
+        continue;
+      }
+      filteredGlyphs.push(glyph);
+    }
+
     if (font.data) {
       const isAddToPathSet = !!(
         state.textRenderingMode & TextRenderingMode.ADD_TO_PATH_FLAG
@@ -1038,13 +1049,13 @@ class PartialEvaluator {
       ) {
         PartialEvaluator.buildFontPaths(
           font,
-          glyphs,
+          filteredGlyphs,
           this.handler,
           this.options
         );
       }
     }
-    return glyphs;
+    return filteredGlyphs;
   }
 
   ensureStateFont(state) {

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -243,8 +243,8 @@ function getUnicodeRangeFor(value, lastPosition = -1) {
 }
 
 const SpecialCharRegExp = new RegExp("^(\\s)|(\\p{Mn})|(\\p{Cf})$", "u");
+const AsciiControlCharRegExp = /[\x00-\x08\x0a-\x1f\x7f]/u;
 const CategoryCache = new Map();
-
 function getCharUnicodeCategory(char) {
   const cachedCategory = CategoryCache.get(char);
   if (cachedCategory) {
@@ -254,7 +254,7 @@ function getCharUnicodeCategory(char) {
   const category = {
     isWhitespace: !!groups?.[1],
     isZeroWidthDiacritic: !!groups?.[2],
-    isInvisibleFormatMark: !!groups?.[3],
+    isInvisibleFormatMark: !!groups?.[3] || AsciiControlCharRegExp.test(char),
   };
   CategoryCache.set(char, category);
   return category;

--- a/test/unit/unicode_spec.js
+++ b/test/unit/unicode_spec.js
@@ -106,6 +106,35 @@ describe("unicode", function () {
           isInvisibleFormatMark: false,
           isWhitespace: false,
         },
+
+        // ASCII control characters
+        // [\x00-\x08\x0a-\x1f\x7f]
+
+        "\x08": {
+          isZeroWidthDiacritic: false,
+          isInvisibleFormatMark: true,
+          isWhitespace: false,
+        },
+        "\x0b": {
+          isZeroWidthDiacritic: false,
+          isInvisibleFormatMark: true,
+          isWhitespace: true,
+        },
+        "\x0c": {
+          isZeroWidthDiacritic: false,
+          isInvisibleFormatMark: true,
+          isWhitespace: true,
+        },
+        "\x1f": {
+          isZeroWidthDiacritic: false,
+          isInvisibleFormatMark: true,
+          isWhitespace: false,
+        },
+        "\x7f": {
+          isZeroWidthDiacritic: false,
+          isInvisibleFormatMark: true,
+          isWhitespace: false,
+        },
       };
       for (const [character, expectation] of Object.entries(tests)) {
         expect(getCharUnicodeCategory(character)).toEqual(expectation);


### PR DESCRIPTION
Fixes [https://github.com/mozilla/pdf.js/issues/20260](url)

It's an honor – this is my first contribution to pdfjs. I'm not sure if the code is 100% correct, please advise.