### PR TITLE
Fix #20478: Remove output.globalObject from webpack config

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -378,8 +378,6 @@ function createWebpackConfig(
   const alias = createWebpackAlias(bundleDefines);
   const experiments = isModule ? { outputModule: true } : undefined;
 
-
-
   return {
     mode: "production",
     optimization: {

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -378,8 +378,7 @@ function createWebpackConfig(
   const alias = createWebpackAlias(bundleDefines);
   const experiments = isModule ? { outputModule: true } : undefined;
 
-  // Required to expose e.g., the `window` object.
-  output.globalObject = "globalThis";
+
 
   return {
     mode: "production",


### PR DESCRIPTION
### Description
This PR fixes a compatibility issue with Next.js 16 where importing `pdfjs-dist` causes an `Object.defineProperty` error.

The issue arises because the combination of `outputModule: true` and `output.globalObject: "globalThis"` in the Webpack configuration generates code that is incompatible with the Webpack runtime used by Next.js (specifically when using `eval`-based source maps).

### Changes
- Removed `output.globalObject = "globalThis"` from gulpfile.mjs

This setting is unnecessary for ES Module builds (`library.type: "module"`) and removing it resolves the conflict, allowing `pdfjs-dist` to be imported correctly in Next.js environments.

Fixes #20478