### PR TITLE
Improves text rendering performance by skipping unnecessary pattern calculations

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2062,7 +2062,20 @@ class CanvasGraphics {
     }
 
     let patternFillTransform, patternStrokeTransform;
-    if (current.patternFill) {
+
+    // Only compute pattern transforms if the text rendering mode actually
+    // uses fill/stroke. This avoids expensive pattern calculations each call
+    // when a patternFill/patternStroke is set, but unused.
+    const fillStrokeMode =
+      current.textRenderingMode & TextRenderingMode.FILL_STROKE_MASK;
+    const needsFill =
+      fillStrokeMode === TextRenderingMode.FILL ||
+      fillStrokeMode === TextRenderingMode.FILL_STROKE;
+    const needsStroke =
+      fillStrokeMode === TextRenderingMode.STROKE ||
+      fillStrokeMode === TextRenderingMode.FILL_STROKE;
+
+    if (needsFill && current.patternFill) {
       ctx.save();
       const pattern = current.fillColor.getPattern(
         ctx,
@@ -2076,7 +2089,7 @@ class CanvasGraphics {
       ctx.fillStyle = pattern;
     }
 
-    if (current.patternStroke) {
+    if (needsStroke && current.patternStroke) {
       ctx.save();
       const pattern = current.strokeColor.getPattern(
         ctx,
@@ -2093,12 +2106,7 @@ class CanvasGraphics {
     let lineWidth = current.lineWidth;
     const scale = current.textMatrixScale;
     if (scale === 0 || lineWidth === 0) {
-      const fillStrokeMode =
-        current.textRenderingMode & TextRenderingMode.FILL_STROKE_MASK;
-      if (
-        fillStrokeMode === TextRenderingMode.STROKE ||
-        fillStrokeMode === TextRenderingMode.FILL_STROKE
-      ) {
+      if (needsStroke) {
         lineWidth = this.getSinglePixelWidth();
       }
     } else {


### PR DESCRIPTION
This PR improves text rendering performance by skipping costly `strokeColor.getPattern()` and `fillColor.getPattern()` calculations when executing `showText()`.

**Background:** we noticed very slow page render speed for some particular PDFs. After investigation, it turns out that if previously a stroke/fill pattern was set, the pattern is still being calculated independent of whether it's needed or not. This caused a high CPU/memory usage and thus a slow page render speed.

This is one "example culprit" (extract from the PDF):

```postscript
/Artifact <</BBox[ 35.4331 209.917 290.551 228.917]/Type/Layout>>BDC
Q
19 w /Pattern CS %<-- pattern is set
/Pt0 SCN
/GS2 gs
q
1 0 0 1 35.433098 219.417267 cm
0 0 m
255.117996 0 l
S %<-- pattern is used for the stroke of the line
Q
EMC
/P <</MCID 1>>BDC
/GS3 gs
q
BT
/F2 1 Tf
-0.025 Tw 9 0 0 9 35.433098 784.440125 Tm
(somit)Tj %<-- text "somit" is being rendered, but no stroke rendering has been defined
ET
Q
q
BT
```

Here is the full pdf of the page - you can open it in Firefox to see how slow it loads:
[weil-im-schoenbuch_2025_50_Seite12.pdf](https://github.com/user-attachments/files/24108542/weil-im-schoenbuch_2025_50_Seite12.pdf)