### PR TITLE
Fix `Worker was terminated` error when loading is cancelled

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -319,7 +319,9 @@ class WorkerMessageHandler {
       }
 
       function onFailure(ex) {
-        ensureNotTerminated();
+        if (terminated) {
+          return;
+        }
 
         if (ex instanceof PasswordException) {
           const task = new WorkerTask(`PasswordException: response ${ex.code}`);


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/issues/11595, where cancelling loading with `loadingTask.destroy()` before it finishes throws a `Worker was terminated` error that CANNOT be caught.

When worker is terminated, an error is thrown here:

https://github.com/mozilla/pdf.js/blob/6c746260a98766b8ece27018d2c48436cfcafa24/src/core/worker.js#L374

Then `onFailure` runs, in which we throw again via `ensureNotTerminated()`. However, this second error is never caught (and cannot be), resulting in console spam.

There is no need to throw any additional errors since the termination is already reported [here](https://github.com/mozilla/pdf.js/blob/6c746260a98766b8ece27018d2c48436cfcafa24/src/core/worker.js#L371-L373), and `onFailure` is supposed to handle errors, not throw them.