### PR TITLE
Use CIDToGIDMap when the font is a type 2 with an OpenType font

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -255,6 +255,8 @@ class CFFParser {
     const charStringOffset = topDict.getByName("CharStrings");
     const charStringIndex = this.parseIndex(charStringOffset).obj;
 
+    cff.charStringCount = charStringIndex.count;
+
     const fontMatrix = topDict.getByName("FontMatrix");
     if (fontMatrix) {
       properties.fontMatrix = fontMatrix;
@@ -1005,6 +1007,7 @@ class CFF {
     this.fdSelect = null;
 
     this.isCIDFont = false;
+    this.charStringCount = 0;
   }
 
   duplicateFirstGlyph() {

--- a/test/pdfs/issue18062.pdf.link
+++ b/test/pdfs/issue18062.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/mozilla/pdf.js/files/15274065/1.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -13123,5 +13123,13 @@
     "rounds": 1,
     "link": true,
     "type": "eq"
+  },
+  {
+    "id": "issue18062",
+    "file": "pdfs/issue18062.pdf",
+    "md5": "b8fb6d5622f0a2f45be8e26da7de969c",
+    "rounds": 1,
+    "link": true,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
It fixes #18062.