### PR TITLE
Feature: Add getPagesInfo() for batch page info retrieval (#20530)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -401,6 +401,26 @@ class WorkerMessageHandler {
       });
     });
 
+    handler.on("GetPagesInfo", function (data) {
+      return pdfManager.ensureDoc("numPages").then(function (numPages) {
+        const promises = [];
+        for (let i = 0; i < numPages; i++) {
+          promises.push(
+            pdfManager.getPage(i).then(function (page) {
+              return Promise.all([
+                pdfManager.ensure(page, "view"),
+                pdfManager.ensure(page, "rotate"),
+                pdfManager.ensure(page, "userUnit"),
+              ]).then(function ([view, rotate, userUnit]) {
+                return { view, rotate, userUnit };
+              });
+            })
+          );
+        }
+        return Promise.all(promises);
+      });
+    });
+
     handler.on("GetPageIndex", function (data) {
       const pageRef = Ref.get(data.num, data.gen);
       return pdfManager.ensureCatalog("getPageIndex", [pageRef]);

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -830,6 +830,16 @@ class PDFDocumentProxy {
   }
 
   /**
+   * @returns {Promise<Array<Object>>} A promise that is resolved with an array
+   *   of objects containing page layout information (view, rotate, userUnit)
+   *   for all pages in the document. Each object in the array corresponds to
+   *   a page, with the first page at index 0.
+   */
+  getPagesInfo() {
+    return this._transport.getPagesInfo();
+  }
+
+  /**
    * @param {RefProxy} ref - The page reference.
    * @returns {Promise<number>} A promise that is resolved with the page index,
    *   starting from zero, that is associated with the reference.
@@ -2975,6 +2985,10 @@ class WorkerTransport {
       num: ref.num,
       gen: ref.gen,
     });
+  }
+
+  getPagesInfo() {
+    return this.messageHandler.sendWithPromise("GetPagesInfo", null);
   }
 
   getAnnotations(pageIndex, intent) {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1288,6 +1288,37 @@ describe("api", function () {
       }
     });
 
+    it("gets pages info", async function () {
+      const pagesInfo = await pdfDocument.getPagesInfo();
+
+      expect(Array.isArray(pagesInfo)).toEqual(true);
+      expect(pagesInfo.length).toEqual(pdfDocument.numPages);
+
+      for (let i = 0; i < pagesInfo.length; i++) {
+        const pageInfo = pagesInfo[i];
+        expect(pageInfo).toEqual(
+          jasmine.objectContaining({
+            view: jasmine.any(Array),
+            rotate: jasmine.any(Number),
+            userUnit: jasmine.any(Number),
+          })
+        );
+      }
+    });
+
+    it("gets pages info matching individual page data", async function () {
+      const pagesInfo = await pdfDocument.getPagesInfo();
+
+      for (let i = 0; i < pagesInfo.length; i++) {
+        const page = await pdfDocument.getPage(i + 1);
+        const pageInfo = pagesInfo[i];
+
+        expect(pageInfo.view).toEqual(page.view);
+        expect(pageInfo.rotate).toEqual(page.rotate);
+        expect(pageInfo.userUnit).toEqual(page.userUnit);
+      }
+    });
+
     it("gets destinations, from /Dests dictionary", async function () {
       const destinations = await pdfDocument.getDestinations();
       expect(destinations).toEqual({


### PR DESCRIPTION
### Description
This PR implements the `getPagesInfo()` method requested in #20530.
Currently, retrieving layout data for all pages requires calling `getPage(i)` sequentially, which causes **N** worker round-trips. This PR introduces a batch retrieval method that fetches `view`, `rotate`, and `userUnit` for all pages in a **single** round-trip.

### Changes
- **API**: Added `PDFDocumentProxy.prototype.getPagesInfo()` in `src/display/api.js`.
- **Worker**: Added `GetPagesInfo` handler in `src/core/worker.js`.
- **Tests**: Added unit tests in `test/unit/api_spec.js` to ensure data consistency matches `getPage()`.

### Performance Verification
I measured the performance improvement using a benchmark script.
The structural improvement (N -> 1 round-trip) provides significant speedup, especially for large documents.

| Document | Method | Time (avg) | Improvement |
| :--- | :--- | :--- | :--- |
| **tracemonkey.pdf** (14 pages) | `getPage` loop | 1.5ms | - |
| | **`getPagesInfo` (New)** | **0.9ms** | **1.67x Faster** |
| **pdf.pdf** (1,310 pages) | `getPage` loop | 83.3ms | - |
| | **`getPagesInfo` (New)** | **44.1ms** | **1.89x Faster** |

> **Screenshot:**
> <img width="918" height="502" alt="image" src="https://github.com/user-attachments/assets/85524132-b46b-42d0-8703-7ffc56b56d5c" />


<details>
<summary><b>🔻 Click to see the benchmark logic</b></summary>

I verified the logic using a script similar to this (simplified for reproducibility in unit tests):

```javascript
describe("getPagesInfo benchmark & verification", function () {
  const tracemonkeyFileName = "tracemonkey.pdf";

  describe("performance comparison", function () {
    let pdfLoadingTask, pdfDocument;

    beforeAll(async function () {
      pdfLoadingTask = getDocument(buildGetDocumentParams(tracemonkeyFileName));
      pdfDocument = await pdfLoadingTask.promise;
    });

    afterAll(async function () {
      await pdfLoadingTask.destroy();
    });

    it("should measure execution time vs multiple getPage calls", async function () {
      const numPages = pdfDocument.numPages;

      // Warm up
      await pdfDocument.getPagesInfo();

      // Method 1: Multiple getPage() calls
      const startGetPage = performance.now();
      const pageInfosOld = [];
      for (let i = 1; i <= numPages; i++) {
        const page = await pdfDocument.getPage(i);
        pageInfosOld.push({
          view: page.view,
          rotate: page.rotate,
          userUnit: page.userUnit,
        });
      }
      const endGetPage = performance.now();
      const getPageTime = endGetPage - startGetPage;

      // Method 2: Single getPagesInfo() call
      const startGetPagesInfo = performance.now();
      const pageInfosNew = await pdfDocument.getPagesInfo();
      const endGetPagesInfo = performance.now();
      const getPagesInfoTime = endGetPagesInfo - startGetPagesInfo;

      // Log results
      console.log(`\n--- Performance Results (${numPages} pages) ---`);
      console.log(`Multiple getPage(): ${getPageTime.toFixed(2)}ms`);
      console.log(`Single getPagesInfo(): ${getPagesInfoTime.toFixed(2)}ms`);
      console.log(`Speedup: ${(getPageTime / Math.max(getPagesInfoTime, 0.01)).toFixed(2)}x`);

      // Verify Consistency
      expect(pageInfosNew.length).toEqual(pageInfosOld.length);
      for (let i = 0; i < pageInfosNew.length; i++) {
        expect(pageInfosNew[i].view).toEqual(pageInfosOld[i].view);
      }
    });
  });

  describe("memory & stability", function () {
    it("should not show significant memory growth on repeated calls", async function () {
      const loadingTask = getDocument(buildGetDocumentParams(tracemonkeyFileName));
      const pdfDoc = await loadingTask.promise;
      
      const getMemory = () => (performance.memory ? performance.memory.usedJSHeapSize : 0);
      const startMem = getMemory();

      for (let i = 0; i < 20; i++) {
        await pdfDoc.getPagesInfo();
      }
      
      const endMem = getMemory();
      if (startMem > 0) {
         console.log(`Memory Growth: ${((endMem - startMem) / 1024 / 1024).toFixed(2)}MB`);
      }
      await loadingTask.destroy();
    });

    it("should handle concurrent calls", async function () {
      const loadingTask = getDocument(buildGetDocumentParams(tracemonkeyFileName));
      const pdfDoc = await loadingTask.promise;
      const results = await Promise.all([
        pdfDoc.getPagesInfo(),
        pdfDoc.getPagesInfo(),
        pdfDoc.getPagesInfo()
      ]);
      expect(results[0]).toEqual(results[1]);
      await loadingTask.destroy();
    });
  });
});