### PR TITLE
Lint and format the HTML in using Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,10 +9,17 @@
 
   "overrides": [
     {
-      files: ["tsconfig.json"],
-      options: {
-        parser: "json",
-      },
+      "files": ["tsconfig.json", ".prettierrc"],
+      "options": {
+        "parser": "json"
+      }
     },
+    {
+      "files": ["**/*.html"],
+      "options": {
+        "parser": "html",
+        "printWidth": 160
+      }
+    }
   ]
 }

--- a/examples/components/pageviewer.html
+++ b/examples/components/pageviewer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2014 Mozilla Foundation
 
@@ -15,29 +15,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <html dir="ltr" mozdisallowselectionprint>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="google" content="notranslate">
-  <title>PDF.js page viewer using built components</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="google" content="notranslate" />
+    <title>PDF.js page viewer using built components</title>
 
-  <style>
-    body {
-      background-color: #808080;
-      margin: 0;
-      padding: 0;
-    }
-  </style>
+    <style>
+      body {
+        background-color: #808080;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
 
-  <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
+    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css" />
 
-  <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
-  <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
-</head>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
+    <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
+  </head>
 
-<body tabindex="1">
-  <div id="pageContainer" class="pdfViewer singlePageView"></div>
+  <body tabindex="1">
+    <div id="pageContainer" class="pdfViewer singlePageView"></div>
 
-  <script src="pageviewer.mjs" type="module"></script>
-</body>
+    <script src="pageviewer.mjs" type="module"></script>
+  </body>
 </html>

--- a/examples/components/simpleviewer.html
+++ b/examples/components/simpleviewer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2014 Mozilla Foundation
 
@@ -15,37 +15,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <html dir="ltr" mozdisallowselectionprint>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="google" content="notranslate">
-  <title>PDF.js viewer using built components</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="google" content="notranslate" />
+    <title>PDF.js viewer using built components</title>
 
-  <style>
-    body {
-      background-color: #808080;
-      margin: 0;
-      padding: 0;
-    }
-    #viewerContainer {
-      overflow: auto;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-    }
-  </style>
+    <style>
+      body {
+        background-color: #808080;
+        margin: 0;
+        padding: 0;
+      }
+      #viewerContainer {
+        overflow: auto;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
 
-  <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
+    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css" />
 
-  <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
-  <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
-</head>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
+    <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
+  </head>
 
-<body tabindex="1">
-  <div id="viewerContainer">
-    <div id="viewer" class="pdfViewer"></div>
-  </div>
+  <body tabindex="1">
+    <div id="viewerContainer">
+      <div id="viewer" class="pdfViewer"></div>
+    </div>
 
-  <script src="simpleviewer.mjs" type="module"></script>
-</body>
+    <script src="simpleviewer.mjs" type="module"></script>
+  </body>
 </html>

--- a/examples/components/singlepageviewer.html
+++ b/examples/components/singlepageviewer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2014 Mozilla Foundation
 
@@ -15,37 +15,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <html dir="ltr" mozdisallowselectionprint>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="google" content="notranslate">
-  <title>PDF.js Single Page Viewer using built components</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="google" content="notranslate" />
+    <title>PDF.js Single Page Viewer using built components</title>
 
-  <style>
-    body {
-      background-color: #808080;
-      margin: 0;
-      padding: 0;
-    }
-    #viewerContainer {
-      overflow: auto;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-    }
-  </style>
+    <style>
+      body {
+        background-color: #808080;
+        margin: 0;
+        padding: 0;
+      }
+      #viewerContainer {
+        overflow: auto;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
 
-  <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
+    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css" />
 
-  <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
-  <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
-</head>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
+    <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
+  </head>
 
-<body tabindex="1">
-  <div id="viewerContainer">
-    <div id="viewer" class="pdfViewer"></div>
-  </div>
+  <body tabindex="1">
+    <div id="viewerContainer">
+      <div id="viewer" class="pdfViewer"></div>
+    </div>
 
-  <script src="singlepageviewer.mjs" type="module"></script>
-</body>
+    <script src="singlepageviewer.mjs" type="module"></script>
+  </body>
 </html>

--- a/examples/image_decoders/jpeg_viewer.html
+++ b/examples/image_decoders/jpeg_viewer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2018 Mozilla Foundation
 
@@ -15,26 +15,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <html dir="ltr" mozdisallowselectionprint>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="google" content="notranslate">
-  <title>PDF.js standalone JpegImage parser</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="google" content="notranslate" />
+    <title>PDF.js standalone JpegImage parser</title>
 
