### PR TITLE
fix: add an eof check in getInt32 to match getUint16

### DIFF
--- a/src/core/base_stream.js
+++ b/src/core/base_stream.js
@@ -104,6 +104,9 @@ class BaseStream {
     const b1 = this.getByte();
     const b2 = this.getByte();
     const b3 = this.getByte();
+    if (b0 === -1 || b1 === -1 || b2 === -1 || b3 === -1) {
+      return -1;
+    }
     return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
   }
 


### PR DESCRIPTION
I noticed that `getInt32` was missing the eof checking that `getUint16` has. This PR just adds that EOF checking (there shouldn't be any functionality change)