### PR TITLE
[Editor] Remove obsolete arguments for `setDims` calls in the highlight code

### DIFF
--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -527,7 +527,7 @@ class HighlightEditor extends AnnotationEditor {
       highlightOutlines: this.#highlightOutlines.getNewOutline(thickness / 2),
     });
     this.fixAndSetPosition();
-    this.setDims(this.width, this.height);
+    this.setDims();
   }
 
   #cleanDrawLayer() {
@@ -646,7 +646,7 @@ class HighlightEditor extends AnnotationEditor {
     highlightDiv.setAttribute("aria-hidden", "true");
     highlightDiv.className = "internal";
     highlightDiv.style.clipPath = this.#clipPathId;
-    this.setDims(this.width, this.height);
+    this.setDims();
 
     bindEvents(this, this.#highlightDiv, ["pointerover", "pointerleave"]);
     this.enableEditing();


### PR DESCRIPTION
The `width` and `height` arguments for `setDims` have been removed in PR #20285, but for two calls in the highlight code they remained. This commit removes them as they are no longer used in the method itself.

Fixes 0722faa9.