### PR TITLE
Run the CI tests in Node.js version 25 too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 25]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Node.js version 25 is the current (non-LTS) release, see https://github.com/nodejs/release#release-schedule, so we should run the tests with that version too to help catch any possible issues sooner.