### PR TITLE
[wontfix] feat: Implement Marquee Zoom

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -767,3 +767,7 @@ pdfjs-views-manager-status-undo-button-label = Undo
 pdfjs-views-manager-status-close-button =
     .title = Close
 pdfjs-views-manager-status-close-button-label = Close
+
+pdfjs-cursor-zoom-tool-button =
+    .title = Enable Zoom Tool
+pdfjs-cursor-zoom-tool-button-label = Zoom

--- a/test/integration/zoom_tool_spec.mjs
+++ b/test/integration/zoom_tool_spec.mjs
@@ -1,0 +1,250 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  awaitPromise,
+  closePages,
+  loadAndWait,
+  waitForPageRendered,
+} from "./test_utils.mjs";
+
+describe("Zoom Tool", () => {
+  describe("Zoom to rectangle", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        ".textLayer .endOfContent",
+        "page-fit"
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must activate and deactivate the zoom tool via button click", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // Open secondary toolbar
+          await page.click("#secondaryToolbarToggleButton");
+          await page.waitForSelector("#secondaryToolbar:not(.hidden)");
+
+          // Click on the zoom tool button
+          await page.click("#cursorZoomTool");
+
+          // Verify the tool is active by checking the toggled class
+          const isToggled = await page.evaluate(() =>
+            document
+              .getElementById("cursorZoomTool")
+              .classList.contains("toggled")
+          );
+          expect(isToggled).withContext(`In ${browserName}`).toBe(true);
+
+          // Verify the viewer container has the zoom-to-rect-grab cursor class
+          const hasGrabClass = await page.evaluate(() =>
+            document
+              .getElementById("viewerContainer")
+              .classList.contains("zoom-to-rect-grab")
+          );
+          expect(hasGrabClass).withContext(`In ${browserName}`).toBe(true);
+
+          // Click on select tool to deactivate zoom tool
+          await page.click("#cursorSelectTool");
+
+          // Verify the zoom tool is no longer toggled
+          const isStillToggled = await page.evaluate(() =>
+            document
+              .getElementById("cursorZoomTool")
+              .classList.contains("toggled")
+          );
+          expect(isStillToggled).withContext(`In ${browserName}`).toBe(false);
+
+          // Verify the viewer container no longer has the cursor class
+          const stillHasGrabClass = await page.evaluate(() =>
+            document
+              .getElementById("viewerContainer")
+              .classList.contains("zoom-to-rect-grab")
+          );
+          expect(stillHasGrabClass)
+            .withContext(`In ${browserName}`)
+            .toBe(false);
+        })
+      );
+    });
+
+    it("must zoom to a drawn rectangle", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // Get initial scale
+          const initialScale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          // Open secondary toolbar and activate zoom tool
+          await page.click("#secondaryToolbarToggleButton");
+          await page.waitForSelector("#secondaryToolbar:not(.hidden)");
+          await page.click("#cursorZoomTool");
+
+          // Wait for the toolbar to close
+          await page.waitForSelector("#secondaryToolbar.hidden");
+
+          // Get the viewer container rect
+          const containerRect = await page.evaluate(() => {
+            const container = document.getElementById("viewerContainer");
+            const rect = container.getBoundingClientRect();
+            return {
+              x: rect.x,
+              y: rect.y,
+              width: rect.width,
+              height: rect.height,
+            };
+          });
+
+          // Draw a rectangle on the viewer (drag from one point to another)
+          const startX = containerRect.x + 100;
+          const startY = containerRect.y + 100;
+          const endX = startX + 200;
+          const endY = startY + 200;
+
+          // Wait for render and perform drag
+          const handle = await waitForPageRendered(page);
+
+          await page.mouse.move(startX, startY);
+          await page.mouse.down();
+          await page.mouse.move(endX, endY, { steps: 5 });
+          await page.mouse.up();
+
+          await awaitPromise(handle);
+
+          // Get the new scale after zooming
+          const newScale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          // The scale should have increased
+          expect(newScale)
+            .withContext(`In ${browserName}`)
+            .toBeGreaterThan(initialScale);
+        })
+      );
+    });
+
+    it("must ignore small drags (clicks)", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // Get initial scale
+          const initialScale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          // Open secondary toolbar and activate zoom tool
+          await page.click("#secondaryToolbarToggleButton");
+          await page.waitForSelector("#secondaryToolbar:not(.hidden)");
+          await page.click("#cursorZoomTool");
+
+          // Wait for the toolbar to close
+          await page.waitForSelector("#secondaryToolbar.hidden");
+
+          // Get the viewer container rect
+          const containerRect = await page.evaluate(() => {
+            const container = document.getElementById("viewerContainer");
+            const rect = container.getBoundingClientRect();
+            return { x: rect.x, y: rect.y };
+          });
+
+          // Perform a very small drag (less than MIN_DRAG_SIZE = 5 pixels)
+          const startX = containerRect.x + 100;
+          const startY = containerRect.y + 100;
+          const endX = startX + 3; // Only 3 pixels
+          const endY = startY + 3;
+
+          await page.mouse.move(startX, startY);
+          await page.mouse.down();
+          await page.mouse.move(endX, endY, { steps: 2 });
+          await page.mouse.up();
+
+          // Wait a bit for any potential zoom to occur
+          await new Promise(resolve => {
+            setTimeout(resolve, 200);
+          });
+
+          // Get the scale after the small drag
+          const newScale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          // The scale should remain the same since the drag was too small
+          expect(newScale).withContext(`In ${browserName}`).toBe(initialScale);
+        })
+      );
+    });
+
+    it("must cancel zoom on Escape key", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // Get initial scale
+          const initialScale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          // Open secondary toolbar and activate zoom tool
+          await page.click("#secondaryToolbarToggleButton");
+          await page.waitForSelector("#secondaryToolbar:not(.hidden)");
+          await page.click("#cursorZoomTool");
+
+          // Wait for the toolbar to close
+          await page.waitForSelector("#secondaryToolbar.hidden");
+
+          // Get the viewer container rect
+          const containerRect = await page.evaluate(() => {
+            const container = document.getElementById("viewerContainer");
+            const rect = container.getBoundingClientRect();
+            return { x: rect.x, y: rect.y };
+          });
+
+          // Start a drag but press Escape before releasing
+          const startX = containerRect.x + 100;
+          const startY = containerRect.y + 100;
+          const endX = startX + 200;
+          const endY = startY + 200;
+
+          await page.mouse.move(startX, startY);
+          await page.mouse.down();
+          await page.mouse.move(endX, endY, { steps: 5 });
+
+          // Press Escape to cancel
+          await page.keyboard.press("Escape");
+
+          await page.mouse.up();
+
+          // Wait a bit for any potential zoom to occur
+          await new Promise(resolve => {
+            setTimeout(resolve, 200);
+          });
+
+          // Get the scale after cancellation
+          const newScale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          // The scale should remain the same since the zoom was cancelled
+          expect(newScale).withContext(`In ${browserName}`).toBe(initialScale);
+        })
+      );
+    });
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -272,6 +272,72 @@ const PDFViewerApplication = {
     this.bindEvents();
     this.bindWindowEvents();
 
+    // Listen for the "zoomtorect" event.
+    this.eventBus._on("zoomtorect", evt => {
+      const { rect } = evt;
+      // The rect is in the viewer ("container") coordinates.
+      // We need to convert it to a page point or use it to calculate the scale.
+
+      // Get the current view (likely the first visible page or just use the current scroll/scale).
+      // Actually, we want to zoom such that the rect fills the viewer container.
+      const container = this.appConfig.mainContainer;
+      const containerWidth = container.clientWidth;
+      const containerHeight = container.clientHeight;
+
+      // Calculate the new scale.
+      // We want the rect's width/height to fit into the container's width/height.
+      const scaleX = containerWidth / rect.width;
+      const scaleY = containerHeight / rect.height;
+      let newScale = Math.min(scaleX, scaleY);
+
+      // Apply the current scale to get the absolute scale factor
+      const currentScale = this.pdfViewer.currentScale;
+      newScale = newScale * currentScale;
+
+      // Clamp the scale
+      // We can use the constants from ui_utils.js via an import or just hardcode/clamp
+      // using the viewer's method if available, but usually we just set currentScaleValue.
+
+      // We need to center the point.
+      // The top-left of the rect in absolute coords (relative to the total scrollable area):
+      const scrollLeft = container.scrollLeft;
+      const scrollTop = container.scrollTop;
+
+      // Rect x/y are relative to the *visible* top-left (clientX/Y logic in ZoomToRect uses client coords, 
+      // but we need to check if we used page coords or client coords).
+      // ZoomToRect used clientX/Y. We should subtract the container's clientRect.
+      const containerRect = container.getBoundingClientRect();
+      const rectX = rect.x - containerRect.left + scrollLeft;
+      const rectY = rect.y - containerRect.top + scrollTop;
+
+      // Calculate the center of the zoom rect in absolute coords (at current scale)
+      const centerX = rectX + rect.width / 2;
+      const centerY = rectY + rect.height / 2;
+
+      // We want to scroll to (centerX, centerY) * (newScale / currentScale)
+      // But pdfViewer.scrollPageIntoView or internal scrolling handles scale changes.
+      // The easiest way is to set the scale, and then scroll.
+      // BUT, setting scale resets scroll.
+
+      // Let's use the pdfViewer.currentScaleValue setter which handles some magic,
+      // but likely we need to do manual scrolling.
+
+      this.pdfViewer.currentScaleValue = newScale;
+
+      // After scale change, we need to scroll to the new center.
+      // We can do this in a timeout or promise, or calculate the *dest* offset.
+      // The center point in the *new* scale will be:
+      const destX = (centerX / currentScale) * newScale;
+      const destY = (centerY / currentScale) * newScale;
+
+      const newScrollLeft = destX - containerWidth / 2;
+      const newScrollTop = destY - containerHeight / 2;
+
+      container.scrollLeft = newScrollLeft;
+      container.scrollTop = newScrollTop;
+
+    });
+
     this._initializedCapability.settled = true;
     this._initializedCapability.resolve();
   },
@@ -410,10 +476,10 @@ const PDFViewerApplication = {
     const eventBus =
       typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
         ? new FirefoxEventBus(
-            AppOptions.get("allowedGlobalEvents"),
-            externalServices,
-            AppOptions.get("isInAutomation")
-          )
+          AppOptions.get("allowedGlobalEvents"),
+          externalServices,
+          AppOptions.get("isInAutomation")
+        )
         : new EventBus();
     this.eventBus = AppOptions.eventBus = eventBus;
 
@@ -457,28 +523,28 @@ const PDFViewerApplication = {
       window.matchMedia("(forced-colors: active)").matches;
     const pageColors = hasForcedColors
       ? {
-          background: AppOptions.get("pageColorsBackground"),
-          foreground: AppOptions.get("pageColorsForeground"),
-        }
+        background: AppOptions.get("pageColorsBackground"),
+        foreground: AppOptions.get("pageColorsForeground"),
+      }
       : null;
 
     let altTextManager;
     if (AppOptions.get("enableUpdatedAddImage")) {
       altTextManager = appConfig.newAltTextDialog
         ? new NewAltTextManager(
-            appConfig.newAltTextDialog,
-            overlayManager,
-            eventBus
-          )
+          appConfig.newAltTextDialog,
+          overlayManager,
+          eventBus
+        )
         : null;
     } else {
       altTextManager = appConfig.altTextDialog
         ? new AltTextManager(
-            appConfig.altTextDialog,
-            container,
-            overlayManager,
-            eventBus
-          )
+          appConfig.altTextDialog,
+          container,
+          overlayManager,
+          eventBus
+        )
         : null;
     }
 
@@ -489,15 +555,15 @@ const PDFViewerApplication = {
     const signatureManager =
       AppOptions.get("enableSignatureEditor") && appConfig.addSignatureDialog
         ? new SignatureManager(
-            appConfig.addSignatureDialog,
-            appConfig.editSignatureDialog,
-            appConfig.annotationEditorParams?.editorSignatureAddSignature ||
-              null,
-            overlayManager,
-            l10n,
-            externalServices.createSignatureStorage(eventBus, abortSignal),
-            eventBus
-          )
+          appConfig.addSignatureDialog,
+          appConfig.editSignatureDialog,
+          appConfig.annotationEditorParams?.editorSignatureAddSignature ||
+          null,
+          overlayManager,
+          l10n,
+          externalServices.createSignatureStorage(eventBus, abortSignal),
+          eventBus
+        )
         : null;
 
     const ltr = appConfig.viewerContainer
@@ -506,35 +572,35 @@ const PDFViewerApplication = {
     const commentManager =
       AppOptions.get("enableComment") && appConfig.editCommentDialog
         ? new CommentManager(
-            appConfig.editCommentDialog,
-            {
-              learnMoreUrl: AppOptions.get("commentLearnMoreUrl"),
-              sidebar:
-                appConfig.annotationEditorParams?.editorCommentsSidebar || null,
-              sidebarResizer:
-                appConfig.annotationEditorParams
-                  ?.editorCommentsSidebarResizer || null,
-              commentsList:
-                appConfig.annotationEditorParams?.editorCommentsSidebarList ||
-                null,
-              commentCount:
-                appConfig.annotationEditorParams?.editorCommentsSidebarCount ||
-                null,
-              sidebarTitle:
-                appConfig.annotationEditorParams?.editorCommentsSidebarTitle ||
-                null,
-              closeButton:
-                appConfig.annotationEditorParams
-                  ?.editorCommentsSidebarCloseButton || null,
-              commentToolbarButton:
-                appConfig.toolbar?.editorCommentButton || null,
-            },
-            eventBus,
-            linkService,
-            overlayManager,
-            ltr,
-            hasForcedColors
-          )
+          appConfig.editCommentDialog,
+          {
+            learnMoreUrl: AppOptions.get("commentLearnMoreUrl"),
+            sidebar:
+              appConfig.annotationEditorParams?.editorCommentsSidebar || null,
+            sidebarResizer:
+              appConfig.annotationEditorParams
+                ?.editorCommentsSidebarResizer || null,
+            commentsList:
+              appConfig.annotationEditorParams?.editorCommentsSidebarList ||
+              null,
+            commentCount:
+              appConfig.annotationEditorParams?.editorCommentsSidebarCount ||
+              null,
+            sidebarTitle:
+              appConfig.annotationEditorParams?.editorCommentsSidebarTitle ||
+              null,
+            closeButton:
+              appConfig.annotationEditorParams
+                ?.editorCommentsSidebarCloseButton || null,
+            commentToolbarButton:
+              appConfig.toolbar?.editorCommentButton || null,
+          },
+          eventBus,
+          linkService,
+          overlayManager,
+          ltr,
+          hasForcedColors
+        )
         : null;
 
     const enableHWA = AppOptions.get("enableHWA"),
@@ -660,8 +726,8 @@ const PDFViewerApplication = {
         overlayManager,
         eventBus,
         l10n,
-        /* fileNameLookup = */ () => this._docFilename,
-        /* titleLookup = */ () => this._docTitle
+        /* fileNameLookup = */() => this._docFilename,
+        /* titleLookup = */() => this._docTitle
       );
     }
 
@@ -968,7 +1034,7 @@ const PDFViewerApplication = {
       this,
       "supportsPrinting",
       AppOptions.get("supportsPrinting") &&
-        PDFPrintServiceFactory.supportsPrinting
+      PDFPrintServiceFactory.supportsPrinting
     );
   },
 
@@ -1742,9 +1808,9 @@ const PDFViewerApplication = {
     // Provides some basic debug information
     console.log(
       `PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` +
-        `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
-        `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
-        `] (PDF.js: ${version || "?"} [${build || "?"}])`
+      `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` +
+      `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` +
+      `] (PDF.js: ${version || "?"} [${build || "?"}])`
     );
     const pdfTitle = this._docTitle;
 
@@ -2396,7 +2462,7 @@ const PDFViewerApplication = {
     document.blockUnblockOnload?.(false);
 
     // Ensure that this method is only ever run once.
-    this._unblockDocumentLoadEvent = () => {};
+    this._unblockDocumentLoadEvent = () => { };
   },
 
   /**

--- a/web/pdf_cursor_tools.js
+++ b/web/pdf_cursor_tools.js
@@ -18,6 +18,7 @@
 import { AnnotationEditorType, shadow } from "pdfjs-lib";
 import { CursorTool, PresentationModeState } from "./ui_utils.js";
 import { GrabToPan } from "./grab_to_pan.js";
+import { ZoomToRect } from "./zoom_to_rect.js";
 
 /**
  * @typedef {Object} PDFCursorToolsOptions
@@ -89,7 +90,8 @@ class PDFCursorTools {
           this._handTool.deactivate();
           break;
         case CursorTool.ZOOM:
-        /* falls through */
+          this._zoomTool.deactivate();
+          break;
       }
     };
 
@@ -103,7 +105,9 @@ class PDFCursorTools {
         this._handTool.activate();
         break;
       case CursorTool.ZOOM:
-      /* falls through */
+        disableActiveTool();
+        this._zoomTool.activate();
+        break;
       default:
         console.error(`switchTool: "${tool}" is an unsupported value.`);
         return;
@@ -179,6 +183,26 @@ class PDFCursorTools {
       "_handTool",
       new GrabToPan({
         element: this.container,
+      })
+    );
+  }
+
+  /**
+   * @private
+   */
+  get _zoomTool() {
+    return shadow(
+      this,
+      "_zoomTool",
+      new ZoomToRect({
+        element: this.container,
+        onZoom: rect => {
+          this.eventBus.dispatch("zoomtorect", {
+            rect,
+            source: this,
+          });
+          this.switchTool(CursorTool.SELECT);
+        },
       })
     );
   }

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -249,7 +249,11 @@ class SecondaryToolbar {
   }
 
   #cursorToolChanged({ tool, disabled }) {
-    const { cursorSelectToolButton, cursorHandToolButton, cursorZoomToolButton } = this.#opts;
+    const {
+      cursorSelectToolButton,
+      cursorHandToolButton,
+      cursorZoomToolButton,
+    } = this.#opts;
 
     toggleCheckedBtn(cursorSelectToolButton, tool === CursorTool.SELECT);
     toggleCheckedBtn(cursorHandToolButton, tool === CursorTool.HAND);

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -49,6 +49,8 @@ import { PagesCountLimit } from "./pdf_viewer.js";
  *   select tool.
  * @property {HTMLButtonElement} cursorHandToolButton - Button to enable the
  *   hand tool.
+ * @property {HTMLButtonElement} cursorZoomToolButton - Button to enable the
+ *   zoom tool.
  * @property {HTMLButtonElement} imageAltTextSettingsButton - Button for opening
  *   the image alt-text settings dialog.
  * @property {HTMLButtonElement} documentPropertiesButton - Button for opening
@@ -95,6 +97,12 @@ class SecondaryToolbar {
         element: options.cursorHandToolButton,
         eventName: "switchcursortool",
         eventDetails: { tool: CursorTool.HAND },
+        close: true,
+      },
+      {
+        element: options.cursorZoomToolButton,
+        eventName: "switchcursortool",
+        eventDetails: { tool: CursorTool.ZOOM },
         close: true,
       },
       {
@@ -241,13 +249,15 @@ class SecondaryToolbar {
   }
 
   #cursorToolChanged({ tool, disabled }) {
-    const { cursorSelectToolButton, cursorHandToolButton } = this.#opts;
+    const { cursorSelectToolButton, cursorHandToolButton, cursorZoomToolButton } = this.#opts;
 
     toggleCheckedBtn(cursorSelectToolButton, tool === CursorTool.SELECT);
     toggleCheckedBtn(cursorHandToolButton, tool === CursorTool.HAND);
+    toggleCheckedBtn(cursorZoomToolButton, tool === CursorTool.ZOOM);
 
     cursorSelectToolButton.disabled = disabled;
     cursorHandToolButton.disabled = disabled;
+    cursorZoomToolButton.disabled = disabled;
   }
 
   #scrollModeChanged({ mode }) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -1463,3 +1463,17 @@ dialog :link {
     display: none;
   }
 }
+
+.zoom-to-rect-grab {
+  cursor: crosshair !important;
+}
+
+.zoom-to-rect-grabbing {
+  position: fixed;
+  z-index: 50000;
+  border: 2px dashed #000;
+  background-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+}
+

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -100,7 +100,6 @@
   --toolbarButton-openFile-icon: url(images/toolbarButton-openFile.svg);
   /*#endif*/
   --secondaryToolbarButton-zoomTool-icon: url(images/toolbarButton-zoomIn.svg);
-  /*#endif*/
   --toolbarButton-download-icon: url(images/toolbarButton-download.svg);
   --toolbarButton-bookmark-icon: url(images/toolbarButton-bookmark.svg);
   --toolbarButton-viewThumbnail-icon: url(images/toolbarButton-viewThumbnail.svg);

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -45,10 +45,8 @@
   --toolbar-icon-bg-color: light-dark(rgb(0 0 0), rgb(255 255 255));
   --toolbar-icon-hover-bg-color: light-dark(rgb(0 0 0), rgb(255 255 255));
 
-  --sidebar-narrow-bg-color: light-dark(
-    rgb(212 212 215 / 0.9),
-    rgb(42 42 46 / 0.9)
-  );
+  --sidebar-narrow-bg-color: light-dark(rgb(212 212 215 / 0.9),
+      rgb(42 42 46 / 0.9));
   --sidebar-toolbar-bg-color: light-dark(rgb(245 246 247), rgb(50 50 52));
   --toolbar-bg-color: light-dark(rgb(249 249 250), rgb(56 56 61));
   --toolbar-border-color: light-dark(rgb(184 184 184), rgb(12 12 13));
@@ -75,10 +73,8 @@
   --doorhanger-separator-color: light-dark(rgb(222 222 222), rgb(92 92 97));
   --dialog-button-border: none;
   --dialog-button-bg-color: light-dark(rgb(12 12 13 / 0.1), rgb(92 92 97));
-  --dialog-button-hover-bg-color: light-dark(
-    rgb(12 12 13 / 0.3),
-    rgb(115 115 115)
-  );
+  --dialog-button-hover-bg-color: light-dark(rgb(12 12 13 / 0.3),
+      rgb(115 115 115));
 
   --loading-icon: url(images/loading.svg);
   --toolbarButton-editorComment-icon: url(images/comment-editButton.svg);
@@ -98,6 +94,8 @@
   --toolbarButton-print-icon: url(images/toolbarButton-print.svg);
   /*#if GENERIC*/
   --toolbarButton-openFile-icon: url(images/toolbarButton-openFile.svg);
+  /*#endif*/
+  --secondaryToolbarButton-zoomTool-icon: url(images/toolbarButton-zoomIn.svg);
   /*#endif*/
   --toolbarButton-download-icon: url(images/toolbarButton-download.svg);
   --toolbarButton-bookmark-icon: url(images/toolbarButton-bookmark.svg);
@@ -122,9 +120,7 @@
   --secondaryToolbarButton-spreadNone-icon: url(images/secondaryToolbarButton-spreadNone.svg);
   --secondaryToolbarButton-spreadOdd-icon: url(images/secondaryToolbarButton-spreadOdd.svg);
   --secondaryToolbarButton-spreadEven-icon: url(images/secondaryToolbarButton-spreadEven.svg);
-  --secondaryToolbarButton-imageAltTextSettings-icon: var(
-    --toolbarButton-editorStamp-icon
-  );
+  --secondaryToolbarButton-imageAltTextSettings-icon: var(--toolbarButton-editorStamp-icon);
   --secondaryToolbarButton-documentProperties-icon: url(images/secondaryToolbarButton-documentProperties.svg);
   --editorParams-stampAddImage-icon: url(images/toolbarButton-zoomIn.svg);
   --comment-edit-button-icon: url(images/comment-editButton.svg);
