### PR TITLE
Decompress object streams asynchronously when it's possible

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -62,10 +62,11 @@ function getLookupTableFactory(initializer) {
 }
 
 class MissingDataException extends BaseException {
-  constructor(begin, end) {
+  constructor(begin, end, objStreamRefNum = 0) {
     super(`Missing data [${begin}, ${end})`, "MissingDataException");
     this.begin = begin;
     this.end = end;
+    this.objStreamRefNum = objStreamRefNum;
   }
 }
 

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1038,8 +1038,8 @@ class PDFDocument {
     };
   }
 
-  parse(recoveryMode) {
-    this.xref.parse(recoveryMode);
+  async parse(recoveryMode) {
+    await this.xref.parse(recoveryMode);
     this.catalog = new Catalog(this.pdfManager, this.xref);
   }
 

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -191,7 +191,7 @@ class NetworkPdfManager extends BasePdfManager {
     try {
       const value = obj[prop];
       if (typeof value === "function") {
-        return value.apply(obj, args);
+        return await value.apply(obj, args);
       }
       return value;
     } catch (ex) {
@@ -199,6 +199,11 @@ class NetworkPdfManager extends BasePdfManager {
         throw ex;
       }
       await this.requestRange(ex.begin, ex.end);
+      if (ex.objectStreamOffset) {
+        await this.pdfDocument.xref.decompressObjectStreams(
+          ex.objectStreamOffset
+        );
+      }
       return this.ensure(obj, prop, args);
     }
   }


### PR DESCRIPTION
Most of the time, the object streams are compressed using FlateDecode (and in future with BrotliDecode).
So in order to improve the performances we can decompress those streams with a built-in decompressor but it has to be done asynchronously. Since it cannot be done when fetching which is synchronous, we need to do it as part of the PDF parsing process.
The drawback is that this requires more memory since we need to keep both the compressed and uncompressed versions of the object streams in memory until the parsing is done.