### PR TITLE
Report loading progress "automatically" when using the `PDFDataTransportStream` class, and remove the `PDFDataRangeTransport.prototype.onDataProgress` method

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -639,8 +639,6 @@ class PDFDataRangeTransport {
 
   #progressiveReadListeners = [];
 
-  #progressListeners = [];
-
   #rangeListeners = [];
 
   /**
@@ -659,6 +657,18 @@ class PDFDataRangeTransport {
     this.initialData = initialData;
     this.progressiveDone = progressiveDone;
     this.contentDispositionFilename = contentDispositionFilename;
+
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
+      Object.defineProperty(this, "onDataProgress", {
+        value: () => {
+          deprecated(
+            "`PDFDataRangeTransport.prototype.onDataProgress` - method was " +
+              "removed, since loading progress is now reported automatically " +
+              "through the `PDFDataTransportStream` class (and related code)."
+          );
+        },
+      });
+    }
   }
 
   /**
@@ -666,13 +676,6 @@ class PDFDataRangeTransport {
    */
   addRangeListener(listener) {
     this.#rangeListeners.push(listener);
-  }
-
-  /**
-   * @param {function} listener
-   */
-  addProgressListener(listener) {
-    this.#progressListeners.push(listener);
   }
 
   /**
@@ -697,18 +700,6 @@ class PDFDataRangeTransport {
     for (const listener of this.#rangeListeners) {
       listener(begin, chunk);
     }
-  }
-
-  /**
-   * @param {number} loaded
-   * @param {number|undefined} total
-   */
-  onDataProgress(loaded, total) {
-    this.#capability.promise.then(() => {
-      for (const listener of this.#progressListeners) {
-        listener(loaded, total);
-      }
-    });
   }
 
   /**

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -799,7 +799,7 @@ class CSSConstants {
 }
 
 function applyOpacity(r, g, b, opacity) {
-  opacity = Math.min(Math.max(opacity ?? 1, 0), 1);
+  opacity = MathClamp(opacity ?? 1, 0, 1);
   const white = 255 * (1 - opacity);
   r = Math.round(r * opacity + white);
   g = Math.round(g * opacity + white);

--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -135,10 +135,7 @@ class PDFFetchStreamReader extends BasePDFStreamReader {
       return { value, done };
     }
     this._loaded += value.byteLength;
-    this.onProgress?.({
-      loaded: this._loaded,
-      total: this._contentLength,
-    });
+    this._callOnProgress();
 
     return { value: getArrayBuffer(value), done: false };
   }

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -129,11 +129,8 @@ class PDFNodeStreamReader extends BasePDFStreamReader {
     if (done) {
       return { value, done };
     }
-    this._loaded += value.length;
-    this.onProgress?.({
-      loaded: this._loaded,
-      total: this._contentLength,
-    });
+    this._loaded += value.byteLength;
+    this._callOnProgress();
 
     return { value: getArrayBuffer(value), done: false };
   }

--- a/src/shared/base_pdf_stream.js
+++ b/src/shared/base_pdf_stream.js
@@ -128,6 +128,10 @@ class BasePDFStreamReader {
     this._stream = stream;
   }
 
+  _callOnProgress() {
+    this.onProgress?.({ loaded: this._loaded, total: this._contentLength });
+  }
+
   /**
    * Gets a promise that is resolved when the headers and other metadata of
    * the PDF data stream are available.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1235,9 +1235,12 @@ function MathClamp(v, min, max) {
   return Math.min(Math.max(v, min), max);
 }
 
-// TODO: Remove this once the `javascript.options.experimental.math_sumprecise`
-//       preference is removed from Firefox.
-if (typeof Math.sumPrecise !== "function") {
+// TODO: Remove this once `Math.sumPrecise` is generally available.
+if (
+  (typeof PDFJSDev === "undefined" ||
+    PDFJSDev.test("SKIP_BABEL && !MOZCENTRAL")) &&
+  typeof Math.sumPrecise !== "function"
+) {
   // Note that this isn't a "proper" polyfill, but since we're only using it to
   // replace `Array.prototype.reduce()` invocations it should be fine.
   Math.sumPrecise = function (numbers) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -613,15 +613,8 @@ class ExternalServices extends BaseExternalServices {
         case "range":
           pdfDataRangeTransport.onDataRange(args.begin, args.chunk);
           break;
-        case "rangeProgress":
-          pdfDataRangeTransport.onDataProgress(args.loaded);
-          break;
         case "progressiveRead":
           pdfDataRangeTransport.onDataProgressiveRead(args.chunk);
-
-          // Don't forget to report loading progress as well, since otherwise
-          // the loadingBar won't update when `disableRange=true` is set.
-          pdfDataRangeTransport.onDataProgress(args.loaded, args.total);
           break;
         case "progressiveDone":
           pdfDataRangeTransport?.onDataProgressiveDone();


### PR DESCRIPTION
This is consistent with the other `BasePDFStream` implementations, and simplifies the API surface of the `PDFDataRangeTransport` class (note the changes in the viewer).
Given that the `onDataProgress` method was changed to a no-op this won't affect third-party users, assuming there even are any since this code was written specifically for the Firefox PDF Viewer.