### PR TITLE
Use enums instead of string for mesh shading figure type

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -18,6 +18,7 @@ import {
   FormatError,
   info,
   MathClamp,
+  MeshFigureType,
   unreachable,
   Util,
   warn,
@@ -582,7 +583,7 @@ class MeshShading extends BaseShading {
       reader.align();
     }
     this.figures.push({
-      type: "triangles",
+      type: MeshFigureType.TRIANGLES,
       coords: new Int32Array(ps),
       colors: new Int32Array(ps),
     });
@@ -600,7 +601,7 @@ class MeshShading extends BaseShading {
       colors.push(color);
     }
     this.figures.push({
-      type: "lattice",
+      type: MeshFigureType.LATTICE,
       coords: new Int32Array(ps),
       colors: new Int32Array(ps),
       verticesPerRow,
@@ -732,7 +733,7 @@ class MeshShading extends BaseShading {
           9,
       ]);
       this.figures.push({
-        type: "patch",
+        type: MeshFigureType.PATCH,
         coords: new Int32Array(ps), // making copies of ps and cs
         colors: new Int32Array(cs),
       });
@@ -802,7 +803,7 @@ class MeshShading extends BaseShading {
           break;
       }
       this.figures.push({
-        type: "patch",
+        type: MeshFigureType.PATCH,
         coords: new Int32Array(ps), // making copies of ps and cs
         colors: new Int32Array(cs),
       });
@@ -811,7 +812,10 @@ class MeshShading extends BaseShading {
 
   _buildFigureFromPatch(index) {
     const figure = this.figures[index];
-    assert(figure.type === "patch", "Unexpected patch mesh figure");
+    assert(
+      figure.type === MeshFigureType.PATCH,
+      "Unexpected patch mesh figure"
+    );
 
     const coords = this.coords,
       colors = this.colors;
@@ -919,7 +923,7 @@ class MeshShading extends BaseShading {
     figureColors[verticesPerRow * splitYBy + splitXBy] = ci[3];
 
     this.figures[index] = {
-      type: "lattice",
+      type: MeshFigureType.LATTICE,
       coords: figureCoords,
       colors: figureColors,
       verticesPerRow,

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { FormatError, info, unreachable, Util } from "../shared/util.js";
+import {
+  FormatError,
+  info,
+  MeshFigureType,
+  unreachable,
+  Util,
+} from "../shared/util.js";
 import { getCurrentTransform } from "./display_utils.js";
 
 const PathType = {
@@ -261,7 +267,7 @@ function drawFigure(data, figure, context) {
   const cs = figure.colors;
   let i, ii;
   switch (figure.type) {
-    case "lattice":
+    case MeshFigureType.LATTICE:
       const verticesPerRow = figure.verticesPerRow;
       const rows = Math.floor(ps.length / verticesPerRow) - 1;
       const cols = verticesPerRow - 1;
@@ -291,7 +297,7 @@ function drawFigure(data, figure, context) {
         }
       }
       break;
-    case "triangles":
+    case MeshFigureType.TRIANGLES:
       for (i = 0, ii = ps.length; i < ii; i += 3) {
         drawTriangle(
           data,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -108,6 +108,12 @@ const PermissionFlag = {
   PRINT_HIGH_QUALITY: 0x800,
 };
 
+const MeshFigureType = {
+  TRIANGLES: 1,
+  LATTICE: 2,
+  PATCH: 3,
+};
+
 const TextRenderingMode = {
   FILL: 0,
   STROKE: 1,
@@ -1327,6 +1333,7 @@ export {
   LINE_DESCENT_FACTOR,
   LINE_FACTOR,
   MathClamp,
+  MeshFigureType,
   normalizeUnicode,
   objectSize,
   OPS,


### PR DESCRIPTION
Refactors the mesh shading figure type to use an enum instead of string literals. 