### PR TITLE
Revert "Add some telemetry in order to know what are the certificates used in pdfs (bug 1973573)"

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1718,13 +1718,6 @@ const PDFViewerApplication = {
     if (pdfDocument !== this.pdfDocument) {
       return; // The document was closed while the metadata resolved.
     }
-    if (info.collectedSignatureCertificates) {
-      this.externalServices.reportTelemetry({
-        type: "signatureCertificates",
-        data: info.collectedSignatureCertificates,
-      });
-    }
-
     this.documentInfo = info;
     this.metadata = metadata;
     this._contentDispositionFilename ??= contentDispositionFilename;


### PR DESCRIPTION
Reverts mozilla/pdf.js#20031

We removed the signature telemetry in bug 1994606 hence this code is useless now.