### PR TITLE
Move Rotate Clockwise button to main toolbar

### DIFF
--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -41,8 +41,6 @@ import { PagesCountLimit } from "./pdf_viewer.js";
  *   page in the document.
  * @property {HTMLButtonElement} lastPageButton - Button to go to the last page
  *   in the document.
- * @property {HTMLButtonElement} pageRotateCwButton - Button to rotate the pages
- *   clockwise.
  * @property {HTMLButtonElement} pageRotateCcwButton - Button to rotate the
  *   pages counterclockwise.
  * @property {HTMLButtonElement} cursorSelectToolButton - Button to enable the
@@ -75,11 +73,6 @@ class SecondaryToolbar {
       { element: options.viewBookmarkButton, eventName: null, close: true },
       { element: options.firstPageButton, eventName: "firstpage", close: true },
       { element: options.lastPageButton, eventName: "lastpage", close: true },
-      {
-        element: options.pageRotateCwButton,
-        eventName: "rotatecw",
-        close: false,
-      },
       {
         element: options.pageRotateCcwButton,
         eventName: "rotateccw",
@@ -197,16 +190,12 @@ class SecondaryToolbar {
   }
 
   #updateUIState() {
-    const {
-      firstPageButton,
-      lastPageButton,
-      pageRotateCwButton,
-      pageRotateCcwButton,
-    } = this.#opts;
+    const { firstPageButton, lastPageButton, pageRotateCcwButton } = this.#opts;
 
     firstPageButton.disabled = this.pageNumber <= 1;
     lastPageButton.disabled = this.pageNumber >= this.pagesCount;
-    pageRotateCwButton.disabled = this.pagesCount === 0;
+    firstPageButton.disabled = this.pageNumber <= 1;
+    lastPageButton.disabled = this.pageNumber >= this.pagesCount;
     pageRotateCcwButton.disabled = this.pagesCount === 0;
   }
 

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -41,6 +41,8 @@ import {
  * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
  *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.
+ * @property {HTMLButtonElement} pageRotateCw - Button to rotate the pages
+ *   clockwise.
  */
 
 class Toolbar {
@@ -67,6 +69,7 @@ class Toolbar {
       { element: options.zoomOut, eventName: "zoomout" },
       { element: options.print, eventName: "print" },
       { element: options.download, eventName: "download" },
+      { element: options.pageRotateCw, eventName: "rotatecw" },
       {
         element: options.editorCommentButton,
         eventName: "switchannotationeditormode",
@@ -381,6 +384,8 @@ class Toolbar {
 
     opts.zoomOut.disabled = pageScale <= MIN_SCALE;
     opts.zoomIn.disabled = pageScale >= MAX_SCALE;
+
+    opts.pageRotateCw.disabled = pagesCount === 0;
 
     let predefinedValueFound = false;
     for (const option of opts.scaleSelect.options) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -542,6 +542,10 @@ body {
   mask-image: var(--toolbarButton-zoomIn-icon);
 }
 
+#pageRotateCw::before {
+  mask-image: var(--secondaryToolbarButton-rotateCw-icon);
+}
+
 #editorCommentButton::before {
   mask-image: var(--toolbarButton-editorComment-icon);
   transform: scaleX(var(--dir-factor));

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -284,6 +284,10 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
               <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
                 <div class="toolbarHorizontalGroup">
+                  <button id="pageRotateCw" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button">
+                    <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
+                  </button>
+                  <div class="splitToolbarButtonSeparator"></div>
                   <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
                     <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
                   </button>
@@ -595,9 +599,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 
                       <div class="horizontalToolbarSeparator"></div>
 
-                      <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button">
-                        <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
-                      </button>
                       <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-ccw-button">
                         <span data-l10n-id="pdfjs-page-rotate-ccw-button-label"></span>
                       </button>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -45,6 +45,7 @@ function getViewerConfiguration() {
       zoomIn: document.getElementById("zoomInButton"),
       zoomOut: document.getElementById("zoomOutButton"),
       print: document.getElementById("printButton"),
+      pageRotateCw: document.getElementById("pageRotateCw"),
       editorCommentButton: document.getElementById("editorCommentButton"),
       editorCommentParamsToolbar: document.getElementById(
         "editorCommentParamsToolbar"
@@ -85,7 +86,6 @@ function getViewerConfiguration() {
       viewBookmarkButton: document.getElementById("viewBookmark"),
       firstPageButton: document.getElementById("firstPage"),
       lastPageButton: document.getElementById("lastPage"),
-      pageRotateCwButton: document.getElementById("pageRotateCw"),
       pageRotateCcwButton: document.getElementById("pageRotateCcw"),
       cursorSelectToolButton: document.getElementById("cursorSelectTool"),
       cursorHandToolButton: document.getElementById("cursorHandTool"),


### PR DESCRIPTION

This PR moves the **Rotate Clockwise** button from the **secondary toolbar (Tools menu)** to the **main toolbar**, placing it next to the **Zoom Out** button for improved accessibility.

## Changes

- **toolbar.js**
  - Added the `pageRotateCw` button definition to the main toolbar.

- **secondary_toolbar.js**
  - Removed the `pageRotateCw` button definition.

- **viewer.html**
  - Updated the main toolbar structure to include the Rotate Clockwise button.

- **viewer.js**
  - Updated button mapping so the Rotate Clockwise action works correctly from the main toolbar.

- **viewer.css**
  - Added styles to ensure the correct icon is displayed in the new location.

## Result
The **Rotate Clockwise** button is now prominently accessible in the main toolbar with no change to underlying functionality.
