### PR TITLE
Replace manual returns with `pending` in the integration tests

### DIFF
--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1072,13 +1072,11 @@ describe("Highlight Editor", () => {
     it("must check that an highlight can be left with the keyboard", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          await switchToHighlight(page);
-
           if (browserName === "chrome") {
-            // Unfortunately, we can't test this on Chrome because we can't set
-            // the caret browsing mode to true.
-            return;
+            pending("Caret browsing mode cannot be used in Chrome.");
           }
+
+          await switchToHighlight(page);
 
           let rect = await getSpanRectFromText(
             page,
@@ -1855,9 +1853,7 @@ describe("Highlight Editor", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           if (navigator.platform.includes("Win")) {
-            // Skip the test on Windows because it permafails.
-            // TODO: Remove this check once #20136 is fixed.
-            return;
+            pending("Fails consistently on Windows (issue #20136).");
           }
 
           await switchToHighlight(page);

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -1217,10 +1217,9 @@ describe("The pen-drawn shape must maintain correct curvature regardless of the 
     await Promise.all(
       pages.map(async ([browserName, page]) => {
         if (browserName === "chrome" && navigator.platform.includes("Win")) {
-          // Skip the test for Chrome on Windows because it doesn't allow to
-          // have elements outside the viewport and thus permafails with e.g.
-          // `Cannot move beyond viewport (x: -32, y: 241)`.
-          return;
+          pending(
+            "Chrome on Windows doesn't allow having elements outside the viewport."
+          );
         }
 
         await switchToInk(page);

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -1375,15 +1375,14 @@ describe("PDF viewer", () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           if (browserName === "firefox") {
-            // Firefox does not support touch events on devices
-            // with no touch screen.
-            return;
+            pending(
+              "Touch events are not supported on devices without touch screen in Firefox."
+            );
           }
           if (browserName === "chrome") {
-            // Skip the test for Chrome as it doesn't support pinch zoom
-            // emulation for WebDriver BiDi yet.
-            // TODO: Remove this check once the issue is fixed.
-            return;
+            pending(
+              "Pinch zoom emulation is not supported for WebDriver BiDi in Chrome."
+            );
           }
 
           const rect = await getSpanRectFromText(page, 1, "type-stable");


### PR DESCRIPTION
This allows Jasmine to track skipped tests and makes it easier to discover them using e.g. `grep`.