### PR TITLE
Add auto-dismiss to editor undo bar after 6 seconds

### DIFF
--- a/web/editor_undo_bar.js
+++ b/web/editor_undo_bar.js
@@ -34,6 +34,10 @@ class EditorUndoBar {
 
   #undoButton;
 
+  #autoHideTimeout = null;
+
+  #autoHideDelayMs = 6000;
+
   static #l10nMessages = Object.freeze({
     highlight: "pdfjs-editor-undo-bar-message-highlight",
     freetext: "pdfjs-editor-undo-bar-message-freetext",
@@ -108,6 +112,13 @@ class EditorUndoBar {
       this.#container.focus();
       this.#focusTimeout = null;
     }, 100);
+
+    if (this.#autoHideTimeout) {
+      clearTimeout(this.#autoHideTimeout);
+    }
+    this.#autoHideTimeout = setTimeout(() => {
+      this.hide();
+    }, this.#autoHideDelayMs);
   }
 
   hide() {
@@ -123,6 +134,11 @@ class EditorUndoBar {
     if (this.#focusTimeout) {
       clearTimeout(this.#focusTimeout);
       this.#focusTimeout = null;
+    }
+
+    if (this.#autoHideTimeout) {
+      clearTimeout(this.#autoHideTimeout);
+      this.#autoHideTimeout = null;
     }
   }
 }


### PR DESCRIPTION
Added automatic dismissal to the editor undo notification bar that appears when removing annotations (signatures, drawings, text, etc.). The bar now auto-hides after 6 seconds while maintaining all existing functionality.

### Current Behavior
- When a user deletes an annotation, the undo bar appears at the top
- The bar remains visible indefinitely until the user:
  - Clicks the close button (×)
  - Performs an undo action
  - Removes another annotation

### New Behavior
- The undo bar automatically dismisses after 6 seconds
- Users can still:
  - Close it immediately via the close button
  - Undo the action before auto-dismiss
  - All existing dismiss triggers remain functional

### Rationale
1. **Improved UX**: Users no longer need to manually dismiss notification bars that are no longer relevant
2. **Cleaner UI**: Reduces visual clutter after the brief notification period
3. **Industry standard**: Follows common UX patterns seen in modern applications (toast notifications, snackbars)
4. **Non-breaking**: Preserves all existing functionality—users can still interact with the bar before it auto-dismisses

### Implementation Details
- Added `#autoHideTimeout` and `#autoHideDelayMs` (6000ms) fields
- Timer starts when the bar is shown and is cleared if:
  - Bar is hidden manually
  - A new notification appears (resets the timer)
  - Component is destroyed
- No changes to public API or existing behavior

### Testing
Verified on:
- Removing highlights, text, drawings, stamps, and signatures
- Manual close still works
- Undo action still works
- Multiple rapid deletions (timer resets correctly)

### Files Changed
- `web/editor_undo_bar.js`: Added auto-hide timer logic