### PR TITLE
fix: Fix mailto links truncated at dash

### DIFF
--- a/test/unit/autolinker_spec.js
+++ b/test/unit/autolinker_spec.js
@@ -209,4 +209,14 @@ describe("autolinker", function () {
       ],
     ]);
   });
+
+  it("should correctly find emails with hyphens in domain (bug 20557)", function () {
+    testLinks([
+      [
+        "john.doe@faculity.uni-cityname.tld",
+        "mailto:john.doe@faculity.uni-cityname.tld",
+      ],
+      ["john.doe@uni-cityname.tld", "mailto:john.doe@uni-cityname.tld"],
+    ]);
+  });
 });

--- a/web/autolinker.js
+++ b/web/autolinker.js
@@ -138,7 +138,7 @@ class Autolinker {
   static findLinks(text) {
     // Regex can be tested and verified at https://regex101.com/r/rXoLiT/2.
     this.#regex ??=
-      /\b(?:https?:\/\/|mailto:|www\.)(?:[\S--[\p{P}<>]]|\/|[\S--[\[\]]]+[\S--[\p{P}<>]])+|(?=\p{L})[\S--[@\p{Ps}\p{Pe}<>]]+@([\S--[\p{P}<>]]+(?:\.[\S--[\p{P}<>]]+)+)/gmv;
+      /\b(?:https?:\/\/|mailto:|www\.)(?:[\S--[\p{P}<>]]|\/|[\S--[\[\]]]+[\S--[\p{P}<>]])+|(?=\p{L})[\S--[@\p{Ps}\p{Pe}<>]]+@([\S--[[\p{P}--\-]<>]]+(?:\.[\S--[[\p{P}--\-]<>]]+)+)/gmv;
 
     const [normalizedText, diffs] = normalize(text, { ignoreDashEOL: true });
     const matches = normalizedText.matchAll(this.#regex);


### PR DESCRIPTION
This PR fixes a bug where `mailto:` links containing hyphens in the domain part were truncated (e.g., `user@uni-city.tld` -> `user@uni`).

### The Fix
Modified the regex in `web/autolinker.js` to explicitly allow hyphens (`-`) in the domain part of email addresses, while maintaining the exclusion of other punctuation.

### Verification
- **Manual:** Verified on the reproduction PDF provided in the issue (#20557). Links with dashes are now correctly detected and clickable.
- **Unit Test:** Regex validity confirmed with strict test cases.

Fixes #20557.