### PR TITLE
Don't use the `aboutstacks.pdf` file in the integration tests

### DIFF
--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -57,7 +57,7 @@ describe("Ink Editor", () => {
     let pages;
 
     beforeEach(async () => {
-      pages = await loadAndWait("aboutstacks.pdf", ".annotationEditorLayer");
+      pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
     });
 
     afterEach(async () => {


### PR DESCRIPTION
For the integration tests we prefer non-linked test cases because those PDF files are directly checked into the Git repository and thus don't need a separate download step that linked test cases do.

However, for the freetext and ink integration tests we currently use `aboutstacks.pdf` which is a linked test case. Fortunately we don't need to use it because for most tests we don't actually use any properties of it: we only create editors on top of the canvas, but for that any PDF file works, so we can simply use the non-linked `empty.pdf` file instead.

The only exception is the "aria-owns" test that needs a line of text from the PDF file, so we move that particular test to a dedicated `describe` block and adapt it to use the non-linked `attachment.pdf` file that just contains a single line of text that can be used for this purpose.

The changes combined make 12 more integration tests run out-of-the-box after a Git clone, which also simplifies running on GitHub Actions.

Related to #11851.