### PR TITLE
[Editor] Make sure the comment dialog always have relative coordinates between 0% and 100%

### DIFF
--- a/web/comment_manager.js
+++ b/web/comment_manager.js
@@ -854,8 +854,9 @@ class CommentDialog {
         posY = 0;
       }
     }
-    posX /= innerWidth;
-    posY /= innerHeight;
+
+    posX = MathClamp(posX / innerWidth, 0, 1);
+    posY = MathClamp(posY / innerHeight, 0, 1);
     this.#setPosition(posX, posY);
 
     await this.#overlayManager.open(this.#dialog);


### PR DESCRIPTION
This way, when the window is resized, the dialog stay visible.