### PR TITLE
Fix #20420: Prevent double decoding of file URL parameter

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -789,7 +789,7 @@ const PDFViewerApplication = {
       const params = parseQueryString(queryString);
       file = params.get("file") ?? AppOptions.get("defaultUrl");
       try {
-        file = new URL(decodeURIComponent(file)).href;
+        file = new URL(file).href;
       } catch {
         file = encodeURIComponent(file).replaceAll("%2F", "/");
       }


### PR DESCRIPTION
Fixes #20420

### Description
This PR fixes a regression where passing a URL with encoded parameters (e.g., `?token=%2Ffoo`) to the viewer would fail due to incorrect double decoding.

*   **The Bug:** In [web/app.js](cci:7://file:///Users/uzairahmedshah/Downloads/Uzair/Development_Coding%20Files/Web%20Development/HTML,CSS,%20JS/Projects/pdf.js/web/app.js:0:0-0:0), the `file` parameter retrieved from `URLSearchParams` was being passed to `decodeURIComponent`. Since `URLSearchParams.get()` already decodes values, this caused a second round of decoding. This corrupted URLs containing encoded characters (like `%2F` becoming `/`), which broke signed URLs or paths requiring encoding.
*   **The Fix:** Removed the redundant `decodeURIComponent` call. The `file` parameter is now passed directly to the [URL](cci:1://file:///Users/uzairahmedshah/Downloads/Uzair/Development_Coding%20Files/Web%20Development/HTML,CSS,%20JS/Projects/pdf.js/web/app.js:2422:2-2445:4) constructor, preserving the correct encoding.

### Testing
Verified manually using a reproduction case:
1.  **Input:** `https://example.com/pdf?token=%2Ffoo`
2.  **Before Fix:** Resulted in `...token=/foo` (Incorrect, broke the token).
3.  **After Fix:** Results in `...token=%2Ffoo` (Correct, preserves encoding).