### PR TITLE
Fix search functionality to respect punctuation(.) and spaces( ) exactly

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -723,11 +723,11 @@ class PDFFindController {
 
         if (p1) {
           // Escape characters like *+?... to not interfere with regexp syntax.
-          return `[ ]*\\${p1}[ ]*`;
+          return `\\${p1}`;
         }
         if (p2) {
-          // Allow whitespaces around punctuation signs.
-          return `[ ]*${p2}[ ]*`;
+          // Match punctuation signs exactly without allowing arbitrary whitespaces.
+          return p2;
         }
         if (p3) {
           // Replace spaces by \s+ to be sure to match any spaces.


### PR DESCRIPTION
**Issue** :
Search functionality is ignoring spaces after dot or full stop.
Ex : on ctrl+f, I searched "exits.if" -> "exits. if" is shown

**What I fixed :** 
- Removed optional spaces around punctuation marks in search regex
- Ensures exact matching for both dots and spaces, other existing functionalities are uniterrupted.
- Fixes issue #20225 where searching for '..' would incorrectly match '. ...'
- Before if "hello.world" is searched, then "hello. world" is also shown. After my code update, search does not ignore spaces(" ") after dot (".")
- Add test cases to prevent regression.

Resolves: https://github.com/mozilla/pdf.js/issues/20225

### Testing
- Verified search works correctly with various punctuation patterns
- Added unit tests to prevent regression
- Tested with different spacing scenarios

**Before :**
<img width="504" height="182" alt="Screenshot 2025-10-22 164411" src="https://github.com/user-attachments/assets/ebac8ba7-e00e-43d4-9ea9-69142715ec79" />
**After:**
<img width="699" height="127" alt="Screenshot 2025-10-22 172608" src="https://github.com/user-attachments/assets/c8119793-6a7b-41c7-89fd-2464a69f851a" />
<img width="688" height="123" alt="Screenshot 2025-10-22 172649" src="https://github.com/user-attachments/assets/7dc77540-404f-4882-8199-19757f5099be" />