@@ -187,6 +183,7 @@ html {
   &[data-toolbar-density="compact"] {
     --toolbar-height: 30px;
   }
+
   &[data-toolbar-density="touch"] {
     --toolbar-height: 44px;
   }
@@ -252,7 +249,7 @@ body {
   cursor: none;
 }
 
-.pdfPresentationMode.pdfPresentationModeControls > *,
+.pdfPresentationMode.pdfPresentationModeControls>*,
 .pdfPresentationMode.pdfPresentationModeControls .textLayer span {
   cursor: default;
 }
@@ -412,7 +409,7 @@ body {
   background-color: var(--dialog-button-hover-bg-color);
 }
 
-.dialogButton:is(:hover, :focus-visible) > span {
+.dialogButton:is(:hover, :focus-visible)>span {
   color: var(--dialog-button-hover-color);
 }
 
@@ -551,7 +548,7 @@ body {
     background-color: var(--button-hover-color);
   }
 
-  & > input {
+  &>input {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -580,7 +577,8 @@ body {
 }
 
 #pageNumber {
-  -moz-appearance: textfield; /* hides the spinner in moz */
+  -moz-appearance: textfield;
+  /* hides the spinner in moz */
   text-align: end;
   width: 40px;
   background-size: 0 0;
@@ -590,6 +588,7 @@ body {
   &::-webkit-inner-spin-button {
     -webkit-appearance: none;
   }
+
   /*#endif*/
 
   .loadingInput:has(> &.loading)::after {
@@ -625,6 +624,7 @@ body {
     inset-inline-end: 4px;
   }
 }
+
 #outlineOptionsContainer {
   display: none;
 
@@ -660,11 +660,11 @@ dialog::backdrop {
   background-color: rgb(0 0 0 / 0.2);
 }
 
-dialog > .row {
+dialog>.row {
   display: table-row;
 }
 
-dialog > .row > * {
+dialog>.row>* {
   display: table-cell;
 }
 
@@ -702,17 +702,17 @@ dialog :link {
   text-align: left;
 }
 
-#documentPropertiesDialog .row > * {
+#documentPropertiesDialog .row>* {
   min-width: 100px;
   text-align: start;
 }
 
-#documentPropertiesDialog .row > span {
+#documentPropertiesDialog .row>span {
   width: 125px;
   word-wrap: break-word;
 }
 
-#documentPropertiesDialog .row > p {
+#documentPropertiesDialog .row>p {
   max-width: 225px;
   word-wrap: break-word;
 }
@@ -725,8 +725,7 @@ dialog :link {
   cursor: grab !important;
 }
 
-.grab-to-pan-grab
-  *:not(input):not(textarea):not(button):not(select):not(:link) {
+.grab-to-pan-grab *:not(input):not(textarea):not(button):not(select):not(:link) {
   cursor: inherit !important;
 }
 
@@ -741,7 +740,8 @@ dialog :link {
   display: block;
   inset: 0;
   overflow: hidden;
-  z-index: 50000; /* should be higher than anything else in PDF.js! */
+  z-index: 50000;
+  /* should be higher than anything else in PDF.js! */
 }
 
 .toolbarButton {
@@ -761,7 +761,7 @@ dialog :link {
   position: relative;
   padding: 0;
 
-  > span {
+  >span {
     display: inline-block;
     width: 0;
     height: 0;
@@ -837,7 +837,7 @@ dialog :link {
       color: var(--doorhanger-hover-color);
     }
 
-    > span {
+    >span {
       display: inline-block;
       width: max-content;
       height: auto;
@@ -852,7 +852,7 @@ dialog :link {
   position: relative;
   flex: none;
 
-  > .toolbarButton {
+  >.toolbarButton {
     width: 100%;
     height: 100%;
   }
@@ -863,10 +863,7 @@ dialog :link {
 
   .menuContainer {
     height: auto;
-    max-height: calc(
-      var(--viewer-container-height) - var(--toolbar-height) -
-        var(--doorhanger-height)
-    );
+    max-height: calc(var(--viewer-container-height) - var(--toolbar-height) - var(--doorhanger-height));
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
@@ -912,7 +909,7 @@ dialog :link {
       padding-inline: 10px;
       padding-block: 10px;
 
-      > .editorParamsSetter {
+      >.editorParamsSetter {
         min-height: 26px;
         display: flex;
         align-items: center;
@@ -964,10 +961,12 @@ dialog :link {
   max-height: calc(var(--viewer-container-height) - 40px);
 
   #secondaryToolbarButtonContainer {
+
     /*#if GENERIC*/
     #secondaryOpenFile::before {
       mask-image: var(--toolbarButton-openFile-icon);
     }
+
     /*#endif*/
 
     #secondaryPrint::before {
@@ -1008,6 +1007,10 @@ dialog :link {
 
     #cursorHandTool::before {
       mask-image: var(--secondaryToolbarButton-handTool-icon);
+    }
+
+    #cursorZoomTool::before {
+      mask-image: var(--secondaryToolbarButton-zoomTool-icon);
     }
 
     #scrollPage::before {
@@ -1066,7 +1069,7 @@ dialog :link {
   flex-wrap: wrap;
   justify-content: flex-start;
 
-  > * {
+  >* {
     height: var(--toolbar-height);
     padding: var(--findbar-padding);
   }
@@ -1090,6 +1093,7 @@ dialog :link {
       &::-webkit-input-placeholder {
         color: rgb(191 191 191);
       }
+
       /*#endif*/
       &::placeholder {
         font-style: normal;
@@ -1188,7 +1192,7 @@ dialog :link {
   }
 
   /* wrapper around (scaled) print canvas elements */
-  #printContainer > .printedPage {
+  #printContainer>.printedPage {
     page-break-after: always;
     page-break-inside: avoid;
 
@@ -1202,11 +1206,11 @@ dialog :link {
     align-items: center;
   }
 
-  #printContainer > .xfaPrintedPage .xfaPage {
+  #printContainer>.xfaPrintedPage .xfaPage {
     position: absolute;
   }
 
-  #printContainer > .xfaPrintedPage {
+  #printContainer>.xfaPrintedPage {
     page-break-after: always;
     page-break-inside: avoid;
     width: 100%;
@@ -1214,7 +1218,7 @@ dialog :link {
     position: relative;
   }
 
-  #printContainer > .printedPage :is(canvas, img) {
+  #printContainer>.printedPage :is(canvas, img) {
     /* The intrinsic canvas / image size will make sure that we fit the page. */
     max-width: 100%;
     max-height: 100%;
@@ -1248,7 +1252,7 @@ dialog :link {
   align-items: center;
   justify-content: center;
 
-  > label {
+  >label {
     width: 100%;
   }
 }
@@ -1288,7 +1292,7 @@ dialog :link {
     background-color: var(--button-hover-color);
   }
 
-  > select {
+  >select {
     appearance: none;
     width: inherit;
     min-width: inherit;
@@ -1303,7 +1307,7 @@ dialog :link {
     outline: none;
     background-color: var(--dropdown-btn-bg-color);
 
-    > option {
+    >option {
       background: var(--doorhanger-bg-color);
       color: var(--main-color);
     }
@@ -1354,7 +1358,7 @@ dialog :link {
     height: 100%;
     justify-content: space-between;
 
-    > * {
+    >* {
       flex: none;
     }
 
@@ -1414,15 +1418,13 @@ dialog :link {
         inset-inline-start: 0;
         height: 100%;
         width: calc(100% + 150px);
-        background: repeating-linear-gradient(
-          135deg,
-          var(--progressBar-blend-color) 0,
-          var(--progressBar-bg-color) 5px,
-          var(--progressBar-bg-color) 45px,
-          var(--progressBar-color) 55px,
-          var(--progressBar-color) 95px,
-          var(--progressBar-blend-color) 100px
-        );
+        background: repeating-linear-gradient(135deg,
+            var(--progressBar-blend-color) 0,
+            var(--progressBar-bg-color) 5px,
+            var(--progressBar-bg-color) 45px,
+            var(--progressBar-color) 55px,
+            var(--progressBar-color) 95px,
+            var(--progressBar-blend-color) 100px);
         animation: progressIndeterminate 1s linear infinite;
       }
     }
@@ -1433,6 +1435,7 @@ dialog :link {
   #sidebarContainer {
     background-color: var(--sidebar-narrow-bg-color);
   }
+
   #outerContainer.viewsManagerOpen #viewerContainer {
     inset-inline-start: 0 !important;
   }
@@ -1442,12 +1445,14 @@ dialog :link {
   #outerContainer .hiddenMediumView {
     display: none !important;
   }
+
   #outerContainer .visibleMediumView:not(.hidden, [hidden]) {
     display: inline-block !important;
   }
 }
 
 @media all and (max-width: 690px) {
+
   .hiddenSmallView,
   .hiddenSmallView * {
     display: none !important;
@@ -1476,4 +1481,3 @@ dialog :link {
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.2);
   pointer-events: none;
 }
-

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -45,8 +45,10 @@
   --toolbar-icon-bg-color: light-dark(rgb(0 0 0), rgb(255 255 255));
   --toolbar-icon-hover-bg-color: light-dark(rgb(0 0 0), rgb(255 255 255));
 
-  --sidebar-narrow-bg-color: light-dark(rgb(212 212 215 / 0.9),
-      rgb(42 42 46 / 0.9));
+  --sidebar-narrow-bg-color: light-dark(
+    rgb(212 212 215 / 0.9),
+    rgb(42 42 46 / 0.9)
+  );
   --sidebar-toolbar-bg-color: light-dark(rgb(245 246 247), rgb(50 50 52));
   --toolbar-bg-color: light-dark(rgb(249 249 250), rgb(56 56 61));
   --toolbar-border-color: light-dark(rgb(184 184 184), rgb(12 12 13));
@@ -73,8 +75,10 @@
   --doorhanger-separator-color: light-dark(rgb(222 222 222), rgb(92 92 97));
   --dialog-button-border: none;
   --dialog-button-bg-color: light-dark(rgb(12 12 13 / 0.1), rgb(92 92 97));
-  --dialog-button-hover-bg-color: light-dark(rgb(12 12 13 / 0.3),
-      rgb(115 115 115));
+  --dialog-button-hover-bg-color: light-dark(
+    rgb(12 12 13 / 0.3),
+    rgb(115 115 115)
+  );
 
   --loading-icon: url(images/loading.svg);
   --toolbarButton-editorComment-icon: url(images/comment-editButton.svg);
@@ -120,7 +124,9 @@
   --secondaryToolbarButton-spreadNone-icon: url(images/secondaryToolbarButton-spreadNone.svg);
   --secondaryToolbarButton-spreadOdd-icon: url(images/secondaryToolbarButton-spreadOdd.svg);
   --secondaryToolbarButton-spreadEven-icon: url(images/secondaryToolbarButton-spreadEven.svg);
-  --secondaryToolbarButton-imageAltTextSettings-icon: var(--toolbarButton-editorStamp-icon);
+  --secondaryToolbarButton-imageAltTextSettings-icon: var(
+    --toolbarButton-editorStamp-icon
+  );
   --secondaryToolbarButton-documentProperties-icon: url(images/secondaryToolbarButton-documentProperties.svg);
   --editorParams-stampAddImage-icon: url(images/toolbarButton-zoomIn.svg);
   --comment-edit-button-icon: url(images/comment-editButton.svg);
@@ -249,7 +255,7 @@ body {
   cursor: none;
 }
 
-.pdfPresentationMode.pdfPresentationModeControls>*,
+.pdfPresentationMode.pdfPresentationModeControls > *,
 .pdfPresentationMode.pdfPresentationModeControls .textLayer span {
   cursor: default;
 }
@@ -409,7 +415,7 @@ body {
   background-color: var(--dialog-button-hover-bg-color);
 }
 
-.dialogButton:is(:hover, :focus-visible)>span {
+.dialogButton:is(:hover, :focus-visible) > span {
   color: var(--dialog-button-hover-color);
 }
 
@@ -548,7 +554,7 @@ body {
     background-color: var(--button-hover-color);
   }
 
-  &>input {
+  & > input {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -660,11 +666,11 @@ dialog::backdrop {
   background-color: rgb(0 0 0 / 0.2);
 }
 
-dialog>.row {
+dialog > .row {
   display: table-row;
 }
 
-dialog>.row>* {
+dialog > .row > * {
   display: table-cell;
 }
 
@@ -702,17 +708,17 @@ dialog :link {
   text-align: left;
 }
 
-#documentPropertiesDialog .row>* {
+#documentPropertiesDialog .row > * {
   min-width: 100px;
   text-align: start;
 }
 
-#documentPropertiesDialog .row>span {
+#documentPropertiesDialog .row > span {
   width: 125px;
   word-wrap: break-word;
 }
 
-#documentPropertiesDialog .row>p {
+#documentPropertiesDialog .row > p {
   max-width: 225px;
   word-wrap: break-word;
 }
@@ -725,7 +731,8 @@ dialog :link {
   cursor: grab !important;
 }
 
-.grab-to-pan-grab *:not(input):not(textarea):not(button):not(select):not(:link) {
+.grab-to-pan-grab
+  *:not(input):not(textarea):not(button):not(select):not(:link) {
   cursor: inherit !important;
 }
 
@@ -761,7 +768,7 @@ dialog :link {
   position: relative;
   padding: 0;
 
-  >span {
+  > span {
     display: inline-block;
     width: 0;
     height: 0;
@@ -837,7 +844,7 @@ dialog :link {
       color: var(--doorhanger-hover-color);
     }
 
-    >span {
+    > span {
       display: inline-block;
       width: max-content;
       height: auto;
@@ -852,7 +859,7 @@ dialog :link {
   position: relative;
   flex: none;
 
-  >.toolbarButton {
+  > .toolbarButton {
     width: 100%;
     height: 100%;
   }
@@ -863,7 +870,10 @@ dialog :link {
 
   .menuContainer {
     height: auto;
-    max-height: calc(var(--viewer-container-height) - var(--toolbar-height) - var(--doorhanger-height));
+    max-height: calc(
+      var(--viewer-container-height) - var(--toolbar-height) -
+        var(--doorhanger-height)
+    );
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
@@ -909,7 +919,7 @@ dialog :link {
       padding-inline: 10px;
       padding-block: 10px;
 
-      >.editorParamsSetter {
+      > .editorParamsSetter {
         min-height: 26px;
         display: flex;
         align-items: center;
@@ -961,7 +971,6 @@ dialog :link {
   max-height: calc(var(--viewer-container-height) - 40px);
 
   #secondaryToolbarButtonContainer {
-
     /*#if GENERIC*/
     #secondaryOpenFile::before {
       mask-image: var(--toolbarButton-openFile-icon);
@@ -1069,7 +1078,7 @@ dialog :link {
   flex-wrap: wrap;
   justify-content: flex-start;
 
-  >* {
+  > * {
     height: var(--toolbar-height);
     padding: var(--findbar-padding);
   }
@@ -1192,7 +1201,7 @@ dialog :link {
   }
 
   /* wrapper around (scaled) print canvas elements */
-  #printContainer>.printedPage {
+  #printContainer > .printedPage {
     page-break-after: always;
     page-break-inside: avoid;
 
@@ -1206,11 +1215,11 @@ dialog :link {
     align-items: center;
   }
 
-  #printContainer>.xfaPrintedPage .xfaPage {
+  #printContainer > .xfaPrintedPage .xfaPage {
     position: absolute;
   }
 
-  #printContainer>.xfaPrintedPage {
+  #printContainer > .xfaPrintedPage {
     page-break-after: always;
     page-break-inside: avoid;
     width: 100%;
@@ -1218,7 +1227,7 @@ dialog :link {
     position: relative;
   }
 
-  #printContainer>.printedPage :is(canvas, img) {
+  #printContainer > .printedPage :is(canvas, img) {
     /* The intrinsic canvas / image size will make sure that we fit the page. */
     max-width: 100%;
     max-height: 100%;
@@ -1252,7 +1261,7 @@ dialog :link {
   align-items: center;
   justify-content: center;
 
-  >label {
+  > label {
     width: 100%;
   }
 }
@@ -1292,7 +1301,7 @@ dialog :link {
     background-color: var(--button-hover-color);
   }
 
-  >select {
+  > select {
     appearance: none;
     width: inherit;
     min-width: inherit;
@@ -1307,7 +1316,7 @@ dialog :link {
     outline: none;
     background-color: var(--dropdown-btn-bg-color);
 
-    >option {
+    > option {
       background: var(--doorhanger-bg-color);
       color: var(--main-color);
     }
@@ -1358,7 +1367,7 @@ dialog :link {
     height: 100%;
     justify-content: space-between;
 
-    >* {
+    > * {
       flex: none;
     }
 
@@ -1418,13 +1427,15 @@ dialog :link {
         inset-inline-start: 0;
         height: 100%;
         width: calc(100% + 150px);
-        background: repeating-linear-gradient(135deg,
-            var(--progressBar-blend-color) 0,
-            var(--progressBar-bg-color) 5px,
-            var(--progressBar-bg-color) 45px,
-            var(--progressBar-color) 55px,
-            var(--progressBar-color) 95px,
-            var(--progressBar-blend-color) 100px);
+        background: repeating-linear-gradient(
+          135deg,
+          var(--progressBar-blend-color) 0,
+          var(--progressBar-bg-color) 5px,
+          var(--progressBar-bg-color) 45px,
+          var(--progressBar-color) 55px,
+          var(--progressBar-color) 95px,
+          var(--progressBar-blend-color) 100px
+        );
         animation: progressIndeterminate 1s linear infinite;
       }
     }
@@ -1452,7 +1463,6 @@ dialog :link {
 }
 
 @media all and (max-width: 690px) {
-
   .hiddenSmallView,
   .hiddenSmallView * {
     display: none !important;
@@ -1477,7 +1487,7 @@ dialog :link {
   position: fixed;
   z-index: 50000;
   border: 2px dashed #000;
-  background-color: rgba(255, 255, 255, 0.2);
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.2);
+  background-color: rgb(255 255 255 / 0.2);
+  box-shadow: 0 0 0 9999px rgb(0 0 0 / 0.2);
   pointer-events: none;
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -21,37 +21,38 @@ Adobe CMap resources are covered by their own copyright but the same license:
 See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-    <!--#if GENERIC || CHROME-->
-    <meta name="google" content="notranslate" />
-    <!--#endif-->
-    <title>PDF.js viewer</title>
 
-    <!--#if MOZCENTRAL-->
-    <!--#include viewer-snippet-firefox-extension.html-->
-    <!--#elif CHROME-->
-    <!--#include viewer-snippet-chrome-extension.html-->
-    <!--#else-->
-    <!--#include viewer-snippet.html-->
-    <!--#endif-->
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <!--#if GENERIC || CHROME-->
+  <meta name="google" content="notranslate" />
+  <!--#endif-->
+  <title>PDF.js viewer</title>
 
-    <!--#if MOZCENTRAL-->
-    <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
-    <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
-    <!--#else-->
-    <link rel="stylesheet" href="viewer.css" />
-    <!--#endif-->
+  <!--#if MOZCENTRAL-->
+  <!--#include viewer-snippet-firefox-extension.html-->
+  <!--#elif CHROME-->
+  <!--#include viewer-snippet-chrome-extension.html-->
+  <!--#else-->
+  <!--#include viewer-snippet.html-->
+  <!--#endif-->
 
-    <!--#if MOZCENTRAL-->
-    <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
-    <!--#elif !MOZCENTRAL-->
-    <!--<script src="viewer.mjs" type="module"></script>-->
-    <!--#elif /* Development mode. */-->
-    <link rel="resource" type="application/l10n" href="locale/locale.json" />
+  <!--#if MOZCENTRAL-->
+  <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
+  <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
+  <!--#else-->
+  <link rel="stylesheet" href="viewer.css" />
+  <!--#endif-->
 
-    <script type="importmap">
+  <!--#if MOZCENTRAL-->
+  <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
+  <!--#elif !MOZCENTRAL-->
+  <!--<script src="viewer.mjs" type="module"></script>-->
+  <!--#elif /* Development mode. */-->
+  <link rel="resource" type="application/l10n" href="locale/locale.json" />
+
+  <script type="importmap">
       {
         "imports": {
           "pdfjs/": "../src/",
@@ -93,1210 +94,1009 @@ See https://github.com/adobe-type-tools/cmap-resources
         }
       }
     </script>
-    <script src="viewer.js" type="module"></script>
-    <!--#endif-->
-  </head>
+  <script src="viewer.js" type="module"></script>
+  <!--#endif-->
+</head>
 
-  <body tabindex="0">
-    <div id="outerContainer">
-      <span id="viewer-alert" class="visuallyHidden" role="alert"></span>
+<body tabindex="0">
+  <div id="outerContainer">
+    <span id="viewer-alert" class="visuallyHidden" role="alert"></span>
 
-      <div id="mainContainer">
-        <div class="toolbar">
-          <div id="toolbarContainer">
-            <div id="toolbarViewer" class="toolbarHorizontalGroup">
-              <div id="toolbarViewerLeft" class="toolbarHorizontalGroup">
-                <button
-                  id="viewsManagerToggleButton"
-                  class="toolbarButton"
-                  type="button"
-                  tabindex="0"
-                  data-l10n-id="pdfjs-toggle-views-manager-button"
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  aria-controls="viewsManager"
-                >
-                  <span data-l10n-id="pdfjs-toggle-views-manager-button-label"></span>
-                </button>
-                <div
-                  id="viewsManager"
-                  class="menuContainer sidebar"
-                  hidden="true"
-                  role="dialog"
-                  aria-describedby="viewsManagerHeaderLabel"
-                  data-l10n-id="pdfjs-views-manager-sidebar"
-                >
-                  <div id="viewsManagerHeader" role="heading" aria-level="2">
-                    <div id="viewsManagerTitle">
-                      <div id="viewsManagerSelector">
-                        <button
-                          class="toolbarButton viewsManagerButton"
-                          type="button"
-                          id="viewsManagerSelectorButton"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-views-manager-view-selector-button"
-                          aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-controls="viewsManagerSelectorOptions"
-                        >
-                          <span data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
+    <div id="mainContainer">
+      <div class="toolbar">
+        <div id="toolbarContainer">
+          <div id="toolbarViewer" class="toolbarHorizontalGroup">
+            <div id="toolbarViewerLeft" class="toolbarHorizontalGroup">
+              <button id="viewsManagerToggleButton" class="toolbarButton" type="button" tabindex="0"
+                data-l10n-id="pdfjs-toggle-views-manager-button" aria-expanded="false" aria-haspopup="true"
+                aria-controls="viewsManager">
+                <span data-l10n-id="pdfjs-toggle-views-manager-button-label"></span>
+              </button>
+              <div id="viewsManager" class="menuContainer sidebar" hidden="true" role="dialog"
+                aria-describedby="viewsManagerHeaderLabel" data-l10n-id="pdfjs-views-manager-sidebar">
+                <div id="viewsManagerHeader" role="heading" aria-level="2">
+                  <div id="viewsManagerTitle">
+                    <div id="viewsManagerSelector">
+                      <button class="toolbarButton viewsManagerButton" type="button" id="viewsManagerSelectorButton"
+                        tabindex="0" data-l10n-id="pdfjs-views-manager-view-selector-button" aria-expanded="false"
+                        aria-haspopup="listbox" aria-controls="viewsManagerSelectorOptions">
+                        <span data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
+                      </button>
+                      <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu hidden withMark">
+                        <li>
+                          <button id="thumbnailsViewMenu" role="option" type="button" tabindex="-1">
+                            <span data-l10n-id="pdfjs-views-manager-pages-option-label"></span>
+                          </button>
+                        </li>
+                        <li>
+                          <button id="outlinesViewMenu" role="option" type="button" tabindex="-1">
+                            <span data-l10n-id="pdfjs-views-manager-outlines-option-label"></span>
+                          </button>
+                        </li>
+                        <li>
+                          <button id="attachmentsViewMenu" role="option" type="button" tabindex="-1">
+                            <span data-l10n-id="pdfjs-views-manager-attachments-option-label"></span>
+                          </button>
+                        </li>
+                        <li>
+                          <button id="layersViewMenu" role="option" type="button" tabindex="-1">
+                            <span data-l10n-id="pdfjs-views-manager-layers-option-label"></span>
+                          </button>
+                        </li>
+                      </menu>
+                    </div>
+                    <span id="viewsManagerHeaderLabel" class="viewsManagerLabel"></span>
+                    <button id="viewsManagerAddFileButton" class="toolbarButton viewsManagerButton" type="button"
+                      tabindex="0" data-l10n-id="pdfjs-views-manager-add-file-button" hidden="true">
+                      <span data-l10n-id="pdfjs-views-manager-add-file-button-label"></span>
+                    </button>
+                    <button id="viewsManagerCurrentOutlineButton" class="toolbarButton viewsManagerButton" type="button"
+                      tabindex="0" data-l10n-id="pdfjs-current-outline-item-button" hidden="true">
+                      <span data-l10n-id="pdfjs-current-outline-item-button-label"></span>
+                    </button>
+                  </div>
+                  <div id="viewsManagerStatus">
+                    <div id="viewsManagerStatusAction" class="hidden">
+                      <span id="viewsManagerStatusActionLabel" class="viewsManagerStatusLabel"
+                        data-l10n-id="pdfjs-views-manager-pages-status-none-action-label"></span>
+                      <div id="actionSelector">
+                        <button id="viewsManagerStatusActionButton" class="viewsManagerButton" type="button"
+                          tabindex="0" aria-haspopup="menu" aria-controls="viewsManagerStatusActionOptions">
+                          <span data-l10n-id="pdfjs-views-manager-pages-status-action-button-label"></span>
                         </button>
-                        <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu hidden withMark">
+                        <menu id="viewsManagerStatusActionOptions" class="popupMenu hidden">
                           <li>
-                            <button id="thumbnailsViewMenu" role="option" type="button" tabindex="-1">
-                              <span data-l10n-id="pdfjs-views-manager-pages-option-label"></span>
+                            <button id="viewsManagerStatusActionCopy" class="noIcon" role="menuitem" type="button"
+                              tabindex="0">
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-copy-button-label"></span>
                             </button>
                           </li>
                           <li>
-                            <button id="outlinesViewMenu" role="option" type="button" tabindex="-1">
-                              <span data-l10n-id="pdfjs-views-manager-outlines-option-label"></span>
+                            <button id="viewsManagerStatusActionCut" class="noIcon" role="menuitem" type="button"
+                              tabindex="0">
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-cut-button-label"></span>
                             </button>
                           </li>
                           <li>
-                            <button id="attachmentsViewMenu" role="option" type="button" tabindex="-1">
-                              <span data-l10n-id="pdfjs-views-manager-attachments-option-label"></span>
+                            <button id="viewsManagerStatusActionDelete" class="noIcon" role="menuitem" type="button"
+                              tabindex="0">
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-delete-button-label"></span>
                             </button>
                           </li>
                           <li>
-                            <button id="layersViewMenu" role="option" type="button" tabindex="-1">
-                              <span data-l10n-id="pdfjs-views-manager-layers-option-label"></span>
+                            <button id="viewsManagerStatusActionSaveAs" class="noIcon" role="menuitem" type="button"
+                              tabindex="0">
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-save-as-button-label"></span>
                             </button>
                           </li>
                         </menu>
                       </div>
-                      <span id="viewsManagerHeaderLabel" class="viewsManagerLabel"></span>
-                      <button
-                        id="viewsManagerAddFileButton"
-                        class="toolbarButton viewsManagerButton"
-                        type="button"
-                        tabindex="0"
-                        data-l10n-id="pdfjs-views-manager-add-file-button"
-                        hidden="true"
-                      >
-                        <span data-l10n-id="pdfjs-views-manager-add-file-button-label"></span>
-                      </button>
-                      <button
-                        id="viewsManagerCurrentOutlineButton"
-                        class="toolbarButton viewsManagerButton"
-                        type="button"
-                        tabindex="0"
-                        data-l10n-id="pdfjs-current-outline-item-button"
-                        hidden="true"
-                      >
-                        <span data-l10n-id="pdfjs-current-outline-item-button-label"></span>
-                      </button>
                     </div>
-                    <div id="viewsManagerStatus">
-                      <div id="viewsManagerStatusAction" class="hidden">
-                        <span
-                          id="viewsManagerStatusActionLabel"
-                          class="viewsManagerStatusLabel"
-                          data-l10n-id="pdfjs-views-manager-pages-status-none-action-label"
-                        ></span>
-                        <div id="actionSelector">
-                          <button
-                            id="viewsManagerStatusActionButton"
-                            class="viewsManagerButton"
-                            type="button"
-                            tabindex="0"
-                            aria-haspopup="menu"
-                            aria-controls="viewsManagerStatusActionOptions"
-                          >
-                            <span data-l10n-id="pdfjs-views-manager-pages-status-action-button-label"></span>
-                          </button>
-                          <menu id="viewsManagerStatusActionOptions" class="popupMenu hidden">
-                            <li>
-                              <button id="viewsManagerStatusActionCopy" class="noIcon" role="menuitem" type="button" tabindex="0">
-                                <span data-l10n-id="pdfjs-views-manager-pages-status-copy-button-label"></span>
-                              </button>
-                            </li>
-                            <li>
-                              <button id="viewsManagerStatusActionCut" class="noIcon" role="menuitem" type="button" tabindex="0">
-                                <span data-l10n-id="pdfjs-views-manager-pages-status-cut-button-label"></span>
-                              </button>
-                            </li>
-                            <li>
-                              <button id="viewsManagerStatusActionDelete" class="noIcon" role="menuitem" type="button" tabindex="0">
-                                <span data-l10n-id="pdfjs-views-manager-pages-status-delete-button-label"></span>
-                              </button>
-                            </li>
-                            <li>
-                              <button id="viewsManagerStatusActionSaveAs" class="noIcon" role="menuitem" type="button" tabindex="0">
-                                <span data-l10n-id="pdfjs-views-manager-pages-status-save-as-button-label"></span>
-                              </button>
-                            </li>
-                          </menu>
-                        </div>
-                      </div>
-                      <div id="viewsManagerStatusUndo" class="hidden">
-                        <span class="viewsManagerStatusLabel" data-l10n-id="pdfjs-views-manager-status-undo-cut-label" data-l10n-args='{"count": 0}'></span>
-                        <div>
-                          <button id="viewsManagerStatusUndoButton" class="viewsManagerButton" type="button" tabindex="0">
-                            <span data-l10n-id="pdfjs-views-manager-status-undo-button-label"></span>
-                          </button>
-                          <button
-                            id="viewsManagerStatusUndoCloseButton"
-                            class="toolbarButton viewsManagerButton viewsCloseButton"
-                            type="button"
-                            tabindex="0"
-                            data-l10n-id="pdfjs-views-manager-status-close-button"
-                          >
-                            <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
-                          </button>
-                        </div>
-                      </div>
-                      <div id="viewsManagerStatusWarning" class="hidden">
-                        <span class="viewsManagerStatusLabel"></span>
-                        <button
-                          id="viewsManagerStatusWarningCloseButton"
-                          class="toolbarButton viewsManagerButton viewsCloseButton"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-views-manager-status-close-button"
-                        >
-                          <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
+                    <div id="viewsManagerStatusUndo" class="hidden">
+                      <span class="viewsManagerStatusLabel" data-l10n-id="pdfjs-views-manager-status-undo-cut-label"
+                        data-l10n-args='{"count": 0}'></span>
+                      <div>
+                        <button id="viewsManagerStatusUndoButton" class="viewsManagerButton" type="button" tabindex="0">
+                          <span data-l10n-id="pdfjs-views-manager-status-undo-button-label"></span>
                         </button>
-                      </div>
-                      <div id="viewsManagerStatusWaiting" class="hidden">
-                        <span class="viewsManagerStatusLabel"></span>
-                        <button
-                          id="viewsManagerStatusWaitingCloseButton"
-                          class="toolbarButton viewsManagerButton viewsCloseButton"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-views-manager-status-close-button"
-                        >
+                        <button id="viewsManagerStatusUndoCloseButton"
+                          class="toolbarButton viewsManagerButton viewsCloseButton" type="button" tabindex="0"
+                          data-l10n-id="pdfjs-views-manager-status-close-button">
                           <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
                         </button>
                       </div>
                     </div>
-                  </div>
-                  <div id="viewsManagerContent" tabindex="-1">
-                    <div id="thumbnailsView" class="thumbnailsView hidden" tabindex="-1"></div>
-                    <div id="outlinesView" class="treeView hidden"></div>
-                    <div id="attachmentsView" class="hidden"></div>
-                    <div id="layersView" class="treeView hidden"></div>
-                  </div>
-                  <div id="viewsManagerResizer" class="sidebarResizer"></div>
-                </div>
-                <!-- sidebarContainer -->
-
-                <div class="toolbarButtonSpacer"></div>
-                <div class="toolbarButtonWithContainer">
-                  <button
-                    id="viewFindButton"
-                    class="toolbarButton"
-                    type="button"
-                    tabindex="0"
-                    data-l10n-id="pdfjs-findbar-button"
-                    aria-expanded="false"
-                    aria-controls="findbar"
-                  >
-                    <span data-l10n-id="pdfjs-findbar-button-label"></span>
-                  </button>
-                  <div class="hidden doorHanger toolbarHorizontalGroup" id="findbar">
-                    <div id="findInputContainer" class="toolbarHorizontalGroup">
-                      <span class="loadingInput end toolbarHorizontalGroup">
-                        <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input" aria-invalid="false" />
-                      </span>
-                      <div class="toolbarHorizontalGroup">
-                        <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-previous-button">
-                          <span data-l10n-id="pdfjs-find-previous-button-label"></span>
-                        </button>
-                        <div class="splitToolbarButtonSeparator"></div>
-                        <button id="findNextButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-next-button">
-                          <span data-l10n-id="pdfjs-find-next-button-label"></span>
-                        </button>
-                      </div>
+                    <div id="viewsManagerStatusWarning" class="hidden">
+                      <span class="viewsManagerStatusLabel"></span>
+                      <button id="viewsManagerStatusWarningCloseButton"
+                        class="toolbarButton viewsManagerButton viewsCloseButton" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-views-manager-status-close-button">
+                        <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
+                      </button>
                     </div>
-
-                    <div id="findbarOptionsOneContainer" class="toolbarHorizontalGroup">
-                      <div class="toggleButton toolbarLabel">
-                        <input type="checkbox" id="findHighlightAll" tabindex="0" />
-                        <label for="findHighlightAll" data-l10n-id="pdfjs-find-highlight-checkbox"></label>
-                      </div>
-                      <div class="toggleButton toolbarLabel">
-                        <input type="checkbox" id="findMatchCase" tabindex="0" />
-                        <label for="findMatchCase" data-l10n-id="pdfjs-find-match-case-checkbox-label"></label>
-                      </div>
-                    </div>
-                    <div id="findbarOptionsTwoContainer" class="toolbarHorizontalGroup">
-                      <div class="toggleButton toolbarLabel">
-                        <input type="checkbox" id="findMatchDiacritics" tabindex="0" />
-                        <label for="findMatchDiacritics" data-l10n-id="pdfjs-find-match-diacritics-checkbox-label"></label>
-                      </div>
-                      <div class="toggleButton toolbarLabel">
-                        <input type="checkbox" id="findEntireWord" tabindex="0" />
-                        <label for="findEntireWord" data-l10n-id="pdfjs-find-entire-word-checkbox-label"></label>
-                      </div>
-                    </div>
-
-                    <div id="findbarMessageContainer" class="toolbarHorizontalGroup" aria-live="polite">
-                      <span id="findResultsCount" class="toolbarLabel"></span>
-                      <span id="findMsg" class="toolbarLabel"></span>
+                    <div id="viewsManagerStatusWaiting" class="hidden">
+                      <span class="viewsManagerStatusLabel"></span>
+                      <button id="viewsManagerStatusWaitingCloseButton"
+                        class="toolbarButton viewsManagerButton viewsCloseButton" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-views-manager-status-close-button">
+                        <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
+                      </button>
                     </div>
                   </div>
-                  <!-- findbar -->
                 </div>
-                <div class="toolbarHorizontalGroup hiddenSmallView">
-                  <button class="toolbarButton" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button">
-                    <span data-l10n-id="pdfjs-previous-button-label"></span>
-                  </button>
-                  <div class="splitToolbarButtonSeparator"></div>
-                  <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
-                    <span data-l10n-id="pdfjs-next-button-label"></span>
-                  </button>
+                <div id="viewsManagerContent" tabindex="-1">
+                  <div id="thumbnailsView" class="thumbnailsView hidden" tabindex="-1"></div>
+                  <div id="outlinesView" class="treeView hidden"></div>
+                  <div id="attachmentsView" class="hidden"></div>
+                  <div id="layersView" class="treeView hidden"></div>
                 </div>
-                <div class="toolbarHorizontalGroup">
-                  <span class="loadingInput start toolbarHorizontalGroup">
-                    <input
-                      type="number"
-                      id="pageNumber"
-                      class="toolbarField"
-                      value="1"
-                      min="1"
-                      tabindex="0"
-                      data-l10n-id="pdfjs-page-input"
-                      autocomplete="off"
-                    />
-                  </span>
-                  <span id="numPages" class="toolbarLabel"></span>
-                </div>
+                <div id="viewsManagerResizer" class="sidebarResizer"></div>
               </div>
-              <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
-                <div class="toolbarHorizontalGroup">
-                  <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
-                    <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
-                  </button>
-                  <div class="splitToolbarButtonSeparator"></div>
-                  <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-in-button">
-                    <span data-l10n-id="pdfjs-zoom-in-button-label"></span>
-                  </button>
+              <!-- sidebarContainer -->
+
+              <div class="toolbarButtonSpacer"></div>
+              <div class="toolbarButtonWithContainer">
+                <button id="viewFindButton" class="toolbarButton" type="button" tabindex="0"
+                  data-l10n-id="pdfjs-findbar-button" aria-expanded="false" aria-controls="findbar">
+                  <span data-l10n-id="pdfjs-findbar-button-label"></span>
+                </button>
+                <div class="hidden doorHanger toolbarHorizontalGroup" id="findbar">
+                  <div id="findInputContainer" class="toolbarHorizontalGroup">
+                    <span class="loadingInput end toolbarHorizontalGroup">
+                      <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input"
+                        aria-invalid="false" />
+                    </span>
+                    <div class="toolbarHorizontalGroup">
+                      <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-find-previous-button">
+                        <span data-l10n-id="pdfjs-find-previous-button-label"></span>
+                      </button>
+                      <div class="splitToolbarButtonSeparator"></div>
+                      <button id="findNextButton" class="toolbarButton" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-find-next-button">
+                        <span data-l10n-id="pdfjs-find-next-button-label"></span>
+                      </button>
+                    </div>
+                  </div>
+
+                  <div id="findbarOptionsOneContainer" class="toolbarHorizontalGroup">
+                    <div class="toggleButton toolbarLabel">
+                      <input type="checkbox" id="findHighlightAll" tabindex="0" />
+                      <label for="findHighlightAll" data-l10n-id="pdfjs-find-highlight-checkbox"></label>
+                    </div>
+                    <div class="toggleButton toolbarLabel">
+                      <input type="checkbox" id="findMatchCase" tabindex="0" />
+                      <label for="findMatchCase" data-l10n-id="pdfjs-find-match-case-checkbox-label"></label>
+                    </div>
+                  </div>
+                  <div id="findbarOptionsTwoContainer" class="toolbarHorizontalGroup">
+                    <div class="toggleButton toolbarLabel">
+                      <input type="checkbox" id="findMatchDiacritics" tabindex="0" />
+                      <label for="findMatchDiacritics"
+                        data-l10n-id="pdfjs-find-match-diacritics-checkbox-label"></label>
+                    </div>
+                    <div class="toggleButton toolbarLabel">
+                      <input type="checkbox" id="findEntireWord" tabindex="0" />
+                      <label for="findEntireWord" data-l10n-id="pdfjs-find-entire-word-checkbox-label"></label>
+                    </div>
+                  </div>
+
+                  <div id="findbarMessageContainer" class="toolbarHorizontalGroup" aria-live="polite">
+                    <span id="findResultsCount" class="toolbarLabel"></span>
+                    <span id="findMsg" class="toolbarLabel"></span>
+                  </div>
                 </div>
-                <span id="scaleSelectContainer" class="dropdownToolbarButton">
-                  <select id="scaleSelect" tabindex="0" data-l10n-id="pdfjs-zoom-select">
-                    <option id="pageAutoOption" value="auto" selected="selected" data-l10n-id="pdfjs-page-scale-auto"></option>
-                    <option id="pageActualOption" value="page-actual" data-l10n-id="pdfjs-page-scale-actual"></option>
-                    <option id="pageFitOption" value="page-fit" data-l10n-id="pdfjs-page-scale-fit"></option>
-                    <option id="pageWidthOption" value="page-width" data-l10n-id="pdfjs-page-scale-width"></option>
-                    <option
-                      id="customScaleOption"
-                      value="custom"
-                      disabled="disabled"
-                      hidden="true"
-                      data-l10n-id="pdfjs-page-scale-percent"
-                      data-l10n-args='{ "scale": 0 }'
-                    ></option>
-                    <option value="0.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 50 }'></option>
-                    <option value="0.75" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 75 }'></option>
-                    <option value="1" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 100 }'></option>
-                    <option value="1.25" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 125 }'></option>
-                    <option value="1.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 150 }'></option>
-                    <option value="2" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 200 }'></option>
-                    <option value="3" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 300 }'></option>
-                    <option value="4" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 400 }'></option>
-                  </select>
+                <!-- findbar -->
+              </div>
+              <div class="toolbarHorizontalGroup hiddenSmallView">
+                <button class="toolbarButton" type="button" id="previous" tabindex="0"
+                  data-l10n-id="pdfjs-previous-button">
+                  <span data-l10n-id="pdfjs-previous-button-label"></span>
+                </button>
+                <div class="splitToolbarButtonSeparator"></div>
+                <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
+                  <span data-l10n-id="pdfjs-next-button-label"></span>
+                </button>
+              </div>
+              <div class="toolbarHorizontalGroup">
+                <span class="loadingInput start toolbarHorizontalGroup">
+                  <input type="number" id="pageNumber" class="toolbarField" value="1" min="1" tabindex="0"
+                    data-l10n-id="pdfjs-page-input" autocomplete="off" />
                 </span>
-              </div>
-              <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
-                <div id="editorModeButtons" class="toolbarHorizontalGroup">
-                  <div id="editorComment" class="toolbarButtonWithContainer" hidden="true">
-                    <button
-                      id="editorCommentButton"
-                      class="toolbarButton"
-                      type="button"
-                      tabindex="0"
-                      disabled="disabled"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      aria-controls="editorCommentParamsToolbar"
-                      data-l10n-id="pdfjs-editor-comment-button"
-                    >
-                      <span data-l10n-id="pdfjs-editor-comment-button-label"></span>
-                    </button>
-                    <div class="editorParamsToolbar hidden menu" id="editorCommentParamsToolbar">
-                      <div id="editorCommentsSidebar" class="menuContainer comment sidebar" role="landmark" aria-labelledby="editorCommentsSidebarHeader">
-                        <div id="editorCommentsSidebarResizer" class="sidebarResizer" role="separator" aria-controls="editorCommentsSidebar" tabindex="0"></div>
-                        <div id="editorCommentsSidebarHeader" role="heading" aria-level="2">
-                          <span class="commentCount">
-                            <span id="editorCommentsSidebarTitle" data-l10n-id="pdfjs-editor-comments-sidebar-title" data-l10n-args='{ "count": 0 }'></span>
-                            <span id="editorCommentsSidebarCount"></span>
-                          </span>
-                          <button id="editorCommentsSidebarCloseButton" type="button" tabindex="0" data-l10n-id="pdfjs-editor-comments-sidebar-close-button">
-                            <span data-l10n-id="pdfjs-editor-comments-sidebar-close-button-label"></span>
-                          </button>
-                        </div>
-                        <div id="editorCommentsSidebarListContainer" tabindex="-1">
-                          <ul id="editorCommentsSidebarList"></ul>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div id="editorSignature" class="toolbarButtonWithContainer" hidden="true">
-                    <button
-                      id="editorSignatureButton"
-                      class="toolbarButton"
-                      type="button"
-                      tabindex="0"
-                      disabled="disabled"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      aria-controls="editorSignatureParamsToolbar"
-                      data-l10n-id="pdfjs-editor-signature-button"
-                    >
-                      <span data-l10n-id="pdfjs-editor-signature-button-label"></span>
-                    </button>
-                    <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorSignatureParamsToolbar">
-                      <div id="addSignatureDoorHanger" class="menuContainer" role="region" data-l10n-id="pdfjs-editor-add-signature-container">
-                        <button
-                          id="editorSignatureAddSignature"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-editor-signature-add-signature-button"
-                        >
-                          <span data-l10n-id="pdfjs-editor-signature-add-signature-button-label" class="editorParamsLabel"></span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  <div id="editorHighlight" class="toolbarButtonWithContainer">
-                    <button
-                      id="editorHighlightButton"
-                      class="toolbarButton"
-                      type="button"
-                      disabled="disabled"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      aria-controls="editorHighlightParamsToolbar"
-                      tabindex="0"
-                      data-l10n-id="pdfjs-editor-highlight-button"
-                    >
-                      <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>
-                    </button>
-                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
-                      <div id="highlightParamsToolbarContainer" class="editorParamsToolbarContainer">
-                        <div id="editorHighlightColorPicker" class="colorPicker">
-                          <span id="highlightColorPickerLabel" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-colorpicker-label"></span>
-                        </div>
-                        <div id="editorHighlightThickness">
-                          <label
-                            for="editorFreeHighlightThickness"
-                            class="editorParamsLabel"
-                            data-l10n-id="pdfjs-editor-free-highlight-thickness-input"
-                          ></label>
-                          <div class="thicknessPicker">
-                            <input
-                              type="range"
-                              id="editorFreeHighlightThickness"
-                              class="editorParamsSlider"
-                              data-l10n-id="pdfjs-editor-free-highlight-thickness-title"
-                              value="12"
-                              min="8"
-                              max="24"
-                              step="1"
-                              tabindex="0"
-                            />
-                          </div>
-                        </div>
-                        <div id="editorHighlightVisibility">
-                          <div class="divider"></div>
-                          <div class="toggler">
-                            <label for="editorHighlightShowAll" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-show-all-button-label"></label>
-                            <button
-                              id="editorHighlightShowAll"
-                              class="toggle-button"
-                              type="button"
-                              data-l10n-id="pdfjs-editor-highlight-show-all-button"
-                              aria-pressed="true"
-                              tabindex="0"
-                            ></button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div id="editorFreeText" class="toolbarButtonWithContainer">
-                    <button
-                      id="editorFreeTextButton"
-                      class="toolbarButton"
-                      type="button"
-                      disabled="disabled"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      aria-controls="editorFreeTextParamsToolbar"
-                      tabindex="0"
-                      data-l10n-id="pdfjs-editor-free-text-button"
-                    >
-                      <span data-l10n-id="pdfjs-editor-free-text-button-label"></span>
-                    </button>
-                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
-                      <div class="editorParamsToolbarContainer">
-                        <div class="editorParamsSetter">
-                          <label for="editorFreeTextColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-color-input"></label>
-                          <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0" />
-                        </div>
-                        <div class="editorParamsSetter">
-                          <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-size-input"></label>
-                          <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="0" />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div id="editorInk" class="toolbarButtonWithContainer">
-                    <button
-                      id="editorInkButton"
-                      class="toolbarButton"
-                      type="button"
-                      disabled="disabled"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      aria-controls="editorInkParamsToolbar"
-                      tabindex="0"
-                      data-l10n-id="pdfjs-editor-ink-button"
-                    >
-                      <span data-l10n-id="pdfjs-editor-ink-button-label"></span>
-                    </button>
-                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
-                      <div class="editorParamsToolbarContainer">
-                        <div class="editorParamsSetter">
-                          <label for="editorInkColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-color-input"></label>
-                          <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0" />
-                        </div>
-                        <div class="editorParamsSetter">
-                          <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-thickness-input"></label>
-                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="0" />
-                        </div>
-                        <div class="editorParamsSetter">
-                          <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input"></label>
-                          <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="1" min="0.05" max="1" step="0.05" tabindex="0" />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div id="editorStamp" class="toolbarButtonWithContainer">
-                    <button
-                      id="editorStampButton"
-                      class="toolbarButton"
-                      type="button"
-                      disabled="disabled"
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      aria-controls="editorStampParamsToolbar"
-                      tabindex="0"
-                      data-l10n-id="pdfjs-editor-stamp-button"
-                    >
-                      <span data-l10n-id="pdfjs-editor-stamp-button-label"></span>
-                    </button>
-                    <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorStampParamsToolbar">
-                      <div class="menuContainer">
-                        <button
-                          id="editorStampAddImage"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-editor-stamp-add-image-button"
-                        >
-                          <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label"></span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
-
-                <div class="toolbarHorizontalGroup hiddenMediumView">
-                  <button id="printButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
-                    <span data-l10n-id="pdfjs-print-button-label"></span>
-                  </button>
-
-                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
-                    <span data-l10n-id="pdfjs-save-button-label"></span>
-                  </button>
-                </div>
-
-                <div class="verticalToolbarSeparator hiddenMediumView"></div>
-
-                <div id="secondaryToolbarToggle" class="toolbarButtonWithContainer">
-                  <button
-                    id="secondaryToolbarToggleButton"
-                    class="toolbarButton"
-                    type="button"
-                    tabindex="0"
-                    data-l10n-id="pdfjs-tools-button"
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    aria-controls="secondaryToolbar"
-                  >
-                    <span data-l10n-id="pdfjs-tools-button-label"></span>
-                  </button>
-                  <div id="secondaryToolbar" class="hidden doorHangerRight menu">
-                    <div id="secondaryToolbarButtonContainer" class="menuContainer">
-                      <!--#if GENERIC-->
-                      <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-open-file-button">
-                        <span data-l10n-id="pdfjs-open-file-button-label"></span>
-                      </button>
-                      <!--#endif-->
-
-                      <div class="visibleMediumView">
-                        <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
-                          <span data-l10n-id="pdfjs-print-button-label"></span>
-                        </button>
-
-                        <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
-                          <span data-l10n-id="pdfjs-save-button-label"></span>
-                        </button>
-
-                        <!--#if !GENERIC-->
-                        <!--            <div class="horizontalToolbarSeparator"></div>-->
-                        <!--#endif-->
-                      </div>
-
-                      <!--#if GENERIC-->
-                      <div class="horizontalToolbarSeparator"></div>
-                      <!--#endif-->
-
-                      <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button">
-                        <span data-l10n-id="pdfjs-presentation-mode-button-label"></span>
-                      </button>
-
-                      <a href="#" id="viewBookmark" class="toolbarButton labeled" tabindex="0" data-l10n-id="pdfjs-bookmark-button">
-                        <span data-l10n-id="pdfjs-bookmark-button-label"></span>
-                      </a>
-
-                      <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>
-
-                      <button id="firstPage" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-first-page-button">
-                        <span data-l10n-id="pdfjs-first-page-button-label"></span>
-                      </button>
-                      <button id="lastPage" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-last-page-button">
-                        <span data-l10n-id="pdfjs-last-page-button-label"></span>
-                      </button>
-
-                      <div class="horizontalToolbarSeparator"></div>
-
-                      <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button">
-                        <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
-                      </button>
-                      <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-ccw-button">
-                        <span data-l10n-id="pdfjs-page-rotate-ccw-button-label"></span>
-                      </button>
-
-                      <div class="horizontalToolbarSeparator"></div>
-
-                      <div id="cursorToolButtons" role="radiogroup">
-                        <button
-                          id="cursorSelectTool"
-                          class="toolbarButton labeled toggled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-cursor-text-select-tool-button"
-                          role="radio"
-                          aria-checked="true"
-                        >
-                          <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label"></span>
-                        </button>
-                        <button
-                          id="cursorHandTool"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-cursor-hand-tool-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-cursor-hand-tool-button-label"></span>
-                        </button>
-                        <button
-                          id="cursorZoomTool"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-cursor-zoom-tool-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-cursor-zoom-tool-button-label">Zoom</span>
-                        </button>
-                      </div>
-
-                      <div class="horizontalToolbarSeparator"></div>
-
-                      <div id="scrollModeButtons" role="radiogroup">
-                        <button
-                          id="scrollPage"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-scroll-page-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-scroll-page-button-label"></span>
-                        </button>
-                        <button
-                          id="scrollVertical"
-                          class="toolbarButton labeled toggled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-scroll-vertical-button"
-                          role="radio"
-                          aria-checked="true"
-                        >
-                          <span data-l10n-id="pdfjs-scroll-vertical-button-label"></span>
-                        </button>
-                        <button
-                          id="scrollHorizontal"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-scroll-horizontal-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-scroll-horizontal-button-label"></span>
-                        </button>
-                        <button
-                          id="scrollWrapped"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-scroll-wrapped-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-scroll-wrapped-button-label"></span>
-                        </button>
-                      </div>
-
-                      <div class="horizontalToolbarSeparator"></div>
-
-                      <div id="spreadModeButtons" role="radiogroup">
-                        <button
-                          id="spreadNone"
-                          class="toolbarButton labeled toggled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-spread-none-button"
-                          role="radio"
-                          aria-checked="true"
-                        >
-                          <span data-l10n-id="pdfjs-spread-none-button-label"></span>
-                        </button>
-                        <button
-                          id="spreadOdd"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-spread-odd-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-spread-odd-button-label"></span>
-                        </button>
-                        <button
-                          id="spreadEven"
-                          class="toolbarButton labeled"
-                          type="button"
-                          tabindex="0"
-                          data-l10n-id="pdfjs-spread-even-button"
-                          role="radio"
-                          aria-checked="false"
-                        >
-                          <span data-l10n-id="pdfjs-spread-even-button-label"></span>
-                        </button>
-                      </div>
-
-                      <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
-                      <button
-                        id="imageAltTextSettings"
-                        type="button"
-                        class="toolbarButton labeled hidden"
-                        tabindex="0"
-                        data-l10n-id="pdfjs-image-alt-text-settings-button"
-                        aria-controls="altTextSettingsDialog"
-                      >
-                        <span data-l10n-id="pdfjs-image-alt-text-settings-button-label"></span>
-                      </button>
-
-                      <div class="horizontalToolbarSeparator"></div>
-
-                      <button
-                        id="documentProperties"
-                        class="toolbarButton labeled"
-                        type="button"
-                        tabindex="0"
-                        data-l10n-id="pdfjs-document-properties-button"
-                        aria-controls="documentPropertiesDialog"
-                      >
-                        <span data-l10n-id="pdfjs-document-properties-button-label"></span>
-                      </button>
-                    </div>
-                  </div>
-                  <!-- secondaryToolbar -->
-                </div>
+                <span id="numPages" class="toolbarLabel"></span>
               </div>
             </div>
-            <div id="loadingBar">
-              <div class="progress">
-                <div class="glimmer"></div>
+            <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
+              <div class="toolbarHorizontalGroup">
+                <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0"
+                  data-l10n-id="pdfjs-zoom-out-button">
+                  <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
+                </button>
+                <div class="splitToolbarButtonSeparator"></div>
+                <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0"
+                  data-l10n-id="pdfjs-zoom-in-button">
+                  <span data-l10n-id="pdfjs-zoom-in-button-label"></span>
+                </button>
+              </div>
+              <span id="scaleSelectContainer" class="dropdownToolbarButton">
+                <select id="scaleSelect" tabindex="0" data-l10n-id="pdfjs-zoom-select">
+                  <option id="pageAutoOption" value="auto" selected="selected" data-l10n-id="pdfjs-page-scale-auto">
+                  </option>
+                  <option id="pageActualOption" value="page-actual" data-l10n-id="pdfjs-page-scale-actual"></option>
+                  <option id="pageFitOption" value="page-fit" data-l10n-id="pdfjs-page-scale-fit"></option>
+                  <option id="pageWidthOption" value="page-width" data-l10n-id="pdfjs-page-scale-width"></option>
+                  <option id="customScaleOption" value="custom" disabled="disabled" hidden="true"
+                    data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 0 }'></option>
+                  <option value="0.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 50 }'></option>
+                  <option value="0.75" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 75 }'>
+                  </option>
+                  <option value="1" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 100 }'></option>
+                  <option value="1.25" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 125 }'>
+                  </option>
+                  <option value="1.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 150 }'>
+                  </option>
+                  <option value="2" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 200 }'></option>
+                  <option value="3" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 300 }'></option>
+                  <option value="4" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 400 }'></option>
+                </select>
+              </span>
+            </div>
+            <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
+              <div id="editorModeButtons" class="toolbarHorizontalGroup">
+                <div id="editorComment" class="toolbarButtonWithContainer" hidden="true">
+                  <button id="editorCommentButton" class="toolbarButton" type="button" tabindex="0" disabled="disabled"
+                    aria-expanded="false" aria-haspopup="true" aria-controls="editorCommentParamsToolbar"
+                    data-l10n-id="pdfjs-editor-comment-button">
+                    <span data-l10n-id="pdfjs-editor-comment-button-label"></span>
+                  </button>
+                  <div class="editorParamsToolbar hidden menu" id="editorCommentParamsToolbar">
+                    <div id="editorCommentsSidebar" class="menuContainer comment sidebar" role="landmark"
+                      aria-labelledby="editorCommentsSidebarHeader">
+                      <div id="editorCommentsSidebarResizer" class="sidebarResizer" role="separator"
+                        aria-controls="editorCommentsSidebar" tabindex="0"></div>
+                      <div id="editorCommentsSidebarHeader" role="heading" aria-level="2">
+                        <span class="commentCount">
+                          <span id="editorCommentsSidebarTitle" data-l10n-id="pdfjs-editor-comments-sidebar-title"
+                            data-l10n-args='{ "count": 0 }'></span>
+                          <span id="editorCommentsSidebarCount"></span>
+                        </span>
+                        <button id="editorCommentsSidebarCloseButton" type="button" tabindex="0"
+                          data-l10n-id="pdfjs-editor-comments-sidebar-close-button">
+                          <span data-l10n-id="pdfjs-editor-comments-sidebar-close-button-label"></span>
+                        </button>
+                      </div>
+                      <div id="editorCommentsSidebarListContainer" tabindex="-1">
+                        <ul id="editorCommentsSidebarList"></ul>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div id="editorSignature" class="toolbarButtonWithContainer" hidden="true">
+                  <button id="editorSignatureButton" class="toolbarButton" type="button" tabindex="0"
+                    disabled="disabled" aria-expanded="false" aria-haspopup="true"
+                    aria-controls="editorSignatureParamsToolbar" data-l10n-id="pdfjs-editor-signature-button">
+                    <span data-l10n-id="pdfjs-editor-signature-button-label"></span>
+                  </button>
+                  <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorSignatureParamsToolbar">
+                    <div id="addSignatureDoorHanger" class="menuContainer" role="region"
+                      data-l10n-id="pdfjs-editor-add-signature-container">
+                      <button id="editorSignatureAddSignature" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-editor-signature-add-signature-button">
+                        <span data-l10n-id="pdfjs-editor-signature-add-signature-button-label"
+                          class="editorParamsLabel"></span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div id="editorHighlight" class="toolbarButtonWithContainer">
+                  <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled"
+                    aria-expanded="false" aria-haspopup="true" aria-controls="editorHighlightParamsToolbar" tabindex="0"
+                    data-l10n-id="pdfjs-editor-highlight-button">
+                    <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>
+                  </button>
+                  <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
+                    <div id="highlightParamsToolbarContainer" class="editorParamsToolbarContainer">
+                      <div id="editorHighlightColorPicker" class="colorPicker">
+                        <span id="highlightColorPickerLabel" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-highlight-colorpicker-label"></span>
+                      </div>
+                      <div id="editorHighlightThickness">
+                        <label for="editorFreeHighlightThickness" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-free-highlight-thickness-input"></label>
+                        <div class="thicknessPicker">
+                          <input type="range" id="editorFreeHighlightThickness" class="editorParamsSlider"
+                            data-l10n-id="pdfjs-editor-free-highlight-thickness-title" value="12" min="8" max="24"
+                            step="1" tabindex="0" />
+                        </div>
+                      </div>
+                      <div id="editorHighlightVisibility">
+                        <div class="divider"></div>
+                        <div class="toggler">
+                          <label for="editorHighlightShowAll" class="editorParamsLabel"
+                            data-l10n-id="pdfjs-editor-highlight-show-all-button-label"></label>
+                          <button id="editorHighlightShowAll" class="toggle-button" type="button"
+                            data-l10n-id="pdfjs-editor-highlight-show-all-button" aria-pressed="true"
+                            tabindex="0"></button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div id="editorFreeText" class="toolbarButtonWithContainer">
+                  <button id="editorFreeTextButton" class="toolbarButton" type="button" disabled="disabled"
+                    aria-expanded="false" aria-haspopup="true" aria-controls="editorFreeTextParamsToolbar" tabindex="0"
+                    data-l10n-id="pdfjs-editor-free-text-button">
+                    <span data-l10n-id="pdfjs-editor-free-text-button-label"></span>
+                  </button>
+                  <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
+                    <div class="editorParamsToolbarContainer">
+                      <div class="editorParamsSetter">
+                        <label for="editorFreeTextColor" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-free-text-color-input"></label>
+                        <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0" />
+                      </div>
+                      <div class="editorParamsSetter">
+                        <label for="editorFreeTextFontSize" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-free-text-size-input"></label>
+                        <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5"
+                          max="100" step="1" tabindex="0" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div id="editorInk" class="toolbarButtonWithContainer">
+                  <button id="editorInkButton" class="toolbarButton" type="button" disabled="disabled"
+                    aria-expanded="false" aria-haspopup="true" aria-controls="editorInkParamsToolbar" tabindex="0"
+                    data-l10n-id="pdfjs-editor-ink-button">
+                    <span data-l10n-id="pdfjs-editor-ink-button-label"></span>
+                  </button>
+                  <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
+                    <div class="editorParamsToolbarContainer">
+                      <div class="editorParamsSetter">
+                        <label for="editorInkColor" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-ink-color-input"></label>
+                        <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0" />
+                      </div>
+                      <div class="editorParamsSetter">
+                        <label for="editorInkThickness" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-ink-thickness-input"></label>
+                        <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1"
+                          max="20" step="1" tabindex="0" />
+                      </div>
+                      <div class="editorParamsSetter">
+                        <label for="editorInkOpacity" class="editorParamsLabel"
+                          data-l10n-id="pdfjs-editor-ink-opacity-input"></label>
+                        <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="1" min="0.05"
+                          max="1" step="0.05" tabindex="0" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div id="editorStamp" class="toolbarButtonWithContainer">
+                  <button id="editorStampButton" class="toolbarButton" type="button" disabled="disabled"
+                    aria-expanded="false" aria-haspopup="true" aria-controls="editorStampParamsToolbar" tabindex="0"
+                    data-l10n-id="pdfjs-editor-stamp-button">
+                    <span data-l10n-id="pdfjs-editor-stamp-button-label"></span>
+                  </button>
+                  <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorStampParamsToolbar">
+                    <div class="menuContainer">
+                      <button id="editorStampAddImage" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-editor-stamp-add-image-button">
+                        <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label"></span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
+
+              <div class="toolbarHorizontalGroup hiddenMediumView">
+                <button id="printButton" class="toolbarButton" type="button" tabindex="0"
+                  data-l10n-id="pdfjs-print-button">
+                  <span data-l10n-id="pdfjs-print-button-label"></span>
+                </button>
+
+                <button id="downloadButton" class="toolbarButton" type="button" tabindex="0"
+                  data-l10n-id="pdfjs-save-button">
+                  <span data-l10n-id="pdfjs-save-button-label"></span>
+                </button>
+              </div>
+
+              <div class="verticalToolbarSeparator hiddenMediumView"></div>
+
+              <div id="secondaryToolbarToggle" class="toolbarButtonWithContainer">
+                <button id="secondaryToolbarToggleButton" class="toolbarButton" type="button" tabindex="0"
+                  data-l10n-id="pdfjs-tools-button" aria-expanded="false" aria-haspopup="true"
+                  aria-controls="secondaryToolbar">
+                  <span data-l10n-id="pdfjs-tools-button-label"></span>
+                </button>
+                <div id="secondaryToolbar" class="hidden doorHangerRight menu">
+                  <div id="secondaryToolbarButtonContainer" class="menuContainer">
+                    <!--#if GENERIC-->
+                    <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-open-file-button">
+                      <span data-l10n-id="pdfjs-open-file-button-label"></span>
+                    </button>
+                    <!--#endif-->
+
+                    <div class="visibleMediumView">
+                      <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-print-button">
+                        <span data-l10n-id="pdfjs-print-button-label"></span>
+                      </button>
+
+                      <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-save-button">
+                        <span data-l10n-id="pdfjs-save-button-label"></span>
+                      </button>
+
+                      <!--#if !GENERIC-->
+                      <!--            <div class="horizontalToolbarSeparator"></div>-->
+                      <!--#endif-->
+                    </div>
+
+                    <!--#if GENERIC-->
+                    <div class="horizontalToolbarSeparator"></div>
+                    <!--#endif-->
+
+                    <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-presentation-mode-button">
+                      <span data-l10n-id="pdfjs-presentation-mode-button-label"></span>
+                    </button>
+
+                    <a href="#" id="viewBookmark" class="toolbarButton labeled" tabindex="0"
+                      data-l10n-id="pdfjs-bookmark-button">
+                      <span data-l10n-id="pdfjs-bookmark-button-label"></span>
+                    </a>
+
+                    <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>
+
+                    <button id="firstPage" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-first-page-button">
+                      <span data-l10n-id="pdfjs-first-page-button-label"></span>
+                    </button>
+                    <button id="lastPage" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-last-page-button">
+                      <span data-l10n-id="pdfjs-last-page-button-label"></span>
+                    </button>
+
+                    <div class="horizontalToolbarSeparator"></div>
+
+                    <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-page-rotate-cw-button">
+                      <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
+                    </button>
+                    <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-page-rotate-ccw-button">
+                      <span data-l10n-id="pdfjs-page-rotate-ccw-button-label"></span>
+                    </button>
+
+                    <div class="horizontalToolbarSeparator"></div>
+
+                    <div id="cursorToolButtons" role="radiogroup">
+                      <button id="cursorSelectTool" class="toolbarButton labeled toggled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-cursor-text-select-tool-button" role="radio" aria-checked="true">
+                        <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label"></span>
+                      </button>
+                      <button id="cursorHandTool" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-cursor-hand-tool-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-cursor-hand-tool-button-label"></span>
+                      </button>
+                      <button id="cursorZoomTool" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-cursor-zoom-tool-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-cursor-zoom-tool-button-label"></span>
+                      </button>
+                    </div>
+
+                    <div class="horizontalToolbarSeparator"></div>
+
+                    <div id="scrollModeButtons" role="radiogroup">
+                      <button id="scrollPage" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-scroll-page-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-scroll-page-button-label"></span>
+                      </button>
+                      <button id="scrollVertical" class="toolbarButton labeled toggled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-scroll-vertical-button" role="radio" aria-checked="true">
+                        <span data-l10n-id="pdfjs-scroll-vertical-button-label"></span>
+                      </button>
+                      <button id="scrollHorizontal" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-scroll-horizontal-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-scroll-horizontal-button-label"></span>
+                      </button>
+                      <button id="scrollWrapped" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-scroll-wrapped-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-scroll-wrapped-button-label"></span>
+                      </button>
+                    </div>
+
+                    <div class="horizontalToolbarSeparator"></div>
+
+                    <div id="spreadModeButtons" role="radiogroup">
+                      <button id="spreadNone" class="toolbarButton labeled toggled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-spread-none-button" role="radio" aria-checked="true">
+                        <span data-l10n-id="pdfjs-spread-none-button-label"></span>
+                      </button>
+                      <button id="spreadOdd" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-spread-odd-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-spread-odd-button-label"></span>
+                      </button>
+                      <button id="spreadEven" class="toolbarButton labeled" type="button" tabindex="0"
+                        data-l10n-id="pdfjs-spread-even-button" role="radio" aria-checked="false">
+                        <span data-l10n-id="pdfjs-spread-even-button-label"></span>
+                      </button>
+                    </div>
+
+                    <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
+                    <button id="imageAltTextSettings" type="button" class="toolbarButton labeled hidden" tabindex="0"
+                      data-l10n-id="pdfjs-image-alt-text-settings-button" aria-controls="altTextSettingsDialog">
+                      <span data-l10n-id="pdfjs-image-alt-text-settings-button-label"></span>
+                    </button>
+
+                    <div class="horizontalToolbarSeparator"></div>
+
+                    <button id="documentProperties" class="toolbarButton labeled" type="button" tabindex="0"
+                      data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
+                      <span data-l10n-id="pdfjs-document-properties-button-label"></span>
+                    </button>
+                  </div>
+                </div>
+                <!-- secondaryToolbar -->
               </div>
             </div>
           </div>
-        </div>
-
-        <div id="viewerContainer" tabindex="0">
-          <div id="viewer" class="pdfViewer"></div>
+          <div id="loadingBar">
+            <div class="progress">
+              <div class="glimmer"></div>
+            </div>
+          </div>
         </div>
       </div>
-      <!-- mainContainer -->
 
-      <div id="dialogContainer">
-        <dialog id="passwordDialog">
-          <div class="row">
-            <label for="password" id="passwordText" data-l10n-id="pdfjs-password-label"></label>
+      <div id="viewerContainer" tabindex="0">
+        <div id="viewer" class="pdfViewer"></div>
+      </div>
+    </div>
+    <!-- mainContainer -->
+
+    <div id="dialogContainer">
+      <dialog id="passwordDialog">
+        <div class="row">
+          <label for="password" id="passwordText" data-l10n-id="pdfjs-password-label"></label>
+        </div>
+        <div class="row">
+          <input type="password" id="password" class="toolbarField" />
+        </div>
+        <div class="buttonRow">
+          <button id="passwordCancel" class="dialogButton" type="button"><span
+              data-l10n-id="pdfjs-password-cancel-button"></span></button>
+          <button id="passwordSubmit" class="dialogButton" type="button"><span
+              data-l10n-id="pdfjs-password-ok-button"></span></button>
+        </div>
+      </dialog>
+      <dialog id="documentPropertiesDialog">
+        <div class="row">
+          <span id="fileNameLabel" data-l10n-id="pdfjs-document-properties-file-name"></span>
+          <p id="fileNameField" aria-labelledby="fileNameLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="fileSizeLabel" data-l10n-id="pdfjs-document-properties-file-size"></span>
+          <p id="fileSizeField" aria-labelledby="fileSizeLabel">-</p>
+        </div>
+        <div class="separator"></div>
+        <div class="row">
+          <span id="titleLabel" data-l10n-id="pdfjs-document-properties-title"></span>
+          <p id="titleField" aria-labelledby="titleLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="authorLabel" data-l10n-id="pdfjs-document-properties-author"></span>
+          <p id="authorField" aria-labelledby="authorLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="subjectLabel" data-l10n-id="pdfjs-document-properties-subject"></span>
+          <p id="subjectField" aria-labelledby="subjectLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="keywordsLabel" data-l10n-id="pdfjs-document-properties-keywords"></span>
+          <p id="keywordsField" aria-labelledby="keywordsLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="creationDateLabel" data-l10n-id="pdfjs-document-properties-creation-date"></span>
+          <p id="creationDateField" aria-labelledby="creationDateLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="modificationDateLabel" data-l10n-id="pdfjs-document-properties-modification-date"></span>
+          <p id="modificationDateField" aria-labelledby="modificationDateLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="creatorLabel" data-l10n-id="pdfjs-document-properties-creator"></span>
+          <p id="creatorField" aria-labelledby="creatorLabel">-</p>
+        </div>
+        <div class="separator"></div>
+        <div class="row">
+          <span id="producerLabel" data-l10n-id="pdfjs-document-properties-producer"></span>
+          <p id="producerField" aria-labelledby="producerLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="versionLabel" data-l10n-id="pdfjs-document-properties-version"></span>
+          <p id="versionField" aria-labelledby="versionLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="pageCountLabel" data-l10n-id="pdfjs-document-properties-page-count"></span>
+          <p id="pageCountField" aria-labelledby="pageCountLabel">-</p>
+        </div>
+        <div class="row">
+          <span id="pageSizeLabel" data-l10n-id="pdfjs-document-properties-page-size"></span>
+          <p id="pageSizeField" aria-labelledby="pageSizeLabel">-</p>
+        </div>
+        <div class="separator"></div>
+        <div class="row">
+          <span id="linearizedLabel" data-l10n-id="pdfjs-document-properties-linearized"></span>
+          <p id="linearizedField" aria-labelledby="linearizedLabel">-</p>
+        </div>
+        <div class="buttonRow">
+          <button id="documentPropertiesClose" class="dialogButton" type="button"><span
+              data-l10n-id="pdfjs-document-properties-close-button"></span></button>
+        </div>
+      </dialog>
+      <dialog class="dialog altText" id="altTextDialog" aria-labelledby="dialogLabel"
+        aria-describedby="dialogDescription">
+        <div id="altTextContainer" class="mainContainer">
+          <div id="overallDescription">
+            <span id="dialogLabel" data-l10n-id="pdfjs-editor-alt-text-dialog-label" class="title"></span>
+            <span id="dialogDescription" data-l10n-id="pdfjs-editor-alt-text-dialog-description"></span>
           </div>
-          <div class="row">
-            <input type="password" id="password" class="toolbarField" />
-          </div>
-          <div class="buttonRow">
-            <button id="passwordCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-cancel-button"></span></button>
-            <button id="passwordSubmit" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-ok-button"></span></button>
-          </div>
-        </dialog>
-        <dialog id="documentPropertiesDialog">
-          <div class="row">
-            <span id="fileNameLabel" data-l10n-id="pdfjs-document-properties-file-name"></span>
-            <p id="fileNameField" aria-labelledby="fileNameLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="fileSizeLabel" data-l10n-id="pdfjs-document-properties-file-size"></span>
-            <p id="fileSizeField" aria-labelledby="fileSizeLabel">-</p>
-          </div>
-          <div class="separator"></div>
-          <div class="row">
-            <span id="titleLabel" data-l10n-id="pdfjs-document-properties-title"></span>
-            <p id="titleField" aria-labelledby="titleLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="authorLabel" data-l10n-id="pdfjs-document-properties-author"></span>
-            <p id="authorField" aria-labelledby="authorLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="subjectLabel" data-l10n-id="pdfjs-document-properties-subject"></span>
-            <p id="subjectField" aria-labelledby="subjectLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="keywordsLabel" data-l10n-id="pdfjs-document-properties-keywords"></span>
-            <p id="keywordsField" aria-labelledby="keywordsLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="creationDateLabel" data-l10n-id="pdfjs-document-properties-creation-date"></span>
-            <p id="creationDateField" aria-labelledby="creationDateLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="modificationDateLabel" data-l10n-id="pdfjs-document-properties-modification-date"></span>
-            <p id="modificationDateField" aria-labelledby="modificationDateLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="creatorLabel" data-l10n-id="pdfjs-document-properties-creator"></span>
-            <p id="creatorField" aria-labelledby="creatorLabel">-</p>
-          </div>
-          <div class="separator"></div>
-          <div class="row">
-            <span id="producerLabel" data-l10n-id="pdfjs-document-properties-producer"></span>
-            <p id="producerField" aria-labelledby="producerLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="versionLabel" data-l10n-id="pdfjs-document-properties-version"></span>
-            <p id="versionField" aria-labelledby="versionLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="pageCountLabel" data-l10n-id="pdfjs-document-properties-page-count"></span>
-            <p id="pageCountField" aria-labelledby="pageCountLabel">-</p>
-          </div>
-          <div class="row">
-            <span id="pageSizeLabel" data-l10n-id="pdfjs-document-properties-page-size"></span>
-            <p id="pageSizeField" aria-labelledby="pageSizeLabel">-</p>
-          </div>
-          <div class="separator"></div>
-          <div class="row">
-            <span id="linearizedLabel" data-l10n-id="pdfjs-document-properties-linearized"></span>
-            <p id="linearizedField" aria-labelledby="linearizedLabel">-</p>
-          </div>
-          <div class="buttonRow">
-            <button id="documentPropertiesClose" class="dialogButton" type="button"><span data-l10n-id="pdfjs-document-properties-close-button"></span></button>
-          </div>
-        </dialog>
-        <dialog class="dialog altText" id="altTextDialog" aria-labelledby="dialogLabel" aria-describedby="dialogDescription">
-          <div id="altTextContainer" class="mainContainer">
-            <div id="overallDescription">
-              <span id="dialogLabel" data-l10n-id="pdfjs-editor-alt-text-dialog-label" class="title"></span>
-              <span id="dialogDescription" data-l10n-id="pdfjs-editor-alt-text-dialog-description"></span>
-            </div>
-            <div id="addDescription">
-              <div class="radio">
-                <div class="radioButton">
-                  <input type="radio" id="descriptionButton" name="altTextOption" tabindex="0" aria-describedby="descriptionAreaLabel" checked />
-                  <label for="descriptionButton" data-l10n-id="pdfjs-editor-alt-text-add-description-label"></label>
-                </div>
-                <div class="radioLabel">
-                  <span id="descriptionAreaLabel" data-l10n-id="pdfjs-editor-alt-text-add-description-description"></span>
-                </div>
+          <div id="addDescription">
+            <div class="radio">
+              <div class="radioButton">
+                <input type="radio" id="descriptionButton" name="altTextOption" tabindex="0"
+                  aria-describedby="descriptionAreaLabel" checked />
+                <label for="descriptionButton" data-l10n-id="pdfjs-editor-alt-text-add-description-label"></label>
               </div>
-              <div class="descriptionArea">
-                <textarea id="descriptionTextarea" aria-labelledby="descriptionAreaLabel" data-l10n-id="pdfjs-editor-alt-text-textarea" tabindex="0"></textarea>
-              </div>
-            </div>
-            <div id="markAsDecorative">
-              <div class="radio">
-                <div class="radioButton">
-                  <input type="radio" id="decorativeButton" name="altTextOption" aria-describedby="decorativeLabel" />
-                  <label for="decorativeButton" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-label"></label>
-                </div>
-                <div class="radioLabel">
-                  <span id="decorativeLabel" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-description"></span>
-                </div>
+              <div class="radioLabel">
+                <span id="descriptionAreaLabel" data-l10n-id="pdfjs-editor-alt-text-add-description-description"></span>
               </div>
             </div>
-            <div id="buttons">
-              <button id="altTextCancel" class="secondaryButton" type="button" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+            <div class="descriptionArea">
+              <textarea id="descriptionTextarea" aria-labelledby="descriptionAreaLabel"
+                data-l10n-id="pdfjs-editor-alt-text-textarea" tabindex="0"></textarea>
+            </div>
+          </div>
+          <div id="markAsDecorative">
+            <div class="radio">
+              <div class="radioButton">
+                <input type="radio" id="decorativeButton" name="altTextOption" aria-describedby="decorativeLabel" />
+                <label for="decorativeButton" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-label"></label>
+              </div>
+              <div class="radioLabel">
+                <span id="decorativeLabel" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-description"></span>
+              </div>
+            </div>
+          </div>
+          <div id="buttons">
+            <button id="altTextCancel" class="secondaryButton" type="button" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+            </button>
+            <button id="altTextSave" class="primaryButton" type="button" tabindex="0"><span
+                data-l10n-id="pdfjs-editor-alt-text-save-button"></span></button>
+          </div>
+        </div>
+      </dialog>
+      <dialog class="dialog newAltText" id="newAltTextDialog" aria-labelledby="newAltTextTitle"
+        aria-describedby="newAltTextDescription" tabindex="0">
+        <div id="newAltTextContainer" class="mainContainer">
+          <div class="title">
+            <span id="newAltTextTitle" data-l10n-id="pdfjs-editor-new-alt-text-dialog-edit-label" role="sectionhead"
+              tabindex="0"></span>
+          </div>
+          <div id="mainContent">
+            <div id="descriptionAndSettings">
+              <div id="descriptionInstruction">
+                <div id="newAltTextDescriptionContainer">
+                  <div class="altTextSpinner" role="status" aria-live="polite"></div>
+                  <textarea id="newAltTextDescriptionTextarea" aria-labelledby="descriptionAreaLabel"
+                    data-l10n-id="pdfjs-editor-new-alt-text-textarea" tabindex="0"></textarea>
+                </div>
+                <span id="newAltTextDescription" role="note"
+                  data-l10n-id="pdfjs-editor-new-alt-text-description"></span>
+                <div id="newAltTextDisclaimer" role="note">
+                  <div>
+                    <span data-l10n-id="pdfjs-editor-new-alt-text-disclaimer1"></span>
+                    <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank"
+                      rel="noopener noreferrer" id="newAltTextLearnMore"
+                      data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url" tabindex="0"></a>
+                  </div>
+                </div>
+              </div>
+              <div id="newAltTextCreateAutomatically" class="toggler">
+                <button id="newAltTextCreateAutomaticallyButton" class="toggle-button" type="button" aria-pressed="true"
+                  tabindex="0"></button>
+                <label for="newAltTextCreateAutomaticallyButton" class="togglerLabel"
+                  data-l10n-id="pdfjs-editor-new-alt-text-create-automatically-button-label"></label>
+              </div>
+              <div id="newAltTextDownloadModel" class="hidden">
+                <span id="newAltTextDownloadModelDescription"
+                  data-l10n-id="pdfjs-editor-new-alt-text-ai-model-downloading-progress" aria-valuemin="0"
+                  data-l10n-args='{ "totalSize": 0, "downloadedSize": 0 }'></span>
+              </div>
+            </div>
+            <div id="newAltTextImagePreview"></div>
+          </div>
+          <div id="newAltTextError" class="messageBar">
+            <div>
+              <div>
+                <span class="title" data-l10n-id="pdfjs-editor-new-alt-text-error-title"></span>
+                <span class="description" data-l10n-id="pdfjs-editor-new-alt-text-error-description"></span>
+              </div>
+              <button id="newAltTextCloseButton" class="closeButton" type="button" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-new-alt-text-error-close-button"></span>
               </button>
-              <button id="altTextSave" class="primaryButton" type="button" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button"></span></button>
             </div>
           </div>
-        </dialog>
-        <dialog class="dialog newAltText" id="newAltTextDialog" aria-labelledby="newAltTextTitle" aria-describedby="newAltTextDescription" tabindex="0">
-          <div id="newAltTextContainer" class="mainContainer">
-            <div class="title">
-              <span id="newAltTextTitle" data-l10n-id="pdfjs-editor-new-alt-text-dialog-edit-label" role="sectionhead" tabindex="0"></span>
-            </div>
-            <div id="mainContent">
-              <div id="descriptionAndSettings">
-                <div id="descriptionInstruction">
-                  <div id="newAltTextDescriptionContainer">
-                    <div class="altTextSpinner" role="status" aria-live="polite"></div>
-                    <textarea
-                      id="newAltTextDescriptionTextarea"
-                      aria-labelledby="descriptionAreaLabel"
-                      data-l10n-id="pdfjs-editor-new-alt-text-textarea"
-                      tabindex="0"
-                    ></textarea>
-                  </div>
-                  <span id="newAltTextDescription" role="note" data-l10n-id="pdfjs-editor-new-alt-text-description"></span>
-                  <div id="newAltTextDisclaimer" role="note">
-                    <div>
-                      <span data-l10n-id="pdfjs-editor-new-alt-text-disclaimer1"></span>
-                      <a
-                        href="https://support.mozilla.org/en-US/kb/pdf-alt-text"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        id="newAltTextLearnMore"
-                        data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
-                        tabindex="0"
-                      ></a>
-                    </div>
-                  </div>
+          <div id="newAltTextButtons" class="dialogButtonsGroup">
+            <button id="newAltTextCancel" type="button" class="secondaryButton hidden" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+            </button>
+            <button id="newAltTextNotNow" type="button" class="secondaryButton" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-new-alt-text-not-now-button"></span>
+            </button>
+            <button id="newAltTextSave" type="button" class="primaryButton" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-alt-text-save-button"></span>
+            </button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog class="dialog" id="altTextSettingsDialog" aria-labelledby="altTextSettingsTitle">
+        <div id="altTextSettingsContainer" class="mainContainer">
+          <div class="title">
+            <span id="altTextSettingsTitle" data-l10n-id="pdfjs-editor-alt-text-settings-dialog-label"
+              role="sectionhead" tabindex="0" class="title"></span>
+          </div>
+          <div id="automaticAltText">
+            <span data-l10n-id="pdfjs-editor-alt-text-settings-automatic-title"></span>
+            <div id="automaticSettings">
+              <div id="createModelSetting">
+                <div class="toggler">
+                  <button id="createModelButton" type="button" class="toggle-button" aria-pressed="true"
+                    tabindex="0"></button>
+                  <label for="createModelButton" class="togglerLabel"
+                    data-l10n-id="pdfjs-editor-alt-text-settings-create-model-button-label"></label>
                 </div>
-                <div id="newAltTextCreateAutomatically" class="toggler">
-                  <button id="newAltTextCreateAutomaticallyButton" class="toggle-button" type="button" aria-pressed="true" tabindex="0"></button>
-                  <label
-                    for="newAltTextCreateAutomaticallyButton"
-                    class="togglerLabel"
-                    data-l10n-id="pdfjs-editor-new-alt-text-create-automatically-button-label"
-                  ></label>
-                </div>
-                <div id="newAltTextDownloadModel" class="hidden">
-                  <span
-                    id="newAltTextDownloadModelDescription"
-                    data-l10n-id="pdfjs-editor-new-alt-text-ai-model-downloading-progress"
-                    aria-valuemin="0"
-                    data-l10n-args='{ "totalSize": 0, "downloadedSize": 0 }'
-                  ></span>
+                <div id="createModelDescription" class="description">
+                  <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description"></span>
+                  <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank" rel="noopener noreferrer"
+                    id="altTextSettingsLearnMore" data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
+                    tabindex="0"></a>
                 </div>
               </div>
-              <div id="newAltTextImagePreview"></div>
+              <div id="aiModelSettings">
+                <div>
+                  <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-label"
+                    data-l10n-args='{ "totalSize": 180 }'></span>
+                  <div id="aiModelDescription" class="description">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-ai-model-description"></span>
+                  </div>
+                </div>
+                <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button"></span>
+                </button>
+                <button id="downloadModelButton" type="button" class="secondaryButton" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button"></span>
+                </button>
+              </div>
             </div>
-            <div id="newAltTextError" class="messageBar">
+          </div>
+          <div class="dialogSeparator"></div>
+          <div id="altTextEditor">
+            <span data-l10n-id="pdfjs-editor-alt-text-settings-editor-title"></span>
+            <div id="showAltTextEditor">
+              <div class="toggler">
+                <button id="showAltTextDialogButton" type="button" class="toggle-button" aria-pressed="true"
+                  tabindex="0"></button>
+                <label for="showAltTextDialogButton" class="togglerLabel"
+                  data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-button-label"></label>
+              </div>
+              <div id="showAltTextDialogDescription" class="description">
+                <span data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-description"></span>
+              </div>
+            </div>
+          </div>
+          <div id="buttons" class="dialogButtonsGroup">
+            <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-alt-text-settings-close-button"></span>
+            </button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog class="dialog signatureDialog" id="addSignatureDialog" aria-labelledby="addSignatureDialogLabel">
+        <span id="addSignatureDialogLabel" data-l10n-id="pdfjs-editor-add-signature-dialog-label"></span>
+        <div id="addSignatureContainer" class="mainContainer">
+          <div class="title">
+            <span role="sectionhead" data-l10n-id="pdfjs-editor-add-signature-dialog-title" tabindex="0"></span>
+          </div>
+          <div role="tablist" id="addSignatureOptions">
+            <button id="addSignatureTypeButton" type="button" role="tab" aria-selected="true"
+              aria-controls="addSignatureTypeContainer" data-l10n-id="pdfjs-editor-add-signature-type-button"
+              tabindex="0"></button>
+            <button id="addSignatureDrawButton" type="button" role="tab" aria-selected="false"
+              aria-controls="addSignatureDrawContainer" data-l10n-id="pdfjs-editor-add-signature-draw-button"
+              tabindex="0"></button>
+            <button id="addSignatureImageButton" type="button" role="tab" aria-selected="false"
+              aria-controls="addSignatureImageContainer" data-l10n-id="pdfjs-editor-add-signature-image-button"
+              tabindex="-1"></button>
+          </div>
+          <div id="addSignatureActionContainer" data-selected="type">
+            <div id="addSignatureTypeContainer" role="tabpanel" aria-labelledby="addSignatureTypeContainer">
+              <input id="addSignatureTypeInput" type="text" data-l10n-id="pdfjs-editor-add-signature-type-input"
+                tabindex="0" />
+            </div>
+            <div id="addSignatureDrawContainer" role="tabpanel" aria-labelledby="addSignatureDrawButton" tabindex="-1">
+              <svg id="addSignatureDraw" xmlns="http://www.w3.org/2000/svg"
+                aria-labelledby="addSignatureDrawPlaceholder"></svg>
+              <span id="addSignatureDrawPlaceholder" data-l10n-id="pdfjs-editor-add-signature-draw-placeholder"></span>
+              <div id="thickness">
+                <div>
+                  <label for="addSignatureDrawThickness"
+                    data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range-label"></label>
+                  <input type="range" id="addSignatureDrawThickness" min="1" max="5" step="1" value="1"
+                    data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range" data-l10n-args='{ "thickness": 1 }'
+                    tabindex="0" />
+                </div>
+              </div>
+            </div>
+            <div id="addSignatureImageContainer" role="tabpanel" aria-labelledby="addSignatureImageButton"
+              tabindex="-1">
+              <svg id="addSignatureImage" xmlns="http://www.w3.org/2000/svg"
+                aria-labelledby="addSignatureImagePlaceholder"></svg>
+              <div id="addSignatureImagePlaceholder">
+                <span data-l10n-id="pdfjs-editor-add-signature-image-placeholder"></span>
+                <label id="addSignatureImageBrowse" for="addSignatureFilePicker" tabindex="0">
+                  <a data-l10n-id="pdfjs-editor-add-signature-image-browse-link"></a>
+                </label>
+                <input id="addSignatureFilePicker" type="file" />
+              </div>
+            </div>
+            <div id="addSignatureControls">
+              <div id="horizontalContainer">
+                <div id="addSignatureDescriptionContainer">
+                  <label for="addSignatureDescInput"
+                    data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
+                  <span id="addSignatureDescription" class="inputWithClearButton">
+                    <input id="addSignatureDescInput" type="text"
+                      data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
+                    <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
+                  </span>
+                </div>
+                <button id="clearSignatureButton" type="button" data-l10n-id="pdfjs-editor-add-signature-clear-button"
+                  tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-add-signature-clear-button-label"></span>
+                </button>
+              </div>
+              <div id="addSignatureSaveContainer">
+                <input type="checkbox" id="addSignatureSaveCheckbox" />
+                <label for="addSignatureSaveCheckbox" data-l10n-id="pdfjs-editor-add-signature-save-checkbox"></label>
+                <span></span>
+                <span id="addSignatureSaveWarning"
+                  data-l10n-id="pdfjs-editor-add-signature-save-warning-message"></span>
+              </div>
+            </div>
+            <div id="addSignatureError" hidden="true" class="messageBar">
               <div>
                 <div>
-                  <span class="title" data-l10n-id="pdfjs-editor-new-alt-text-error-title"></span>
-                  <span class="description" data-l10n-id="pdfjs-editor-new-alt-text-error-description"></span>
+                  <span id="addSignatureErrorTitle" class="title"
+                    data-l10n-id="pdfjs-editor-add-signature-image-upload-error-title"></span>
+                  <span id="addSignatureErrorDescription" class="description"
+                    data-l10n-id="pdfjs-editor-add-signature-image-upload-error-description"></span>
                 </div>
-                <button id="newAltTextCloseButton" class="closeButton" type="button" tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-new-alt-text-error-close-button"></span>
+                <button id="addSignatureErrorCloseButton" class="closeButton" type="button" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-add-signature-error-close-button"></span>
                 </button>
               </div>
-            </div>
-            <div id="newAltTextButtons" class="dialogButtonsGroup">
-              <button id="newAltTextCancel" type="button" class="secondaryButton hidden" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
-              </button>
-              <button id="newAltTextNotNow" type="button" class="secondaryButton" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-new-alt-text-not-now-button"></span>
-              </button>
-              <button id="newAltTextSave" type="button" class="primaryButton" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-alt-text-save-button"></span>
-              </button>
-            </div>
-          </div>
-        </dialog>
-
-        <dialog class="dialog" id="altTextSettingsDialog" aria-labelledby="altTextSettingsTitle">
-          <div id="altTextSettingsContainer" class="mainContainer">
-            <div class="title">
-              <span id="altTextSettingsTitle" data-l10n-id="pdfjs-editor-alt-text-settings-dialog-label" role="sectionhead" tabindex="0" class="title"></span>
-            </div>
-            <div id="automaticAltText">
-              <span data-l10n-id="pdfjs-editor-alt-text-settings-automatic-title"></span>
-              <div id="automaticSettings">
-                <div id="createModelSetting">
-                  <div class="toggler">
-                    <button id="createModelButton" type="button" class="toggle-button" aria-pressed="true" tabindex="0"></button>
-                    <label for="createModelButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-create-model-button-label"></label>
-                  </div>
-                  <div id="createModelDescription" class="description">
-                    <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description"></span>
-                    <a
-                      href="https://support.mozilla.org/en-US/kb/pdf-alt-text"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      id="altTextSettingsLearnMore"
-                      data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
-                      tabindex="0"
-                    ></a>
-                  </div>
-                </div>
-                <div id="aiModelSettings">
-                  <div>
-                    <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-label" data-l10n-args='{ "totalSize": 180 }'></span>
-                    <div id="aiModelDescription" class="description">
-                      <span data-l10n-id="pdfjs-editor-alt-text-settings-ai-model-description"></span>
-                    </div>
-                  </div>
-                  <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0">
-                    <span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button"></span>
-                  </button>
-                  <button id="downloadModelButton" type="button" class="secondaryButton" tabindex="0">
-                    <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button"></span>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div class="dialogSeparator"></div>
-            <div id="altTextEditor">
-              <span data-l10n-id="pdfjs-editor-alt-text-settings-editor-title"></span>
-              <div id="showAltTextEditor">
-                <div class="toggler">
-                  <button id="showAltTextDialogButton" type="button" class="toggle-button" aria-pressed="true" tabindex="0"></button>
-                  <label for="showAltTextDialogButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-button-label"></label>
-                </div>
-                <div id="showAltTextDialogDescription" class="description">
-                  <span data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-description"></span>
-                </div>
-              </div>
-            </div>
-            <div id="buttons" class="dialogButtonsGroup">
-              <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-alt-text-settings-close-button"></span>
-              </button>
-            </div>
-          </div>
-        </dialog>
-
-        <dialog class="dialog signatureDialog" id="addSignatureDialog" aria-labelledby="addSignatureDialogLabel">
-          <span id="addSignatureDialogLabel" data-l10n-id="pdfjs-editor-add-signature-dialog-label"></span>
-          <div id="addSignatureContainer" class="mainContainer">
-            <div class="title">
-              <span role="sectionhead" data-l10n-id="pdfjs-editor-add-signature-dialog-title" tabindex="0"></span>
-            </div>
-            <div role="tablist" id="addSignatureOptions">
-              <button
-                id="addSignatureTypeButton"
-                type="button"
-                role="tab"
-                aria-selected="true"
-                aria-controls="addSignatureTypeContainer"
-                data-l10n-id="pdfjs-editor-add-signature-type-button"
-                tabindex="0"
-              ></button>
-              <button
-                id="addSignatureDrawButton"
-                type="button"
-                role="tab"
-                aria-selected="false"
-                aria-controls="addSignatureDrawContainer"
-                data-l10n-id="pdfjs-editor-add-signature-draw-button"
-                tabindex="0"
-              ></button>
-              <button
-                id="addSignatureImageButton"
-                type="button"
-                role="tab"
-                aria-selected="false"
-                aria-controls="addSignatureImageContainer"
-                data-l10n-id="pdfjs-editor-add-signature-image-button"
-                tabindex="-1"
-              ></button>
-            </div>
-            <div id="addSignatureActionContainer" data-selected="type">
-              <div id="addSignatureTypeContainer" role="tabpanel" aria-labelledby="addSignatureTypeContainer">
-                <input id="addSignatureTypeInput" type="text" data-l10n-id="pdfjs-editor-add-signature-type-input" tabindex="0" />
-              </div>
-              <div id="addSignatureDrawContainer" role="tabpanel" aria-labelledby="addSignatureDrawButton" tabindex="-1">
-                <svg id="addSignatureDraw" xmlns="http://www.w3.org/2000/svg" aria-labelledby="addSignatureDrawPlaceholder"></svg>
-                <span id="addSignatureDrawPlaceholder" data-l10n-id="pdfjs-editor-add-signature-draw-placeholder"></span>
-                <div id="thickness">
-                  <div>
-                    <label for="addSignatureDrawThickness" data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range-label"></label>
-                    <input
-                      type="range"
-                      id="addSignatureDrawThickness"
-                      min="1"
-                      max="5"
-                      step="1"
-                      value="1"
-                      data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range"
-                      data-l10n-args='{ "thickness": 1 }'
-                      tabindex="0"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div id="addSignatureImageContainer" role="tabpanel" aria-labelledby="addSignatureImageButton" tabindex="-1">
-                <svg id="addSignatureImage" xmlns="http://www.w3.org/2000/svg" aria-labelledby="addSignatureImagePlaceholder"></svg>
-                <div id="addSignatureImagePlaceholder">
-                  <span data-l10n-id="pdfjs-editor-add-signature-image-placeholder"></span>
-                  <label id="addSignatureImageBrowse" for="addSignatureFilePicker" tabindex="0">
-                    <a data-l10n-id="pdfjs-editor-add-signature-image-browse-link"></a>
-                  </label>
-                  <input id="addSignatureFilePicker" type="file" />
-                </div>
-              </div>
-              <div id="addSignatureControls">
-                <div id="horizontalContainer">
-                  <div id="addSignatureDescriptionContainer">
-                    <label for="addSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
-                    <span id="addSignatureDescription" class="inputWithClearButton">
-                      <input id="addSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
-                      <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
-                    </span>
-                  </div>
-                  <button id="clearSignatureButton" type="button" data-l10n-id="pdfjs-editor-add-signature-clear-button" tabindex="0">
-                    <span data-l10n-id="pdfjs-editor-add-signature-clear-button-label"></span>
-                  </button>
-                </div>
-                <div id="addSignatureSaveContainer">
-                  <input type="checkbox" id="addSignatureSaveCheckbox" />
-                  <label for="addSignatureSaveCheckbox" data-l10n-id="pdfjs-editor-add-signature-save-checkbox"></label>
-                  <span></span>
-                  <span id="addSignatureSaveWarning" data-l10n-id="pdfjs-editor-add-signature-save-warning-message"></span>
-                </div>
-              </div>
-              <div id="addSignatureError" hidden="true" class="messageBar">
-                <div>
-                  <div>
-                    <span id="addSignatureErrorTitle" class="title" data-l10n-id="pdfjs-editor-add-signature-image-upload-error-title"></span>
-                    <span id="addSignatureErrorDescription" class="description" data-l10n-id="pdfjs-editor-add-signature-image-upload-error-description"></span>
-                  </div>
-                  <button id="addSignatureErrorCloseButton" class="closeButton" type="button" tabindex="0">
-                    <span data-l10n-id="pdfjs-editor-add-signature-error-close-button"></span>
-                  </button>
-                </div>
-              </div>
-              <div class="dialogButtonsGroup">
-                <button id="addSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
-                </button>
-                <button id="addSignatureAddButton" type="button" class="primaryButton" disabled tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-add-signature-add-button"></span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </dialog>
-
-        <dialog class="dialog signatureDialog" id="editSignatureDescriptionDialog" aria-labelledby="editSignatureDescriptionTitle">
-          <div id="editSignatureDescriptionContainer" class="mainContainer">
-            <div class="title">
-              <span id="editSignatureDescriptionTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-signature-dialog-title" tabindex="0"></span>
-            </div>
-            <div id="editSignatureDescriptionAndView">
-              <div id="editSignatureDescriptionContainer">
-                <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
-                <span id="editSignatureDescription" class="inputWithClearButton">
-                  <input id="editSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
-                  <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
-                </span>
-              </div>
-              <svg id="editSignatureView" xmlns="http://www.w3.org/2000/svg"></svg>
             </div>
             <div class="dialogButtonsGroup">
-              <button id="editSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
+              <button id="addSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
                 <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
               </button>
-              <button id="editSignatureUpdateButton" type="button" class="primaryButton" disabled tabindex="0">
-                <span data-l10n-id="pdfjs-editor-edit-signature-update-button"></span>
+              <button id="addSignatureAddButton" type="button" class="primaryButton" disabled tabindex="0">
+                <span data-l10n-id="pdfjs-editor-add-signature-add-button"></span>
               </button>
             </div>
           </div>
-        </dialog>
-
-        <dialog class="dialog commentManager" id="commentManagerDialog" aria-labelledby="commentManagerTitle">
-          <div class="mainContainer">
-            <div class="title" id="commentManagerToolbar">
-              <span id="commentManagerTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-comment-dialog-title-when-adding"></span>
-            </div>
-            <textarea id="commentManagerTextInput" data-l10n-id="pdfjs-editor-edit-comment-dialog-text-input" tabindex="0"></textarea>
-            <div class="dialogButtonsGroup">
-              <button id="commentManagerCancelButton" type="button" class="secondaryButton" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-edit-comment-dialog-cancel-button"></span>
-              </button>
-              <button id="commentManagerSaveButton" type="button" class="primaryButton" disabled tabindex="0">
-                <span data-l10n-id="pdfjs-editor-edit-comment-dialog-save-button-when-adding"></span>
-              </button>
-            </div>
-          </div>
-        </dialog>
-
-        <!--#if !MOZCENTRAL-->
-        <dialog id="printServiceDialog" style="min-width: 200px">
-          <div class="row">
-            <span data-l10n-id="pdfjs-print-progress-message"></span>
-          </div>
-          <div class="row">
-            <progress value="0" max="100"></progress>
-            <span data-l10n-id="pdfjs-print-progress-percent" data-l10n-args='{ "progress": 0 }' class="relative-progress">0%</span>
-          </div>
-          <div class="buttonRow">
-            <button id="printCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-print-progress-close-button"></span></button>
-          </div>
-        </dialog>
-        <!--#endif-->
-        <!--#if CHROME-->
-        <!--#include viewer-snippet-chrome-overlays.html-->
-        <!--#endif-->
-      </div>
-      <!-- dialogContainer -->
-
-      <div id="editorUndoBar" class="messageBar" role="status" aria-labelledby="editorUndoBarMessage" tabindex="-1" hidden>
-        <div>
-          <div>
-            <span id="editorUndoBarMessage" class="description"></span>
-          </div>
-          <button id="editorUndoBarUndoButton" class="undoButton" type="button" tabindex="0" data-l10n-id="pdfjs-editor-undo-bar-undo-button">
-            <span data-l10n-id="pdfjs-editor-undo-bar-undo-button-label"></span>
-          </button>
-          <button id="editorUndoBarCloseButton" class="closeButton" type="button" tabindex="0" data-l10n-id="pdfjs-editor-undo-bar-close-button">
-            <span data-l10n-id="pdfjs-editor-undo-bar-close-button-label"></span>
-          </button>
         </div>
-      </div>
-      <!-- editorUndoBar -->
+      </dialog>
+
+      <dialog class="dialog signatureDialog" id="editSignatureDescriptionDialog"
+        aria-labelledby="editSignatureDescriptionTitle">
+        <div id="editSignatureDescriptionContainer" class="mainContainer">
+          <div class="title">
+            <span id="editSignatureDescriptionTitle" role="sectionhead"
+              data-l10n-id="pdfjs-editor-edit-signature-dialog-title" tabindex="0"></span>
+          </div>
+          <div id="editSignatureDescriptionAndView">
+            <div id="editSignatureDescriptionContainer">
+              <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
+              <span id="editSignatureDescription" class="inputWithClearButton">
+                <input id="editSignatureDescInput" type="text"
+                  data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
+                <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
+              </span>
+            </div>
+            <svg id="editSignatureView" xmlns="http://www.w3.org/2000/svg"></svg>
+          </div>
+          <div class="dialogButtonsGroup">
+            <button id="editSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
+            </button>
+            <button id="editSignatureUpdateButton" type="button" class="primaryButton" disabled tabindex="0">
+              <span data-l10n-id="pdfjs-editor-edit-signature-update-button"></span>
+            </button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog class="dialog commentManager" id="commentManagerDialog" aria-labelledby="commentManagerTitle">
+        <div class="mainContainer">
+          <div class="title" id="commentManagerToolbar">
+            <span id="commentManagerTitle" role="sectionhead"
+              data-l10n-id="pdfjs-editor-edit-comment-dialog-title-when-adding"></span>
+          </div>
+          <textarea id="commentManagerTextInput" data-l10n-id="pdfjs-editor-edit-comment-dialog-text-input"
+            tabindex="0"></textarea>
+          <div class="dialogButtonsGroup">
+            <button id="commentManagerCancelButton" type="button" class="secondaryButton" tabindex="0">
+              <span data-l10n-id="pdfjs-editor-edit-comment-dialog-cancel-button"></span>
+            </button>
+            <button id="commentManagerSaveButton" type="button" class="primaryButton" disabled tabindex="0">
+              <span data-l10n-id="pdfjs-editor-edit-comment-dialog-save-button-when-adding"></span>
+            </button>
+          </div>
+        </div>
+      </dialog>
+
+      <!--#if !MOZCENTRAL-->
+      <dialog id="printServiceDialog" style="min-width: 200px">
+        <div class="row">
+          <span data-l10n-id="pdfjs-print-progress-message"></span>
+        </div>
+        <div class="row">
+          <progress value="0" max="100"></progress>
+          <span data-l10n-id="pdfjs-print-progress-percent" data-l10n-args='{ "progress": 0 }'
+            class="relative-progress">0%</span>
+        </div>
+        <div class="buttonRow">
+          <button id="printCancel" class="dialogButton" type="button"><span
+              data-l10n-id="pdfjs-print-progress-close-button"></span></button>
+        </div>
+      </dialog>
+      <!--#endif-->
+      <!--#if CHROME-->
+      <!--#include viewer-snippet-chrome-overlays.html-->
+      <!--#endif-->
     </div>
-    <!-- outerContainer -->
-    <div id="printContainer"></div>
-  </body>
+    <!-- dialogContainer -->
+
+    <div id="editorUndoBar" class="messageBar" role="status" aria-labelledby="editorUndoBarMessage" tabindex="-1"
+      hidden>
+      <div>
+        <div>
+          <span id="editorUndoBarMessage" class="description"></span>
+        </div>
+        <button id="editorUndoBarUndoButton" class="undoButton" type="button" tabindex="0"
+          data-l10n-id="pdfjs-editor-undo-bar-undo-button">
+          <span data-l10n-id="pdfjs-editor-undo-bar-undo-button-label"></span>
+        </button>
+        <button id="editorUndoBarCloseButton" class="closeButton" type="button" tabindex="0"
+          data-l10n-id="pdfjs-editor-undo-bar-close-button">
+          <span data-l10n-id="pdfjs-editor-undo-bar-close-button-label"></span>
+        </button>
+      </div>
+    </div>
+    <!-- editorUndoBar -->
+  </div>
+  <!-- outerContainer -->
+  <div id="printContainer"></div>
+</body>
+
 </html>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -21,38 +21,37 @@ Adobe CMap resources are covered by their own copyright but the same license:
 See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <!--#if GENERIC || CHROME-->
+    <meta name="google" content="notranslate" />
+    <!--#endif-->
+    <title>PDF.js viewer</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-  <!--#if GENERIC || CHROME-->
-  <meta name="google" content="notranslate" />
-  <!--#endif-->
-  <title>PDF.js viewer</title>
+    <!--#if MOZCENTRAL-->
+    <!--#include viewer-snippet-firefox-extension.html-->
+    <!--#elif CHROME-->
+    <!--#include viewer-snippet-chrome-extension.html-->
+    <!--#else-->
+    <!--#include viewer-snippet.html-->
+    <!--#endif-->
 
-  <!--#if MOZCENTRAL-->
-  <!--#include viewer-snippet-firefox-extension.html-->
-  <!--#elif CHROME-->
-  <!--#include viewer-snippet-chrome-extension.html-->
-  <!--#else-->
-  <!--#include viewer-snippet.html-->
-  <!--#endif-->
+    <!--#if MOZCENTRAL-->
+    <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
+    <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
+    <!--#else-->
+    <link rel="stylesheet" href="viewer.css" />
+    <!--#endif-->
 
-  <!--#if MOZCENTRAL-->
-  <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
-  <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
-  <!--#else-->
-  <link rel="stylesheet" href="viewer.css" />
-  <!--#endif-->
+    <!--#if MOZCENTRAL-->
+    <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
+    <!--#elif !MOZCENTRAL-->
+    <!--<script src="viewer.mjs" type="module"></script>-->
+    <!--#elif /* Development mode. */-->
+    <link rel="resource" type="application/l10n" href="locale/locale.json" />
 
-  <!--#if MOZCENTRAL-->
-  <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
-  <!--#elif !MOZCENTRAL-->
-  <!--<script src="viewer.mjs" type="module"></script>-->
-  <!--#elif /* Development mode. */-->
-  <link rel="resource" type="application/l10n" href="locale/locale.json" />
-
-  <script type="importmap">
+    <script type="importmap">
       {
         "imports": {
           "pdfjs/": "../src/",
@@ -94,1009 +93,1210 @@ See https://github.com/adobe-type-tools/cmap-resources
         }
       }
     </script>
-  <script src="viewer.js" type="module"></script>
-  <!--#endif-->
-</head>
+    <script src="viewer.js" type="module"></script>
+    <!--#endif-->
+  </head>
 
-<body tabindex="0">
-  <div id="outerContainer">
-    <span id="viewer-alert" class="visuallyHidden" role="alert"></span>
+  <body tabindex="0">
+    <div id="outerContainer">
+      <span id="viewer-alert" class="visuallyHidden" role="alert"></span>
 
-    <div id="mainContainer">
-      <div class="toolbar">
-        <div id="toolbarContainer">
-          <div id="toolbarViewer" class="toolbarHorizontalGroup">
-            <div id="toolbarViewerLeft" class="toolbarHorizontalGroup">
-              <button id="viewsManagerToggleButton" class="toolbarButton" type="button" tabindex="0"
-                data-l10n-id="pdfjs-toggle-views-manager-button" aria-expanded="false" aria-haspopup="true"
-                aria-controls="viewsManager">
-                <span data-l10n-id="pdfjs-toggle-views-manager-button-label"></span>
-              </button>
-              <div id="viewsManager" class="menuContainer sidebar" hidden="true" role="dialog"
-                aria-describedby="viewsManagerHeaderLabel" data-l10n-id="pdfjs-views-manager-sidebar">
-                <div id="viewsManagerHeader" role="heading" aria-level="2">
-                  <div id="viewsManagerTitle">
-                    <div id="viewsManagerSelector">
-                      <button class="toolbarButton viewsManagerButton" type="button" id="viewsManagerSelectorButton"
-                        tabindex="0" data-l10n-id="pdfjs-views-manager-view-selector-button" aria-expanded="false"
-                        aria-haspopup="listbox" aria-controls="viewsManagerSelectorOptions">
-                        <span data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
-                      </button>
-                      <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu hidden withMark">
-                        <li>
-                          <button id="thumbnailsViewMenu" role="option" type="button" tabindex="-1">
-                            <span data-l10n-id="pdfjs-views-manager-pages-option-label"></span>
-                          </button>
-                        </li>
-                        <li>
-                          <button id="outlinesViewMenu" role="option" type="button" tabindex="-1">
-                            <span data-l10n-id="pdfjs-views-manager-outlines-option-label"></span>
-                          </button>
-                        </li>
-                        <li>
-                          <button id="attachmentsViewMenu" role="option" type="button" tabindex="-1">
-                            <span data-l10n-id="pdfjs-views-manager-attachments-option-label"></span>
-                          </button>
-                        </li>
-                        <li>
-                          <button id="layersViewMenu" role="option" type="button" tabindex="-1">
-                            <span data-l10n-id="pdfjs-views-manager-layers-option-label"></span>
-                          </button>
-                        </li>
-                      </menu>
-                    </div>
-                    <span id="viewsManagerHeaderLabel" class="viewsManagerLabel"></span>
-                    <button id="viewsManagerAddFileButton" class="toolbarButton viewsManagerButton" type="button"
-                      tabindex="0" data-l10n-id="pdfjs-views-manager-add-file-button" hidden="true">
-                      <span data-l10n-id="pdfjs-views-manager-add-file-button-label"></span>
-                    </button>
-                    <button id="viewsManagerCurrentOutlineButton" class="toolbarButton viewsManagerButton" type="button"
-                      tabindex="0" data-l10n-id="pdfjs-current-outline-item-button" hidden="true">
-                      <span data-l10n-id="pdfjs-current-outline-item-button-label"></span>
-                    </button>
-                  </div>
-                  <div id="viewsManagerStatus">
-                    <div id="viewsManagerStatusAction" class="hidden">
-                      <span id="viewsManagerStatusActionLabel" class="viewsManagerStatusLabel"
-                        data-l10n-id="pdfjs-views-manager-pages-status-none-action-label"></span>
-                      <div id="actionSelector">
-                        <button id="viewsManagerStatusActionButton" class="viewsManagerButton" type="button"
-                          tabindex="0" aria-haspopup="menu" aria-controls="viewsManagerStatusActionOptions">
-                          <span data-l10n-id="pdfjs-views-manager-pages-status-action-button-label"></span>
+      <div id="mainContainer">
+        <div class="toolbar">
+          <div id="toolbarContainer">
+            <div id="toolbarViewer" class="toolbarHorizontalGroup">
+              <div id="toolbarViewerLeft" class="toolbarHorizontalGroup">
+                <button
+                  id="viewsManagerToggleButton"
+                  class="toolbarButton"
+                  type="button"
+                  tabindex="0"
+                  data-l10n-id="pdfjs-toggle-views-manager-button"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-controls="viewsManager"
+                >
+                  <span data-l10n-id="pdfjs-toggle-views-manager-button-label"></span>
+                </button>
+                <div
+                  id="viewsManager"
+                  class="menuContainer sidebar"
+                  hidden="true"
+                  role="dialog"
+                  aria-describedby="viewsManagerHeaderLabel"
+                  data-l10n-id="pdfjs-views-manager-sidebar"
+                >
+                  <div id="viewsManagerHeader" role="heading" aria-level="2">
+                    <div id="viewsManagerTitle">
+                      <div id="viewsManagerSelector">
+                        <button
+                          class="toolbarButton viewsManagerButton"
+                          type="button"
+                          id="viewsManagerSelectorButton"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-views-manager-view-selector-button"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-controls="viewsManagerSelectorOptions"
+                        >
+                          <span data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
                         </button>
-                        <menu id="viewsManagerStatusActionOptions" class="popupMenu hidden">
+                        <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu hidden withMark">
                           <li>
-                            <button id="viewsManagerStatusActionCopy" class="noIcon" role="menuitem" type="button"
-                              tabindex="0">
-                              <span data-l10n-id="pdfjs-views-manager-pages-status-copy-button-label"></span>
+                            <button id="thumbnailsViewMenu" role="option" type="button" tabindex="-1">
+                              <span data-l10n-id="pdfjs-views-manager-pages-option-label"></span>
                             </button>
                           </li>
                           <li>
-                            <button id="viewsManagerStatusActionCut" class="noIcon" role="menuitem" type="button"
-                              tabindex="0">
-                              <span data-l10n-id="pdfjs-views-manager-pages-status-cut-button-label"></span>
+                            <button id="outlinesViewMenu" role="option" type="button" tabindex="-1">
+                              <span data-l10n-id="pdfjs-views-manager-outlines-option-label"></span>
                             </button>
                           </li>
                           <li>
-                            <button id="viewsManagerStatusActionDelete" class="noIcon" role="menuitem" type="button"
-                              tabindex="0">
-                              <span data-l10n-id="pdfjs-views-manager-pages-status-delete-button-label"></span>
+                            <button id="attachmentsViewMenu" role="option" type="button" tabindex="-1">
+                              <span data-l10n-id="pdfjs-views-manager-attachments-option-label"></span>
                             </button>
                           </li>
                           <li>
-                            <button id="viewsManagerStatusActionSaveAs" class="noIcon" role="menuitem" type="button"
-                              tabindex="0">
-                              <span data-l10n-id="pdfjs-views-manager-pages-status-save-as-button-label"></span>
+                            <button id="layersViewMenu" role="option" type="button" tabindex="-1">
+                              <span data-l10n-id="pdfjs-views-manager-layers-option-label"></span>
                             </button>
                           </li>
                         </menu>
                       </div>
+                      <span id="viewsManagerHeaderLabel" class="viewsManagerLabel"></span>
+                      <button
+                        id="viewsManagerAddFileButton"
+                        class="toolbarButton viewsManagerButton"
+                        type="button"
+                        tabindex="0"
+                        data-l10n-id="pdfjs-views-manager-add-file-button"
+                        hidden="true"
+                      >
+                        <span data-l10n-id="pdfjs-views-manager-add-file-button-label"></span>
+                      </button>
+                      <button
+                        id="viewsManagerCurrentOutlineButton"
+                        class="toolbarButton viewsManagerButton"
+                        type="button"
+                        tabindex="0"
+                        data-l10n-id="pdfjs-current-outline-item-button"
+                        hidden="true"
+                      >
+                        <span data-l10n-id="pdfjs-current-outline-item-button-label"></span>
+                      </button>
                     </div>
-                    <div id="viewsManagerStatusUndo" class="hidden">
-                      <span class="viewsManagerStatusLabel" data-l10n-id="pdfjs-views-manager-status-undo-cut-label"
-                        data-l10n-args='{"count": 0}'></span>
-                      <div>
-                        <button id="viewsManagerStatusUndoButton" class="viewsManagerButton" type="button" tabindex="0">
-                          <span data-l10n-id="pdfjs-views-manager-status-undo-button-label"></span>
+                    <div id="viewsManagerStatus">
+                      <div id="viewsManagerStatusAction" class="hidden">
+                        <span
+                          id="viewsManagerStatusActionLabel"
+                          class="viewsManagerStatusLabel"
+                          data-l10n-id="pdfjs-views-manager-pages-status-none-action-label"
+                        ></span>
+                        <div id="actionSelector">
+                          <button
+                            id="viewsManagerStatusActionButton"
+                            class="viewsManagerButton"
+                            type="button"
+                            tabindex="0"
+                            aria-haspopup="menu"
+                            aria-controls="viewsManagerStatusActionOptions"
+                          >
+                            <span data-l10n-id="pdfjs-views-manager-pages-status-action-button-label"></span>
+                          </button>
+                          <menu id="viewsManagerStatusActionOptions" class="popupMenu hidden">
+                            <li>
+                              <button id="viewsManagerStatusActionCopy" class="noIcon" role="menuitem" type="button" tabindex="0">
+                                <span data-l10n-id="pdfjs-views-manager-pages-status-copy-button-label"></span>
+                              </button>
+                            </li>
+                            <li>
+                              <button id="viewsManagerStatusActionCut" class="noIcon" role="menuitem" type="button" tabindex="0">
+                                <span data-l10n-id="pdfjs-views-manager-pages-status-cut-button-label"></span>
+                              </button>
+                            </li>
+                            <li>
+                              <button id="viewsManagerStatusActionDelete" class="noIcon" role="menuitem" type="button" tabindex="0">
+                                <span data-l10n-id="pdfjs-views-manager-pages-status-delete-button-label"></span>
+                              </button>
+                            </li>
+                            <li>
+                              <button id="viewsManagerStatusActionSaveAs" class="noIcon" role="menuitem" type="button" tabindex="0">
+                                <span data-l10n-id="pdfjs-views-manager-pages-status-save-as-button-label"></span>
+                              </button>
+                            </li>
+                          </menu>
+                        </div>
+                      </div>
+                      <div id="viewsManagerStatusUndo" class="hidden">
+                        <span class="viewsManagerStatusLabel" data-l10n-id="pdfjs-views-manager-status-undo-cut-label" data-l10n-args='{"count": 0}'></span>
+                        <div>
+                          <button id="viewsManagerStatusUndoButton" class="viewsManagerButton" type="button" tabindex="0">
+                            <span data-l10n-id="pdfjs-views-manager-status-undo-button-label"></span>
+                          </button>
+                          <button
+                            id="viewsManagerStatusUndoCloseButton"
+                            class="toolbarButton viewsManagerButton viewsCloseButton"
+                            type="button"
+                            tabindex="0"
+                            data-l10n-id="pdfjs-views-manager-status-close-button"
+                          >
+                            <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
+                          </button>
+                        </div>
+                      </div>
+                      <div id="viewsManagerStatusWarning" class="hidden">
+                        <span class="viewsManagerStatusLabel"></span>
+                        <button
+                          id="viewsManagerStatusWarningCloseButton"
+                          class="toolbarButton viewsManagerButton viewsCloseButton"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-views-manager-status-close-button"
+                        >
+                          <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
                         </button>
-                        <button id="viewsManagerStatusUndoCloseButton"
-                          class="toolbarButton viewsManagerButton viewsCloseButton" type="button" tabindex="0"
-                          data-l10n-id="pdfjs-views-manager-status-close-button">
+                      </div>
+                      <div id="viewsManagerStatusWaiting" class="hidden">
+                        <span class="viewsManagerStatusLabel"></span>
+                        <button
+                          id="viewsManagerStatusWaitingCloseButton"
+                          class="toolbarButton viewsManagerButton viewsCloseButton"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-views-manager-status-close-button"
+                        >
                           <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
                         </button>
                       </div>
                     </div>
-                    <div id="viewsManagerStatusWarning" class="hidden">
-                      <span class="viewsManagerStatusLabel"></span>
-                      <button id="viewsManagerStatusWarningCloseButton"
-                        class="toolbarButton viewsManagerButton viewsCloseButton" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-views-manager-status-close-button">
-                        <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
-                      </button>
-                    </div>
-                    <div id="viewsManagerStatusWaiting" class="hidden">
-                      <span class="viewsManagerStatusLabel"></span>
-                      <button id="viewsManagerStatusWaitingCloseButton"
-                        class="toolbarButton viewsManagerButton viewsCloseButton" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-views-manager-status-close-button">
-                        <span data-l10n-id="pdfjs-views-manager-status-close-button-label"></span>
-                      </button>
-                    </div>
                   </div>
+                  <div id="viewsManagerContent" tabindex="-1">
+                    <div id="thumbnailsView" class="thumbnailsView hidden" tabindex="-1"></div>
+                    <div id="outlinesView" class="treeView hidden"></div>
+                    <div id="attachmentsView" class="hidden"></div>
+                    <div id="layersView" class="treeView hidden"></div>
+                  </div>
+                  <div id="viewsManagerResizer" class="sidebarResizer"></div>
                 </div>
-                <div id="viewsManagerContent" tabindex="-1">
-                  <div id="thumbnailsView" class="thumbnailsView hidden" tabindex="-1"></div>
-                  <div id="outlinesView" class="treeView hidden"></div>
-                  <div id="attachmentsView" class="hidden"></div>
-                  <div id="layersView" class="treeView hidden"></div>
-                </div>
-                <div id="viewsManagerResizer" class="sidebarResizer"></div>
-              </div>
-              <!-- sidebarContainer -->
+                <!-- sidebarContainer -->
 
-              <div class="toolbarButtonSpacer"></div>
-              <div class="toolbarButtonWithContainer">
-                <button id="viewFindButton" class="toolbarButton" type="button" tabindex="0"
-                  data-l10n-id="pdfjs-findbar-button" aria-expanded="false" aria-controls="findbar">
-                  <span data-l10n-id="pdfjs-findbar-button-label"></span>
-                </button>
-                <div class="hidden doorHanger toolbarHorizontalGroup" id="findbar">
-                  <div id="findInputContainer" class="toolbarHorizontalGroup">
-                    <span class="loadingInput end toolbarHorizontalGroup">
-                      <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input"
-                        aria-invalid="false" />
-                    </span>
-                    <div class="toolbarHorizontalGroup">
-                      <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-find-previous-button">
-                        <span data-l10n-id="pdfjs-find-previous-button-label"></span>
-                      </button>
-                      <div class="splitToolbarButtonSeparator"></div>
-                      <button id="findNextButton" class="toolbarButton" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-find-next-button">
-                        <span data-l10n-id="pdfjs-find-next-button-label"></span>
-                      </button>
-                    </div>
-                  </div>
-
-                  <div id="findbarOptionsOneContainer" class="toolbarHorizontalGroup">
-                    <div class="toggleButton toolbarLabel">
-                      <input type="checkbox" id="findHighlightAll" tabindex="0" />
-                      <label for="findHighlightAll" data-l10n-id="pdfjs-find-highlight-checkbox"></label>
-                    </div>
-                    <div class="toggleButton toolbarLabel">
-                      <input type="checkbox" id="findMatchCase" tabindex="0" />
-                      <label for="findMatchCase" data-l10n-id="pdfjs-find-match-case-checkbox-label"></label>
-                    </div>
-                  </div>
-                  <div id="findbarOptionsTwoContainer" class="toolbarHorizontalGroup">
-                    <div class="toggleButton toolbarLabel">
-                      <input type="checkbox" id="findMatchDiacritics" tabindex="0" />
-                      <label for="findMatchDiacritics"
-                        data-l10n-id="pdfjs-find-match-diacritics-checkbox-label"></label>
-                    </div>
-                    <div class="toggleButton toolbarLabel">
-                      <input type="checkbox" id="findEntireWord" tabindex="0" />
-                      <label for="findEntireWord" data-l10n-id="pdfjs-find-entire-word-checkbox-label"></label>
-                    </div>
-                  </div>
-
-                  <div id="findbarMessageContainer" class="toolbarHorizontalGroup" aria-live="polite">
-                    <span id="findResultsCount" class="toolbarLabel"></span>
-                    <span id="findMsg" class="toolbarLabel"></span>
-                  </div>
-                </div>
-                <!-- findbar -->
-              </div>
-              <div class="toolbarHorizontalGroup hiddenSmallView">
-                <button class="toolbarButton" type="button" id="previous" tabindex="0"
-                  data-l10n-id="pdfjs-previous-button">
-                  <span data-l10n-id="pdfjs-previous-button-label"></span>
-                </button>
-                <div class="splitToolbarButtonSeparator"></div>
-                <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
-                  <span data-l10n-id="pdfjs-next-button-label"></span>
-                </button>
-              </div>
-              <div class="toolbarHorizontalGroup">
-                <span class="loadingInput start toolbarHorizontalGroup">
-                  <input type="number" id="pageNumber" class="toolbarField" value="1" min="1" tabindex="0"
-                    data-l10n-id="pdfjs-page-input" autocomplete="off" />
-                </span>
-                <span id="numPages" class="toolbarLabel"></span>
-              </div>
-            </div>
-            <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
-              <div class="toolbarHorizontalGroup">
-                <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0"
-                  data-l10n-id="pdfjs-zoom-out-button">
-                  <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
-                </button>
-                <div class="splitToolbarButtonSeparator"></div>
-                <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0"
-                  data-l10n-id="pdfjs-zoom-in-button">
-                  <span data-l10n-id="pdfjs-zoom-in-button-label"></span>
-                </button>
-              </div>
-              <span id="scaleSelectContainer" class="dropdownToolbarButton">
-                <select id="scaleSelect" tabindex="0" data-l10n-id="pdfjs-zoom-select">
-                  <option id="pageAutoOption" value="auto" selected="selected" data-l10n-id="pdfjs-page-scale-auto">
-                  </option>
-                  <option id="pageActualOption" value="page-actual" data-l10n-id="pdfjs-page-scale-actual"></option>
-                  <option id="pageFitOption" value="page-fit" data-l10n-id="pdfjs-page-scale-fit"></option>
-                  <option id="pageWidthOption" value="page-width" data-l10n-id="pdfjs-page-scale-width"></option>
-                  <option id="customScaleOption" value="custom" disabled="disabled" hidden="true"
-                    data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 0 }'></option>
-                  <option value="0.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 50 }'></option>
-                  <option value="0.75" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 75 }'>
-                  </option>
-                  <option value="1" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 100 }'></option>
-                  <option value="1.25" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 125 }'>
-                  </option>
-                  <option value="1.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 150 }'>
-                  </option>
-                  <option value="2" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 200 }'></option>
-                  <option value="3" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 300 }'></option>
-                  <option value="4" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 400 }'></option>
-                </select>
-              </span>
-            </div>
-            <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
-              <div id="editorModeButtons" class="toolbarHorizontalGroup">
-                <div id="editorComment" class="toolbarButtonWithContainer" hidden="true">
-                  <button id="editorCommentButton" class="toolbarButton" type="button" tabindex="0" disabled="disabled"
-                    aria-expanded="false" aria-haspopup="true" aria-controls="editorCommentParamsToolbar"
-                    data-l10n-id="pdfjs-editor-comment-button">
-                    <span data-l10n-id="pdfjs-editor-comment-button-label"></span>
+                <div class="toolbarButtonSpacer"></div>
+                <div class="toolbarButtonWithContainer">
+                  <button
+                    id="viewFindButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-findbar-button"
+                    aria-expanded="false"
+                    aria-controls="findbar"
+                  >
+                    <span data-l10n-id="pdfjs-findbar-button-label"></span>
                   </button>
-                  <div class="editorParamsToolbar hidden menu" id="editorCommentParamsToolbar">
-                    <div id="editorCommentsSidebar" class="menuContainer comment sidebar" role="landmark"
-                      aria-labelledby="editorCommentsSidebarHeader">
-                      <div id="editorCommentsSidebarResizer" class="sidebarResizer" role="separator"
-                        aria-controls="editorCommentsSidebar" tabindex="0"></div>
-                      <div id="editorCommentsSidebarHeader" role="heading" aria-level="2">
-                        <span class="commentCount">
-                          <span id="editorCommentsSidebarTitle" data-l10n-id="pdfjs-editor-comments-sidebar-title"
-                            data-l10n-args='{ "count": 0 }'></span>
-                          <span id="editorCommentsSidebarCount"></span>
-                        </span>
-                        <button id="editorCommentsSidebarCloseButton" type="button" tabindex="0"
-                          data-l10n-id="pdfjs-editor-comments-sidebar-close-button">
-                          <span data-l10n-id="pdfjs-editor-comments-sidebar-close-button-label"></span>
+                  <div class="hidden doorHanger toolbarHorizontalGroup" id="findbar">
+                    <div id="findInputContainer" class="toolbarHorizontalGroup">
+                      <span class="loadingInput end toolbarHorizontalGroup">
+                        <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input" aria-invalid="false" />
+                      </span>
+                      <div class="toolbarHorizontalGroup">
+                        <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-previous-button">
+                          <span data-l10n-id="pdfjs-find-previous-button-label"></span>
+                        </button>
+                        <div class="splitToolbarButtonSeparator"></div>
+                        <button id="findNextButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-next-button">
+                          <span data-l10n-id="pdfjs-find-next-button-label"></span>
                         </button>
                       </div>
-                      <div id="editorCommentsSidebarListContainer" tabindex="-1">
-                        <ul id="editorCommentsSidebarList"></ul>
+                    </div>
+
+                    <div id="findbarOptionsOneContainer" class="toolbarHorizontalGroup">
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findHighlightAll" tabindex="0" />
+                        <label for="findHighlightAll" data-l10n-id="pdfjs-find-highlight-checkbox"></label>
+                      </div>
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findMatchCase" tabindex="0" />
+                        <label for="findMatchCase" data-l10n-id="pdfjs-find-match-case-checkbox-label"></label>
                       </div>
                     </div>
+                    <div id="findbarOptionsTwoContainer" class="toolbarHorizontalGroup">
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findMatchDiacritics" tabindex="0" />
+                        <label for="findMatchDiacritics" data-l10n-id="pdfjs-find-match-diacritics-checkbox-label"></label>
+                      </div>
+                      <div class="toggleButton toolbarLabel">
+                        <input type="checkbox" id="findEntireWord" tabindex="0" />
+                        <label for="findEntireWord" data-l10n-id="pdfjs-find-entire-word-checkbox-label"></label>
+                      </div>
+                    </div>
+
+                    <div id="findbarMessageContainer" class="toolbarHorizontalGroup" aria-live="polite">
+                      <span id="findResultsCount" class="toolbarLabel"></span>
+                      <span id="findMsg" class="toolbarLabel"></span>
+                    </div>
                   </div>
+                  <!-- findbar -->
                 </div>
-                <div id="editorSignature" class="toolbarButtonWithContainer" hidden="true">
-                  <button id="editorSignatureButton" class="toolbarButton" type="button" tabindex="0"
-                    disabled="disabled" aria-expanded="false" aria-haspopup="true"
-                    aria-controls="editorSignatureParamsToolbar" data-l10n-id="pdfjs-editor-signature-button">
-                    <span data-l10n-id="pdfjs-editor-signature-button-label"></span>
+                <div class="toolbarHorizontalGroup hiddenSmallView">
+                  <button class="toolbarButton" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button">
+                    <span data-l10n-id="pdfjs-previous-button-label"></span>
                   </button>
-                  <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorSignatureParamsToolbar">
-                    <div id="addSignatureDoorHanger" class="menuContainer" role="region"
-                      data-l10n-id="pdfjs-editor-add-signature-container">
-                      <button id="editorSignatureAddSignature" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-editor-signature-add-signature-button">
-                        <span data-l10n-id="pdfjs-editor-signature-add-signature-button-label"
-                          class="editorParamsLabel"></span>
-                      </button>
-                    </div>
-                  </div>
+                  <div class="splitToolbarButtonSeparator"></div>
+                  <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
+                    <span data-l10n-id="pdfjs-next-button-label"></span>
+                  </button>
                 </div>
-                <div id="editorHighlight" class="toolbarButtonWithContainer">
-                  <button id="editorHighlightButton" class="toolbarButton" type="button" disabled="disabled"
-                    aria-expanded="false" aria-haspopup="true" aria-controls="editorHighlightParamsToolbar" tabindex="0"
-                    data-l10n-id="pdfjs-editor-highlight-button">
-                    <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>
-                  </button>
-                  <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
-                    <div id="highlightParamsToolbarContainer" class="editorParamsToolbarContainer">
-                      <div id="editorHighlightColorPicker" class="colorPicker">
-                        <span id="highlightColorPickerLabel" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-highlight-colorpicker-label"></span>
-                      </div>
-                      <div id="editorHighlightThickness">
-                        <label for="editorFreeHighlightThickness" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-free-highlight-thickness-input"></label>
-                        <div class="thicknessPicker">
-                          <input type="range" id="editorFreeHighlightThickness" class="editorParamsSlider"
-                            data-l10n-id="pdfjs-editor-free-highlight-thickness-title" value="12" min="8" max="24"
-                            step="1" tabindex="0" />
-                        </div>
-                      </div>
-                      <div id="editorHighlightVisibility">
-                        <div class="divider"></div>
-                        <div class="toggler">
-                          <label for="editorHighlightShowAll" class="editorParamsLabel"
-                            data-l10n-id="pdfjs-editor-highlight-show-all-button-label"></label>
-                          <button id="editorHighlightShowAll" class="toggle-button" type="button"
-                            data-l10n-id="pdfjs-editor-highlight-show-all-button" aria-pressed="true"
-                            tabindex="0"></button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div id="editorFreeText" class="toolbarButtonWithContainer">
-                  <button id="editorFreeTextButton" class="toolbarButton" type="button" disabled="disabled"
-                    aria-expanded="false" aria-haspopup="true" aria-controls="editorFreeTextParamsToolbar" tabindex="0"
-                    data-l10n-id="pdfjs-editor-free-text-button">
-                    <span data-l10n-id="pdfjs-editor-free-text-button-label"></span>
-                  </button>
-                  <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
-                    <div class="editorParamsToolbarContainer">
-                      <div class="editorParamsSetter">
-                        <label for="editorFreeTextColor" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-free-text-color-input"></label>
-                        <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0" />
-                      </div>
-                      <div class="editorParamsSetter">
-                        <label for="editorFreeTextFontSize" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-free-text-size-input"></label>
-                        <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5"
-                          max="100" step="1" tabindex="0" />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div id="editorInk" class="toolbarButtonWithContainer">
-                  <button id="editorInkButton" class="toolbarButton" type="button" disabled="disabled"
-                    aria-expanded="false" aria-haspopup="true" aria-controls="editorInkParamsToolbar" tabindex="0"
-                    data-l10n-id="pdfjs-editor-ink-button">
-                    <span data-l10n-id="pdfjs-editor-ink-button-label"></span>
-                  </button>
-                  <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
-                    <div class="editorParamsToolbarContainer">
-                      <div class="editorParamsSetter">
-                        <label for="editorInkColor" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-ink-color-input"></label>
-                        <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0" />
-                      </div>
-                      <div class="editorParamsSetter">
-                        <label for="editorInkThickness" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-ink-thickness-input"></label>
-                        <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1"
-                          max="20" step="1" tabindex="0" />
-                      </div>
-                      <div class="editorParamsSetter">
-                        <label for="editorInkOpacity" class="editorParamsLabel"
-                          data-l10n-id="pdfjs-editor-ink-opacity-input"></label>
-                        <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="1" min="0.05"
-                          max="1" step="0.05" tabindex="0" />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div id="editorStamp" class="toolbarButtonWithContainer">
-                  <button id="editorStampButton" class="toolbarButton" type="button" disabled="disabled"
-                    aria-expanded="false" aria-haspopup="true" aria-controls="editorStampParamsToolbar" tabindex="0"
-                    data-l10n-id="pdfjs-editor-stamp-button">
-                    <span data-l10n-id="pdfjs-editor-stamp-button-label"></span>
-                  </button>
-                  <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorStampParamsToolbar">
-                    <div class="menuContainer">
-                      <button id="editorStampAddImage" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-editor-stamp-add-image-button">
-                        <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label"></span>
-                      </button>
-                    </div>
-                  </div>
+                <div class="toolbarHorizontalGroup">
+                  <span class="loadingInput start toolbarHorizontalGroup">
+                    <input
+                      type="number"
+                      id="pageNumber"
+                      class="toolbarField"
+                      value="1"
+                      min="1"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-page-input"
+                      autocomplete="off"
+                    />
+                  </span>
+                  <span id="numPages" class="toolbarLabel"></span>
                 </div>
               </div>
-
-              <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
-
-              <div class="toolbarHorizontalGroup hiddenMediumView">
-                <button id="printButton" class="toolbarButton" type="button" tabindex="0"
-                  data-l10n-id="pdfjs-print-button">
-                  <span data-l10n-id="pdfjs-print-button-label"></span>
-                </button>
-
-                <button id="downloadButton" class="toolbarButton" type="button" tabindex="0"
-                  data-l10n-id="pdfjs-save-button">
-                  <span data-l10n-id="pdfjs-save-button-label"></span>
-                </button>
+              <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
+                <div class="toolbarHorizontalGroup">
+                  <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
+                    <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
+                  </button>
+                  <div class="splitToolbarButtonSeparator"></div>
+                  <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-in-button">
+                    <span data-l10n-id="pdfjs-zoom-in-button-label"></span>
+                  </button>
+                </div>
+                <span id="scaleSelectContainer" class="dropdownToolbarButton">
+                  <select id="scaleSelect" tabindex="0" data-l10n-id="pdfjs-zoom-select">
+                    <option id="pageAutoOption" value="auto" selected="selected" data-l10n-id="pdfjs-page-scale-auto"></option>
+                    <option id="pageActualOption" value="page-actual" data-l10n-id="pdfjs-page-scale-actual"></option>
+                    <option id="pageFitOption" value="page-fit" data-l10n-id="pdfjs-page-scale-fit"></option>
+                    <option id="pageWidthOption" value="page-width" data-l10n-id="pdfjs-page-scale-width"></option>
+                    <option
+                      id="customScaleOption"
+                      value="custom"
+                      disabled="disabled"
+                      hidden="true"
+                      data-l10n-id="pdfjs-page-scale-percent"
+                      data-l10n-args='{ "scale": 0 }'
+                    ></option>
+                    <option value="0.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 50 }'></option>
+                    <option value="0.75" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 75 }'></option>
+                    <option value="1" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 100 }'></option>
+                    <option value="1.25" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 125 }'></option>
+                    <option value="1.5" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 150 }'></option>
+                    <option value="2" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 200 }'></option>
+                    <option value="3" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 300 }'></option>
+                    <option value="4" data-l10n-id="pdfjs-page-scale-percent" data-l10n-args='{ "scale": 400 }'></option>
+                  </select>
+                </span>
               </div>
-
-              <div class="verticalToolbarSeparator hiddenMediumView"></div>
-
-              <div id="secondaryToolbarToggle" class="toolbarButtonWithContainer">
-                <button id="secondaryToolbarToggleButton" class="toolbarButton" type="button" tabindex="0"
-                  data-l10n-id="pdfjs-tools-button" aria-expanded="false" aria-haspopup="true"
-                  aria-controls="secondaryToolbar">
-                  <span data-l10n-id="pdfjs-tools-button-label"></span>
-                </button>
-                <div id="secondaryToolbar" class="hidden doorHangerRight menu">
-                  <div id="secondaryToolbarButtonContainer" class="menuContainer">
-                    <!--#if GENERIC-->
-                    <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-open-file-button">
-                      <span data-l10n-id="pdfjs-open-file-button-label"></span>
+              <div id="toolbarViewerRight" class="toolbarHorizontalGroup">
+                <div id="editorModeButtons" class="toolbarHorizontalGroup">
+                  <div id="editorComment" class="toolbarButtonWithContainer" hidden="true">
+                    <button
+                      id="editorCommentButton"
+                      class="toolbarButton"
+                      type="button"
+                      tabindex="0"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorCommentParamsToolbar"
+                      data-l10n-id="pdfjs-editor-comment-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-comment-button-label"></span>
                     </button>
-                    <!--#endif-->
+                    <div class="editorParamsToolbar hidden menu" id="editorCommentParamsToolbar">
+                      <div id="editorCommentsSidebar" class="menuContainer comment sidebar" role="landmark" aria-labelledby="editorCommentsSidebarHeader">
+                        <div id="editorCommentsSidebarResizer" class="sidebarResizer" role="separator" aria-controls="editorCommentsSidebar" tabindex="0"></div>
+                        <div id="editorCommentsSidebarHeader" role="heading" aria-level="2">
+                          <span class="commentCount">
+                            <span id="editorCommentsSidebarTitle" data-l10n-id="pdfjs-editor-comments-sidebar-title" data-l10n-args='{ "count": 0 }'></span>
+                            <span id="editorCommentsSidebarCount"></span>
+                          </span>
+                          <button id="editorCommentsSidebarCloseButton" type="button" tabindex="0" data-l10n-id="pdfjs-editor-comments-sidebar-close-button">
+                            <span data-l10n-id="pdfjs-editor-comments-sidebar-close-button-label"></span>
+                          </button>
+                        </div>
+                        <div id="editorCommentsSidebarListContainer" tabindex="-1">
+                          <ul id="editorCommentsSidebarList"></ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorSignature" class="toolbarButtonWithContainer" hidden="true">
+                    <button
+                      id="editorSignatureButton"
+                      class="toolbarButton"
+                      type="button"
+                      tabindex="0"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorSignatureParamsToolbar"
+                      data-l10n-id="pdfjs-editor-signature-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-signature-button-label"></span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorSignatureParamsToolbar">
+                      <div id="addSignatureDoorHanger" class="menuContainer" role="region" data-l10n-id="pdfjs-editor-add-signature-container">
+                        <button
+                          id="editorSignatureAddSignature"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-editor-signature-add-signature-button"
+                        >
+                          <span data-l10n-id="pdfjs-editor-signature-add-signature-button-label" class="editorParamsLabel"></span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorHighlight" class="toolbarButtonWithContainer">
+                    <button
+                      id="editorHighlightButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorHighlightParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-highlight-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-highlight-button-label"></span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorHighlightParamsToolbar">
+                      <div id="highlightParamsToolbarContainer" class="editorParamsToolbarContainer">
+                        <div id="editorHighlightColorPicker" class="colorPicker">
+                          <span id="highlightColorPickerLabel" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-colorpicker-label"></span>
+                        </div>
+                        <div id="editorHighlightThickness">
+                          <label
+                            for="editorFreeHighlightThickness"
+                            class="editorParamsLabel"
+                            data-l10n-id="pdfjs-editor-free-highlight-thickness-input"
+                          ></label>
+                          <div class="thicknessPicker">
+                            <input
+                              type="range"
+                              id="editorFreeHighlightThickness"
+                              class="editorParamsSlider"
+                              data-l10n-id="pdfjs-editor-free-highlight-thickness-title"
+                              value="12"
+                              min="8"
+                              max="24"
+                              step="1"
+                              tabindex="0"
+                            />
+                          </div>
+                        </div>
+                        <div id="editorHighlightVisibility">
+                          <div class="divider"></div>
+                          <div class="toggler">
+                            <label for="editorHighlightShowAll" class="editorParamsLabel" data-l10n-id="pdfjs-editor-highlight-show-all-button-label"></label>
+                            <button
+                              id="editorHighlightShowAll"
+                              class="toggle-button"
+                              type="button"
+                              data-l10n-id="pdfjs-editor-highlight-show-all-button"
+                              aria-pressed="true"
+                              tabindex="0"
+                            ></button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorFreeText" class="toolbarButtonWithContainer">
+                    <button
+                      id="editorFreeTextButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorFreeTextParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-free-text-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-free-text-button-label"></span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorFreeTextParamsToolbar">
+                      <div class="editorParamsToolbarContainer">
+                        <div class="editorParamsSetter">
+                          <label for="editorFreeTextColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-color-input"></label>
+                          <input type="color" id="editorFreeTextColor" class="editorParamsColor" tabindex="0" />
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-size-input"></label>
+                          <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="0" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorInk" class="toolbarButtonWithContainer">
+                    <button
+                      id="editorInkButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorInkParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-ink-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-ink-button-label"></span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight" id="editorInkParamsToolbar">
+                      <div class="editorParamsToolbarContainer">
+                        <div class="editorParamsSetter">
+                          <label for="editorInkColor" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-color-input"></label>
+                          <input type="color" id="editorInkColor" class="editorParamsColor" tabindex="0" />
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-thickness-input"></label>
+                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="0" />
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input"></label>
+                          <input type="range" id="editorInkOpacity" class="editorParamsSlider" value="1" min="0.05" max="1" step="0.05" tabindex="0" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="editorStamp" class="toolbarButtonWithContainer">
+                    <button
+                      id="editorStampButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-controls="editorStampParamsToolbar"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-stamp-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-stamp-button-label"></span>
+                    </button>
+                    <div class="editorParamsToolbar hidden doorHangerRight menu" id="editorStampParamsToolbar">
+                      <div class="menuContainer">
+                        <button
+                          id="editorStampAddImage"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-editor-stamp-add-image-button"
+                        >
+                          <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label"></span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
 
-                    <div class="visibleMediumView">
-                      <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-print-button">
-                        <span data-l10n-id="pdfjs-print-button-label"></span>
+                <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
+
+                <div class="toolbarHorizontalGroup hiddenMediumView">
+                  <button id="printButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
+                    <span data-l10n-id="pdfjs-print-button-label"></span>
+                  </button>
+
+                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
+                    <span data-l10n-id="pdfjs-save-button-label"></span>
+                  </button>
+                </div>
+
+                <div class="verticalToolbarSeparator hiddenMediumView"></div>
+
+                <div id="secondaryToolbarToggle" class="toolbarButtonWithContainer">
+                  <button
+                    id="secondaryToolbarToggleButton"
+                    class="toolbarButton"
+                    type="button"
+                    tabindex="0"
+                    data-l10n-id="pdfjs-tools-button"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-controls="secondaryToolbar"
+                  >
+                    <span data-l10n-id="pdfjs-tools-button-label"></span>
+                  </button>
+                  <div id="secondaryToolbar" class="hidden doorHangerRight menu">
+                    <div id="secondaryToolbarButtonContainer" class="menuContainer">
+                      <!--#if GENERIC-->
+                      <button id="secondaryOpenFile" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-open-file-button">
+                        <span data-l10n-id="pdfjs-open-file-button-label"></span>
                       </button>
-
-                      <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-save-button">
-                        <span data-l10n-id="pdfjs-save-button-label"></span>
-                      </button>
-
-                      <!--#if !GENERIC-->
-                      <!--            <div class="horizontalToolbarSeparator"></div>-->
                       <!--#endif-->
+
+                      <div class="visibleMediumView">
+                        <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
+                          <span data-l10n-id="pdfjs-print-button-label"></span>
+                        </button>
+
+                        <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
+                          <span data-l10n-id="pdfjs-save-button-label"></span>
+                        </button>
+
+                        <!--#if !GENERIC-->
+                        <!--            <div class="horizontalToolbarSeparator"></div>-->
+                        <!--#endif-->
+                      </div>
+
+                      <!--#if GENERIC-->
+                      <div class="horizontalToolbarSeparator"></div>
+                      <!--#endif-->
+
+                      <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button">
+                        <span data-l10n-id="pdfjs-presentation-mode-button-label"></span>
+                      </button>
+
+                      <a href="#" id="viewBookmark" class="toolbarButton labeled" tabindex="0" data-l10n-id="pdfjs-bookmark-button">
+                        <span data-l10n-id="pdfjs-bookmark-button-label"></span>
+                      </a>
+
+                      <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>
+
+                      <button id="firstPage" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-first-page-button">
+                        <span data-l10n-id="pdfjs-first-page-button-label"></span>
+                      </button>
+                      <button id="lastPage" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-last-page-button">
+                        <span data-l10n-id="pdfjs-last-page-button-label"></span>
+                      </button>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button">
+                        <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
+                      </button>
+                      <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-ccw-button">
+                        <span data-l10n-id="pdfjs-page-rotate-ccw-button-label"></span>
+                      </button>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <div id="cursorToolButtons" role="radiogroup">
+                        <button
+                          id="cursorSelectTool"
+                          class="toolbarButton labeled toggled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-cursor-text-select-tool-button"
+                          role="radio"
+                          aria-checked="true"
+                        >
+                          <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label"></span>
+                        </button>
+                        <button
+                          id="cursorHandTool"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-cursor-hand-tool-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-cursor-hand-tool-button-label"></span>
+                        </button>
+                        <button
+                          id="cursorZoomTool"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-cursor-zoom-tool-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-cursor-zoom-tool-button-label"></span>
+                        </button>
+                      </div>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <div id="scrollModeButtons" role="radiogroup">
+                        <button
+                          id="scrollPage"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-page-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-scroll-page-button-label"></span>
+                        </button>
+                        <button
+                          id="scrollVertical"
+                          class="toolbarButton labeled toggled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-vertical-button"
+                          role="radio"
+                          aria-checked="true"
+                        >
+                          <span data-l10n-id="pdfjs-scroll-vertical-button-label"></span>
+                        </button>
+                        <button
+                          id="scrollHorizontal"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-horizontal-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-scroll-horizontal-button-label"></span>
+                        </button>
+                        <button
+                          id="scrollWrapped"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-scroll-wrapped-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-scroll-wrapped-button-label"></span>
+                        </button>
+                      </div>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <div id="spreadModeButtons" role="radiogroup">
+                        <button
+                          id="spreadNone"
+                          class="toolbarButton labeled toggled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-spread-none-button"
+                          role="radio"
+                          aria-checked="true"
+                        >
+                          <span data-l10n-id="pdfjs-spread-none-button-label"></span>
+                        </button>
+                        <button
+                          id="spreadOdd"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-spread-odd-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-spread-odd-button-label"></span>
+                        </button>
+                        <button
+                          id="spreadEven"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-spread-even-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-spread-even-button-label"></span>
+                        </button>
+                      </div>
+
+                      <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
+                      <button
+                        id="imageAltTextSettings"
+                        type="button"
+                        class="toolbarButton labeled hidden"
+                        tabindex="0"
+                        data-l10n-id="pdfjs-image-alt-text-settings-button"
+                        aria-controls="altTextSettingsDialog"
+                      >
+                        <span data-l10n-id="pdfjs-image-alt-text-settings-button-label"></span>
+                      </button>
+
+                      <div class="horizontalToolbarSeparator"></div>
+
+                      <button
+                        id="documentProperties"
+                        class="toolbarButton labeled"
+                        type="button"
+                        tabindex="0"
+                        data-l10n-id="pdfjs-document-properties-button"
+                        aria-controls="documentPropertiesDialog"
+                      >
+                        <span data-l10n-id="pdfjs-document-properties-button-label"></span>
+                      </button>
                     </div>
-
-                    <!--#if GENERIC-->
-                    <div class="horizontalToolbarSeparator"></div>
-                    <!--#endif-->
-
-                    <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-presentation-mode-button">
-                      <span data-l10n-id="pdfjs-presentation-mode-button-label"></span>
-                    </button>
-
-                    <a href="#" id="viewBookmark" class="toolbarButton labeled" tabindex="0"
-                      data-l10n-id="pdfjs-bookmark-button">
-                      <span data-l10n-id="pdfjs-bookmark-button-label"></span>
-                    </a>
-
-                    <div id="viewBookmarkSeparator" class="horizontalToolbarSeparator"></div>
-
-                    <button id="firstPage" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-first-page-button">
-                      <span data-l10n-id="pdfjs-first-page-button-label"></span>
-                    </button>
-                    <button id="lastPage" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-last-page-button">
-                      <span data-l10n-id="pdfjs-last-page-button-label"></span>
-                    </button>
-
-                    <div class="horizontalToolbarSeparator"></div>
-
-                    <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-page-rotate-cw-button">
-                      <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
-                    </button>
-                    <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-page-rotate-ccw-button">
-                      <span data-l10n-id="pdfjs-page-rotate-ccw-button-label"></span>
-                    </button>
-
-                    <div class="horizontalToolbarSeparator"></div>
-
-                    <div id="cursorToolButtons" role="radiogroup">
-                      <button id="cursorSelectTool" class="toolbarButton labeled toggled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-cursor-text-select-tool-button" role="radio" aria-checked="true">
-                        <span data-l10n-id="pdfjs-cursor-text-select-tool-button-label"></span>
-                      </button>
-                      <button id="cursorHandTool" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-cursor-hand-tool-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-cursor-hand-tool-button-label"></span>
-                      </button>
-                      <button id="cursorZoomTool" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-cursor-zoom-tool-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-cursor-zoom-tool-button-label"></span>
-                      </button>
-                    </div>
-
-                    <div class="horizontalToolbarSeparator"></div>
-
-                    <div id="scrollModeButtons" role="radiogroup">
-                      <button id="scrollPage" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-scroll-page-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-scroll-page-button-label"></span>
-                      </button>
-                      <button id="scrollVertical" class="toolbarButton labeled toggled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-scroll-vertical-button" role="radio" aria-checked="true">
-                        <span data-l10n-id="pdfjs-scroll-vertical-button-label"></span>
-                      </button>
-                      <button id="scrollHorizontal" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-scroll-horizontal-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-scroll-horizontal-button-label"></span>
-                      </button>
-                      <button id="scrollWrapped" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-scroll-wrapped-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-scroll-wrapped-button-label"></span>
-                      </button>
-                    </div>
-
-                    <div class="horizontalToolbarSeparator"></div>
-
-                    <div id="spreadModeButtons" role="radiogroup">
-                      <button id="spreadNone" class="toolbarButton labeled toggled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-spread-none-button" role="radio" aria-checked="true">
-                        <span data-l10n-id="pdfjs-spread-none-button-label"></span>
-                      </button>
-                      <button id="spreadOdd" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-spread-odd-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-spread-odd-button-label"></span>
-                      </button>
-                      <button id="spreadEven" class="toolbarButton labeled" type="button" tabindex="0"
-                        data-l10n-id="pdfjs-spread-even-button" role="radio" aria-checked="false">
-                        <span data-l10n-id="pdfjs-spread-even-button-label"></span>
-                      </button>
-                    </div>
-
-                    <div id="imageAltTextSettingsSeparator" class="horizontalToolbarSeparator hidden"></div>
-                    <button id="imageAltTextSettings" type="button" class="toolbarButton labeled hidden" tabindex="0"
-                      data-l10n-id="pdfjs-image-alt-text-settings-button" aria-controls="altTextSettingsDialog">
-                      <span data-l10n-id="pdfjs-image-alt-text-settings-button-label"></span>
-                    </button>
-
-                    <div class="horizontalToolbarSeparator"></div>
-
-                    <button id="documentProperties" class="toolbarButton labeled" type="button" tabindex="0"
-                      data-l10n-id="pdfjs-document-properties-button" aria-controls="documentPropertiesDialog">
-                      <span data-l10n-id="pdfjs-document-properties-button-label"></span>
-                    </button>
                   </div>
+                  <!-- secondaryToolbar -->
                 </div>
-                <!-- secondaryToolbar -->
+              </div>
+            </div>
+            <div id="loadingBar">
+              <div class="progress">
+                <div class="glimmer"></div>
               </div>
             </div>
           </div>
-          <div id="loadingBar">
-            <div class="progress">
-              <div class="glimmer"></div>
-            </div>
-          </div>
+        </div>
+
+        <div id="viewerContainer" tabindex="0">
+          <div id="viewer" class="pdfViewer"></div>
         </div>
       </div>
+      <!-- mainContainer -->
 
-      <div id="viewerContainer" tabindex="0">
-        <div id="viewer" class="pdfViewer"></div>
-      </div>
-    </div>
-    <!-- mainContainer -->
-
-    <div id="dialogContainer">
-      <dialog id="passwordDialog">
-        <div class="row">
-          <label for="password" id="passwordText" data-l10n-id="pdfjs-password-label"></label>
-        </div>
-        <div class="row">
-          <input type="password" id="password" class="toolbarField" />
-        </div>
-        <div class="buttonRow">
-          <button id="passwordCancel" class="dialogButton" type="button"><span
-              data-l10n-id="pdfjs-password-cancel-button"></span></button>
-          <button id="passwordSubmit" class="dialogButton" type="button"><span
-              data-l10n-id="pdfjs-password-ok-button"></span></button>
-        </div>
-      </dialog>
-      <dialog id="documentPropertiesDialog">
-        <div class="row">
-          <span id="fileNameLabel" data-l10n-id="pdfjs-document-properties-file-name"></span>
-          <p id="fileNameField" aria-labelledby="fileNameLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="fileSizeLabel" data-l10n-id="pdfjs-document-properties-file-size"></span>
-          <p id="fileSizeField" aria-labelledby="fileSizeLabel">-</p>
-        </div>
-        <div class="separator"></div>
-        <div class="row">
-          <span id="titleLabel" data-l10n-id="pdfjs-document-properties-title"></span>
-          <p id="titleField" aria-labelledby="titleLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="authorLabel" data-l10n-id="pdfjs-document-properties-author"></span>
-          <p id="authorField" aria-labelledby="authorLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="subjectLabel" data-l10n-id="pdfjs-document-properties-subject"></span>
-          <p id="subjectField" aria-labelledby="subjectLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="keywordsLabel" data-l10n-id="pdfjs-document-properties-keywords"></span>
-          <p id="keywordsField" aria-labelledby="keywordsLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="creationDateLabel" data-l10n-id="pdfjs-document-properties-creation-date"></span>
-          <p id="creationDateField" aria-labelledby="creationDateLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="modificationDateLabel" data-l10n-id="pdfjs-document-properties-modification-date"></span>
-          <p id="modificationDateField" aria-labelledby="modificationDateLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="creatorLabel" data-l10n-id="pdfjs-document-properties-creator"></span>
-          <p id="creatorField" aria-labelledby="creatorLabel">-</p>
-        </div>
-        <div class="separator"></div>
-        <div class="row">
-          <span id="producerLabel" data-l10n-id="pdfjs-document-properties-producer"></span>
-          <p id="producerField" aria-labelledby="producerLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="versionLabel" data-l10n-id="pdfjs-document-properties-version"></span>
-          <p id="versionField" aria-labelledby="versionLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="pageCountLabel" data-l10n-id="pdfjs-document-properties-page-count"></span>
-          <p id="pageCountField" aria-labelledby="pageCountLabel">-</p>
-        </div>
-        <div class="row">
-          <span id="pageSizeLabel" data-l10n-id="pdfjs-document-properties-page-size"></span>
-          <p id="pageSizeField" aria-labelledby="pageSizeLabel">-</p>
-        </div>
-        <div class="separator"></div>
-        <div class="row">
-          <span id="linearizedLabel" data-l10n-id="pdfjs-document-properties-linearized"></span>
-          <p id="linearizedField" aria-labelledby="linearizedLabel">-</p>
-        </div>
-        <div class="buttonRow">
-          <button id="documentPropertiesClose" class="dialogButton" type="button"><span
-              data-l10n-id="pdfjs-document-properties-close-button"></span></button>
-        </div>
-      </dialog>
-      <dialog class="dialog altText" id="altTextDialog" aria-labelledby="dialogLabel"
-        aria-describedby="dialogDescription">
-        <div id="altTextContainer" class="mainContainer">
-          <div id="overallDescription">
-            <span id="dialogLabel" data-l10n-id="pdfjs-editor-alt-text-dialog-label" class="title"></span>
-            <span id="dialogDescription" data-l10n-id="pdfjs-editor-alt-text-dialog-description"></span>
+      <div id="dialogContainer">
+        <dialog id="passwordDialog">
+          <div class="row">
+            <label for="password" id="passwordText" data-l10n-id="pdfjs-password-label"></label>
           </div>
-          <div id="addDescription">
-            <div class="radio">
-              <div class="radioButton">
-                <input type="radio" id="descriptionButton" name="altTextOption" tabindex="0"
-                  aria-describedby="descriptionAreaLabel" checked />
-                <label for="descriptionButton" data-l10n-id="pdfjs-editor-alt-text-add-description-label"></label>
-              </div>
-              <div class="radioLabel">
-                <span id="descriptionAreaLabel" data-l10n-id="pdfjs-editor-alt-text-add-description-description"></span>
-              </div>
+          <div class="row">
+            <input type="password" id="password" class="toolbarField" />
+          </div>
+          <div class="buttonRow">
+            <button id="passwordCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-cancel-button"></span></button>
+            <button id="passwordSubmit" class="dialogButton" type="button"><span data-l10n-id="pdfjs-password-ok-button"></span></button>
+          </div>
+        </dialog>
+        <dialog id="documentPropertiesDialog">
+          <div class="row">
+            <span id="fileNameLabel" data-l10n-id="pdfjs-document-properties-file-name"></span>
+            <p id="fileNameField" aria-labelledby="fileNameLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="fileSizeLabel" data-l10n-id="pdfjs-document-properties-file-size"></span>
+            <p id="fileSizeField" aria-labelledby="fileSizeLabel">-</p>
+          </div>
+          <div class="separator"></div>
+          <div class="row">
+            <span id="titleLabel" data-l10n-id="pdfjs-document-properties-title"></span>
+            <p id="titleField" aria-labelledby="titleLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="authorLabel" data-l10n-id="pdfjs-document-properties-author"></span>
+            <p id="authorField" aria-labelledby="authorLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="subjectLabel" data-l10n-id="pdfjs-document-properties-subject"></span>
+            <p id="subjectField" aria-labelledby="subjectLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="keywordsLabel" data-l10n-id="pdfjs-document-properties-keywords"></span>
+            <p id="keywordsField" aria-labelledby="keywordsLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="creationDateLabel" data-l10n-id="pdfjs-document-properties-creation-date"></span>
+            <p id="creationDateField" aria-labelledby="creationDateLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="modificationDateLabel" data-l10n-id="pdfjs-document-properties-modification-date"></span>
+            <p id="modificationDateField" aria-labelledby="modificationDateLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="creatorLabel" data-l10n-id="pdfjs-document-properties-creator"></span>
+            <p id="creatorField" aria-labelledby="creatorLabel">-</p>
+          </div>
+          <div class="separator"></div>
+          <div class="row">
+            <span id="producerLabel" data-l10n-id="pdfjs-document-properties-producer"></span>
+            <p id="producerField" aria-labelledby="producerLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="versionLabel" data-l10n-id="pdfjs-document-properties-version"></span>
+            <p id="versionField" aria-labelledby="versionLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="pageCountLabel" data-l10n-id="pdfjs-document-properties-page-count"></span>
+            <p id="pageCountField" aria-labelledby="pageCountLabel">-</p>
+          </div>
+          <div class="row">
+            <span id="pageSizeLabel" data-l10n-id="pdfjs-document-properties-page-size"></span>
+            <p id="pageSizeField" aria-labelledby="pageSizeLabel">-</p>
+          </div>
+          <div class="separator"></div>
+          <div class="row">
+            <span id="linearizedLabel" data-l10n-id="pdfjs-document-properties-linearized"></span>
+            <p id="linearizedField" aria-labelledby="linearizedLabel">-</p>
+          </div>
+          <div class="buttonRow">
+            <button id="documentPropertiesClose" class="dialogButton" type="button"><span data-l10n-id="pdfjs-document-properties-close-button"></span></button>
+          </div>
+        </dialog>
+        <dialog class="dialog altText" id="altTextDialog" aria-labelledby="dialogLabel" aria-describedby="dialogDescription">
+          <div id="altTextContainer" class="mainContainer">
+            <div id="overallDescription">
+              <span id="dialogLabel" data-l10n-id="pdfjs-editor-alt-text-dialog-label" class="title"></span>
+              <span id="dialogDescription" data-l10n-id="pdfjs-editor-alt-text-dialog-description"></span>
             </div>
-            <div class="descriptionArea">
-              <textarea id="descriptionTextarea" aria-labelledby="descriptionAreaLabel"
-                data-l10n-id="pdfjs-editor-alt-text-textarea" tabindex="0"></textarea>
-            </div>
-          </div>
-          <div id="markAsDecorative">
-            <div class="radio">
-              <div class="radioButton">
-                <input type="radio" id="decorativeButton" name="altTextOption" aria-describedby="decorativeLabel" />
-                <label for="decorativeButton" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-label"></label>
-              </div>
-              <div class="radioLabel">
-                <span id="decorativeLabel" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-description"></span>
-              </div>
-            </div>
-          </div>
-          <div id="buttons">
-            <button id="altTextCancel" class="secondaryButton" type="button" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
-            </button>
-            <button id="altTextSave" class="primaryButton" type="button" tabindex="0"><span
-                data-l10n-id="pdfjs-editor-alt-text-save-button"></span></button>
-          </div>
-        </div>
-      </dialog>
-      <dialog class="dialog newAltText" id="newAltTextDialog" aria-labelledby="newAltTextTitle"
-        aria-describedby="newAltTextDescription" tabindex="0">
-        <div id="newAltTextContainer" class="mainContainer">
-          <div class="title">
-            <span id="newAltTextTitle" data-l10n-id="pdfjs-editor-new-alt-text-dialog-edit-label" role="sectionhead"
-              tabindex="0"></span>
-          </div>
-          <div id="mainContent">
-            <div id="descriptionAndSettings">
-              <div id="descriptionInstruction">
-                <div id="newAltTextDescriptionContainer">
-                  <div class="altTextSpinner" role="status" aria-live="polite"></div>
-                  <textarea id="newAltTextDescriptionTextarea" aria-labelledby="descriptionAreaLabel"
-                    data-l10n-id="pdfjs-editor-new-alt-text-textarea" tabindex="0"></textarea>
+            <div id="addDescription">
+              <div class="radio">
+                <div class="radioButton">
+                  <input type="radio" id="descriptionButton" name="altTextOption" tabindex="0" aria-describedby="descriptionAreaLabel" checked />
+                  <label for="descriptionButton" data-l10n-id="pdfjs-editor-alt-text-add-description-label"></label>
                 </div>
-                <span id="newAltTextDescription" role="note"
-                  data-l10n-id="pdfjs-editor-new-alt-text-description"></span>
-                <div id="newAltTextDisclaimer" role="note">
-                  <div>
-                    <span data-l10n-id="pdfjs-editor-new-alt-text-disclaimer1"></span>
-                    <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank"
-                      rel="noopener noreferrer" id="newAltTextLearnMore"
-                      data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url" tabindex="0"></a>
+                <div class="radioLabel">
+                  <span id="descriptionAreaLabel" data-l10n-id="pdfjs-editor-alt-text-add-description-description"></span>
+                </div>
+              </div>
+              <div class="descriptionArea">
+                <textarea id="descriptionTextarea" aria-labelledby="descriptionAreaLabel" data-l10n-id="pdfjs-editor-alt-text-textarea" tabindex="0"></textarea>
+              </div>
+            </div>
+            <div id="markAsDecorative">
+              <div class="radio">
+                <div class="radioButton">
+                  <input type="radio" id="decorativeButton" name="altTextOption" aria-describedby="decorativeLabel" />
+                  <label for="decorativeButton" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-label"></label>
+                </div>
+                <div class="radioLabel">
+                  <span id="decorativeLabel" data-l10n-id="pdfjs-editor-alt-text-mark-decorative-description"></span>
+                </div>
+              </div>
+            </div>
+            <div id="buttons">
+              <button id="altTextCancel" class="secondaryButton" type="button" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+              </button>
+              <button id="altTextSave" class="primaryButton" type="button" tabindex="0"><span data-l10n-id="pdfjs-editor-alt-text-save-button"></span></button>
+            </div>
+          </div>
+        </dialog>
+        <dialog class="dialog newAltText" id="newAltTextDialog" aria-labelledby="newAltTextTitle" aria-describedby="newAltTextDescription" tabindex="0">
+          <div id="newAltTextContainer" class="mainContainer">
+            <div class="title">
+              <span id="newAltTextTitle" data-l10n-id="pdfjs-editor-new-alt-text-dialog-edit-label" role="sectionhead" tabindex="0"></span>
+            </div>
+            <div id="mainContent">
+              <div id="descriptionAndSettings">
+                <div id="descriptionInstruction">
+                  <div id="newAltTextDescriptionContainer">
+                    <div class="altTextSpinner" role="status" aria-live="polite"></div>
+                    <textarea
+                      id="newAltTextDescriptionTextarea"
+                      aria-labelledby="descriptionAreaLabel"
+                      data-l10n-id="pdfjs-editor-new-alt-text-textarea"
+                      tabindex="0"
+                    ></textarea>
+                  </div>
+                  <span id="newAltTextDescription" role="note" data-l10n-id="pdfjs-editor-new-alt-text-description"></span>
+                  <div id="newAltTextDisclaimer" role="note">
+                    <div>
+                      <span data-l10n-id="pdfjs-editor-new-alt-text-disclaimer1"></span>
+                      <a
+                        href="https://support.mozilla.org/en-US/kb/pdf-alt-text"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        id="newAltTextLearnMore"
+                        data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
+                        tabindex="0"
+                      ></a>
+                    </div>
                   </div>
                 </div>
+                <div id="newAltTextCreateAutomatically" class="toggler">
+                  <button id="newAltTextCreateAutomaticallyButton" class="toggle-button" type="button" aria-pressed="true" tabindex="0"></button>
+                  <label
+                    for="newAltTextCreateAutomaticallyButton"
+                    class="togglerLabel"
+                    data-l10n-id="pdfjs-editor-new-alt-text-create-automatically-button-label"
+                  ></label>
+                </div>
+                <div id="newAltTextDownloadModel" class="hidden">
+                  <span
+                    id="newAltTextDownloadModelDescription"
+                    data-l10n-id="pdfjs-editor-new-alt-text-ai-model-downloading-progress"
+                    aria-valuemin="0"
+                    data-l10n-args='{ "totalSize": 0, "downloadedSize": 0 }'
+                  ></span>
+                </div>
               </div>
-              <div id="newAltTextCreateAutomatically" class="toggler">
-                <button id="newAltTextCreateAutomaticallyButton" class="toggle-button" type="button" aria-pressed="true"
-                  tabindex="0"></button>
-                <label for="newAltTextCreateAutomaticallyButton" class="togglerLabel"
-                  data-l10n-id="pdfjs-editor-new-alt-text-create-automatically-button-label"></label>
-              </div>
-              <div id="newAltTextDownloadModel" class="hidden">
-                <span id="newAltTextDownloadModelDescription"
-                  data-l10n-id="pdfjs-editor-new-alt-text-ai-model-downloading-progress" aria-valuemin="0"
-                  data-l10n-args='{ "totalSize": 0, "downloadedSize": 0 }'></span>
-              </div>
+              <div id="newAltTextImagePreview"></div>
             </div>
-            <div id="newAltTextImagePreview"></div>
-          </div>
-          <div id="newAltTextError" class="messageBar">
-            <div>
+            <div id="newAltTextError" class="messageBar">
               <div>
-                <span class="title" data-l10n-id="pdfjs-editor-new-alt-text-error-title"></span>
-                <span class="description" data-l10n-id="pdfjs-editor-new-alt-text-error-description"></span>
+                <div>
+                  <span class="title" data-l10n-id="pdfjs-editor-new-alt-text-error-title"></span>
+                  <span class="description" data-l10n-id="pdfjs-editor-new-alt-text-error-description"></span>
+                </div>
+                <button id="newAltTextCloseButton" class="closeButton" type="button" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-new-alt-text-error-close-button"></span>
+                </button>
               </div>
-              <button id="newAltTextCloseButton" class="closeButton" type="button" tabindex="0">
-                <span data-l10n-id="pdfjs-editor-new-alt-text-error-close-button"></span>
+            </div>
+            <div id="newAltTextButtons" class="dialogButtonsGroup">
+              <button id="newAltTextCancel" type="button" class="secondaryButton hidden" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
+              </button>
+              <button id="newAltTextNotNow" type="button" class="secondaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-new-alt-text-not-now-button"></span>
+              </button>
+              <button id="newAltTextSave" type="button" class="primaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-save-button"></span>
               </button>
             </div>
           </div>
-          <div id="newAltTextButtons" class="dialogButtonsGroup">
-            <button id="newAltTextCancel" type="button" class="secondaryButton hidden" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-alt-text-cancel-button"></span>
-            </button>
-            <button id="newAltTextNotNow" type="button" class="secondaryButton" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-new-alt-text-not-now-button"></span>
-            </button>
-            <button id="newAltTextSave" type="button" class="primaryButton" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-alt-text-save-button"></span>
-            </button>
-          </div>
-        </div>
-      </dialog>
+        </dialog>
 
-      <dialog class="dialog" id="altTextSettingsDialog" aria-labelledby="altTextSettingsTitle">
-        <div id="altTextSettingsContainer" class="mainContainer">
-          <div class="title">
-            <span id="altTextSettingsTitle" data-l10n-id="pdfjs-editor-alt-text-settings-dialog-label"
-              role="sectionhead" tabindex="0" class="title"></span>
-          </div>
-          <div id="automaticAltText">
-            <span data-l10n-id="pdfjs-editor-alt-text-settings-automatic-title"></span>
-            <div id="automaticSettings">
-              <div id="createModelSetting">
-                <div class="toggler">
-                  <button id="createModelButton" type="button" class="toggle-button" aria-pressed="true"
-                    tabindex="0"></button>
-                  <label for="createModelButton" class="togglerLabel"
-                    data-l10n-id="pdfjs-editor-alt-text-settings-create-model-button-label"></label>
-                </div>
-                <div id="createModelDescription" class="description">
-                  <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description"></span>
-                  <a href="https://support.mozilla.org/en-US/kb/pdf-alt-text" target="_blank" rel="noopener noreferrer"
-                    id="altTextSettingsLearnMore" data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
-                    tabindex="0"></a>
-                </div>
-              </div>
-              <div id="aiModelSettings">
-                <div>
-                  <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-label"
-                    data-l10n-args='{ "totalSize": 180 }'></span>
-                  <div id="aiModelDescription" class="description">
-                    <span data-l10n-id="pdfjs-editor-alt-text-settings-ai-model-description"></span>
+        <dialog class="dialog" id="altTextSettingsDialog" aria-labelledby="altTextSettingsTitle">
+          <div id="altTextSettingsContainer" class="mainContainer">
+            <div class="title">
+              <span id="altTextSettingsTitle" data-l10n-id="pdfjs-editor-alt-text-settings-dialog-label" role="sectionhead" tabindex="0" class="title"></span>
+            </div>
+            <div id="automaticAltText">
+              <span data-l10n-id="pdfjs-editor-alt-text-settings-automatic-title"></span>
+              <div id="automaticSettings">
+                <div id="createModelSetting">
+                  <div class="toggler">
+                    <button id="createModelButton" type="button" class="toggle-button" aria-pressed="true" tabindex="0"></button>
+                    <label for="createModelButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-create-model-button-label"></label>
+                  </div>
+                  <div id="createModelDescription" class="description">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-create-model-description"></span>
+                    <a
+                      href="https://support.mozilla.org/en-US/kb/pdf-alt-text"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      id="altTextSettingsLearnMore"
+                      data-l10n-id="pdfjs-editor-new-alt-text-disclaimer-learn-more-url"
+                      tabindex="0"
+                    ></a>
                   </div>
                 </div>
-                <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button"></span>
-                </button>
-                <button id="downloadModelButton" type="button" class="secondaryButton" tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button"></span>
-                </button>
+                <div id="aiModelSettings">
+                  <div>
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-label" data-l10n-args='{ "totalSize": 180 }'></span>
+                    <div id="aiModelDescription" class="description">
+                      <span data-l10n-id="pdfjs-editor-alt-text-settings-ai-model-description"></span>
+                    </div>
+                  </div>
+                  <button id="deleteModelButton" type="button" class="secondaryButton" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-delete-model-button"></span>
+                  </button>
+                  <button id="downloadModelButton" type="button" class="secondaryButton" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-alt-text-settings-download-model-button"></span>
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="dialogSeparator"></div>
-          <div id="altTextEditor">
-            <span data-l10n-id="pdfjs-editor-alt-text-settings-editor-title"></span>
-            <div id="showAltTextEditor">
-              <div class="toggler">
-                <button id="showAltTextDialogButton" type="button" class="toggle-button" aria-pressed="true"
-                  tabindex="0"></button>
-                <label for="showAltTextDialogButton" class="togglerLabel"
-                  data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-button-label"></label>
-              </div>
-              <div id="showAltTextDialogDescription" class="description">
-                <span data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-description"></span>
+            <div class="dialogSeparator"></div>
+            <div id="altTextEditor">
+              <span data-l10n-id="pdfjs-editor-alt-text-settings-editor-title"></span>
+              <div id="showAltTextEditor">
+                <div class="toggler">
+                  <button id="showAltTextDialogButton" type="button" class="toggle-button" aria-pressed="true" tabindex="0"></button>
+                  <label for="showAltTextDialogButton" class="togglerLabel" data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-button-label"></label>
+                </div>
+                <div id="showAltTextDialogDescription" class="description">
+                  <span data-l10n-id="pdfjs-editor-alt-text-settings-show-dialog-description"></span>
+                </div>
               </div>
             </div>
+            <div id="buttons" class="dialogButtonsGroup">
+              <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-alt-text-settings-close-button"></span>
+              </button>
+            </div>
           </div>
-          <div id="buttons" class="dialogButtonsGroup">
-            <button id="altTextSettingsCloseButton" type="button" class="primaryButton" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-alt-text-settings-close-button"></span>
-            </button>
-          </div>
-        </div>
-      </dialog>
+        </dialog>
 
-      <dialog class="dialog signatureDialog" id="addSignatureDialog" aria-labelledby="addSignatureDialogLabel">
-        <span id="addSignatureDialogLabel" data-l10n-id="pdfjs-editor-add-signature-dialog-label"></span>
-        <div id="addSignatureContainer" class="mainContainer">
-          <div class="title">
-            <span role="sectionhead" data-l10n-id="pdfjs-editor-add-signature-dialog-title" tabindex="0"></span>
-          </div>
-          <div role="tablist" id="addSignatureOptions">
-            <button id="addSignatureTypeButton" type="button" role="tab" aria-selected="true"
-              aria-controls="addSignatureTypeContainer" data-l10n-id="pdfjs-editor-add-signature-type-button"
-              tabindex="0"></button>
-            <button id="addSignatureDrawButton" type="button" role="tab" aria-selected="false"
-              aria-controls="addSignatureDrawContainer" data-l10n-id="pdfjs-editor-add-signature-draw-button"
-              tabindex="0"></button>
-            <button id="addSignatureImageButton" type="button" role="tab" aria-selected="false"
-              aria-controls="addSignatureImageContainer" data-l10n-id="pdfjs-editor-add-signature-image-button"
-              tabindex="-1"></button>
-          </div>
-          <div id="addSignatureActionContainer" data-selected="type">
-            <div id="addSignatureTypeContainer" role="tabpanel" aria-labelledby="addSignatureTypeContainer">
-              <input id="addSignatureTypeInput" type="text" data-l10n-id="pdfjs-editor-add-signature-type-input"
-                tabindex="0" />
+        <dialog class="dialog signatureDialog" id="addSignatureDialog" aria-labelledby="addSignatureDialogLabel">
+          <span id="addSignatureDialogLabel" data-l10n-id="pdfjs-editor-add-signature-dialog-label"></span>
+          <div id="addSignatureContainer" class="mainContainer">
+            <div class="title">
+              <span role="sectionhead" data-l10n-id="pdfjs-editor-add-signature-dialog-title" tabindex="0"></span>
             </div>
-            <div id="addSignatureDrawContainer" role="tabpanel" aria-labelledby="addSignatureDrawButton" tabindex="-1">
-              <svg id="addSignatureDraw" xmlns="http://www.w3.org/2000/svg"
-                aria-labelledby="addSignatureDrawPlaceholder"></svg>
-              <span id="addSignatureDrawPlaceholder" data-l10n-id="pdfjs-editor-add-signature-draw-placeholder"></span>
-              <div id="thickness">
+            <div role="tablist" id="addSignatureOptions">
+              <button
+                id="addSignatureTypeButton"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                aria-controls="addSignatureTypeContainer"
+                data-l10n-id="pdfjs-editor-add-signature-type-button"
+                tabindex="0"
+              ></button>
+              <button
+                id="addSignatureDrawButton"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="addSignatureDrawContainer"
+                data-l10n-id="pdfjs-editor-add-signature-draw-button"
+                tabindex="0"
+              ></button>
+              <button
+                id="addSignatureImageButton"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="addSignatureImageContainer"
+                data-l10n-id="pdfjs-editor-add-signature-image-button"
+                tabindex="-1"
+              ></button>
+            </div>
+            <div id="addSignatureActionContainer" data-selected="type">
+              <div id="addSignatureTypeContainer" role="tabpanel" aria-labelledby="addSignatureTypeContainer">
+                <input id="addSignatureTypeInput" type="text" data-l10n-id="pdfjs-editor-add-signature-type-input" tabindex="0" />
+              </div>
+              <div id="addSignatureDrawContainer" role="tabpanel" aria-labelledby="addSignatureDrawButton" tabindex="-1">
+                <svg id="addSignatureDraw" xmlns="http://www.w3.org/2000/svg" aria-labelledby="addSignatureDrawPlaceholder"></svg>
+                <span id="addSignatureDrawPlaceholder" data-l10n-id="pdfjs-editor-add-signature-draw-placeholder"></span>
+                <div id="thickness">
+                  <div>
+                    <label for="addSignatureDrawThickness" data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range-label"></label>
+                    <input
+                      type="range"
+                      id="addSignatureDrawThickness"
+                      min="1"
+                      max="5"
+                      step="1"
+                      value="1"
+                      data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range"
+                      data-l10n-args='{ "thickness": 1 }'
+                      tabindex="0"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div id="addSignatureImageContainer" role="tabpanel" aria-labelledby="addSignatureImageButton" tabindex="-1">
+                <svg id="addSignatureImage" xmlns="http://www.w3.org/2000/svg" aria-labelledby="addSignatureImagePlaceholder"></svg>
+                <div id="addSignatureImagePlaceholder">
+                  <span data-l10n-id="pdfjs-editor-add-signature-image-placeholder"></span>
+                  <label id="addSignatureImageBrowse" for="addSignatureFilePicker" tabindex="0">
+                    <a data-l10n-id="pdfjs-editor-add-signature-image-browse-link"></a>
+                  </label>
+                  <input id="addSignatureFilePicker" type="file" />
+                </div>
+              </div>
+              <div id="addSignatureControls">
+                <div id="horizontalContainer">
+                  <div id="addSignatureDescriptionContainer">
+                    <label for="addSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
+                    <span id="addSignatureDescription" class="inputWithClearButton">
+                      <input id="addSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
+                      <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
+                    </span>
+                  </div>
+                  <button id="clearSignatureButton" type="button" data-l10n-id="pdfjs-editor-add-signature-clear-button" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-add-signature-clear-button-label"></span>
+                  </button>
+                </div>
+                <div id="addSignatureSaveContainer">
+                  <input type="checkbox" id="addSignatureSaveCheckbox" />
+                  <label for="addSignatureSaveCheckbox" data-l10n-id="pdfjs-editor-add-signature-save-checkbox"></label>
+                  <span></span>
+                  <span id="addSignatureSaveWarning" data-l10n-id="pdfjs-editor-add-signature-save-warning-message"></span>
+                </div>
+              </div>
+              <div id="addSignatureError" hidden="true" class="messageBar">
                 <div>
-                  <label for="addSignatureDrawThickness"
-                    data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range-label"></label>
-                  <input type="range" id="addSignatureDrawThickness" min="1" max="5" step="1" value="1"
-                    data-l10n-id="pdfjs-editor-add-signature-draw-thickness-range" data-l10n-args='{ "thickness": 1 }'
-                    tabindex="0" />
+                  <div>
+                    <span id="addSignatureErrorTitle" class="title" data-l10n-id="pdfjs-editor-add-signature-image-upload-error-title"></span>
+                    <span id="addSignatureErrorDescription" class="description" data-l10n-id="pdfjs-editor-add-signature-image-upload-error-description"></span>
+                  </div>
+                  <button id="addSignatureErrorCloseButton" class="closeButton" type="button" tabindex="0">
+                    <span data-l10n-id="pdfjs-editor-add-signature-error-close-button"></span>
+                  </button>
                 </div>
               </div>
-            </div>
-            <div id="addSignatureImageContainer" role="tabpanel" aria-labelledby="addSignatureImageButton"
-              tabindex="-1">
-              <svg id="addSignatureImage" xmlns="http://www.w3.org/2000/svg"
-                aria-labelledby="addSignatureImagePlaceholder"></svg>
-              <div id="addSignatureImagePlaceholder">
-                <span data-l10n-id="pdfjs-editor-add-signature-image-placeholder"></span>
-                <label id="addSignatureImageBrowse" for="addSignatureFilePicker" tabindex="0">
-                  <a data-l10n-id="pdfjs-editor-add-signature-image-browse-link"></a>
-                </label>
-                <input id="addSignatureFilePicker" type="file" />
-              </div>
-            </div>
-            <div id="addSignatureControls">
-              <div id="horizontalContainer">
-                <div id="addSignatureDescriptionContainer">
-                  <label for="addSignatureDescInput"
-                    data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
-                  <span id="addSignatureDescription" class="inputWithClearButton">
-                    <input id="addSignatureDescInput" type="text"
-                      data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
-                    <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
-                  </span>
-                </div>
-                <button id="clearSignatureButton" type="button" data-l10n-id="pdfjs-editor-add-signature-clear-button"
-                  tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-add-signature-clear-button-label"></span>
+              <div class="dialogButtonsGroup">
+                <button id="addSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
+                </button>
+                <button id="addSignatureAddButton" type="button" class="primaryButton" disabled tabindex="0">
+                  <span data-l10n-id="pdfjs-editor-add-signature-add-button"></span>
                 </button>
               </div>
-              <div id="addSignatureSaveContainer">
-                <input type="checkbox" id="addSignatureSaveCheckbox" />
-                <label for="addSignatureSaveCheckbox" data-l10n-id="pdfjs-editor-add-signature-save-checkbox"></label>
-                <span></span>
-                <span id="addSignatureSaveWarning"
-                  data-l10n-id="pdfjs-editor-add-signature-save-warning-message"></span>
-              </div>
             </div>
-            <div id="addSignatureError" hidden="true" class="messageBar">
-              <div>
-                <div>
-                  <span id="addSignatureErrorTitle" class="title"
-                    data-l10n-id="pdfjs-editor-add-signature-image-upload-error-title"></span>
-                  <span id="addSignatureErrorDescription" class="description"
-                    data-l10n-id="pdfjs-editor-add-signature-image-upload-error-description"></span>
-                </div>
-                <button id="addSignatureErrorCloseButton" class="closeButton" type="button" tabindex="0">
-                  <span data-l10n-id="pdfjs-editor-add-signature-error-close-button"></span>
-                </button>
+          </div>
+        </dialog>
+
+        <dialog class="dialog signatureDialog" id="editSignatureDescriptionDialog" aria-labelledby="editSignatureDescriptionTitle">
+          <div id="editSignatureDescriptionContainer" class="mainContainer">
+            <div class="title">
+              <span id="editSignatureDescriptionTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-signature-dialog-title" tabindex="0"></span>
+            </div>
+            <div id="editSignatureDescriptionAndView">
+              <div id="editSignatureDescriptionContainer">
+                <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
+                <span id="editSignatureDescription" class="inputWithClearButton">
+                  <input id="editSignatureDescInput" type="text" data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
+                  <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
+                </span>
               </div>
+              <svg id="editSignatureView" xmlns="http://www.w3.org/2000/svg"></svg>
             </div>
             <div class="dialogButtonsGroup">
-              <button id="addSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
+              <button id="editSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
                 <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
               </button>
-              <button id="addSignatureAddButton" type="button" class="primaryButton" disabled tabindex="0">
-                <span data-l10n-id="pdfjs-editor-add-signature-add-button"></span>
+              <button id="editSignatureUpdateButton" type="button" class="primaryButton" disabled tabindex="0">
+                <span data-l10n-id="pdfjs-editor-edit-signature-update-button"></span>
               </button>
             </div>
           </div>
-        </div>
-      </dialog>
+        </dialog>
 
-      <dialog class="dialog signatureDialog" id="editSignatureDescriptionDialog"
-        aria-labelledby="editSignatureDescriptionTitle">
-        <div id="editSignatureDescriptionContainer" class="mainContainer">
-          <div class="title">
-            <span id="editSignatureDescriptionTitle" role="sectionhead"
-              data-l10n-id="pdfjs-editor-edit-signature-dialog-title" tabindex="0"></span>
-          </div>
-          <div id="editSignatureDescriptionAndView">
-            <div id="editSignatureDescriptionContainer">
-              <label for="editSignatureDescInput" data-l10n-id="pdfjs-editor-add-signature-description-label"></label>
-              <span id="editSignatureDescription" class="inputWithClearButton">
-                <input id="editSignatureDescInput" type="text"
-                  data-l10n-id="pdfjs-editor-add-signature-description-input" tabindex="0" />
-                <button class="clearInputButton" type="button" tabindex="0" aria-hidden="true"></button>
-              </span>
+        <dialog class="dialog commentManager" id="commentManagerDialog" aria-labelledby="commentManagerTitle">
+          <div class="mainContainer">
+            <div class="title" id="commentManagerToolbar">
+              <span id="commentManagerTitle" role="sectionhead" data-l10n-id="pdfjs-editor-edit-comment-dialog-title-when-adding"></span>
             </div>
-            <svg id="editSignatureView" xmlns="http://www.w3.org/2000/svg"></svg>
+            <textarea id="commentManagerTextInput" data-l10n-id="pdfjs-editor-edit-comment-dialog-text-input" tabindex="0"></textarea>
+            <div class="dialogButtonsGroup">
+              <button id="commentManagerCancelButton" type="button" class="secondaryButton" tabindex="0">
+                <span data-l10n-id="pdfjs-editor-edit-comment-dialog-cancel-button"></span>
+              </button>
+              <button id="commentManagerSaveButton" type="button" class="primaryButton" disabled tabindex="0">
+                <span data-l10n-id="pdfjs-editor-edit-comment-dialog-save-button-when-adding"></span>
+              </button>
+            </div>
           </div>
-          <div class="dialogButtonsGroup">
-            <button id="editSignatureCancelButton" type="button" class="secondaryButton" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-add-signature-cancel-button"></span>
-            </button>
-            <button id="editSignatureUpdateButton" type="button" class="primaryButton" disabled tabindex="0">
-              <span data-l10n-id="pdfjs-editor-edit-signature-update-button"></span>
-            </button>
-          </div>
-        </div>
-      </dialog>
+        </dialog>
 
-      <dialog class="dialog commentManager" id="commentManagerDialog" aria-labelledby="commentManagerTitle">
-        <div class="mainContainer">
-          <div class="title" id="commentManagerToolbar">
-            <span id="commentManagerTitle" role="sectionhead"
-              data-l10n-id="pdfjs-editor-edit-comment-dialog-title-when-adding"></span>
+        <!--#if !MOZCENTRAL-->
+        <dialog id="printServiceDialog" style="min-width: 200px">
+          <div class="row">
+            <span data-l10n-id="pdfjs-print-progress-message"></span>
           </div>
-          <textarea id="commentManagerTextInput" data-l10n-id="pdfjs-editor-edit-comment-dialog-text-input"
-            tabindex="0"></textarea>
-          <div class="dialogButtonsGroup">
-            <button id="commentManagerCancelButton" type="button" class="secondaryButton" tabindex="0">
-              <span data-l10n-id="pdfjs-editor-edit-comment-dialog-cancel-button"></span>
-            </button>
-            <button id="commentManagerSaveButton" type="button" class="primaryButton" disabled tabindex="0">
-              <span data-l10n-id="pdfjs-editor-edit-comment-dialog-save-button-when-adding"></span>
-            </button>
+          <div class="row">
+            <progress value="0" max="100"></progress>
+            <span data-l10n-id="pdfjs-print-progress-percent" data-l10n-args='{ "progress": 0 }' class="relative-progress">0%</span>
           </div>
-        </div>
-      </dialog>
-
-      <!--#if !MOZCENTRAL-->
-      <dialog id="printServiceDialog" style="min-width: 200px">
-        <div class="row">
-          <span data-l10n-id="pdfjs-print-progress-message"></span>
-        </div>
-        <div class="row">
-          <progress value="0" max="100"></progress>
-          <span data-l10n-id="pdfjs-print-progress-percent" data-l10n-args='{ "progress": 0 }'
-            class="relative-progress">0%</span>
-        </div>
-        <div class="buttonRow">
-          <button id="printCancel" class="dialogButton" type="button"><span
-              data-l10n-id="pdfjs-print-progress-close-button"></span></button>
-        </div>
-      </dialog>
-      <!--#endif-->
-      <!--#if CHROME-->
-      <!--#include viewer-snippet-chrome-overlays.html-->
-      <!--#endif-->
-    </div>
-    <!-- dialogContainer -->
-
-    <div id="editorUndoBar" class="messageBar" role="status" aria-labelledby="editorUndoBarMessage" tabindex="-1"
-      hidden>
-      <div>
-        <div>
-          <span id="editorUndoBarMessage" class="description"></span>
-        </div>
-        <button id="editorUndoBarUndoButton" class="undoButton" type="button" tabindex="0"
-          data-l10n-id="pdfjs-editor-undo-bar-undo-button">
-          <span data-l10n-id="pdfjs-editor-undo-bar-undo-button-label"></span>
-        </button>
-        <button id="editorUndoBarCloseButton" class="closeButton" type="button" tabindex="0"
-          data-l10n-id="pdfjs-editor-undo-bar-close-button">
-          <span data-l10n-id="pdfjs-editor-undo-bar-close-button-label"></span>
-        </button>
+          <div class="buttonRow">
+            <button id="printCancel" class="dialogButton" type="button"><span data-l10n-id="pdfjs-print-progress-close-button"></span></button>
+          </div>
+        </dialog>
+        <!--#endif-->
+        <!--#if CHROME-->
+        <!--#include viewer-snippet-chrome-overlays.html-->
+        <!--#endif-->
       </div>
-    </div>
-    <!-- editorUndoBar -->
-  </div>
-  <!-- outerContainer -->
-  <div id="printContainer"></div>
-</body>
+      <!-- dialogContainer -->
 
+      <div id="editorUndoBar" class="messageBar" role="status" aria-labelledby="editorUndoBarMessage" tabindex="-1" hidden>
+        <div>
+          <div>
+            <span id="editorUndoBarMessage" class="description"></span>
+          </div>
+          <button id="editorUndoBarUndoButton" class="undoButton" type="button" tabindex="0" data-l10n-id="pdfjs-editor-undo-bar-undo-button">
+            <span data-l10n-id="pdfjs-editor-undo-bar-undo-button-label"></span>
+          </button>
+          <button id="editorUndoBarCloseButton" class="closeButton" type="button" tabindex="0" data-l10n-id="pdfjs-editor-undo-bar-close-button">
+            <span data-l10n-id="pdfjs-editor-undo-bar-close-button-label"></span>
+          </button>
+        </div>
+      </div>
+      <!-- editorUndoBar -->
+    </div>
+    <!-- outerContainer -->
+    <div id="printContainer"></div>
+  </body>
 </html>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -708,6 +708,17 @@ See https://github.com/adobe-type-tools/cmap-resources
                         >
                           <span data-l10n-id="pdfjs-cursor-hand-tool-button-label"></span>
                         </button>
+                        <button
+                          id="cursorZoomTool"
+                          class="toolbarButton labeled"
+                          type="button"
+                          tabindex="0"
+                          data-l10n-id="pdfjs-cursor-zoom-tool-button"
+                          role="radio"
+                          aria-checked="false"
+                        >
+                          <span data-l10n-id="pdfjs-cursor-zoom-tool-button-label">Zoom</span>
+                        </button>
                       </div>
 
                       <div class="horizontalToolbarSeparator"></div>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -89,6 +89,7 @@ function getViewerConfiguration() {
       pageRotateCcwButton: document.getElementById("pageRotateCcw"),
       cursorSelectToolButton: document.getElementById("cursorSelectTool"),
       cursorHandToolButton: document.getElementById("cursorHandTool"),
+      cursorZoomToolButton: document.getElementById("cursorZoomTool"),
       scrollPageButton: document.getElementById("scrollPage"),
       scrollVerticalButton: document.getElementById("scrollVertical"),
       scrollHorizontalButton: document.getElementById("scrollHorizontal"),

--- a/web/zoom_to_rect.js
+++ b/web/zoom_to_rect.js
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+// Minimum drag size (in pixels) to trigger zoom, prevents accidental clicks
+const MIN_DRAG_SIZE = 5;
+
 class ZoomToRect {
   #activateAC = null;
 
@@ -123,7 +126,7 @@ class ZoomToRect {
         height: Math.abs(this.startY - event.clientY),
       };
       // Ignore very small clicks/drags to prevent accidental zooms
-      if (rect.width > 5 && rect.height > 5) {
+      if (rect.width > MIN_DRAG_SIZE && rect.height > MIN_DRAG_SIZE) {
         this.onZoom(rect);
       }
     }

--- a/web/zoom_to_rect.js
+++ b/web/zoom_to_rect.js
@@ -1,0 +1,132 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class ZoomToRect {
+    #activateAC = null;
+
+    #mouseDownAC = null;
+
+    constructor({ element, onZoom }) {
+        this.element = element;
+        this.document = element.ownerDocument;
+        this.onZoom = onZoom;
+
+        const overlay = (this.overlay = document.createElement("div"));
+        overlay.className = "zoom-to-rect-grabbing";
+        // We need to disable pointer events on the overlay so that the mouse events
+        // can pass through to the document for the 'mouseup' event to trigger properly,
+        // or we need to capture events.
+        // However, for a selection box, usually we want it to just be visual.
+        // In GrabToPan, it appends to body.
+    }
+
+    activate() {
+        if (!this.#activateAC) {
+            this.#activateAC = new AbortController();
+
+            this.element.addEventListener("mousedown", this.#onMouseDown.bind(this), {
+                capture: true,
+                signal: this.#activateAC.signal,
+            });
+            this.element.classList.add("zoom-to-rect-grab");
+        }
+    }
+
+    deactivate() {
+        if (this.#activateAC) {
+            this.#activateAC.abort();
+            this.#activateAC = null;
+            this.#endZoom();
+            this.element.classList.remove("zoom-to-rect-grab");
+        }
+    }
+
+    toggle() {
+        if (this.#activateAC) {
+            this.deactivate();
+        } else {
+            this.activate();
+        }
+    }
+
+    #onMouseDown(event) {
+        if (event.button !== 0) {
+            return;
+        }
+        // TODO: Ignore targets like scrollbars if necessary, similar to GrabToPan.
+
+        this.startX = event.clientX;
+        this.startY = event.clientY;
+
+        this.#mouseDownAC = new AbortController();
+        const boundEndZoom = this.#endZoom.bind(this);
+        const mouseOpts = { capture: true, signal: this.#mouseDownAC.signal };
+
+        this.document.addEventListener(
+            "mousemove",
+            this.#onMouseMove.bind(this),
+            mouseOpts
+        );
+        this.document.addEventListener("mouseup", boundEndZoom, mouseOpts);
+
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    #onMouseMove(event) {
+        const currentX = event.clientX;
+        const currentY = event.clientY;
+
+        const x = Math.min(this.startX, currentX);
+        const y = Math.min(this.startY, currentY);
+        const width = Math.abs(this.startX - currentX);
+        const height = Math.abs(this.startY - currentY);
+
+        if (!this.overlay.parentNode) {
+            this.document.body.append(this.overlay);
+        }
+
+        this.overlay.style.left = `${x}px`;
+        this.overlay.style.top = `${y}px`;
+        this.overlay.style.width = `${width}px`;
+        this.overlay.style.height = `${height}px`;
+    }
+
+    #endZoom(event) {
+        this.#mouseDownAC?.abort();
+        this.#mouseDownAC = null;
+
+        if (this.overlay.parentNode) {
+            this.overlay.remove();
+            this.overlay.style.width = "0";
+            this.overlay.style.height = "0";
+        }
+
+        if (event) {
+            const rect = {
+                x: Math.min(this.startX, event.clientX),
+                y: Math.min(this.startY, event.clientY),
+                width: Math.abs(this.startX - event.clientX),
+                height: Math.abs(this.startY - event.clientY),
+            };
+            // Ignore very small clicks/drags to prevent accidental zooms
+            if (rect.width > 5 && rect.height > 5) {
+                this.onZoom(rect);
+            }
+        }
+    }
+}
+
+export { ZoomToRect };

--- a/web/zoom_to_rect.js
+++ b/web/zoom_to_rect.js
@@ -25,11 +25,6 @@ class ZoomToRect {
 
         const overlay = (this.overlay = document.createElement("div"));
         overlay.className = "zoom-to-rect-grabbing";
-        // We need to disable pointer events on the overlay so that the mouse events
-        // can pass through to the document for the 'mouseup' event to trigger properly,
-        // or we need to capture events.
-        // However, for a selection box, usually we want it to just be visual.
-        // In GrabToPan, it appends to body.
     }
 
     activate() {
@@ -133,7 +128,6 @@ class ZoomToRect {
             }
         }
     }
-
 }
 
 export { ZoomToRect };


### PR DESCRIPTION
## Description
This PR implements the Marquee Zoom feature, allowing users to select a rectangular area on a PDF page to zoom into it.

## Changes
- **Tool Implementation**: Added `ZoomToRect` class in `web/zoom_to_rect.js` to handle mouse interactions, overlay drawing, and zoom calculation.
- **UI Integration**: 
    - Added "Zoom" tool button to the Secondary Toolbar in `web/viewer.html`.
    - Added styling for the tool cursor and selection box in `web/viewer.css`.
    - Updated `web/secondary_toolbar.js` and `web/pdf_cursor_tools.js` to manage the new tool state.
- **Configuration**: Registered `cursorZoomToolButton` in `web/viewer.js` to ensure proper initialization.

## Verification
- Verified that the tool appears in the secondary toolbar with the correct icon.
- Tested on `compressed.tracemonkey-pldi-09.pdf`:
    - Selecting the tool changes the cursor to a crosshair.
    - Dragging a rectangle zooms the view to fit the selection.
    - Pressing `Escape` cancels the operation.
- Confirmed that the PDF loads correctly with the new configuration.

Closes #1260