### PR TITLE
Revert "Remove some files from talos tests because they aren't available on webarchive"

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -654,7 +654,6 @@
     "md5": "8f9347b0d5620537850b24b8385b0982",
     "rounds": 1,
     "link": true,
-    "talos": false,
     "firstPage": 4,
     "lastPage": 4,
     "type": "eq"
@@ -665,7 +664,6 @@
     "md5": "8f9347b0d5620537850b24b8385b0982",
     "rounds": 1,
     "link": true,
-    "talos": false,
     "firstPage": 4,
     "lastPage": 4,
     "type": "eq",


### PR DESCRIPTION
This reverts commit fbce8bf829cba78281ea93e845c524725ff2c3ff. The file is available in the Web Archive again.

Fixes #20528.