### PR TITLE
Reset `sameLineText` dependencies data on `setTextMatrix`

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1843,7 +1843,9 @@ class CanvasGraphics {
   }
 
   setTextMatrix(opIdx, matrix) {
-    this.dependencyTracker?.recordSimpleData("textMatrix", opIdx);
+    this.dependencyTracker
+      ?.resetIncrementalData("sameLineText")
+      .recordSimpleData("textMatrix", opIdx);
     const { current } = this;
     current.textMatrix = matrix;
     current.textMatrixScale = Math.hypot(matrix[0], matrix[1]);


### PR DESCRIPTION
The position of the text rendered by `showText` is affected incrementally by the preceding `showText` operations "on the same line". For this reason, we keep track of all of them (with their dependencies) in `sameLineText`.

`sameLineText` can be reset whenever we explicitly position the text somewhere else. We were previously only doing it for `moveText`, and this patch updates the code to also do it on `setTextMatrix` (which resets `this.current.x/y` in `CanvasGraphics` to 0).

The complexity of subsequent `sameLineText` operations dependency tracking grows quadratically with the number of operations on the same line, so this patch fixes the performance problem when there are whole pages of text that only use `setTextMatrix` and not `moveText`.