### PR TITLE
Tweak the "scroll into view" viewer integration test

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -1453,10 +1453,12 @@ describe("PDF viewer", () => {
           const rect = await getRect(page, annotationSelector);
           const containerRect = await getRect(page, "#viewerContainer");
           expect(
-            Math.abs(2 * (rect.y - containerRect.y) - containerRect.height)
+            Math.abs(
+              2 * (Math.ceil(rect.y) - containerRect.y) - containerRect.height
+            )
           )
             .withContext(`In ${browserName}`)
-            .toBeLessThan(1);
+            .toBeLessThanOrEqual(1);
         })
       );
     });


### PR DESCRIPTION
On GitHub Actions this test could fail with `Expected 1.3125 to be less than 1` due to slight differences in the decimals of the `rect.y` value. However, for this check we're only really interested in full pixels, so this commit rounds the value up to the next integer to not be affected by small decimal differences so the test passes on GitHub Actions too.

Related to #11851.