### PR TITLE
[wontfix] style: use group opacity for text selection to fix overlapping artifacts

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1371,8 +1371,12 @@ class AnnotationEditorUIManager {
     if (!boxes) {
       return;
     }
+    const layer = this.#getLayerForTextLayer(textLayer);
+    if (layer) {
+      layer.div.hidden = false;
+    }
     this.#floatingToolbar ||= new FloatingToolbar(this);
-    this.#floatingToolbar.show(textLayer, boxes, this.direction === "ltr");
+    this.#floatingToolbar.show(layer?.div || textLayer, boxes, this.direction === "ltr");
   }
 
   /**
@@ -1427,6 +1431,14 @@ class AnnotationEditorUIManager {
     if (!selection || selection.isCollapsed) {
       if (this.#selectedTextNode) {
         this.#floatingToolbar?.hide();
+        const anchorElement = this.#getAnchorElementForSelection(selection);
+        const textLayer = anchorElement?.closest(".textLayer");
+        if (textLayer) {
+          const layer = this.#getLayerForTextLayer(textLayer);
+          if (layer?.isEmpty && this.#mode === AnnotationEditorType.NONE) {
+            layer.div.hidden = true;
+          }
+        }
         this.#selectedTextNode = null;
         this.#dispatchUpdateStates({
           hasSelectedText: false,

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -52,6 +52,10 @@
 }
 
 .textLayer {
+  @media screen and (forced-colors: active) {
+    opacity: 1;
+  }
+
   &.highlighting {
     cursor: var(--editorFreeHighlight-editing-cursor);
 
@@ -230,14 +234,7 @@
   }
 }
 
-.annotationEditorLayer
-  :is(
-    .freeTextEditor,
-    .inkEditor,
-    .stampEditor,
-    .highlightEditor,
-    .signatureEditor
-  ),
+.annotationEditorLayer,
 .textLayer {
   .editToolbar {
     --editor-toolbar-delete-image: url(images/editor-toolbar-delete.svg);
@@ -273,6 +270,7 @@
       --alt-text-warning-color: var(--editor-toolbar-fg-color);
       --alt-text-hover-done-color: var(--editor-toolbar-hover-fg-color);
       --alt-text-hover-warning-color: var(--editor-toolbar-hover-fg-color);
+      opacity: 1;
     }
 
     display: flex;
@@ -282,8 +280,9 @@
     justify-content: center;
     align-items: center;
     cursor: default;
-    pointer-events: auto;
+    pointer-events: auto !important;
     box-sizing: content-box;
+    z-index: 100001;
     padding: var(--editor-toolbar-padding);
 
     position: absolute;

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -18,18 +18,20 @@
   text-align: initial;
   inset: 0;
   overflow: clip;
-  opacity: 0.25;
+  opacity: 1;
   line-height: 1;
   text-size-adjust: none;
   forced-color-adjust: none;
   transform-origin: 0 0;
-  caret-color: CanvasText;
   z-index: 0;
+  mix-blend-mode: multiply;
 
   @media screen and (forced-colors: active) {
-    opacity: 1;
     forced-color-adjust: auto;
+    mix-blend-mode: normal;
   }
+
+  caret-color: CanvasText;
 
   &.highlighting {
     touch-action: none;
@@ -61,7 +63,8 @@
 
     --scale-x: 1;
     --rotate: 0deg;
-    transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
+    transform: rotate(var(--rotate)) scaleX(var(--scale-x))
+      scale(var(--min-font-size-inv));
   }
 
   .markedContent {
@@ -74,8 +77,8 @@
   }
 
   .highlight {
-    --highlight-bg-color: rgb(180 0 170);
-    --highlight-selected-bg-color: rgb(0 100 0);
+    --highlight-bg-color: rgb(180 0 170 / 0.25);
+    --highlight-selected-bg-color: rgb(0 100 0 / 0.25);
     --highlight-backdrop-filter: none;
     --highlight-selected-backdrop-filter: none;
 
@@ -83,7 +86,9 @@
       --highlight-bg-color: transparent;
       --highlight-selected-bg-color: transparent;
       --highlight-backdrop-filter: var(--hcm-highlight-filter);
-      --highlight-selected-backdrop-filter: var(--hcm-highlight-selected-filter);
+      --highlight-selected-backdrop-filter: var(
+        --hcm-highlight-selected-filter
+      );
     }
 
     margin: -1px;
@@ -117,11 +122,10 @@
   ::selection {
     /* stylelint-disable declaration-block-no-duplicate-properties */
     /*#if !MOZCENTRAL*/
-    background: rgba(0 0 255);
+    background: rgba(0 0 255 / 0.25);
     /*#endif*/
+    background: color-mix(in srgb, AccentColor, transparent 75%);
     /* stylelint-enable declaration-block-no-duplicate-properties */
