### PR TITLE
Add the font PT Astra Serif as a possible substitution for Times New Roman

### DIFF
--- a/src/core/font_substitutions.js
+++ b/src/core/font_substitutions.js
@@ -51,6 +51,7 @@ const substitutionMap = new Map([
         "FreeSerif",
         "Linux Libertine O",
         "Libertinus Serif",
+        "PT Astra Serif",
         "DejaVu Serif",
         "Bitstream Vera Serif",
         "Ubuntu",

--- a/test/unit/font_substitutions_spec.js
+++ b/test/unit/font_substitutions_spec.js
@@ -140,7 +140,7 @@ describe("getFontSubstitution", function () {
     expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+)$/);
   });
 
-  it("should substitute an unknown font but with a standard font", () => {
+  it("should substitute an unknown sans-serif font but with a standard font", () => {
     const fontName = "Foo";
     const fontSubstitution = getFontSubstitution(
       new Map(),
@@ -172,7 +172,7 @@ describe("getFontSubstitution", function () {
     expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),sans-serif$/);
   });
 
-  it("should substitute an unknown font but with a standard italic font", () => {
+  it("should substitute an unknown sans-serif font but with a standard italic font", () => {
     const fontName = "Foo-Italic";
     const fontSubstitution = getFontSubstitution(
       new Map(),
@@ -206,7 +206,7 @@ describe("getFontSubstitution", function () {
     expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),sans-serif$/);
   });
 
-  it("should substitute an unknown font but with a standard bold font", () => {
+  it("should substitute an unknown sans-serif font but with a standard bold font", () => {
     const fontName = "Foo-Bold";
     const fontSubstitution = getFontSubstitution(
       new Map(),
@@ -239,7 +239,7 @@ describe("getFontSubstitution", function () {
     expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),sans-serif$/);
   });
 
-  it("should substitute an unknown font but with a standard bold italic font", () => {
+  it("should substitute an unknown sans-serif font but with a standard bold italic font", () => {
     const fontName = "Foo-BoldItalic";
     const fontSubstitution = getFontSubstitution(
       new Map(),
@@ -273,6 +273,136 @@ describe("getFontSubstitution", function () {
       })
     );
     expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),sans-serif$/);
+  });
+
+  it("should substitute an unknown serif font but with a standard font", () => {
+    const fontName = "Foo";
+    const fontSubstitution = getFontSubstitution(
+      new Map(),
+      idFactory,
+      localFontPath,
+      fontName,
+      "Times-Roman",
+      "TrueType"
+    );
+    expect(fontSubstitution).toEqual(
+      jasmine.objectContaining({
+        guessFallback: false,
+        baseFontName: "Foo",
+        src:
+          "local(Foo),local(Times New Roman),local(Times-Roman),local(Times)," +
+          "local(Liberation Serif),local(Nimbus Roman),local(Nimbus Roman L)," +
+          "local(Tinos),local(Thorndale),local(TeX Gyre Termes)," +
+          "local(FreeSerif),local(Linux Libertine O)," +
+          "local(Libertinus Serif),local(PT Astra Serif)," +
+          "local(DejaVu Serif),local(Bitstream Vera Serif)," +
+          "local(Ubuntu)",
+        style: {
+          style: "normal",
+          weight: "normal",
+        },
+      })
+    );
+    expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),serif$/);
+  });
+
+  it("should substitute an unknown serif font but with a standard italic font", () => {
+    const fontName = "Foo-Italic";
+    const fontSubstitution = getFontSubstitution(
+      new Map(),
+      idFactory,
+      localFontPath,
+      fontName,
+      "Times-Italic",
+      "TrueType"
+    );
+    expect(fontSubstitution).toEqual(
+      jasmine.objectContaining({
+        guessFallback: false,
+        baseFontName: "Foo-Italic",
+        src:
+          "local(Foo-Italic),local(Times New Roman Italic)," +
+          "local(Times-Roman Italic),local(Times Italic)," +
+          "local(Liberation Serif Italic),local(Nimbus Roman Italic)," +
+          "local(Nimbus Roman L Italic)," +
+          "local(Tinos Italic),local(Thorndale Italic)," +
+          "local(TeX Gyre Termes Italic),local(FreeSerif Italic)," +
+          "local(Linux Libertine O Italic),local(Libertinus Serif Italic)," +
+          "local(PT Astra Serif Italic),local(DejaVu Serif Italic)," +
+          "local(Bitstream Vera Serif Italic),local(Ubuntu Italic)",
+        style: {
+          style: "italic",
+          weight: "normal",
+        },
+      })
+    );
+    expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),serif$/);
+  });
+
+  it("should substitute an unknown serif font but with a standard bold font", () => {
+    const fontName = "Foo-Bold";
+    const fontSubstitution = getFontSubstitution(
+      new Map(),
+      idFactory,
+      localFontPath,
+      fontName,
+      "Times-Bold",
+      "TrueType"
+    );
+    expect(fontSubstitution).toEqual(
+      jasmine.objectContaining({
+        guessFallback: false,
+        baseFontName: "Foo-Bold",
+        src:
+          "local(Foo-Bold),local(Times New Roman Bold),local(Times-Roman Bold)," +
+          "local(Times Bold),local(Liberation Serif Bold)," +
+          "local(Nimbus Roman Bold),local(Nimbus Roman L Bold)," +
+          "local(Tinos Bold),local(Thorndale Bold)," +
+          "local(TeX Gyre Termes Bold)," +
+          "local(FreeSerif Bold),local(Linux Libertine O Bold)," +
+          "local(Libertinus Serif Bold),local(PT Astra Serif Bold)," +
+          "local(DejaVu Serif Bold),local(Bitstream Vera Serif Bold)," +
+          "local(Ubuntu Bold)",
+        style: {
+          style: "normal",
+          weight: "bold",
+        },
+      })
+    );
+    expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),serif$/);
+  });
+
+  it("should substitute an unknown serif font but with a standard bold italic font", () => {
+    const fontName = "Foo-BoldItalic";
+    const fontSubstitution = getFontSubstitution(
+      new Map(),
+      idFactory,
+      localFontPath,
+      fontName,
+      "Times-BoldItalic",
+      "TrueType"
+    );
+    expect(fontSubstitution).toEqual(
+      jasmine.objectContaining({
+        guessFallback: false,
+        baseFontName: "Foo-BoldItalic",
+        src:
+          "local(Foo-BoldItalic),local(Times New Roman Bold Italic)," +
+          "local(Times-Roman Bold Italic),local(Times Bold Italic)," +
+          "local(Liberation Serif Bold Italic),local(Nimbus Roman Bold Italic)," +
+          "local(Nimbus Roman L Bold Italic),local(Tinos Bold Italic)," +
+          "local(Thorndale Bold Italic),local(TeX Gyre Termes Bold Italic)," +
+          "local(FreeSerif Bold Italic),local(Linux Libertine O Bold Italic)," +
+          "local(Libertinus Serif Bold Italic)," +
+          "local(PT Astra Serif Bold Italic),local(DejaVu Serif Bold Italic)," +
+          "local(Bitstream Vera Serif Bold Italic),local(Ubuntu Bold Italic)",
+        style: {
+          style: "italic",
+          weight: "bold",
+        },
+      })
+    );
+    expect(fontSubstitution.css).toMatch(/^"Foo",g_d(\d+)_sf(\d+),serif$/);
   });
 
   it("should substitute Calibri", () => {


### PR DESCRIPTION
Metric-compatible font with Times New Roman created by ParaType, based on their serif font PT Serif, released under OFL-1.1 license.

https://www.paratype.com/fonts/pt/pt-astra-serif