### PR TITLE
Include missing `cached-iterable` dev dependency in `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^24.10.0",
         "autoprefixer": "^10.4.21",
         "babel-loader": "^10.0.0",
+        "cached-iterable": "^0.3.0",
         "caniuse-lite": "^1.0.30001754",
         "core-js": "^3.46.0",
         "eslint": "^9.39.1",
@@ -4100,7 +4101,6 @@
       "resolved": "https://registry.npmjs.org/cached-iterable/-/cached-iterable-0.3.0.tgz",
       "integrity": "sha512-MDqM6TpBVebZD4UDtmlFp8EjVtRcsB6xt9aRdWymjk0fWVUUGgmt/V7o0H0gkI2Tkvv8B0ucjidZm4mLosdlWw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^24.10.0",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^10.0.0",
+    "cached-iterable": "^0.3.0",
     "caniuse-lite": "^1.0.30001754",
     "core-js": "^3.46.0",
     "eslint": "^9.39.1",


### PR DESCRIPTION
I found that `web/viewer.html` depends on `node_modules/cached-iterable`, but this is not directly declared in package.json. 

When I install dependencies using other package managers (pnpm), it doesn't work properly. 

This is because all dependencies of npm are stored in the root directory of node_modules, and other dependencies in the project that indirectly depend on cached-iterable will also be in the root directory, so it happens to work normally when using npm.

<img width="598" height="121" alt="image" src="https://github.com/user-attachments/assets/0c1e9c00-837d-4767-ac46-39f801f88b04" />
