### PR TITLE
Use OIDC trusted publishing in the GitHub Actions release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -34,6 +34,4 @@ jobs:
         run: npx gulp dist
 
       - name: Publish the `pdfjs-dist` library to NPM
-        run: npm publish ./build/dist --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ./build/dist


### PR DESCRIPTION
This commit updates the release pipeline to use OIDC trusted publishing now that we have configured it between GitHub Actions and NPM. This solution allows us to remove the token variable (because there is no longer a fixed token) and provenance flag (because provenance attestations are generated by default with this approach); refer to https://docs.npmjs.com/trusted-publishers for more information.