### PR TITLE
Hide the menu container in changing it's visibility

### DIFF
--- a/web/menu.css
+++ b/web/menu.css
@@ -13,6 +13,16 @@
  * limitations under the License.
  */
 
+button.hasPopupMenu {
+  &[aria-expanded="true"] + menu {
+    visibility: visible;
+  }
+
+  &[aria-expanded="false"] + menu {
+    visibility: hidden;
+  }
+}
+
 .popupMenu {
   --menuitem-checkmark-icon: url(images/checkmark.svg);
   --menu-mark-icon-size: 0;
@@ -75,6 +85,7 @@
   top: 1px;
   margin: 0;
   padding: 5px;
+  box-sizing: border-box;
 
   background: var(--menu-bg);
   background-blend-mode: var(--menu-background-blend-mode);

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -130,7 +130,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <div id="viewsManagerTitle">
                       <div id="viewsManagerSelector">
                         <button
-                          class="toolbarButton viewsManagerButton"
+                          class="toolbarButton viewsManagerButton hasPopupMenu"
                           type="button"
                           id="viewsManagerSelectorButton"
                           tabindex="0"
@@ -141,7 +141,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                         >
                           <span data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
                         </button>
-                        <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu hidden withMark">
+                        <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu withMark">
                           <li>
                             <button id="thumbnailsViewMenu" role="option" type="button" tabindex="-1">
                               <span data-l10n-id="pdfjs-views-manager-pages-option-label"></span>
@@ -196,15 +196,16 @@ See https://github.com/adobe-type-tools/cmap-resources
                         <div id="actionSelector">
                           <button
                             id="viewsManagerStatusActionButton"
-                            class="viewsManagerButton"
+                            class="viewsManagerButton hasPopupMenu"
                             type="button"
                             tabindex="0"
                             aria-haspopup="menu"
                             aria-controls="viewsManagerStatusActionOptions"
+                            aria-expanded="false"
                           >
                             <span data-l10n-id="pdfjs-views-manager-pages-status-action-button-label"></span>
                           </button>
-                          <menu id="viewsManagerStatusActionOptions" class="popupMenu hidden">
+                          <menu id="viewsManagerStatusActionOptions" class="popupMenu">
                             <li>
                               <button id="viewsManagerStatusActionCopy" class="noIcon" role="menuitem" type="button" tabindex="0">
                                 <span data-l10n-id="pdfjs-views-manager-pages-status-copy-button-label"></span>

--- a/web/views_manager.css
+++ b/web/views_manager.css
@@ -394,6 +394,7 @@
 
         #actionSelector {
           height: 32px;
+          min-width: 115px;
           width: auto;
           display: block;
 
@@ -425,8 +426,9 @@
             }
           }
 
-          > .contextMenu {
-            min-width: 115px;
+          > .popupMenu {
+            width: auto;
+            z-index: 1;
           }
         }
       }


### PR DESCRIPTION
This way, the dimensions of the menu container don't depend on its visibility.
This patch fixes few keyboard issues I noticed when reading: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role#keyboard_interactions