-  <style>
-    body {
-      background-color: #808080;
-      margin: 0;
-      padding: 0;
-    }
-  </style>
+    <style>
+      body {
+        background-color: #808080;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
 
-  <script src="../../node_modules/pdfjs-dist/image_decoders/pdf.image_decoders.mjs" type="module"></script>
-</head>
+    <script src="../../node_modules/pdfjs-dist/image_decoders/pdf.image_decoders.mjs" type="module"></script>
+  </head>
 
-<body tabindex="1">
-  <canvas id="jpegCanvas" width="0" height="0"></canvas>
+  <body tabindex="1">
+    <canvas id="jpegCanvas" width="0" height="0"></canvas>
 
-  <script src="jpeg_viewer.mjs" type="module"></script>
-</body>
+    <script src="jpeg_viewer.mjs" type="module"></script>
+  </body>
 </html>

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -1,76 +1,71 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>'Hello, world!' example</title>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>'Hello, world!' example</title>
+  </head>
+  <body>
+    <h1>'Hello, world!' example</h1>
 
-<h1>'Hello, world!' example</h1>
+    <canvas id="the-canvas" style="border: 1px solid black; direction: ltr"></canvas>
 
-<canvas id="the-canvas" style="border: 1px solid black; direction: ltr;"></canvas>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
 
-<script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
+    <script id="script" type="module">
+      //
+      // If absolute URL from the remote server is provided, configure the CORS
+      // header on that server.
+      //
+      const url = "./helloworld.pdf";
 
-<script id="script" type="module">
-  //
-  // If absolute URL from the remote server is provided, configure the CORS
-  // header on that server.
-  //
-  const url = './helloworld.pdf';
+      //
+      // The workerSrc property shall be specified.
+      //
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "../../node_modules/pdfjs-dist/build/pdf.worker.mjs";
 
-  //
-  // The workerSrc property shall be specified.
-  //
-  pdfjsLib.GlobalWorkerOptions.workerSrc =
-    '../../node_modules/pdfjs-dist/build/pdf.worker.mjs';
+      //
+      // Asynchronous download PDF
+      //
+      const loadingTask = pdfjsLib.getDocument(url);
+      const pdf = await loadingTask.promise;
+      //
+      // Fetch the first page
+      //
+      const page = await pdf.getPage(1);
+      const scale = 1.5;
+      const viewport = page.getViewport({ scale });
+      // Support HiDPI-screens.
+      const outputScale = window.devicePixelRatio || 1;
 
-  //
-  // Asynchronous download PDF
-  //
-  const loadingTask = pdfjsLib.getDocument(url);
-  const pdf = await loadingTask.promise;
-  //
-  // Fetch the first page
-  //
-  const page = await pdf.getPage(1);
-  const scale = 1.5;
-  const viewport = page.getViewport({ scale });
-  // Support HiDPI-screens.
-  const outputScale = window.devicePixelRatio || 1;
+      //
+      // Prepare canvas using PDF page dimensions
+      //
+      const canvas = document.getElementById("the-canvas");
+      const context = canvas.getContext("2d");
 
-  //
-  // Prepare canvas using PDF page dimensions
-  //
-  const canvas = document.getElementById("the-canvas");
-  const context = canvas.getContext("2d");
+      canvas.width = Math.floor(viewport.width * outputScale);
+      canvas.height = Math.floor(viewport.height * outputScale);
+      canvas.style.width = Math.floor(viewport.width) + "px";
+      canvas.style.height = Math.floor(viewport.height) + "px";
 
-  canvas.width = Math.floor(viewport.width * outputScale);
-  canvas.height = Math.floor(viewport.height * outputScale);
-  canvas.style.width = Math.floor(viewport.width) + "px";
-  canvas.style.height = Math.floor(viewport.height) + "px";
+      const transform = outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null;
 
-  const transform = outputScale !== 1
-    ? [outputScale, 0, 0, outputScale, 0, 0]
-    : null;
+      //
+      // Render PDF page into canvas context
+      //
+      const renderContext = {
+        canvasContext: context,
+        transform,
+        viewport,
+      };
+      page.render(renderContext);
+    </script>
 
-  //
-  // Render PDF page into canvas context
-  //
-  const renderContext = {
-    canvasContext: context,
-    transform,
-    viewport,
-  };
-  page.render(renderContext);
-</script>
-
-<hr>
-<h2>JavaScript code:</h2>
-<pre id="code"></pre>
-<script>
-  document.getElementById('code').textContent =
-      document.getElementById('script').text;
-</script>
-</body>
+    <hr />
+    <h2>JavaScript code:</h2>
+    <pre id="code"></pre>
+    <script>
+      document.getElementById("code").textContent = document.getElementById("script").text;
+    </script>
+  </body>
 </html>

--- a/examples/learning/helloworld64.html
+++ b/examples/learning/helloworld64.html
@@ -1,81 +1,77 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>'Hello, world!' base64 example</title>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>'Hello, world!' base64 example</title>
+  </head>
+  <body>
+    <h1>'Hello, world!' example</h1>
 
-<h1>'Hello, world!' example</h1>
+    <canvas id="the-canvas" style="border: 1px solid black; direction: ltr"></canvas>
 
-<canvas id="the-canvas" style="border: 1px solid black; direction: ltr;"></canvas>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
 
-<script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
+    <script id="script" type="module">
+      // atob() is used to convert base64 encoded PDF to binary-like data.
+      // (See also https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/
+      // Base64_encoding_and_decoding.)
+      var pdfData = atob(
+        "JVBERi0xLjcKCjEgMCBvYmogICUgZW50cnkgcG9pbnQKPDwKICAvVHlwZSAvQ2F0YWxvZwog" +
+          "IC9QYWdlcyAyIDAgUgo+PgplbmRvYmoKCjIgMCBvYmoKPDwKICAvVHlwZSAvUGFnZXMKICAv" +
+          "TWVkaWFCb3ggWyAwIDAgMjAwIDIwMCBdCiAgL0NvdW50IDEKICAvS2lkcyBbIDMgMCBSIF0K" +
+          "Pj4KZW5kb2JqCgozIDAgb2JqCjw8CiAgL1R5cGUgL1BhZ2UKICAvUGFyZW50IDIgMCBSCiAg" +
+          "L1Jlc291cmNlcyA8PAogICAgL0ZvbnQgPDwKICAgICAgL0YxIDQgMCBSIAogICAgPj4KICA+" +
+          "PgogIC9Db250ZW50cyA1IDAgUgo+PgplbmRvYmoKCjQgMCBvYmoKPDwKICAvVHlwZSAvRm9u" +
+          "dAogIC9TdWJ0eXBlIC9UeXBlMQogIC9CYXNlRm9udCAvVGltZXMtUm9tYW4KPj4KZW5kb2Jq" +
+          "Cgo1IDAgb2JqICAlIHBhZ2UgY29udGVudAo8PAogIC9MZW5ndGggNDQKPj4Kc3RyZWFtCkJU" +
+          "CjcwIDUwIFRECi9GMSAxMiBUZgooSGVsbG8sIHdvcmxkISkgVGoKRVQKZW5kc3RyZWFtCmVu" +
+          "ZG9iagoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDEwIDAwMDAwIG4g" +
+          "CjAwMDAwMDAwNzkgMDAwMDAgbiAKMDAwMDAwMDE3MyAwMDAwMCBuIAowMDAwMDAwMzAxIDAw" +
+          "MDAwIG4gCjAwMDAwMDAzODAgMDAwMDAgbiAKdHJhaWxlcgo8PAogIC9TaXplIDYKICAvUm9v" +
+          "dCAxIDAgUgo+PgpzdGFydHhyZWYKNDkyCiUlRU9G"
+      );
 
-<script id="script" type="module">
-  // atob() is used to convert base64 encoded PDF to binary-like data.
-  // (See also https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/
-  // Base64_encoding_and_decoding.)
-  var pdfData = atob(
-    'JVBERi0xLjcKCjEgMCBvYmogICUgZW50cnkgcG9pbnQKPDwKICAvVHlwZSAvQ2F0YWxvZwog' +
-    'IC9QYWdlcyAyIDAgUgo+PgplbmRvYmoKCjIgMCBvYmoKPDwKICAvVHlwZSAvUGFnZXMKICAv' +
-    'TWVkaWFCb3ggWyAwIDAgMjAwIDIwMCBdCiAgL0NvdW50IDEKICAvS2lkcyBbIDMgMCBSIF0K' +
-    'Pj4KZW5kb2JqCgozIDAgb2JqCjw8CiAgL1R5cGUgL1BhZ2UKICAvUGFyZW50IDIgMCBSCiAg' +
-    'L1Jlc291cmNlcyA8PAogICAgL0ZvbnQgPDwKICAgICAgL0YxIDQgMCBSIAogICAgPj4KICA+' +
-    'PgogIC9Db250ZW50cyA1IDAgUgo+PgplbmRvYmoKCjQgMCBvYmoKPDwKICAvVHlwZSAvRm9u' +
-    'dAogIC9TdWJ0eXBlIC9UeXBlMQogIC9CYXNlRm9udCAvVGltZXMtUm9tYW4KPj4KZW5kb2Jq' +
-    'Cgo1IDAgb2JqICAlIHBhZ2UgY29udGVudAo8PAogIC9MZW5ndGggNDQKPj4Kc3RyZWFtCkJU' +
-    'CjcwIDUwIFRECi9GMSAxMiBUZgooSGVsbG8sIHdvcmxkISkgVGoKRVQKZW5kc3RyZWFtCmVu' +
-    'ZG9iagoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDEwIDAwMDAwIG4g' +
-    'CjAwMDAwMDAwNzkgMDAwMDAgbiAKMDAwMDAwMDE3MyAwMDAwMCBuIAowMDAwMDAwMzAxIDAw' +
-    'MDAwIG4gCjAwMDAwMDAzODAgMDAwMDAgbiAKdHJhaWxlcgo8PAogIC9TaXplIDYKICAvUm9v' +
-    'dCAxIDAgUgo+PgpzdGFydHhyZWYKNDkyCiUlRU9G');
+      //
+      // The workerSrc property shall be specified.
+      //
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "../../node_modules/pdfjs-dist/build/pdf.worker.mjs";
 
-  //
-  // The workerSrc property shall be specified.
-  //
-  pdfjsLib.GlobalWorkerOptions.workerSrc =
-    '../../node_modules/pdfjs-dist/build/pdf.worker.mjs';
+      // Opening PDF by passing its binary data as a string. It is still preferable
+      // to use Uint8Array, but string or array-like structure will work too.
+      var loadingTask = pdfjsLib.getDocument({ data: pdfData });
+      var pdf = await loadingTask.promise;
+      // Fetch the first page.
+      var page = await pdf.getPage(1);
+      var scale = 1.5;
+      var viewport = page.getViewport({ scale: scale });
+      // Support HiDPI-screens.
+      var outputScale = window.devicePixelRatio || 1;
 
-  // Opening PDF by passing its binary data as a string. It is still preferable
-  // to use Uint8Array, but string or array-like structure will work too.
-  var loadingTask = pdfjsLib.getDocument({ data: pdfData, });
-  var pdf = await loadingTask.promise;
-  // Fetch the first page.
-  var page = await pdf.getPage(1);
-  var scale = 1.5;
-  var viewport = page.getViewport({ scale: scale, });
-  // Support HiDPI-screens.
-  var outputScale = window.devicePixelRatio || 1;
+      // Prepare canvas using PDF page dimensions.
+      var canvas = document.getElementById("the-canvas");
+      var context = canvas.getContext("2d");
 
-  // Prepare canvas using PDF page dimensions.
-  var canvas = document.getElementById('the-canvas');
-  var context = canvas.getContext('2d');
+      canvas.width = Math.floor(viewport.width * outputScale);
+      canvas.height = Math.floor(viewport.height * outputScale);
+      canvas.style.width = Math.floor(viewport.width) + "px";
+      canvas.style.height = Math.floor(viewport.height) + "px";
 
-  canvas.width = Math.floor(viewport.width * outputScale);
-  canvas.height = Math.floor(viewport.height * outputScale);
-  canvas.style.width = Math.floor(viewport.width) + "px";
-  canvas.style.height =  Math.floor(viewport.height) + "px";
+      var transform = outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null;
 
-  var transform = outputScale !== 1
-    ? [outputScale, 0, 0, outputScale, 0, 0]
-    : null;
+      // Render PDF page into canvas context.
+      var renderContext = {
+        canvasContext: context,
+        transform,
+        viewport,
+      };
+      page.render(renderContext);
+    </script>
 
-  // Render PDF page into canvas context.
-  var renderContext = {
-    canvasContext: context,
-    transform,
-    viewport,
-  };
-  page.render(renderContext);
-</script>
-
-<hr>
-<h2>JavaScript code:</h2>
-<pre id="code"></pre>
-<script>
-  document.getElementById('code').textContent =
-    document.getElementById('script').text;
-</script>
-</body>
+    <hr />
+    <h2>JavaScript code:</h2>
+    <pre id="code"></pre>
+    <script>
+      document.getElementById("code").textContent = document.getElementById("script").text;
+    </script>
+  </body>
 </html>

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -1,139 +1,134 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>Previous/Next example</title>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Previous/Next example</title>
+  </head>
+  <body>
+    <h1>'Previous/Next' example</h1>
 
-<h1>'Previous/Next' example</h1>
+    <div>
+      <button id="prev" type="button">Previous</button>
+      <button id="next" type="button">Next</button>
+      &nbsp; &nbsp;
+      <span>Page: <span id="page_num"></span> / <span id="page_count"></span></span>
+    </div>
 
-<div>
-  <button id="prev" type="button">Previous</button>
-  <button id="next" type="button">Next</button>
-  &nbsp; &nbsp;
-  <span>Page: <span id="page_num"></span> / <span id="page_count"></span></span>
-</div>
+    <div>
+      <canvas id="the-canvas" style="border: 1px solid black; direction: ltr"></canvas>
+    </div>
 
-<div>
-  <canvas id="the-canvas" style="border: 1px solid black; direction: ltr;"></canvas>
-</div>
+    <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
 
-<script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
+    <script id="script" type="module">
+      //
+      // If absolute URL from the remote server is provided, configure the CORS
+      // header on that server.
+      //
+      var url = "../../web/compressed.tracemonkey-pldi-09.pdf";
 
-<script id="script" type="module">
-  //
-  // If absolute URL from the remote server is provided, configure the CORS
-  // header on that server.
-  //
-  var url = '../../web/compressed.tracemonkey-pldi-09.pdf';
+      //
+      // In cases when the pdf.worker.js is located at the different folder than the
+      // PDF.js's one, or the PDF.js is executed via eval(), the workerSrc property
+      // shall be specified.
+      //
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "../../node_modules/pdfjs-dist/build/pdf.worker.mjs";
 
-  //
-  // In cases when the pdf.worker.js is located at the different folder than the
-  // PDF.js's one, or the PDF.js is executed via eval(), the workerSrc property
-  // shall be specified.
-  //
-  pdfjsLib.GlobalWorkerOptions.workerSrc =
-    '../../node_modules/pdfjs-dist/build/pdf.worker.mjs';
+      var pdfDoc = null,
+        pageNum = 1,
+        pageRendering = false,
+        pageNumPending = null,
+        scale = 0.8,
+        canvas = document.getElementById("the-canvas"),
+        ctx = canvas.getContext("2d");
 
-  var pdfDoc = null,
-      pageNum = 1,
-      pageRendering = false,
-      pageNumPending = null,
-      scale = 0.8,
-      canvas = document.getElementById('the-canvas'),
-      ctx = canvas.getContext('2d');
+      /**
+       * Get page info from document, resize canvas accordingly, and render page.
+       * @param num Page number.
+       */
+      function renderPage(num) {
+        pageRendering = true;
+        // Using promise to fetch the page
+        pdfDoc.getPage(num).then(function (page) {
+          var viewport = page.getViewport({ scale: scale });
+          // Support HiDPI-screens.
+          var outputScale = window.devicePixelRatio || 1;
 
-  /**
-   * Get page info from document, resize canvas accordingly, and render page.
-   * @param num Page number.
-   */
-  function renderPage(num) {
-    pageRendering = true;
-    // Using promise to fetch the page
-    pdfDoc.getPage(num).then(function(page) {
-      var viewport = page.getViewport({ scale: scale, });
-      // Support HiDPI-screens.
-      var outputScale = window.devicePixelRatio || 1;
+          canvas.width = Math.floor(viewport.width * outputScale);
+          canvas.height = Math.floor(viewport.height * outputScale);
+          canvas.style.width = Math.floor(viewport.width) + "px";
+          canvas.style.height = Math.floor(viewport.height) + "px";
 
-      canvas.width = Math.floor(viewport.width * outputScale);
-      canvas.height = Math.floor(viewport.height * outputScale);
-      canvas.style.width = Math.floor(viewport.width) + "px";
-      canvas.style.height =  Math.floor(viewport.height) + "px";
+          var transform = outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null;
 
-      var transform = outputScale !== 1
-        ? [outputScale, 0, 0, outputScale, 0, 0]
-        : null;
+          // Render PDF page into canvas context
+          var renderContext = {
+            canvasContext: ctx,
+            transform: transform,
+            viewport: viewport,
+          };
+          var renderTask = page.render(renderContext);
 
-      // Render PDF page into canvas context
-      var renderContext = {
-        canvasContext: ctx,
-        transform: transform,
-        viewport: viewport,
-      };
-      var renderTask = page.render(renderContext);
+          // Wait for rendering to finish
+          renderTask.promise.then(function () {
+            pageRendering = false;
+            if (pageNumPending !== null) {
+              // New page rendering is pending
+              renderPage(pageNumPending);
+              pageNumPending = null;
+            }
+          });
+        });
 
-      // Wait for rendering to finish
-      renderTask.promise.then(function () {
-        pageRendering = false;
-        if (pageNumPending !== null) {
-          // New page rendering is pending
-          renderPage(pageNumPending);
-          pageNumPending = null;
+        // Update page counters
+        document.getElementById("page_num").textContent = num;
+      }
+
+      /**
+       * If another page rendering in progress, waits until the rendering is
+       * finished. Otherwise, executes rendering immediately.
+       */
+      function queueRenderPage(num) {
+        if (pageRendering) {
+          pageNumPending = num;
+        } else {
+          renderPage(num);
         }
-      });
-    });
+      }
 
-    // Update page counters
-    document.getElementById('page_num').textContent = num;
-  }
+      /**
+       * Displays previous page.
+       */
+      function onPrevPage() {
+        if (pageNum <= 1) {
+          return;
+        }
+        pageNum--;
+        queueRenderPage(pageNum);
+      }
+      document.getElementById("prev").addEventListener("click", onPrevPage);
 
-  /**
-   * If another page rendering in progress, waits until the rendering is
-   * finished. Otherwise, executes rendering immediately.
-   */
-  function queueRenderPage(num) {
-    if (pageRendering) {
-      pageNumPending = num;
-    } else {
-      renderPage(num);
-    }
-  }
+      /**
+       * Displays next page.
+       */
+      function onNextPage() {
+        if (pageNum >= pdfDoc.numPages) {
+          return;
+        }
+        pageNum++;
+        queueRenderPage(pageNum);
+      }
+      document.getElementById("next").addEventListener("click", onNextPage);
 
-  /**
-   * Displays previous page.
-   */
-  function onPrevPage() {
-    if (pageNum <= 1) {
-      return;
-    }
-    pageNum--;
-    queueRenderPage(pageNum);
-  }
-  document.getElementById('prev').addEventListener('click', onPrevPage);
+      /**
+       * Asynchronously downloads PDF.
+       */
+      var loadingTask = pdfjsLib.getDocument(url);
+      pdfDoc = await loadingTask.promise;
+      document.getElementById("page_count").textContent = pdfDoc.numPages;
 
-  /**
-   * Displays next page.
-   */
-  function onNextPage() {
-    if (pageNum >= pdfDoc.numPages) {
-      return;
-    }
-    pageNum++;
-    queueRenderPage(pageNum);
-  }
-  document.getElementById('next').addEventListener('click', onNextPage);
-
-  /**
-   * Asynchronously downloads PDF.
-   */
-  var loadingTask = pdfjsLib.getDocument(url);
-  pdfDoc = await loadingTask.promise;
-  document.getElementById('page_count').textContent = pdfDoc.numPages;
-
-  // Initial/first page rendering
-  renderPage(pageNum);
-</script>
-
-</body>
+      // Initial/first page rendering
+      renderPage(pageNum);
+    </script>
+  </body>
 </html>

--- a/examples/mobile-viewer/viewer.html
+++ b/examples/mobile-viewer/viewer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2016 Mozilla Foundation
 
@@ -16,13 +16,13 @@ limitations under the License.
 -->
 <html dir="ltr">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
     <title>PDF.js viewer</title>
 
-    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css">
-    <link rel="stylesheet" type="text/css" href="viewer.css">
+    <link rel="stylesheet" href="../../node_modules/pdfjs-dist/web/pdf_viewer.css" />
+    <link rel="stylesheet" type="text/css" href="viewer.css" />
 
     <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
     <script src="../../node_modules/pdfjs-dist/web/pdf_viewer.mjs" type="module"></script>
@@ -46,12 +46,12 @@ limitations under the License.
       <button class="toolbarButton pageUp" title="Previous Page" id="previous" type="button"></button>
       <button class="toolbarButton pageDown" title="Next Page" id="next" type="button"></button>
 
-      <input type="number" id="pageNumber" class="toolbarField pageNumber" value="1" size="4" min="1">
+      <input type="number" id="pageNumber" class="toolbarField pageNumber" value="1" size="4" min="1" />
 
       <button class="toolbarButton zoomOut" title="Zoom Out" id="zoomOut" type="button"></button>
       <button class="toolbarButton zoomIn" title="Zoom In" id="zoomIn" type="button"></button>
     </footer>
 
-     <script src="viewer.mjs" type="module"></script>
+    <script src="viewer.mjs" type="module"></script>
   </body>
 </html>

--- a/examples/text-only/index.html
+++ b/examples/text-only/index.html
@@ -1,14 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Text-only PDF.js example</title>
     <script src="../../node_modules/pdfjs-dist/build/pdf.mjs" type="module"></script>
     <script src="pdf2svg.mjs" type="module"></script>
-</head>
-<body>
-  <p>Text-only PDF.js example</p>
-  <div id="pageContainer" style="display: inline-block; border: solid 1px black;">
-  </div>
-</body>
+  </head>
+  <body>
+    <p>Text-only PDF.js example</p>
+    <div id="pageContainer" style="display: inline-block; border: solid 1px black"></div>
+  </body>
 </html>

--- a/examples/webpack/index.html
+++ b/examples/webpack/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>webpack example</title>
-  <script src="../../build/webpack/main.bundle.js"></script>
-</head>
-<body>
-  <canvas id="theCanvas"></canvas>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>webpack example</title>
+    <script src="../../build/webpack/main.bundle.js"></script>
+  </head>
+  <body>
+    <canvas id="theCanvas"></canvas>
+  </body>
 </html>

--- a/extensions/chromium/options/options.html
+++ b/extensions/chromium/options/options.html
@@ -15,171 +15,171 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <html>
-<head>
-<meta charset="utf-8">
-<title>PDF.js viewer options</title>
-<style>
-body {
-  min-width: 400px; /* a page at the settings page is at least 400px wide */
-  margin: 14px 17px; /* already added by default in Chrome 40.0.2212.0 */
-}
-.settings-row {
-  margin: 1em 0;
-}
-.checkbox label {
-  display: inline-flex;
-  align-items: center;
-}
-.checkbox label input {
-  flex-shrink: 0;
-}
-</style>
-</head>
-<body>
-<div id="settings-boxes"></div>
-<button id="reset-button" type="button">Restore default settings</button>
+  <head>
+    <meta charset="utf-8" />
+    <title>PDF.js viewer options</title>
+    <style>
+      body {
+        min-width: 400px; /* a page at the settings page is at least 400px wide */
+        margin: 14px 17px; /* already added by default in Chrome 40.0.2212.0 */
+      }
+      .settings-row {
+        margin: 1em 0;
+      }
+      .checkbox label {
+        display: inline-flex;
+        align-items: center;
+      }
+      .checkbox label input {
+        flex-shrink: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="settings-boxes"></div>
+    <button id="reset-button" type="button">Restore default settings</button>
 
-<template id="checkbox-template">
-<div class="settings-row checkbox">
-  <label>
-    <input type="checkbox">
-    <span></span>
-  </label>
-</div>
-</template>
+    <template id="checkbox-template">
+      <div class="settings-row checkbox">
+        <label>
+          <input type="checkbox" />
+          <span></span>
+        </label>
+      </div>
+    </template>
 
-<template id="viewerCssTheme-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="0">Use system theme</option>
-      <option value="1">Light theme</option>
-      <option value="2">Dark theme</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="viewerCssTheme-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="0">Use system theme</option>
+            <option value="1">Light theme</option>
+            <option value="2">Dark theme</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="viewOnLoad-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="-1">Default</option>
-      <option value="0">Show previous position</option>
-      <option value="1">Show initial position</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="viewOnLoad-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="-1">Default</option>
+            <option value="0">Show previous position</option>
+            <option value="1">Show initial position</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="defaultZoomValue-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="auto" selected="selected">Automatic Zoom</option>
-      <option value="page-actual">Actual Size</option>
-      <option value="page-fit">Page Fit</option>
-      <option value="page-width">Page Width</option>
-      <option value="custom" class="custom-zoom" hidden></option>
-      <option value="50">50%</option>
-      <option value="75">75%</option>
-      <option value="100">100%</option>
-      <option value="125">125%</option>
-      <option value="150">150%</option>
-      <option value="200">200%</option>
-      <option value="300">300%</option>
-      <option value="400">400%</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="defaultZoomValue-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="auto" selected="selected">Automatic Zoom</option>
+            <option value="page-actual">Actual Size</option>
+            <option value="page-fit">Page Fit</option>
+            <option value="page-width">Page Width</option>
+            <option value="custom" class="custom-zoom" hidden></option>
+            <option value="50">50%</option>
+            <option value="75">75%</option>
+            <option value="100">100%</option>
+            <option value="125">125%</option>
+            <option value="150">150%</option>
+            <option value="200">200%</option>
+            <option value="300">300%</option>
+            <option value="400">400%</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="sidebarViewOnLoad-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="-1">Default</option>
-      <option value="0">Do not show sidebar</option>
-      <option value="1">Show thumbnails in sidebar</option>
-      <option value="2">Show document outline in sidebar</option>
-      <option value="3">Show attachments in sidebar</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="sidebarViewOnLoad-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="-1">Default</option>
+            <option value="0">Do not show sidebar</option>
+            <option value="1">Show thumbnails in sidebar</option>
+            <option value="2">Show document outline in sidebar</option>
+            <option value="3">Show attachments in sidebar</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="cursorToolOnLoad-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="0">Text selection tool</option>
-      <option value="1">Hand tool</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="cursorToolOnLoad-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="0">Text selection tool</option>
+            <option value="1">Hand tool</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="textLayerMode-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="0">Disable text selection</option>
-      <option value="1">Enable text selection</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="textLayerMode-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="0">Disable text selection</option>
+            <option value="1">Enable text selection</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="externalLinkTarget-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="0">Default</option>
-      <option value="1">Current window/tab</option>
-      <option value="2">New window/tab</option>
-      <option value="3">Parent window/tab</option>
-      <option value="4">Top window/tab</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="externalLinkTarget-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="0">Default</option>
+            <option value="1">Current window/tab</option>
+            <option value="2">New window/tab</option>
+            <option value="3">Parent window/tab</option>
+            <option value="4">Top window/tab</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="scrollModeOnLoad-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="-1">Default</option>
-      <option value="3">Page scrolling</option>
-      <option value="0">Vertical scrolling</option>
-      <option value="1">Horizontal scrolling</option>
-      <option value="2">Wrapped scrolling</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="scrollModeOnLoad-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="-1">Default</option>
+            <option value="3">Page scrolling</option>
+            <option value="0">Vertical scrolling</option>
+            <option value="1">Horizontal scrolling</option>
+            <option value="2">Wrapped scrolling</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<template id="spreadModeOnLoad-template">
-<div class="settings-row">
-  <label>
-    <span></span>
-    <select>
-      <option value="-1">Default</option>
-      <option value="0">No spreads</option>
-      <option value="1">Odd spreads</option>
-      <option value="2">Even spreads</option>
-    </select>
-  </label>
-</div>
-</template>
+    <template id="spreadModeOnLoad-template">
+      <div class="settings-row">
+        <label>
+          <span></span>
+          <select>
+            <option value="-1">Default</option>
+            <option value="0">No spreads</option>
+            <option value="1">Odd spreads</option>
+            <option value="2">Even spreads</option>
+          </select>
+        </label>
+      </div>
+    </template>
 
-<script src="options.js"></script>
-</body>
+    <script src="options.js"></script>
+  </body>
 </html>

--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -151,7 +151,7 @@ function preprocess(inFilename, outFilename, defines) {
   let state = STATE_NONE;
   const stack = [];
   const control =
-    /^(?:\/\/|\s*\/\*|<!--)\s*#(if|elif|else|endif|expand|include|error)\b(?:\s+(.*?)(?:\*\/|-->)?$)?/;
+    /^(?:\/\/|\s*\/\*|\s*<!--)\s*#(if|elif|else|endif|expand|include|error)\b(?:\s+(.*?)(?:\*\/|-->)?$)?/;
 
   while ((line = readLine()) !== null) {
     ++lineNumber;
@@ -213,7 +213,7 @@ function preprocess(inFilename, outFilename, defines) {
     ) {
       writeLine(
         line
-          .replaceAll(/^\/\/|^<!--/g, "  ")
+          .replaceAll(/^\/\/|^\s*<!--/g, "  ")
           .replaceAll(/(^\s*)\/\*/g, "$1  ")
           .replaceAll(/\*\/$|-->$/g, "")
       );

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2023,7 +2023,7 @@ gulp.task(
 
 gulp.task("lint", function (done) {
   console.log();
-  console.log("### Linting JS/CSS/JSON/SVG files");
+  console.log("### Linting JS/CSS/JSON/SVG/HTML files");
 
   // Ensure that we lint the Firefox specific *.jsm files too.
   const esLintOptions = [
@@ -2047,9 +2047,10 @@ gulp.task("lint", function (done) {
   const prettierOptions = [
     "node_modules/prettier/bin/prettier.cjs",
     "**/*.json",
+    "**/*.html",
   ];
   if (process.argv.includes("--fix")) {
-    prettierOptions.push("--log-level", "silent", "--write");
+    prettierOptions.push("--log-level", "error", "--write");
   } else {
     prettierOptions.push("--log-level", "warn", "--check");
   }

--- a/test/font/font_test.html
+++ b/test/font/font_test.html
@@ -1,25 +1,24 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <title>PDF.js font tests</title>
+  <head>
+    <title>PDF.js font tests</title>
 
-  <link rel="stylesheet" type="text/css" href="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
+    <link rel="stylesheet" type="text/css" href="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.css" />
 
-  <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
-  <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+    <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+    <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
 
-  <script type="importmap">
-    {
-      "imports": {
-        "pdfjs/": "../../src/",
-        "pdfjs-lib": "../../src/pdf.js",
-        "pdfjs-web/": "../../web/",
-        "pdfjs-test/": "../"
+    <script type="importmap">
+      {
+        "imports": {
+          "pdfjs/": "../../src/",
+          "pdfjs-lib": "../../src/pdf.js",
+          "pdfjs-web/": "../../web/",
+          "pdfjs-test/": "../"
+        }
       }
-    }
-  </script>
-  <script src="jasmine-boot.js" type="module"></script>
-</head>
-<body>
-</body>
+    </script>
+    <script src="jasmine-boot.js" type="module"></script>
+  </head>
+  <body></body>
 </html>

--- a/test/resources/reftest-analyzer.html
+++ b/test/resources/reftest-analyzer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2012 Mozilla Foundation
 
@@ -30,149 +30,150 @@ the terms of any one of the MPL, the GPL or the LGPL.
 Original author: L. David Baron <dbaron@dbaron.org>
 -->
 <html>
-<head>
-  <title>Reftest analyzer</title>
-  <meta charset="utf-8">
-  <link rel="stylesheet" href="reftest-analyzer.css">
-  <script src="reftest-analyzer.js"></script>
-</head>
-<body>
-  <div id="entry">
-    <h1>Reftest analyzer</h1>
-    <p>
-      Paste your log into this textarea:<br>
-      <textarea cols="80" rows="10" id="logEntry"></textarea><br>
-      <input type="button" value="Process pasted log" id="logPasted">
-    </p>
-    <p>
-      <br>...or load it from a file:<br>
-      <input type="file" id="fileEntry">
-    </p>
-  </div>
-  <div id="loading">Loading log...</div>
-  <div id="viewer">
-    <div id="pixelarea">
-      <div id="pixelinfo">
-        <table>
-          <tbody>
-            <tr>
-              <th>Pixel at:</th>
-              <td colspan="2" id="coords"></td>
-            </tr>
-            <tr>
-              <th>Test:</th>
-              <td id="pix1rgb"></td>
-              <td id="pix1hex"></td>
-            </tr>
-            <tr>
-              <th>Reference:</th>
-              <td id="pix2rgb"></td>
-              <td id="pix2hex"></td>
-            </tr>
-          </tbody>
-        </table>
-        <div>
-          <div id="pixelhint">?
-            <div>
-              <p>Move the mouse over the reftest image on the right to show
-              magnified pixels on the left. The color information above is for
-              the pixel centered in the magnified view.</p>
-              <p>The test is shown in the upper triangle of each pixel and
-              the reference is shown in the lower triangle.</p>
+  <head>
+    <title>Reftest analyzer</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="reftest-analyzer.css" />
+    <script src="reftest-analyzer.js"></script>
+  </head>
+  <body>
+    <div id="entry">
+      <h1>Reftest analyzer</h1>
+      <p>
+        Paste your log into this textarea:<br />
+        <textarea cols="80" rows="10" id="logEntry"></textarea><br />
+        <input type="button" value="Process pasted log" id="logPasted" />
+      </p>
+      <p>
+        <br />...or load it from a file:<br />
+        <input type="file" id="fileEntry" />
+      </p>
+    </div>
+    <div id="loading">Loading log...</div>
+    <div id="viewer">
+      <div id="pixelarea">
+        <div id="pixelinfo">
+          <table>
+            <tbody>
+              <tr>
+                <th>Pixel at:</th>
+                <td colspan="2" id="coords"></td>
+              </tr>
+              <tr>
+                <th>Test:</th>
+                <td id="pix1rgb"></td>
+                <td id="pix1hex"></td>
+              </tr>
+              <tr>
+                <th>Reference:</th>
+                <td id="pix2rgb"></td>
+                <td id="pix2hex"></td>
+              </tr>
+            </tbody>
+          </table>
+          <div>
+            <div id="pixelhint">
+              ?
+              <div>
+                <p>
+                  Move the mouse over the reftest image on the right to show magnified pixels on the left. The color information above is for the pixel centered
+                  in the magnified view.
+                </p>
+                <p>The test is shown in the upper triangle of each pixel and the reference is shown in the lower triangle.</p>
+              </div>
             </div>
           </div>
         </div>
+        <div id="magnification">
+          <svg xmlns="http://www.w3.org/2000/svg" width="84" height="84" shape-rendering="optimizeSpeed">
+            <g id="mag" />
+          </svg>
+        </div>
       </div>
-      <div id="magnification">
-        <svg xmlns="http://www.w3.org/2000/svg" width="84" height="84" shape-rendering="optimizeSpeed">
-          <g id="mag" />
-        </svg>
+      <div id="itemlist">
+        <table id="itemtable"></table>
       </div>
-    </div>
-    <div id="itemlist">
-      <table id="itemtable"></table>
-    </div>
-    <div id="imagepane">
-    <form id="imgcontrols">
-      <label>
-        <input type="radio" name="which" id="testImage" value="0" checked="checked"> Test
-      </label>
-      <label>
-        <input type="radio" name="which" id="referenceImage" value="1"> Reference
-      </label>
-      <label>
-        <input type="checkbox" id="differences"> Circle differences
-      </label>
-      <span id="shortcuts">Shortcuts: n=next p=previous t=toggle d=differences</span>
-    </form>
-    <div id="images">
-      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="800" height="1000" id="svg">
-        <defs>
-          <!-- use sRGB to avoid loss of data -->
-          <filter id="showDifferences" x="0%" y="0%" width="100%" height="100%"
-                  style="color-interpolation-filters: sRGB">
-            <feImage id="feimage1" result="img1" xlink:href="#image1" />
-            <feImage id="feimage2" result="img2" xlink:href="#image2" />
-            <!-- inv1 and inv2 are the images with RGB inverted -->
-            <feComponentTransfer result="inv1" in="img1">
-              <feFuncR type="linear" slope="-1" intercept="1" />
-              <feFuncG type="linear" slope="-1" intercept="1" />
-              <feFuncB type="linear" slope="-1" intercept="1" />
-            </feComponentTransfer>
-            <feComponentTransfer result="inv2" in="img2">
-              <feFuncR type="linear" slope="-1" intercept="1" />
-              <feFuncG type="linear" slope="-1" intercept="1" />
-              <feFuncB type="linear" slope="-1" intercept="1" />
-            </feComponentTransfer>
-            <!-- w1 will have non-white pixels anywhere that img2
+      <div id="imagepane">
+        <form id="imgcontrols">
+          <label>
+            <input type="radio" name="which" id="testImage" value="0" checked="checked" />
+            Test
+          </label>
+          <label>
+            <input type="radio" name="which" id="referenceImage" value="1" />
+            Reference
+          </label>
+          <label> <input type="checkbox" id="differences" /> Circle differences </label>
+          <span id="shortcuts">Shortcuts: n=next p=previous t=toggle d=differences</span>
+        </form>
+        <div id="images">
+          <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="800" height="1000" id="svg">
+            <defs>
+              <!-- use sRGB to avoid loss of data -->
+              <filter id="showDifferences" x="0%" y="0%" width="100%" height="100%" style="color-interpolation-filters: sRGB">
+                <feImage id="feimage1" result="img1" xlink:href="#image1" />
+                <feImage id="feimage2" result="img2" xlink:href="#image2" />
+                <!-- inv1 and inv2 are the images with RGB inverted -->
+                <feComponentTransfer result="inv1" in="img1">
+                  <feFuncR type="linear" slope="-1" intercept="1" />
+                  <feFuncG type="linear" slope="-1" intercept="1" />
+                  <feFuncB type="linear" slope="-1" intercept="1" />
+                </feComponentTransfer>
+                <feComponentTransfer result="inv2" in="img2">
+                  <feFuncR type="linear" slope="-1" intercept="1" />
+                  <feFuncG type="linear" slope="-1" intercept="1" />
+                  <feFuncB type="linear" slope="-1" intercept="1" />
+                </feComponentTransfer>
+                <!-- w1 will have non-white pixels anywhere that img2
                  is brighter than img1, and w2 for the reverse.
                  It would be nice not to have to go through these
                  intermediate states, but feComposite
                  type="arithmetic" can't transform the RGB channels
                  and leave the alpha channel untouched. -->
-            <feComposite result="w1" in="img1" in2="inv2" operator="arithmetic" k2="1" k3="1" />
-            <feComposite result="w2" in="img2" in2="inv1" operator="arithmetic" k2="1" k3="1" />
-            <!-- c1 will have non-black pixels anywhere that img2
+                <feComposite result="w1" in="img1" in2="inv2" operator="arithmetic" k2="1" k3="1" />
+                <feComposite result="w2" in="img2" in2="inv1" operator="arithmetic" k2="1" k3="1" />
+                <!-- c1 will have non-black pixels anywhere that img2
                  is brighter than img1, and c2 for the reverse -->
-            <feComponentTransfer result="c1" in="w1">
-              <feFuncR type="linear" slope="-1" intercept="1" />
-              <feFuncG type="linear" slope="-1" intercept="1" />
-              <feFuncB type="linear" slope="-1" intercept="1" />
-            </feComponentTransfer>
-            <feComponentTransfer result="c2" in="w2">
-              <feFuncR type="linear" slope="-1" intercept="1" />
-              <feFuncG type="linear" slope="-1" intercept="1" />
-              <feFuncB type="linear" slope="-1" intercept="1" />
-            </feComponentTransfer>
-            <!-- c will be nonblack (and fully on) for every pixel+component where there are differences -->
-            <feComposite result="c" in="c1" in2="c2" operator="arithmetic" k2="255" k3="255" />
-            <!-- a will be opaque for every pixel with differences and transparent for all others -->
-            <feColorMatrix result="a" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  1 1 1 0 0" />
+                <feComponentTransfer result="c1" in="w1">
+                  <feFuncR type="linear" slope="-1" intercept="1" />
+                  <feFuncG type="linear" slope="-1" intercept="1" />
+                  <feFuncB type="linear" slope="-1" intercept="1" />
+                </feComponentTransfer>
+                <feComponentTransfer result="c2" in="w2">
+                  <feFuncR type="linear" slope="-1" intercept="1" />
+                  <feFuncG type="linear" slope="-1" intercept="1" />
+                  <feFuncB type="linear" slope="-1" intercept="1" />
+                </feComponentTransfer>
+                <!-- c will be nonblack (and fully on) for every pixel+component where there are differences -->
+                <feComposite result="c" in="c1" in2="c2" operator="arithmetic" k2="255" k3="255" />
+                <!-- a will be opaque for every pixel with differences and transparent for all others -->
+                <feColorMatrix result="a" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  1 1 1 0 0" />
 
-            <!-- a, dilated by 4 pixels -->
-            <feMorphology result="dila4" in="a" operator="dilate" radius="4" />
-            <!-- a, dilated by 1 pixel -->
-            <feMorphology result="dila1" in="a" operator="dilate" radius="1" />
+                <!-- a, dilated by 4 pixels -->
+                <feMorphology result="dila4" in="a" operator="dilate" radius="4" />
+                <!-- a, dilated by 1 pixel -->
+                <feMorphology result="dila1" in="a" operator="dilate" radius="1" />
 
-            <!-- all the pixels in the 3-pixel dilation of a but not in the 1-pixel dilation of a, to highlight the diffs -->
-            <feComposite result="highlight" in="dila4" in2="dila1" operator="out" />
+                <!-- all the pixels in the 3-pixel dilation of a but not in the 1-pixel dilation of a, to highlight the diffs -->
+                <feComposite result="highlight" in="dila4" in2="dila1" operator="out" />
 
-            <feFlood result="red" flood-color="red" />
-            <feComposite result="redhighlight" in="red" in2="highlight" operator="in" />
-            <feFlood result="black" flood-color="black" flood-opacity="0.5" />
-            <feMerge>
-              <feMergeNode in="black" />
-              <feMergeNode in="redhighlight" />
-            </feMerge>
-          </filter>
-        </defs>
-        <g id="magnify">
-          <image x="0" y="0" id="image1" />
-          <image x="0" y="0" id="image2" />
-        </g>
-        <rect id="diffrect" filter="url(#showDifferences)" pointer-events="none" x="0" y="0" width="100%" height="100%" />
-      </svg>
+                <feFlood result="red" flood-color="red" />
+                <feComposite result="redhighlight" in="red" in2="highlight" operator="in" />
+                <feFlood result="black" flood-color="black" flood-opacity="0.5" />
+                <feMerge>
+                  <feMergeNode in="black" />
+                  <feMergeNode in="redhighlight" />
+                </feMerge>
+              </filter>
+            </defs>
+            <g id="magnify">
+              <image x="0" y="0" id="image1" />
+              <image x="0" y="0" id="image2" />
+            </g>
+            <rect id="diffrect" filter="url(#showDifferences)" pointer-events="none" x="0" y="0" width="100%" height="100%" />
+          </svg>
+        </div>
+      </div>
     </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/test/test_slave.html
+++ b/test/test_slave.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright 2015 Mozilla Foundation
 
@@ -17,29 +17,29 @@ limitations under the License.
 <html>
   <head>
     <title>PDF.js test slave</title>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <script src="../build/generic/build/pdf.mjs" type="module"></script>
     <script src="../build/components/pdf_viewer.mjs" type="module"></script>
 
-    <link rel="resource" type="application/l10n" href="../build/generic/web/locale/locale.json">
+    <link rel="resource" type="application/l10n" href="../build/generic/web/locale/locale.json" />
   </head>
   <body>
     <p>Inflight requests: <span id="inflight"></span></p>
     <p>
-      <input type="checkbox" id="disableScrolling">
+      <input type="checkbox" id="disableScrolling" />
       <label for="disableScrolling">Disable automatic scrolling</label>
     </p>
-    <pre id="output" style="max-height: 800px; overflow-y: scroll;"></pre>
+    <pre id="output" style="max-height: 800px; overflow-y: scroll"></pre>
     <div id="end"></div>
   </body>
   <script type="module">
     import { Driver } from "./driver.js";
 
     const driver = new Driver({
-      disableScrolling: document.getElementById('disableScrolling'),
-      inflight: document.getElementById('inflight'),
-      output: document.getElementById('output'),
-      end: document.getElementById('end')
+      disableScrolling: document.getElementById("disableScrolling"),
+      inflight: document.getElementById("inflight"),
+      output: document.getElementById("output"),
+      end: document.getElementById("end"),
     });
     driver.run();
   </script>

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -1,56 +1,55 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <title>PDF.js unit tests</title>
+  <head>
+    <title>PDF.js unit tests</title>
 
-  <link rel="stylesheet" type="text/css" href="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
+    <link rel="stylesheet" type="text/css" href="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.css" />
 
-  <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
-  <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+    <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+    <script src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
 
-  <script type="importmap">
-    {
-      "imports": {
-        "pdfjs/": "../../src/",
-        "pdfjs-lib": "../../src/pdf.js",
-        "pdfjs-web/": "../../web/",
-        "pdfjs-test/": "../",
+    <script type="importmap">
+      {
+        "imports": {
+          "pdfjs/": "../../src/",
+          "pdfjs-lib": "../../src/pdf.js",
+          "pdfjs-web/": "../../web/",
+          "pdfjs-test/": "../",
 
-        "fluent-bundle": "../../node_modules/@fluent/bundle/esm/index.js",
-        "fluent-dom": "../../node_modules/@fluent/dom/esm/index.js",
-        "cached-iterable": "../../node_modules/cached-iterable/src/index.mjs",
+          "fluent-bundle": "../../node_modules/@fluent/bundle/esm/index.js",
+          "fluent-dom": "../../node_modules/@fluent/dom/esm/index.js",
+          "cached-iterable": "../../node_modules/cached-iterable/src/index.mjs",
 
-        "display-cmap_reader_factory": "../../src/display/cmap_reader_factory.js",
-        "display-standard_fontdata_factory": "../../src/display/standard_fontdata_factory.js",
-        "display-wasm_factory": "../../src/display/wasm_factory.js",
-        "display-fetch_stream": "../../src/display/fetch_stream.js",
-        "display-network": "../../src/display/network.js",
-        "display-node_stream": "../../src/display/stubs.js",
-        "display-node_utils": "../../src/display/stubs.js",
+          "display-cmap_reader_factory": "../../src/display/cmap_reader_factory.js",
+          "display-standard_fontdata_factory": "../../src/display/standard_fontdata_factory.js",
+          "display-wasm_factory": "../../src/display/wasm_factory.js",
+          "display-fetch_stream": "../../src/display/fetch_stream.js",
+          "display-network": "../../src/display/network.js",
+          "display-node_stream": "../../src/display/stubs.js",
+          "display-node_utils": "../../src/display/stubs.js",
 
-        "web-alt_text_manager": "../../web/alt_text_manager.js",
-        "web-annotation_editor_params": "../../web/annotation_editor_params.js",
-        "web-download_manager": "../../web/download_manager.js",
-        "web-external_services": "../../web/genericcom.js",
-        "web-null_l10n": "../../web/genericl10n.js",
-        "web-pdf_attachment_viewer": "../../web/pdf_attachment_viewer.js",
-        "web-pdf_cursor_tools": "../../web/pdf_cursor_tools.js",
-        "web-pdf_document_properties": "../../web/pdf_document_properties.js",
-        "web-pdf_find_bar": "../../web/pdf_find_bar.js",
-        "web-pdf_layer_viewer": "../../web/pdf_layer_viewer.js",
-        "web-pdf_outline_viewer": "../../web/pdf_outline_viewer.js",
-        "web-pdf_presentation_mode": "../../web/pdf_presentation_mode.js",
-        "web-pdf_sidebar": "../../web/pdf_sidebar.js",
-        "web-pdf_thumbnail_viewer": "../../web/pdf_thumbnail_viewer.js",
-        "web-preferences": "../../web/genericcom.js",
-        "web-print_service": "../../web/pdf_print_service.js",
-        "web-secondary_toolbar": "../../web/secondary_toolbar.js",
-        "web-toolbar": "../../web/toolbar.js"
+          "web-alt_text_manager": "../../web/alt_text_manager.js",
+          "web-annotation_editor_params": "../../web/annotation_editor_params.js",
+          "web-download_manager": "../../web/download_manager.js",
+          "web-external_services": "../../web/genericcom.js",
+          "web-null_l10n": "../../web/genericl10n.js",
+          "web-pdf_attachment_viewer": "../../web/pdf_attachment_viewer.js",
+          "web-pdf_cursor_tools": "../../web/pdf_cursor_tools.js",
+          "web-pdf_document_properties": "../../web/pdf_document_properties.js",
+          "web-pdf_find_bar": "../../web/pdf_find_bar.js",
+          "web-pdf_layer_viewer": "../../web/pdf_layer_viewer.js",
+          "web-pdf_outline_viewer": "../../web/pdf_outline_viewer.js",
+          "web-pdf_presentation_mode": "../../web/pdf_presentation_mode.js",
+          "web-pdf_sidebar": "../../web/pdf_sidebar.js",
+          "web-pdf_thumbnail_viewer": "../../web/pdf_thumbnail_viewer.js",
+          "web-preferences": "../../web/genericcom.js",
+          "web-print_service": "../../web/pdf_print_service.js",
+          "web-secondary_toolbar": "../../web/secondary_toolbar.js",
+          "web-toolbar": "../../web/toolbar.js"
+        }
       }
-    }
-  </script>
-  <script src="jasmine-boot.js" type="module"></script>
-</head>
-<body>
-</body>
+    </script>
+    <script src="jasmine-boot.js" type="module"></script>
+  </head>
+  <body></body>
 </html>

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+﻿<!doctype html>
 <!--
 Copyright 2012 Mozilla Foundation
 
@@ -22,26 +22,26 @@ See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <title>PDF.js viewer</title>
 
-<!--#if MOZCENTRAL-->
-<!--#include viewer-snippet-firefox-extension.html-->
-<!--#endif-->
+    <!--#if MOZCENTRAL-->
+    <!--#include viewer-snippet-firefox-extension.html-->
+    <!--#endif-->
 
-<!--#if MOZCENTRAL-->
-<!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
-<!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
-<!--#else-->
-<link rel="stylesheet" href="viewer-geckoview.css">
-<!--#endif-->
+    <!--#if MOZCENTRAL-->
+    <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
+    <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
+    <!--#else-->
+    <link rel="stylesheet" href="viewer-geckoview.css" />
+    <!--#endif-->
 
-<!--#if !MOZCENTRAL-->
-    <link rel="resource" type="application/l10n" href="locale/locale.json">
-<!--#endif-->
+    <!--#if !MOZCENTRAL-->
+    <link rel="resource" type="application/l10n" href="locale/locale.json" />
+    <!--#endif-->
 
-<!--#if !MOZCENTRAL-->
+    <!--#if !MOZCENTRAL-->
     <script>
       if (typeof PDFJSDev === "undefined") {
         window.isGECKOVIEW = true;
@@ -91,17 +91,14 @@ See https://github.com/adobe-type-tools/cmap-resources
       }
     </script>
     <script src="viewer-geckoview.js" type="module"></script>
-<!--#else-->
-<!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
-<!--#endif-->
-
+    <!--#else-->
+    <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
+    <!--#endif-->
   </head>
 
   <body tabindex="0">
     <div id="outerContainer">
-
       <div id="mainContainer">
-
         <div id="floatingToolbar">
           <button id="download" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-download-button">
             <span data-l10n-id="pdfjs-download-button-label"></span>
@@ -111,7 +108,8 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="viewerContainer" tabindex="0">
           <div id="viewer" class="pdfViewer"></div>
         </div>
-      </div> <!-- mainContainer -->
+      </div>
+      <!-- mainContainer -->
 
       <div id="dialogContainer">
         <dialog id="passwordDialog">
@@ -119,16 +117,21 @@ See https://github.com/adobe-type-tools/cmap-resources
             <label for="password" id="passwordText" data-l10n-id="pdfjs-password-label"></label>
           </div>
           <div class="row">
-            <input type="password" id="password" class="toolbarField">
+            <input type="password" id="password" class="toolbarField" />
           </div>
           <div class="buttonRow">
-            <button id="passwordCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-cancel-button"></span></button>
-            <button id="passwordSubmit" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-ok-button"></span></button>
+            <button id="passwordCancel" class="dialogButton" type="button">
+              <span data-l10n-id="pdfjs-password-cancel-button"></span>
+            </button>
+            <button id="passwordSubmit" class="dialogButton" type="button">
+              <span data-l10n-id="pdfjs-password-ok-button"></span>
+            </button>
           </div>
         </dialog>
-      </div>  <!-- dialogContainer -->
-
-    </div> <!-- outerContainer -->
+      </div>
+      <!-- dialogContainer -->
+    </div>
+    <!-- outerContainer -->
     <div id="printContainer"></div>
   </body>
 </html>

--- a/web/viewer-snippet-chrome-extension.html
+++ b/web/viewer-snippet-chrome-extension.html
@@ -1,4 +1,4 @@
 <!-- This snippet is used in the Chromium extension (included from viewer.html) -->
-<base href="/content/web/">
-<link rel="resource" type="application/l10n" href="locale/locale.json">
+<base href="/content/web/" />
+<link rel="resource" type="application/l10n" href="locale/locale.json" />
 <script src="../build/pdf.mjs" type="module"></script>

--- a/web/viewer-snippet-chrome-overlays.html
+++ b/web/viewer-snippet-chrome-overlays.html
@@ -4,7 +4,9 @@
          users with recognizing which checkbox they have to click when they
          visit chrome://extensions.
     -->
-    <p id="chrome-pdfjs-logo-bg" style="
+    <p
+      id="chrome-pdfjs-logo-bg"
+      style="
         display: block;
         padding-left: 60px;
         min-height: 48px;
@@ -12,19 +14,19 @@
         background-repeat: no-repeat;
         font-size: 14px;
         line-height: 1.8em;
-        word-break: break-all;">
-      Click on
-      "<span id="chrome-file-access-label">Allow access to file URLs</span>"
-      at
+        word-break: break-all;
+      "
+    >
+      Click on "<span id="chrome-file-access-label">Allow access to file URLs</span>" at
       <a id="chrome-link-to-extensions-page">chrome://extensions</a>
-      <br>
+      <br />
       to view <span id="chrome-url-of-local-file">this PDF file.</span>
     </p>
   </div>
   <div class="row">
     <p>
       or select the file again:
-      <input type="file" id="chrome-file-fallback" accept=".pdf">
+      <input type="file" id="chrome-file-fallback" accept=".pdf" />
     </p>
   </div>
 </dialog>

--- a/web/viewer-snippet.html
+++ b/web/viewer-snippet.html
@@ -1,3 +1,3 @@
 <!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="locale/locale.json">
+<link rel="resource" type="application/l10n" href="locale/locale.json" />
 <script src="../build/pdf.mjs" type="module"></script>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+﻿<!doctype html>
 <!--
 Copyright 2012 Mozilla Foundation
 
@@ -22,34 +22,34 @@ See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<!--#if GENERIC || CHROME-->
-    <meta name="google" content="notranslate">
-<!--#endif-->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <!--#if GENERIC || CHROME-->
+    <meta name="google" content="notranslate" />
+    <!--#endif-->
     <title>PDF.js viewer</title>
 
-<!--#if MOZCENTRAL-->
-<!--#include viewer-snippet-firefox-extension.html-->
-<!--#elif CHROME-->
-<!--#include viewer-snippet-chrome-extension.html-->
-<!--#else-->
-<!--#include viewer-snippet.html-->
-<!--#endif-->
+    <!--#if MOZCENTRAL-->
+    <!--#include viewer-snippet-firefox-extension.html-->
+    <!--#elif CHROME-->
+    <!--#include viewer-snippet-chrome-extension.html-->
+    <!--#else-->
+    <!--#include viewer-snippet.html-->
+    <!--#endif-->
 
-<!--#if MOZCENTRAL-->
-<!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
-<!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
-<!--#else-->
-    <link rel="stylesheet" href="viewer.css">
-<!--#endif-->
+    <!--#if MOZCENTRAL-->
+    <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
+    <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
+    <!--#else-->
+    <link rel="stylesheet" href="viewer.css" />
+    <!--#endif-->
 
-<!--#if MOZCENTRAL-->
-<!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
-<!--#elif !MOZCENTRAL-->
-<!--<script src="viewer.mjs" type="module"></script>-->
-<!--#elif /* Development mode. */-->
-    <link rel="resource" type="application/l10n" href="locale/locale.json">
+    <!--#if MOZCENTRAL-->
+    <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
+    <!--#elif !MOZCENTRAL-->
+    <!--<script src="viewer.mjs" type="module"></script>-->
+    <!--#elif /* Development mode. */-->
+    <link rel="resource" type="application/l10n" href="locale/locale.json" />
 
     <script type="importmap">
       {
@@ -94,7 +94,7 @@ See https://github.com/adobe-type-tools/cmap-resources
       }
     </script>
     <script src="viewer.js" type="module"></script>
-<!--#endif-->
+    <!--#endif-->
   </head>
 
   <body tabindex="0">
@@ -105,17 +105,53 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="toolbarSidebar" class="toolbarHorizontalGroup">
           <div id="toolbarSidebarLeft">
             <div id="sidebarViewButtons" class="toolbarHorizontalGroup toggled" role="radiogroup">
-              <button id="viewThumbnail" class="toolbarButton toggled" type="button" tabindex="0" data-l10n-id="pdfjs-thumbs-button" role="radio" aria-checked="true" aria-controls="thumbnailView">
-                 <span data-l10n-id="pdfjs-thumbs-button-label"></span>
+              <button
+                id="viewThumbnail"
+                class="toolbarButton toggled"
+                type="button"
+                tabindex="0"
+                data-l10n-id="pdfjs-thumbs-button"
+                role="radio"
+                aria-checked="true"
+                aria-controls="thumbnailView"
+              >
+                <span data-l10n-id="pdfjs-thumbs-button-label"></span>
               </button>
-              <button id="viewOutline" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-document-outline-button" role="radio" aria-checked="false" aria-controls="outlineView">
-                 <span data-l10n-id="pdfjs-document-outline-button-label"></span>
+              <button
+                id="viewOutline"
+                class="toolbarButton"
+                type="button"
+                tabindex="0"
+                data-l10n-id="pdfjs-document-outline-button"
+                role="radio"
+                aria-checked="false"
+                aria-controls="outlineView"
+              >
+                <span data-l10n-id="pdfjs-document-outline-button-label"></span>
               </button>
-              <button id="viewAttachments" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-attachments-button" role="radio" aria-checked="false" aria-controls="attachmentsView">
-                 <span data-l10n-id="pdfjs-attachments-button-label"></span>
+              <button
+                id="viewAttachments"
+                class="toolbarButton"
+                type="button"
+                tabindex="0"
+                data-l10n-id="pdfjs-attachments-button"
+                role="radio"
+                aria-checked="false"
+                aria-controls="attachmentsView"
+              >
+                <span data-l10n-id="pdfjs-attachments-button-label"></span>
               </button>
-              <button id="viewLayers" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-layers-button" role="radio" aria-checked="false" aria-controls="layersView">
-                 <span data-l10n-id="pdfjs-layers-button-label"></span>
+              <button
+                id="viewLayers"
+                class="toolbarButton"
+                type="button"
+                tabindex="0"
+                data-l10n-id="pdfjs-layers-button"
+                role="radio"
+                aria-checked="false"
+                aria-controls="layersView"
+              >
+                <span data-l10n-id="pdfjs-layers-button-label"></span>
               </button>
             </div>
           </div>
@@ -124,42 +160,63 @@ See https://github.com/adobe-type-tools/cmap-resources
             <div id="outlineOptionsContainer" class="toolbarHorizontalGroup">
               <div class="verticalToolbarSeparator"></div>
 
-              <button id="currentOutlineItem" class="toolbarButton" type="button" disabled="disabled" tabindex="0" data-l10n-id="pdfjs-current-outline-item-button">
+              <button
+                id="currentOutlineItem"
+                class="toolbarButton"
+                type="button"
+                disabled="disabled"
+                tabindex="0"
+                data-l10n-id="pdfjs-current-outline-item-button"
+              >
                 <span data-l10n-id="pdfjs-current-outline-item-button-label"></span>
               </button>
             </div>
           </div>
         </div>
         <div id="sidebarContent">
-          <div id="thumbnailView">
-          </div>
-          <div id="outlineView" class="hidden">
-          </div>
-          <div id="attachmentsView" class="hidden">
-          </div>
-          <div id="layersView" class="hidden">
-          </div>
+          <div id="thumbnailView"></div>
+          <div id="outlineView" class="hidden"></div>
+          <div id="attachmentsView" class="hidden"></div>
+          <div id="layersView" class="hidden"></div>
         </div>
         <div id="sidebarResizer"></div>
-      </div>  <!-- sidebarContainer -->
+      </div>
+      <!-- sidebarContainer -->
 
       <div id="mainContainer">
         <div class="toolbar">
           <div id="toolbarContainer">
             <div id="toolbarViewer" class="toolbarHorizontalGroup">
               <div id="toolbarViewerLeft" class="toolbarHorizontalGroup">
-                <button id="sidebarToggleButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-toggle-sidebar-button" aria-expanded="false" aria-haspopup="true" aria-controls="sidebarContainer">
+                <button
+                  id="sidebarToggleButton"
+                  class="toolbarButton"
+                  type="button"
+                  tabindex="0"
+                  data-l10n-id="pdfjs-toggle-sidebar-button"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-controls="sidebarContainer"
+                >
                   <span data-l10n-id="pdfjs-toggle-sidebar-button-label"></span>
                 </button>
                 <div class="toolbarButtonSpacer"></div>
                 <div class="toolbarButtonWithContainer">
-                  <button id="viewFindButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-findbar-button" aria-expanded="false" aria-controls="findbar">
+                  <button
+                    id="viewFindButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-findbar-button"
+                    aria-expanded="false"
+                    aria-controls="findbar"
+                  >
                     <span data-l10n-id="pdfjs-findbar-button-label"></span>
                   </button>
                   <div class="hidden doorHanger toolbarHorizontalGroup" id="findbar">
                     <div id="findInputContainer" class="toolbarHorizontalGroup">
                       <span class="loadingInput end toolbarHorizontalGroup">
-                        <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input" aria-invalid="false">
+                        <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input" aria-invalid="false" />
                       </span>
                       <div class="toolbarHorizontalGroup">
                         <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-previous-button">
@@ -197,7 +254,8 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <span id="findResultsCount" class="toolbarLabel"></span>
                       <span id="findMsg" class="toolbarLabel"></span>
                     </div>
-                  </div>  <!-- findbar -->
+                  </div>
+                  <!-- findbar -->
                 </div>
                 <div class="toolbarHorizontalGroup hiddenSmallView">
                   <button class="toolbarButton" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button">
@@ -210,7 +268,16 @@ See https://github.com/adobe-type-tools/cmap-resources
                 </div>
                 <div class="toolbarHorizontalGroup">
                   <span class="loadingInput start toolbarHorizontalGroup">
-                    <input type="number" id="pageNumber" class="toolbarField" value="1" min="1" tabindex="0" data-l10n-id="pdfjs-page-input" autocomplete="off">
+                    <input
+                      type="number"
+                      id="pageNumber"
+                      class="toolbarField"
+                      value="1"
+                      min="1"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-page-input"
+                      autocomplete="off"
+                    />
                   </span>
                   <span id="numPages" class="toolbarLabel"></span>
                 </div>
@@ -231,7 +298,14 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <option id="pageActualOption" value="page-actual" data-l10n-id="pdfjs-page-scale-actual"></option>
                     <option id="pageFitOption" value="page-fit" data-l10n-id="pdfjs-page-scale-fit"></option>
                     <option id="pageWidthOption" value="page-width" data-l10n-id="pdfjs-page-scale-width"></option>
-                    <option id="customScaleOption" value="custom" disabled="disabled" hidden="true" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 0 }'></option>
+                    <option
+                      id="customScaleOption"
+                      value="custom"
+                      disabled="disabled"
+                      hidden="true"
+                      data-l10n-id="pdfjs-page-scale-percent"
+                      data-l10n-args='{ "scale": 0 }'
+                    ></option>
                     <option value="0.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 50 }'></option>
                     <option value="0.75" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 75 }'></option>
                     <option value="1" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 100 }'></option>
@@ -246,7 +320,17 @@ See https://github.com/adobe-type-tools/cmap-resources
               <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
                 <div id="editorModeButtons" class="toolbarHorizontalGroup">
                   <div id="editorComment" class="toolbarButtonWithContainer" hidden="true">
-                    <button id="editorCommentButton" class="toolbarButton" type="button" tabindex="0" disabled="disabled" aria-expanded="false" aria-haspopup="true" aria-controls="editorCommentParamsToolbar" data-l10n-id="pdfjs-editor-comment-button">
+                    <button
+                      id="editorCommentButton"
+                      class="toolbarButton"
+                      type="button"
+                      tabindex="0"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorCommentParamsToolbar"
+                      data-l10n-id="pdfjs-editor-comment-button"
+                    >
                       <span data-l10n-id="pdfjs-editor-comment-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden menu" id="editorCommentParamsToolbar">
@@ -268,19 +352,45 @@ See https://github.com/adobe-type-tools/cmap-resources
                     </div>
                   </div>
                   <div id="editorSignature" class="toolbarButtonWithContainer" hidden="true">
-                    <button id="editorSignatureButton" class="toolbarButton" type="button" tabindex="0" disabled="disabled" aria-expanded="false" aria-haspopup="true" aria-controls="editorSignatureParamsToolbar" data-l10n-id="pdfjs-editor-signature-button">
+                    <button
+                      id="editorSignatureButton"
+                      class="toolbarButton"
+                      type="button"
+                      tabindex="0"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorSignatureParamsToolbar"
+                      data-l10n-id="pdfjs-editor-signature-button"
+                    >
                       <span data-l10n-id="pdfjs-editor-signature-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorSignatureParamsToolbar">
                       <div id="addSignatureDoorHanger" class="menuContainer" role="region" data-l10n-id="pdfjs-editor-add-signature-container">
-                        <button id="editorSignatureAddSignature" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-editor-signature-add-signature-button">
+                        <button
+                          id="editorSignatureAddSignature"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-editor-signature-add-signature-button"
+                        >
                           <span data-l10n-id="pdfjs-editor-signature-add-signature-button-label" class="editorParamsLabel"></span>
                         </button>
                       </div>
                     </div>
                   </div>
                   <div id="editorHighlight" class="toolbarButtonWithContainer">
-                    <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled" aria-expanded="false" aria-haspopup="true" aria-controls="editorHighlightParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-highlight-button">
+                    <button
+                      id="editorHighlightButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorHighlightParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-highlight-button"
+                    >
                       <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
@@ -289,66 +399,123 @@ See https://github.com/adobe-type-tools/cmap-resources
                           <span id="highlightColorPickerLabel" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-colorpicker-label"></span>
                         </div>
                         <div id="editorHighlightThickness">
-                          <label for="editorFreeHighlightThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-highlight-thickness-input"></label>
+                          <label
+                            for="editorFreeHighlightThickness"
+                            class="editorParamsLabel"
+                            data-l10n-id="pdfjs-editor-free-highlight-thickness-input"
+                          ></label>
                           <div class="thicknessPicker">
-                            <input type="range" id="editorFreeHighlightThickness" class="editorParamsSlider" data-l10n-id="pdfjs-editor-free-highlight-thickness-title" value="12" min="8" max="24" step="1" tabindex="0">
+                            <input
+                              type="range"
+                              id="editorFreeHighlightThickness"
+                              class="editorParamsSlider"
+                              data-l10n-id="pdfjs-editor-free-highlight-thickness-title"
+                              value="12"
+                              min="8"
+                              max="24"
+                              step="1"
+                              tabindex="0"
+                            />
                           </div>
                         </div>
                         <div id="editorHighlightVisibility">
                           <div class="divider"></div>
                           <div class="toggler">
                             <label for="editorHighlightShowAll" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-show-all-button-label"></label>
-                            <button id="editorHighlightShowAll" class="toggle-button" type="button" data-l10n-id="pdfjs-editor-highlight-show-all-button" aria-pressed="true" tabindex="0"></button>
+                            <button
+                              id="editorHighlightShowAll"
+                              class="toggle-button"
+                              type="button"
+                              data-l10n-id="pdfjs-editor-highlight-show-all-button"
+                              aria-pressed="true"
+                              tabindex="0"
+                            ></button>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div id="editorFreeText" class="toolbarButtonWithContainer">
-                    <button id="editorFreeTextButton" class="toolbarButton" type="button" disabled="disabled" aria-expanded="false" aria-haspopup="true" aria-controls="editorFreeTextParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-free-text-button">
+                    <button
+                      id="editorFreeTextButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorFreeTextParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-free-text-button"
+                    >
                       <span data-l10n-id="pdfjs-editor-free-text-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
                       <div class="editorParamsToolbarContainer">
                         <div class="editorParamsSetter">
                           <label for="editorFreeTextColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-color-input"></label>
-                          <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0">
+                          <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0" />
                         </div>
                         <div class="editorParamsSetter">
                           <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-size-input"></label>
-                          <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="0">
+                          <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="0" />
                         </div>
                       </div>
                     </div>
                   </div>
                   <div id="editorInk" class="toolbarButtonWithContainer">
-                    <button id="editorInkButton" class="toolbarButton" type="button" disabled="disabled" aria-expanded="false" aria-haspopup="true" aria-controls="editorInkParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-ink-button">
+                    <button
+                      id="editorInkButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorInkParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-ink-button"
+                    >
                       <span data-l10n-id="pdfjs-editor-ink-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
                       <div class="editorParamsToolbarContainer">
                         <div class="editorParamsSetter">
                           <label for="editorInkColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-color-input"></label>
-                          <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0">
+                          <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0" />
                         </div>
                         <div class="editorParamsSetter">
                           <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-thickness-input"></label>
-                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="0">
+                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="0" />
                         </div>
                         <div class="editorParamsSetter">
                           <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input"></label>
-                          <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="1" min="0.05" max="1" step="0.05" tabindex="0">
+                          <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="1" min="0.05" max="1" step="0.05" tabindex="0" />
                         </div>
                       </div>
                     </div>
                   </div>
                   <div id="editorStamp" class="toolbarButtonWithContainer">
-                    <button id="editorStampButton" class="toolbarButton" type="button" disabled="disabled" aria-expanded="false" aria-haspopup="true" aria-controls="editorStampParamsToolbar" tabindex="0" data-l10n-id="pdfjs-editor-stamp-button">
+                    <button
+                      id="editorStampButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorStampParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-stamp-button"
+                    >
                       <span data-l10n-id="pdfjs-editor-stamp-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorStampParamsToolbar">
                       <div class="menuContainer">
-                        <button id="editorStampAddImage" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-editor-stamp-add-image-button">
+                        <button
+                          id="editorStampAddImage"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-editor-stamp-add-image-button"
+                        >
                           <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label"></span>
                         </button>
                       </div>
@@ -371,16 +538,25 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div class="verticalToolbarSeparator hiddenMediumView"></div>
 
                 <div id="secondaryToolbarToggle" class="toolbarButtonWithContainer">
-                  <button id="secondaryToolbarToggleButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-tools-button" aria-expanded="false" aria-haspopup="true" aria-controls="secondaryToolbar">
+                  <button
+                    id="secondaryToolbarToggleButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-tools-button"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-controls="secondaryToolbar"
+                  >
                     <span data-l10n-id="pdfjs-tools-button-label"></span>
                   </button>
                   <div id="secondaryToolbar" class="hidden doorHangerRight menu">
                     <div id="secondaryToolbarButtonContainer" class="menuContainer">
-<!--#if GENERIC-->
+                      <!--#if GENERIC-->
                       <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-open-file-button">
                         <span data-l10n-id="pdfjs-open-file-button-label"></span>
                       </button>
-<!--#endif-->
+                      <!--#endif-->
 
                       <div class="visibleMediumView">
                         <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
@@ -391,14 +567,14 @@ See https://github.com/adobe-type-tools/cmap-resources
                           <span data-l10n-id="pdfjs-save-button-label"></span>
                         </button>
 
-<!--#if !GENERIC-->
-<!--            <div class="horizontalToolbarSeparator"></div>-->
-<!--#endif-->
+                        <!--#if !GENERIC-->
+                        <!--            <div class="horizontalToolbarSeparator"></div>-->
+                        <!--#endif-->
                       </div>
 
-<!--#if GENERIC-->
+                      <!--#if GENERIC-->
                       <div class="horizontalToolbarSeparator"></div>
-<!--#endif-->
+                      <!--#endif-->
 
                       <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button">
                         <span data-l10n-id="pdfjs-presentation-mode-button-label"></span>
@@ -429,10 +605,26 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <div class="horizontalToolbarSeparator"></div>
 
                       <div id="cursorToolButtons" role="radiogroup">
-                        <button id="cursorSelectTool" class="toolbarButton labeled toggled" type="button" tabindex="0" data-l10n-id="pdfjs-cursor-text-select-tool-button" role="radio" aria-checked="true">
+                        <button
+                          id="cursorSelectTool"
+                          class="toolbarButton labeled toggled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-cursor-text-select-tool-button"
+                          role="radio"
+                          aria-checked="true"
+                        >
                           <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label"></span>
                         </button>
-                        <button id="cursorHandTool" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-cursor-hand-tool-button" role="radio" aria-checked="false">
+                        <button
+                          id="cursorHandTool"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-cursor-hand-tool-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
                           <span data-l10n-id="pdfjs-cursor-hand-tool-button-label"></span>
                         </button>
                       </div>
@@ -440,16 +632,48 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <div class="horizontalToolbarSeparator"></div>
 
                       <div id="scrollModeButtons" role="radiogroup">
-                        <button id="scrollPage" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-scroll-page-button" role="radio" aria-checked="false">
+                        <button
+                          id="scrollPage"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-page-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
                           <span data-l10n-id="pdfjs-scroll-page-button-label"></span>
                         </button>
-                        <button id="scrollVertical" class="toolbarButton labeled toggled" type="button" tabindex="0" data-l10n-id="pdfjs-scroll-vertical-button" role="radio" aria-checked="true">
+                        <button
+                          id="scrollVertical"
+                          class="toolbarButton labeled toggled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-vertical-button"
+                          role="radio"
+                          aria-checked="true"
+                        >
                           <span data-l10n-id="pdfjs-scroll-vertical-button-label"></span>
                         </button>
-                        <button id="scrollHorizontal" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-scroll-horizontal-button" role="radio" aria-checked="false">
+                        <button
+                          id="scrollHorizontal"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-horizontal-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
                           <span data-l10n-id="pdfjs-scroll-horizontal-button-label"></span>
                         </button>
-                        <button id="scrollWrapped" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-scroll-wrapped-button" role="radio" aria-checked="false">
+                        <button
+                          id="scrollWrapped"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-wrapped-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
                           <span data-l10n-id="pdfjs-scroll-wrapped-button-label"></span>
                         </button>
                       </div>
@@ -457,36 +681,74 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <div class="horizontalToolbarSeparator"></div>
 
                       <div id="spreadModeButtons" role="radiogroup">
-                        <button id="spreadNone" class="toolbarButton labeled toggled" type="button" tabindex="0" data-l10n-id="pdfjs-spread-none-button" role="radio" aria-checked="true">
+                        <button
+                          id="spreadNone"
+                          class="toolbarButton labeled toggled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-spread-none-button"
+                          role="radio"
+                          aria-checked="true"
+                        >
                           <span data-l10n-id="pdfjs-spread-none-button-label"></span>
                         </button>
-                        <button id="spreadOdd" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-spread-odd-button" role="radio" aria-checked="false">
+                        <button
+                          id="spreadOdd"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-spread-odd-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
                           <span data-l10n-id="pdfjs-spread-odd-button-label"></span>
                         </button>
-                        <button id="spreadEven" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-spread-even-button" role="radio" aria-checked="false">
+                        <button
+                          id="spreadEven"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-spread-even-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
                           <span data-l10n-id="pdfjs-spread-even-button-label"></span>
                         </button>
                       </div>
 
                       <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
-                      <button id="imageAltTextSettings" type="button" class="toolbarButton labeled hidden" tabindex="0" data-l10n-id="pdfjs-image-alt-text-settings-button" aria-controls="altTextSettingsDialog">
+                      <button
+                        id="imageAltTextSettings"
+                        type="button"
+                        class="toolbarButton labeled hidden"
+                        tabindex="0"
+                        data-l10n-id="pdfjs-image-alt-text-settings-button"
+                        aria-controls="altTextSettingsDialog"
+                      >
                         <span data-l10n-id="pdfjs-image-alt-text-settings-button-label"></span>
                       </button>
 
                       <div class="horizontalToolbarSeparator"></div>
 
-                      <button id="documentProperties" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
+                      <button
+                        id="documentProperties"
+                        class="toolbarButton labeled"
+                        type="button"
+                        tabindex="0"
+                        data-l10n-id="pdfjs-document-properties-button"
+                        aria-controls="documentPropertiesDialog"
+                      >
                         <span data-l10n-id="pdfjs-document-properties-button-label"></span>
                       </button>
                     </div>
-                  </div>  <!-- secondaryToolbar -->
+                  </div>
+                  <!-- secondaryToolbar -->
                 </div>
               </div>
             </div>
             <div id="loadingBar">
               <div class="progress">
-                <div class="glimmer">
-                </div>
+                <div class="glimmer"></div>
               </div>
             </div>
           </div>
@@ -495,7 +757,8 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="viewerContainer" tabindex="0">
           <div id="viewer" class="pdfViewer"></div>
         </div>
-      </div> <!-- mainContainer -->
+      </div>
+      <!-- mainContainer -->
 
       <div id="dialogContainer">
         <dialog id="passwordDialog">
@@ -503,7 +766,7 @@ See https://github.com/adobe-type-tools/cmap-resources
             <label for="password" id="passwordText" data-l10n-id="pdfjs-password-label"></label>
           </div>
           <div class="row">
-            <input type="password" id="password" class="toolbarField">
+            <input type="password" id="password" class="toolbarField" />
           </div>
           <div class="buttonRow">
             <button id="passwordCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-cancel-button"></span></button>
@@ -583,7 +846,7 @@ See https://github.com/adobe-type-tools/cmap-resources
             <div id="addDescription">
               <div class="radio">
                 <div class="radioButton">
-                  <input type="radio" id="descriptionButton" name="altTextOption" tabindex="0" aria-describedby="descriptionAreaLabel" checked>
+                  <input type="radio" id="descriptionButton" name="altTextOption" tabindex="0" aria-describedby="descriptionAreaLabel" checked />
                   <label for="descriptionButton" data-l10n-id="pdfjs-editor-alt-text-add-description-label"></label>
                 </div>
                 <div class="radioLabel">
@@ -597,7 +860,7 @@ See https://github.com/adobe-type-tools/cmap-resources
             <div id="markAsDecorative">
               <div class="radio">
                 <div class="radioButton">
-                  <input type="radio" id="decorativeButton" name="altTextOption" aria-describedby="decorativeLabel">
+                  <input type="radio" id="decorativeButton" name="altTextOption" aria-describedby="decorativeLabel" />
                   <label for="decorativeButton" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-label"></label>
                 </div>
                 <div class="radioLabel">
@@ -606,7 +869,9 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
             </div>
             <div id="buttons">
-              <button id="altTextCancel" class="secondaryButton" type="button" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span></button>
+              <button id="altTextCancel" class="secondaryButton" type="button" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+              </button>
               <button id="altTextSave" class="primaryButton" type="button" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button"></span></button>
             </div>
           </div>
@@ -621,17 +886,43 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div id="descriptionInstruction">
                   <div id="newAltTextDescriptionContainer">
                     <div class="altTextSpinner" role="status" aria-live="polite"></div>
-                    <textarea id="newAltTextDescriptionTextarea" aria-labelledby="descriptionAreaLabel" data-l10n-id="pdfjs-editor-new-alt-text-textarea" tabindex="0"></textarea>
+                    <textarea
+                      id="newAltTextDescriptionTextarea"
+                      aria-labelledby="descriptionAreaLabel"
+                      data-l10n-id="pdfjs-editor-new-alt-text-textarea"
+                      tabindex="0"
+                    ></textarea>
                   </div>
                   <span id="newAltTextDescription" role="note" data-l10n-id="pdfjs-editor-new-alt-text-description"></span>
-                  <div id="newAltTextDisclaimer" role="note"><div><span data-l10n-id="pdfjs-editor-new-alt-text-disclaimer1"></span> <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank" rel="noopener noreferrer" id="newAltTextLearnMore" data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url" tabindex="0"></a></div></div>
+                  <div id="newAltTextDisclaimer" role="note">
+                    <div>
+                      <span data-l10n-id="pdfjs-editor-new-alt-text-disclaimer1"></span>
+                      <a
+                        href="https://support.mozilla.org/en-US/kb/pdf-alt-text"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        id="newAltTextLearnMore"
+                        data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
+                        tabindex="0"
+                      ></a>
+                    </div>
+                  </div>
                 </div>
                 <div id="newAltTextCreateAutomatically" class="toggler">
                   <button id="newAltTextCreateAutomaticallyButton" class="toggle-button" type="button" aria-pressed="true" tabindex="0"></button>
-                  <label for="newAltTextCreateAutomaticallyButton" class="togglerLabel" data-l10n-id="pdfjs-editor-new-alt-text-create-automatically-button-label"></label>
+                  <label
+                    for="newAltTextCreateAutomaticallyButton"
+                    class="togglerLabel"
+                    data-l10n-id="pdfjs-editor-new-alt-text-create-automatically-button-label"
+                  ></label>
                 </div>
                 <div id="newAltTextDownloadModel" class="hidden">
-                  <span id="newAltTextDownloadModelDescription" data-l10n-id="pdfjs-editor-new-alt-text-ai-model-downloading-progress" aria-valuemin="0" data-l10n-args='{ "totalSize": 0, "downloadedSize": 0 }'></span>
+                  <span
+                    id="newAltTextDownloadModelDescription"
+                    data-l10n-id="pdfjs-editor-new-alt-text-ai-model-downloading-progress"
+                    aria-valuemin="0"
+                    data-l10n-args='{ "totalSize": 0, "downloadedSize": 0 }'
+                  ></span>
                 </div>
               </div>
               <div id="newAltTextImagePreview"></div>
@@ -640,15 +931,23 @@ See https://github.com/adobe-type-tools/cmap-resources
               <div>
                 <div>
                   <span class="title" data-l10n-id="pdfjs-editor-new-alt-text-error-title"></span>
-                  <span  class="description" data-l10n-id="pdfjs-editor-new-alt-text-error-description"></span>
+                  <span class="description" data-l10n-id="pdfjs-editor-new-alt-text-error-description"></span>
                 </div>
-                <button id="newAltTextCloseButton" class="closeButton" type="button" tabindex="0"><span data-l10n-id="pdfjs-editor-new-alt-text-error-close-button"></span></button>
+                <button id="newAltTextCloseButton" class="closeButton" type="button" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-new-alt-text-error-close-button"></span>
+                </button>
               </div>
             </div>
             <div id="newAltTextButtons" class="dialogButtonsGroup">
-              <button id="newAltTextCancel" type="button" class="secondaryButton hidden" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span></button>
-              <button id="newAltTextNotNow" type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-new-alt-text-not-now-button"></span></button>
-              <button id="newAltTextSave" type="button" class="primaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button"></span></button>
+              <button id="newAltTextCancel" type="button" class="secondaryButton hidden" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+              </button>
+              <button id="newAltTextNotNow" type="button" class="secondaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-new-alt-text-not-now-button"></span>
+              </button>
+              <button id="newAltTextSave" type="button" class="primaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-save-button"></span>
+              </button>
             </div>
           </div>
         </dialog>
@@ -667,7 +966,15 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <label for="createModelButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-create-model-button-label"></label>
                   </div>
                   <div id="createModelDescription" class="description">
-                    <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description"></span> <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank" rel="noopener noreferrer" id="altTextSettingsLearnMore" data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url" tabindex="0"></a>
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description"></span>
+                    <a
+                      href="https://support.mozilla.org/en-US/kb/pdf-alt-text"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      id="altTextSettingsLearnMore"
+                      data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
+                      tabindex="0"
+                    ></a>
                   </div>
                 </div>
                 <div id="aiModelSettings">
@@ -677,8 +984,12 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <span data-l10n-id="pdfjs-editor-alt-text-settings-ai-model-description"></span>
                     </div>
                   </div>
-                  <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button"></span></button>
-                  <button id="downloadModelButton" type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button"></span></button>
+                  <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button"></span>
+                  </button>
+                  <button id="downloadModelButton" type="button" class="secondaryButton" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button"></span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -696,7 +1007,9 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
             </div>
             <div id="buttons" class="dialogButtonsGroup">
-              <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-settings-close-button"></span></button>
+              <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-settings-close-button"></span>
+              </button>
             </div>
           </div>
         </dialog>
@@ -708,13 +1021,37 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span role="sectionhead" data-l10n-id="pdfjs-editor-add-signature-dialog-title" tabindex="0"></span>
             </div>
             <div role="tablist" id="addSignatureOptions">
-              <button id="addSignatureTypeButton" type="button" role="tab" aria-selected="true" aria-controls="addSignatureTypeContainer" data-l10n-id="pdfjs-editor-add-signature-type-button" tabindex="0"></button>
-              <button id="addSignatureDrawButton" type="button" role="tab" aria-selected="false" aria-controls="addSignatureDrawContainer" data-l10n-id="pdfjs-editor-add-signature-draw-button" tabindex="0"></button>
-              <button id="addSignatureImageButton" type="button" role="tab" aria-selected="false" aria-controls="addSignatureImageContainer" data-l10n-id="pdfjs-editor-add-signature-image-button" tabindex="-1"></button>
+              <button
+                id="addSignatureTypeButton"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                aria-controls="addSignatureTypeContainer"
+                data-l10n-id="pdfjs-editor-add-signature-type-button"
+                tabindex="0"
+              ></button>
+              <button
+                id="addSignatureDrawButton"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="addSignatureDrawContainer"
+                data-l10n-id="pdfjs-editor-add-signature-draw-button"
+                tabindex="0"
+              ></button>
+              <button
+                id="addSignatureImageButton"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="addSignatureImageContainer"
+                data-l10n-id="pdfjs-editor-add-signature-image-button"
+                tabindex="-1"
+              ></button>
             </div>
             <div id="addSignatureActionContainer" data-selected="type">
               <div id="addSignatureTypeContainer" role="tabpanel" aria-labelledby="addSignatureTypeContainer">
-                <input id="addSignatureTypeInput" type="text" data-l10n-id="pdfjs-editor-add-signature-type-input" tabindex="0"></input>
+                <input id="addSignatureTypeInput" type="text" data-l10n-id="pdfjs-editor-add-signature-type-input" tabindex="0" />
               </div>
               <div id="addSignatureDrawContainer" role="tabpanel" aria-labelledby="addSignatureDrawButton" tabindex="-1">
                 <svg id="addSignatureDraw" xmlns="http://www.w3.org/2000/svg" aria-labelledby="addSignatureDrawPlaceholder"></svg>
@@ -722,7 +1059,17 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div id="thickness">
                   <div>
                     <label for="addSignatureDrawThickness" data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range-label"></label>
-                    <input type="range" id="addSignatureDrawThickness" min="1" max="5" step="1" value="1" data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range" data-l10n-args='{ "thickness": 1 }' tabindex="0">
+                    <input
+                      type="range"
+                      id="addSignatureDrawThickness"
+                      min="1"
+                      max="5"
+                      step="1"
+                      value="1"
+                      data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range"
+                      data-l10n-args='{ "thickness": 1 }'
+                      tabindex="0"
+                    />
                   </div>
                 </div>
               </div>
@@ -733,7 +1080,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <label id="addSignatureImageBrowse" for="addSignatureFilePicker" tabindex="0">
                     <a data-l10n-id="pdfjs-editor-add-signature-image-browse-link"></a>
                   </label>
-                  <input id="addSignatureFilePicker" type="file"></input>
+                  <input id="addSignatureFilePicker" type="file" />
                 </div>
               </div>
               <div id="addSignatureControls">
@@ -741,14 +1088,16 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <div id="addSignatureDescriptionContainer">
                     <label for="addSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
                     <span id="addSignatureDescription" class="inputWithClearButton">
-                      <input id="addSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0"></input>
+                      <input id="addSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
                       <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
                     </span>
                   </div>
-                  <button id="clearSignatureButton" type="button" data-l10n-id="pdfjs-editor-add-signature-clear-button" tabindex="0"><span data-l10n-id="pdfjs-editor-add-signature-clear-button-label"></span></button>
+                  <button id="clearSignatureButton" type="button" data-l10n-id="pdfjs-editor-add-signature-clear-button" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-add-signature-clear-button-label"></span>
+                  </button>
                 </div>
                 <div id="addSignatureSaveContainer">
-                  <input type="checkbox" id="addSignatureSaveCheckbox"></input>
+                  <input type="checkbox" id="addSignatureSaveCheckbox" />
                   <label for="addSignatureSaveCheckbox" data-l10n-id="pdfjs-editor-add-signature-save-checkbox"></label>
                   <span></span>
                   <span id="addSignatureSaveWarning" data-l10n-id="pdfjs-editor-add-signature-save-warning-message"></span>
@@ -760,58 +1109,68 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <span id="addSignatureErrorTitle" class="title" data-l10n-id="pdfjs-editor-add-signature-image-upload-error-title"></span>
                     <span id="addSignatureErrorDescription" class="description" data-l10n-id="pdfjs-editor-add-signature-image-upload-error-description"></span>
                   </div>
-                  <button id="addSignatureErrorCloseButton" class="closeButton" type="button" tabindex="0"><span data-l10n-id="pdfjs-editor-add-signature-error-close-button"></span></button>
+                  <button id="addSignatureErrorCloseButton" class="closeButton" type="button" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-add-signature-error-close-button"></span>
+                  </button>
                 </div>
               </div>
               <div class="dialogButtonsGroup">
-                <button id="addSignatureCancelButton" type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span></button>
-                <button id="addSignatureAddButton" type="button" class="primaryButton" disabled tabindex="0"><span data-l10n-id="pdfjs-editor-add-signature-add-button"></span></button>
+                <button id="addSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
+                </button>
+                <button id="addSignatureAddButton" type="button" class="primaryButton" disabled tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-add-signature-add-button"></span>
+                </button>
               </div>
             </div>
           </div>
-       </dialog>
+        </dialog>
 
-       <dialog class="dialog signatureDialog" id="editSignatureDescriptionDialog" aria-labelledby="editSignatureDescriptionTitle">
-        <div id="editSignatureDescriptionContainer" class="mainContainer">
-          <div class="title">
-            <span id="editSignatureDescriptionTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-signature-dialog-title" tabindex="0"></span>
-          </div>
-          <div id="editSignatureDescriptionAndView">
-            <div id="editSignatureDescriptionContainer">
-              <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
-              <span id="editSignatureDescription" class="inputWithClearButton">
-                <input id="editSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0"></input>
-                <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
-              </span>
+        <dialog class="dialog signatureDialog" id="editSignatureDescriptionDialog" aria-labelledby="editSignatureDescriptionTitle">
+          <div id="editSignatureDescriptionContainer" class="mainContainer">
+            <div class="title">
+              <span id="editSignatureDescriptionTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-signature-dialog-title" tabindex="0"></span>
             </div>
-            <svg id="editSignatureView" xmlns="http://www.w3.org/2000/svg"></svg>
+            <div id="editSignatureDescriptionAndView">
+              <div id="editSignatureDescriptionContainer">
+                <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
+                <span id="editSignatureDescription" class="inputWithClearButton">
+                  <input id="editSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
+                  <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
+                </span>
+              </div>
+              <svg id="editSignatureView" xmlns="http://www.w3.org/2000/svg"></svg>
+            </div>
+            <div class="dialogButtonsGroup">
+              <button id="editSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
+              </button>
+              <button id="editSignatureUpdateButton" type="button" class="primaryButton" disabled tabindex="0">
+                <span data-l10n-id="pdfjs-editor-edit-signature-update-button"></span>
+              </button>
+            </div>
           </div>
-          <div class="dialogButtonsGroup">
-            <button id="editSignatureCancelButton" type="button" class="secondaryButton" tabindex="0"><span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span></button>
-            <button id="editSignatureUpdateButton" type="button" class="primaryButton" disabled tabindex="0"><span data-l10n-id="pdfjs-editor-edit-signature-update-button"></span></button>
-          </div>
-        </div>
-      </dialog>
+        </dialog>
 
-      <dialog class="dialog commentManager" id="commentManagerDialog" aria-labelledby="commentManagerTitle">
-        <div class="mainContainer">
-          <div class="title" id="commentManagerToolbar">
-            <span id="commentManagerTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-comment-dialog-title-when-adding"></span>
+        <dialog class="dialog commentManager" id="commentManagerDialog" aria-labelledby="commentManagerTitle">
+          <div class="mainContainer">
+            <div class="title" id="commentManagerToolbar">
+              <span id="commentManagerTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-comment-dialog-title-when-adding"></span>
+            </div>
+            <textarea id="commentManagerTextInput" data-l10n-id="pdfjs-editor-edit-comment-dialog-text-input" tabindex="0"></textarea>
+            <div class="dialogButtonsGroup">
+              <button id="commentManagerCancelButton" type="button" class="secondaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-edit-comment-dialog-cancel-button"></span>
+              </button>
+              <button id="commentManagerSaveButton" type="button" class="primaryButton" disabled tabindex="0">
+                <span data-l10n-id="pdfjs-editor-edit-comment-dialog-save-button-when-adding"></span>
+              </button>
+            </div>
           </div>
-          <textarea id="commentManagerTextInput" data-l10n-id="pdfjs-editor-edit-comment-dialog-text-input" tabindex="0"></textarea>
-          <div class="dialogButtonsGroup">
-            <button id="commentManagerCancelButton" type="button" class="secondaryButton" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-edit-comment-dialog-cancel-button"></span>
-            </button>
-            <button id="commentManagerSaveButton" type="button" class="primaryButton" disabled tabindex="0">
-              <span data-l10n-id="pdfjs-editor-edit-comment-dialog-save-button-when-adding"></span>
-            </button>
-          </div>
-        </div>
-      </dialog>
+        </dialog>
 
-<!--#if !MOZCENTRAL-->
-        <dialog id="printServiceDialog" style="min-width: 200px;">
+        <!--#if !MOZCENTRAL-->
+        <dialog id="printServiceDialog" style="min-width: 200px">
           <div class="row">
             <span data-l10n-id="pdfjs-print-progress-message"></span>
           </div>
@@ -823,11 +1182,12 @@ See https://github.com/adobe-type-tools/cmap-resources
             <button id="printCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-print-progress-close-button"></span></button>
           </div>
         </dialog>
-<!--#endif-->
-<!--#if CHROME-->
-<!--#include viewer-snippet-chrome-overlays.html-->
-<!--#endif-->
-      </div>  <!-- dialogContainer -->
+        <!--#endif-->
+        <!--#if CHROME-->
+        <!--#include viewer-snippet-chrome-overlays.html-->
+        <!--#endif-->
+      </div>
+      <!-- dialogContainer -->
 
       <div id="editorUndoBar" class="messageBar" role="status" aria-labelledby="editorUndoBarMessage" tabindex="-1" hidden>
         <div>
@@ -841,9 +1201,10 @@ See https://github.com/adobe-type-tools/cmap-resources
             <span data-l10n-id="pdfjs-editor-undo-bar-close-button-label"></span>
           </button>
         </div>
-      </div> <!-- editorUndoBar -->
-
-    </div> <!-- outerContainer -->
+      </div>
+      <!-- editorUndoBar -->
+    </div>
+    <!-- outerContainer -->
     <div id="printContainer"></div>
   </body>
 </html>


### PR DESCRIPTION
The linter found some issues in viewer.html with </input> which isn't required and a missing closing div in test/resources/reftest-analyzer.html.
The HTML can now be nicely formatted. In order to not break the build for mozilla-central, the preprocessor has been fixed in order to take into account the white spaces at the beginning of a comment line.
And finally, make .prettierrc (which is supposed to be either json or yaml) itself lintable.