### PR TITLE
Use Python 3.14 in the GitHub workflows

### DIFF
--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Use Python 3.13
+      - name: Use Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install Fluent dependencies

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Use Python 3.13
+      - name: Use Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install Fonttools


### PR DESCRIPTION
Python 3.14 is the current stable version, released on October 7th. The dependencies we use also support Python 3.14 now, most importantly `fonttools` for which the OS-specific builds have been published (see the `cp314` wheels on https://pypi.org/project/fonttools/#files).