### PR TITLE
fix: support text selection under search highlights

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -307,6 +307,9 @@ class TextLayerBuilder {
         if (anchor.nodeType === Node.TEXT_NODE) {
           anchor = anchor.parentNode;
         }
+        if (anchor.classList?.contains("highlight")) {
+          anchor = anchor.parentNode;
+        }
         if (!modifyStart && range.endOffset === 0) {
           do {
             while (!anchor.previousSibling) {


### PR DESCRIPTION
Fixes an issue where highlighted search results interfere with text selection. From what we can tell, the issue stems from moving `.endOfContent` to the search highlight span, preventing the selection range from being extended.

Steps to reproduce the issue:
1. Open the pdf.js demo viewer at https://mozilla.github.io/pdf.js/web/viewer.html
2. Use the toolbar to search for a keyword e.g. "javascript"
3. Try to create a text selection range that begins inside of, ends inside of, or spans the highlighted search result.
4. Observe various issues:
    - flickering
    - individual characters in the search highlight cannot be smoothly selected/deselected when dragging
    

https://github.com/user-attachments/assets/2896282c-c541-4053-8a49-f7109332428c



The fix was tested on the demo viewer locally:
```
npx gulp dist-install && npx gulp server

# http://localhost:8888/web/viewer.html
```



https://github.com/user-attachments/assets/91905c44-301e-45e7-b329-7eb6b7f44a5a



