### PR TITLE
Accessibility: Add localized aria-label to Download button in viewer …

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <!--
 Copyright 2012 Mozilla Foundation
 
@@ -339,11 +339,18 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <!-- findbar -->
                 </div>
                 <div class="toolbarHorizontalGroup hiddenSmallView">
-                  <button class="toolbarButton" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button">
+                  <button
+                    class="toolbarButton"
+                    type="button"
+                    id="previous"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-previous-button"
+                    data-l10n-attrs="title aria-label"
+                  >
                     <span data-l10n-id="pdfjs-previous-button-label"></span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
+                  <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-attrs="title aria-label">
                     <span data-l10n-id="pdfjs-next-button-label"></span>
                   </button>
                 </div>
@@ -365,11 +372,25 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
               <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
                 <div class="toolbarHorizontalGroup">
-                  <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
+                  <button
+                    id="zoomOutButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-zoom-out-button"
+                    data-l10n-attrs="title aria-label"
+                  >
                     <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-in-button">
+                  <button
+                    id="zoomInButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-zoom-in-button"
+                    data-l10n-attrs="title aria-label"
+                  >
                     <span data-l10n-id="pdfjs-zoom-in-button-label"></span>
                   </button>
                 </div>
@@ -607,11 +628,25 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
 
                 <div class="toolbarHorizontalGroup hiddenMediumView">
-                  <button id="printButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
+                  <button
+                    id="printButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-print-button"
+                    data-l10n-attrs="title aria-label"
+                  >
                     <span data-l10n-id="pdfjs-print-button-label"></span>
                   </button>
 
-                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
+                  <button
+                    id="downloadButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-save-button"
+                    data-l10n-attrs="title aria-label"
+                  >
                     <span data-l10n-id="pdfjs-save-button-label"></span>
                   </button>
                 </div>


### PR DESCRIPTION
### Summary
Adds a localized `aria-label` to the Download button in the viewer toolbar to improve accessibility for screen
reader users.

### Details
Previously, only the `title` attribute was localized, so the button did not expose an accessible name. By adding
`data-l10n-attrs="title aria-label"`, both `title` and `aria-label` are now populated by the localization system,
consistent with other toolbar buttons.

### Result
Screen readers can now correctly announce the purpose of the Download button.

Fixes: #20473