-    background: AccentColor;
-    color: transparent;
   }
 
   /* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -18,17 +18,16 @@
   text-align: initial;
   inset: 0;
   overflow: clip;
-  opacity: 1;
+  opacity: 0.4;
   line-height: 1;
   text-size-adjust: none;
   forced-color-adjust: none;
   transform-origin: 0 0;
   z-index: 0;
-  mix-blend-mode: multiply;
 
   @media screen and (forced-colors: active) {
+    opacity: 1;
     forced-color-adjust: auto;
-    mix-blend-mode: normal;
   }
 
   caret-color: CanvasText;
@@ -77,8 +76,8 @@
   }
 
   .highlight {
-    --highlight-bg-color: rgb(180 0 170 / 0.25);
-    --highlight-selected-bg-color: rgb(0 100 0 / 0.25);
+    --highlight-bg-color: rgb(180 0 170);
+    --highlight-selected-bg-color: rgb(0 100 0);
     --highlight-backdrop-filter: none;
     --highlight-selected-backdrop-filter: none;
 
@@ -122,9 +121,9 @@
   ::selection {
     /* stylelint-disable declaration-block-no-duplicate-properties */
     /*#if !MOZCENTRAL*/
-    background: rgba(0 0 255 / 0.25);
+    background: rgb(0 0 255);
     /*#endif*/
-    background: color-mix(in srgb, AccentColor, transparent 75%);
+    background: AccentColor;
     /* stylelint-enable declaration-block-no-duplicate-properties */
   }
 

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -28,6 +28,7 @@
 
   @media screen and (forced-colors: active) {
     opacity: 1;
+    forced-color-adjust: auto;
   }
 
   &.highlighting {

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -18,13 +18,17 @@
   text-align: initial;
   inset: 0;
   overflow: clip;
-  opacity: 1;
+  opacity: 0.25;
   line-height: 1;
   text-size-adjust: none;
   forced-color-adjust: none;
   transform-origin: 0 0;
   caret-color: CanvasText;
   z-index: 0;
+
+  @media screen and (forced-colors: active) {
+    opacity: 1;
+  }
 
   &.highlighting {
     touch-action: none;
@@ -50,13 +54,13 @@
   .markedContent span:not(.markedContent) {
     z-index: 1;
 
-    --font-height: 0; /* set by text_layer.js */
+    --font-height: 0;
+    /* set by text_layer.js */
     font-size: calc(var(--text-scale-factor) * var(--font-height));
 
     --scale-x: 1;
     --rotate: 0deg;
-    transform: rotate(var(--rotate)) scaleX(var(--scale-x))
-      scale(var(--min-font-size-inv));
+    transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
   }
 
   .markedContent {
@@ -69,8 +73,8 @@
   }
 
   .highlight {
-    --highlight-bg-color: rgb(180 0 170 / 0.25);
-    --highlight-selected-bg-color: rgb(0 100 0 / 0.25);
+    --highlight-bg-color: rgb(180 0 170);
+    --highlight-selected-bg-color: rgb(0 100 0);
     --highlight-backdrop-filter: none;
     --highlight-selected-backdrop-filter: none;
 
@@ -78,9 +82,7 @@
       --highlight-bg-color: transparent;
       --highlight-selected-bg-color: transparent;
       --highlight-backdrop-filter: var(--hcm-highlight-filter);
-      --highlight-selected-backdrop-filter: var(
-        --hcm-highlight-selected-filter
-      );
+      --highlight-selected-backdrop-filter: var(--hcm-highlight-selected-filter);
     }
 
     margin: -1px;
@@ -114,10 +116,11 @@
   ::selection {
     /* stylelint-disable declaration-block-no-duplicate-properties */
     /*#if !MOZCENTRAL*/
-    background: rgba(0 0 255 / 0.25);
+    background: rgba(0 0 255);
     /*#endif*/
     /* stylelint-enable declaration-block-no-duplicate-properties */
-    background: color-mix(in srgb, AccentColor, transparent 75%);
+    background: AccentColor;
+    color: transparent;
   }
 
   /* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */
@@ -125,6 +128,7 @@
   br::selection {
     background: transparent;
   }
+
   /*#endif*/
 
   .endOfContent {

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -18,7 +18,7 @@
   text-align: initial;
   inset: 0;
   overflow: clip;
-  opacity: 0.4;
+  opacity: 0.25;
   line-height: 1;
   text-size-adjust: none;
   forced-color-adjust: none;


### PR DESCRIPTION
## Description
This PR addresses visual artifacts where text selection boxes would overlap incorrectly. 
By applying group opacity and using `mix-blend-mode`, we ensure that the selection highlight renders correctly on Chrome and other browsers.

## Issue fixed
Fixes #17561

## Type of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.