### PR TITLE
Move text layer scaling logic to CSS

### DIFF
--- a/test/unit/text_layer_spec.js
+++ b/test/unit/text_layer_spec.js
@@ -101,11 +101,12 @@ describe("textLayer", function () {
     const getTransform = container => {
       const transform = [];
 
-      for (const span of container.childNodes) {
-        const t = span.style.transform;
-        expect(t).toMatch(/^scaleX\([\d.]+\)$/);
-
-        transform.push(t);
+      for (const { style } of container.childNodes) {
+        transform.push({
+          fontHeight: style.getPropertyValue("--font-height"),
+          scaleX: style.getPropertyValue("--scale-x"),
+          rotate: style.getPropertyValue("--rotate"),
+        });
       }
       return transform;
     };

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -38,9 +38,25 @@
     transform-origin: 0% 0%;
   }
 
+  /* We multiply the font size by --min-font-size, and then scale the text
+   * elements by 1/--min-font-size. This allows us to effectively ignore the
+   * minimum font size enforced by the browser, so that the text layer <span>s
+   * can always match the size of the text in the canvas. */
+  --min-font-size: 1;
+  --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
+  --min-font-size-inv: calc(1 / var(--min-font-size));
+
   > :not(.markedContent),
   .markedContent span:not(.markedContent) {
     z-index: 1;
+
+    --font-height: 0; /* set by text_layer.js */
+    font-size: calc(var(--text-scale-factor) * var(--font-height));
+
+    --scale-x: 1;
+    --rotate: 0deg;
+    transform: rotate(var(--rotate)) scaleX(var(--scale-x))
+      scale(var(--min-font-size-inv));
   }
 
   /* Only necessary in Google Chrome, see issue 14205, and most unfortunately


### PR DESCRIPTION
Commit message:

> **Move text layer scaling logic to CSS**
>
>This commit moves all the logic to scale up&down `<span>`s in the text layer, introduced in #18283, to CSS.
>
> The motivation for this change is that #18283 is still not enough for all cases. That PR fixed the problem in Chrome&Firefox desktop, which allow users to set an actual minimum font size in the browser settings. However, other browsers (e.g. the Chrome-based WebView on Android) have more complex logic and they scale up small text rather than simply applying a minimum.
>
> A workaround for that behavior is probably out of scope for PDF.js itself as it only affects not officially supported platforms. However, having access to the actual expected font height (through `--font-height`) allows embedders of PDF.js to implement a workaround by themselves.

In my app that uses PDF.js I'm currently patching the PDF.js code to export the text height as `textDiv.dataset.fontHeight = fontHeight;`. I find the approach proposed in this PR to be cleaner, as it has the benefit of moving style-related logic from the JS file to the CSS file.

What do you think about this change?