### PR TITLE
Add colour luminance utility functions to display_utils

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -615,6 +615,30 @@ function getRGB(color) {
   return [0, 0, 0];
 }
 
+/**
+ * Calculate the relative luminance of an RGB color.
+ * @param {Array<number>} rgb - RGB values [r, g, b] in range 0-255.
+ * @returns {number} Luminance value between 0 and 1.
+ */
+function getColorLuminance(rgb) {
+  const [r, g, b] = rgb.map(c => {
+    const normalized = c / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : Math.pow((normalized + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Determine if a color is considered "light" based on its luminance.
+ * @param {Array<number>} rgb - RGB values [r, g, b] in range 0-255.
+ * @returns {boolean} True if the color is light, false if dark.
+ */
+function isLightColor(rgb) {
+  return getColorLuminance(rgb) > 0.5;
+}
+
 function getColorValues(colors) {
   const span = document.createElement("span");
   span.style.visibility = "hidden";
@@ -1041,6 +1065,7 @@ export {
   deprecated,
   fetchData,
   findContrastColor,
+  getColorLuminance,
   getColorValues,
   getCurrentTransform,
   getCurrentTransformInverse,
@@ -1049,6 +1074,7 @@ export {
   getRGB,
   getXfaPageViewport,
   isDataScheme,
+  isLightColor,
   isPdfFile,
   isValidFetchUrl,
   makePathFromDrawOPS,

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -16,8 +16,10 @@
 import {
   applyOpacity,
   findContrastColor,
+  getColorLuminance,
   getFilenameFromUrl,
   getPdfFilenameFromUrl,
+  isLightColor,
   isValidFetchUrl,
   PDFDateString,
   renderRichText,
@@ -389,6 +391,36 @@ describe("display_utils", function () {
             '<span style="font-weight: bold;">Hello</span> world!</p></div>'
         )
       );
+    });
+  });
+
+  describe("getColorLuminance", function () {
+    it("should calculate luminance for pure colors", function () {
+      expect(getColorLuminance([0, 0, 0])).toBeCloseTo(0, 3); // Black
+      expect(getColorLuminance([255, 255, 255])).toBeCloseTo(1, 3); // White
+      expect(getColorLuminance([255, 0, 0])).toBeCloseTo(0.2126, 3); // Red
+      expect(getColorLuminance([0, 255, 0])).toBeCloseTo(0.7152, 3); // Green
+      expect(getColorLuminance([0, 0, 255])).toBeCloseTo(0.0722, 3); // Blue
+    });
+
+    it("should calculate luminance for mixed colors", function () {
+      expect(getColorLuminance([128, 128, 128])).toBeCloseTo(0.2158, 3); // Gray
+      expect(getColorLuminance([255, 255, 0])).toBeCloseTo(0.9278, 3); // Yellow
+    });
+  });
+
+  describe("isLightColor", function () {
+    it("should identify light colors correctly", function () {
+      expect(isLightColor([255, 255, 255])).toBe(true); // White
+      expect(isLightColor([255, 255, 0])).toBe(true); // Yellow
+      expect(isLightColor([200, 200, 200])).toBe(false); // Light gray
+    });
+
+    it("should identify dark colors correctly", function () {
+      expect(isLightColor([0, 0, 0])).toBe(false); // Black
+      expect(isLightColor([255, 0, 0])).toBe(false); // Red
+      expect(isLightColor([0, 0, 255])).toBe(false); // Blue
+      expect(isLightColor([100, 100, 100])).toBe(false); // Dark gray
     });
   });
 });


### PR DESCRIPTION
- Add getColorLuminance() for WCAG-compliant relative luminance calculation
- Add isLightColor() for determining if a color is light or dark
- Include comprehensive test coverage for both functions
- Useful for accessibility features and color analysis in PDF rendering