### PR TITLE
a11y: show toolbar tooltips on keyboard focus (Fixes #19156)

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -843,6 +843,22 @@ dialog :link {
       height: auto;
     }
   }
+  /* Show tooltips for keyboard users */
+  &:focus::after,
+  &:hover::after {
+    content: attr(title);
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
+    background: rgb(0 0 0 / 0.8);
+    color: #fff;
+    padding: 4px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    pointer-events: none;
+  }
 }
 
 .toolbarButtonWithContainer {


### PR DESCRIPTION
Improves keyboard accessibility in the PDF.js viewer toolbar by making tooltips appear when a button receives keyboard focus, not only on mouse hover. This helps keyboard-only users understand the purpose of toolbar buttons while navigating with Tab.

Changes

Added CSS to show tooltips on :focus in addition to :hover.

Behavior for mouse users remains unchanged.

Testing

Verified tooltips appear on focus via keyboard.

Verified hover tooltips still work normally.

Fixes #19156