### PR TITLE
[Editor] Remove useless computations when setting the dimensions of an editor

### DIFF
--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -494,8 +494,7 @@ class DrawingEditor extends AnnotationEditor {
       this.#convertToParentSpace(bbox);
     if (this.div) {
       this.fixAndSetPosition();
-      const [parentWidth, parentHeight] = this.parentDimensions;
-      this.setDims(this.width * parentWidth, this.height * parentHeight);
+      this.setDims();
     }
     this._onResized();
   }
@@ -655,8 +654,7 @@ class DrawingEditor extends AnnotationEditor {
     div.append(drawDiv);
     drawDiv.setAttribute("aria-hidden", "true");
     drawDiv.className = "internal";
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    this.setDims(this.width * parentWidth, this.height * parentHeight);
+    this.setDims();
     this._uiManager.addShouldRescale(this);
     this.disableEditing();
 

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -63,8 +63,6 @@ class AnnotationEditor {
 
   #dragPointerType = "";
 
-  #keepAspectRatio = false;
-
   #resizersDiv = null;
 
   #lastPointerCoords = null;
@@ -736,34 +734,15 @@ class AnnotationEditor {
 
   /**
    * Set the dimensions of this editor.
-   * @param {number} width
-   * @param {number} height
    */
-  setDims(width, height) {
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    const { style } = this.div;
-    style.width = `${((100 * width) / parentWidth).toFixed(2)}%`;
-    if (!this.#keepAspectRatio) {
-      style.height = `${((100 * height) / parentHeight).toFixed(2)}%`;
-    }
-  }
-
-  fixDims() {
-    const { style } = this.div;
-    const { height, width } = style;
-    const widthPercent = width.endsWith("%");
-    const heightPercent = !this.#keepAspectRatio && height.endsWith("%");
-    if (widthPercent && heightPercent) {
-      return;
-    }
-
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    if (!widthPercent) {
-      style.width = `${((100 * parseFloat(width)) / parentWidth).toFixed(2)}%`;
-    }
-    if (!this.#keepAspectRatio && !heightPercent) {
-      style.height = `${((100 * parseFloat(height)) / parentHeight).toFixed(2)}%`;
-    }
+  setDims() {
+    const {
+      div: { style },
+      width,
+      height,
+    } = this;
+    style.width = `${(100 * width).toFixed(2)}%`;
+    style.height = `${(100 * height).toFixed(2)}%`;
   }
 
   /**
@@ -872,8 +851,7 @@ class AnnotationEditor {
     this.height = height;
     this.x = x;
     this.y = y;
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    this.setDims(parentWidth * width, parentHeight * height);
+    this.setDims();
     this.fixAndSetPosition();
     this._onResized();
   }
@@ -1050,7 +1028,7 @@ class AnnotationEditor {
     this.x = newX;
     this.y = newY;
 
-    this.setDims(parentWidth * newWidth, parentHeight * newHeight);
+    this.setDims();
     this.fixAndSetPosition();
 
     this._onResizing();
@@ -1417,7 +1395,7 @@ class AnnotationEditor {
     this.width = newWidth;
     this.height = newHeight;
 
-    this.setDims(parentWidth * newWidth, parentHeight * newHeight);
+    this.setDims();
     this.fixAndSetPosition();
 
     this._onResizing();
@@ -2258,19 +2236,6 @@ class AnnotationEditor {
     } else {
       this.parent.setActiveEditor(null);
     }
-  }
-
-  /**
-   * Set the aspect ratio to use when resizing.
-   * @param {number} width
-   * @param {number} height
-   */
-  setAspectRatio(width, height) {
-    this.#keepAspectRatio = true;
-    const aspectRatio = width / height;
-    const { style } = this.div;
-    style.aspectRatio = aspectRatio;
-    style.height = "auto";
   }
 
   static get MIN_SIZE() {

--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -525,8 +525,7 @@ class HighlightEditor extends AnnotationEditor {
       highlightOutlines: this.#highlightOutlines.getNewOutline(thickness / 2),
     });
     this.fixAndSetPosition();
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    this.setDims(this.width * parentWidth, this.height * parentHeight);
+    this.setDims(this.width, this.height);
   }
 
   #cleanDrawLayer() {
@@ -645,8 +644,7 @@ class HighlightEditor extends AnnotationEditor {
     highlightDiv.setAttribute("aria-hidden", "true");
     highlightDiv.className = "internal";
     highlightDiv.style.clipPath = this.#clipPathId;
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    this.setDims(this.width * parentWidth, this.height * parentHeight);
+    this.setDims(this.width, this.height);
 
     bindEvents(this, this.#highlightDiv, ["pointerover", "pointerleave"]);
     this.enableEditing();

--- a/src/display/editor/signature.js
+++ b/src/display/editor/signature.js
@@ -276,7 +276,6 @@ class SignatureEditor extends DrawingEditor {
       drawOutlines: outline,
       drawingOptions,
     });
-    const [parentWidth, parentHeight] = this.parentDimensions;
     const [, pageHeight] = this.pageDimensions;
     let newHeight = heightInPage / pageHeight;
     // Ensure the signature doesn't exceed the page height.
@@ -290,7 +289,7 @@ class SignatureEditor extends DrawingEditor {
     }
 
     this.height = newHeight;
-    this.setDims(parentWidth * this.width, parentHeight * this.height);
+    this.setDims();
     this.x = savedX;
     this.y = savedY;
     this.center();

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -443,11 +443,6 @@ class StampEditor extends AnnotationEditor {
       width *= factor;
       height *= factor;
     }
-    const [parentWidth, parentHeight] = this.parentDimensions;
-    this.setDims(
-      (width * parentWidth) / pageWidth,
-      (height * parentHeight) / pageHeight
-    );
 
     this._uiManager.enableWaiting(false);
     const canvas = (this.#canvas = document.createElement("canvas"));
@@ -456,6 +451,8 @@ class StampEditor extends AnnotationEditor {
 
     this.width = width / pageWidth;
     this.height = height / pageHeight;
+    this.setDims();
+
     if (this._initialOptions?.isCentered) {
       this.center();
     } else {


### PR DESCRIPTION
And remove an unused function AnnotationEditor::setAspectRatio/fixDims.