### PR TITLE
Add setter for some FontFaceObject properties

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -457,6 +457,10 @@ class FontFaceObject {
     return this.#fontData.disableFontFace ?? false;
   }
 
+  set disableFontFace(value) {
+    shadow(this, "disableFontFace", !!value);
+  }
+
   get fontExtraProperties() {
     return this.#fontData.fontExtraProperties ?? false;
   }
@@ -499,6 +503,10 @@ class FontFaceObject {
 
   get bbox() {
     return this.#fontData.bbox;
+  }
+
+  set bbox(bbox) {
+    shadow(this, "bbox", bbox);
   }
 
   get fontMatrix() {

--- a/test/pdfs/issue20426.pdf.link
+++ b/test/pdfs/issue20426.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/23383534/test.1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -1949,6 +1949,14 @@
     "forms": true
   },
   {
+    "id": "issue20426",
+    "file": "pdfs/issue20426.pdf",
+    "md5": "b9a753df595f1dd30505a67c96373dd8",
+    "link": true,
+    "rounds": 1,
+    "type": "eq"
+  },
+  {
     "id": "issue13845",
     "file": "pdfs/issue13845.pdf",
     "md5": "7c6b675f61ae68a2e416f4aa26da567c",


### PR DESCRIPTION
This fixes https://github.com/mozilla/pdf.js/issues/20426 which was caused as a regression of https://github.com/mozilla/pdf.js/pull/20197.

From https://bugzilla.mozilla.org/show_bug.cgi?id=1998618#c2:
> The pdf contains a font with some characters outside of the range [0x0000-0xFFFF] and when writing the cmap we use the format 4 which is supposed to only handle characters in this range !
For this specific font, a format 8 would have been better:
https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage

For now, this makes the properties `disableFontFace` and `bbox` mutable as they are later reassgined in https://github.com/mozilla/pdf.js/blob/master/src/core/evaluator.js#L4742 while falling back to browser fonts and in https://github.com/mozilla/pdf.js/blob/master/src/core/evaluator.js#L4830. 
