### PR TITLE
Fix zoom position bug by using viewport-relative coordinates for  containerTopLeft

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -2457,10 +2457,11 @@ class PDFViewer {
   }
 
   get containerTopLeft() {
-    return (this.#containerTopLeft ||= [
-      this.container.offsetTop,
-      this.container.offsetLeft,
-    ]);
+    if (!this.#containerTopLeft) {
+      const rect = this.container.getBoundingClientRect();
+      this.#containerTopLeft = [rect.top, rect.left];
+    }
+    return this.#containerTopLeft;
   }
 
   #cleanupTimeouts() {


### PR DESCRIPTION
ssue Zooming in the PDF.js viewer (particularly in Firefox when the PDF fills the display width or when custom CSS filters like invert are applied) causes the view to jump to the top-left corner instead of anchoring to the cursor's location.

Root Cause The issue stems from a coordinate system mismatch in PDFViewer.#setScaleUpdatePages. It calculates the new scroll position by subtracting this.containerTopLeft from a viewport-relative zoom origin (derived from clientX/clientY).

Previously, 
containerTopLeft
 used offsetTop and offsetLeft, which are relative to the offsetParent. In complex layouts or when certain CSS properties are applied, the offsetParent relation can become inconsistent with viewport coordinates, leading to incorrect offsets and the "top-left jump" behavior.

Solution Updated the 
containerTopLeft
 getter in 
web/pdf_viewer.js
 to use this.container.getBoundingClientRect().

getBoundingClientRect() returns coordinates relative to the viewport.
This ensures that 
containerTopLeft
 and the zoom origin are in the same coordinate system, resulting in accurate scroll anchoring regardless of CSS filters or DOM hierarchy.
Verification

Verified the coordinate transformation logic: origin (viewport) - 
containerTopLeft
 (viewport) correctly yields the interior coordinate relative to the viewer container.
Code analysis confirms this robustly handles the scenario described in issue #20630.