### PR TITLE
Use DecompressionStream in async code

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -699,6 +699,12 @@ class CMapFactory {
     if (encoding instanceof Name) {
       return createBuiltInCMap(encoding.name, fetchBuiltInCMap);
     } else if (encoding instanceof BaseStream) {
+      if (encoding.isAsync) {
+        const bytes = await encoding.asyncGetBytes();
+        if (bytes) {
+          encoding = new Stream(bytes, 0, bytes.length, encoding.dict);
+        }
+      }
       const parsedCMap = await parseCMap(
         /* cMap = */ new CMap(),
         /* lexer = */ new Lexer(encoding),

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1706,7 +1706,7 @@ class PartialEvaluator {
     return null;
   }
 
-  getOperatorList({
+  async getOperatorList({
     stream,
     task,
     resources,
@@ -1715,6 +1715,13 @@ class PartialEvaluator {
     fallbackFontDict = null,
     prevRefs = null,
   }) {
+    if (stream.isAsync) {
+      const bytes = await stream.asyncGetBytes();
+      if (bytes) {
+        stream = new Stream(bytes, 0, bytes.length, stream.dict);
+      }
+    }
+
     const objId = stream.dict?.objId;
     const seenRefs = new RefSet(prevRefs);
 
@@ -2373,7 +2380,7 @@ class PartialEvaluator {
     });
   }
 
-  getTextContent({
+  async getTextContent({
     stream,
     task,
     resources,
@@ -2389,6 +2396,13 @@ class PartialEvaluator {
     prevRefs = null,
     intersector = null,
   }) {
+    if (stream.isAsync) {
+      const bytes = await stream.asyncGetBytes();
+      if (bytes) {
+        stream = new Stream(bytes, 0, bytes.length, stream.dict);
+      }
+    }
+
     const objId = stream.dict?.objId;
     const seenRefs = new RefSet(prevRefs);
 
@@ -4565,8 +4579,16 @@ class PartialEvaluator {
       if (fontFile) {
         if (!(fontFile instanceof BaseStream)) {
           throw new FormatError("FontFile should be a stream");
-        } else if (fontFile.isEmpty) {
-          throw new FormatError("FontFile is empty");
+        } else {
+          if (fontFile.isAsync) {
+            const bytes = await fontFile.asyncGetBytes();
+            if (bytes) {
+              fontFile = new Stream(bytes, 0, bytes.length, fontFile.dict);
+            }
+          }
+          if (fontFile.isEmpty) {
+            throw new FormatError("FontFile is empty");
+          }
         }
       }
     } catch (ex) {

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -51,6 +51,7 @@ class Stream extends BaseStream {
     const strEnd = this.end;
 
     if (!length) {
+      this.pos = strEnd;
       return bytes.subarray(pos, strEnd);
     }
     let end = pos + length;

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -68,6 +68,7 @@ describe("CFFParser", function () {
   });
 
   beforeEach(function () {
+    fontData.reset();
     parser = new CFFParser(fontData, {}, SEAC_ANALYSIS_ENABLED);
     cff = parser.parse();
   });
@@ -168,6 +169,7 @@ describe("CFFParser", function () {
   });
 
   it("parses a CharString endchar with 4 args w/seac enabled", function () {
+    fontData.reset();
     const cffParser = new CFFParser(
       fontData,
       {},
@@ -197,6 +199,7 @@ describe("CFFParser", function () {
   });
 
   it("parses a CharString endchar with 4 args w/seac disabled", function () {
+    fontData.reset();
     const cffParser = new CFFParser(
       fontData,
       {},


### PR DESCRIPTION
Usually, content stream or fonts are compressed using FlateDecode. So use the DecompressionStream API to decompress those streams in the async code path.