### PR TITLE
Add font weight to font instance.

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4599,6 +4599,10 @@ class PartialEvaluator {
     if (typeof italicAngle !== "number") {
       italicAngle = 0;
     }
+    let fontWeight = descriptor.get("FontWeight");
+    if (typeof fontWeight !== "number") {
+      fontWeight = 400;
+    }
 
     const properties = {
       type,
@@ -4623,6 +4627,7 @@ class PartialEvaluator {
       capHeight,
       flags,
       italicAngle,
+      fontWeight,
       isType3Font,
       cssFontInfo,
       scaleFactors: glyphScaleFactors,

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -91,6 +91,7 @@ const EXPORT_DATA_PROPERTIES = [
   "fallbackName",
   "fontExtraProperties",
   "fontMatrix",
+  "fontWeight",
   "isInvalidPDFjsFont",
   "isType3Font",
   "italic",
@@ -1036,6 +1037,7 @@ class Font {
     this.descent = properties.descent / PDF_GLYPH_SPACE_UNITS;
     this.lineHeight = this.ascent - this.descent;
     this.fontMatrix = properties.fontMatrix;
+    this.fontWeight = properties.fontWeight;
     this.bbox = properties.bbox;
     this.defaultEncoding = properties.defaultEncoding;
 


### PR DESCRIPTION
Extract `fontWeight` from font descriptor. It can be used to use a `<strong>` tag when necessary in text layers. 