### PR TITLE
Ensure that pending requests are resolved when calling `PDFDataTransportStreamReader.prototype.progressiveDone`

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { AbortException, assert, warn } from "../shared/util.js";
+import { AbortException, assert } from "../shared/util.js";
 import {
   BasePDFStream,
   BasePDFStreamRangeReader,
@@ -58,8 +58,7 @@ function getArrayBuffer(val) {
   if (val instanceof ArrayBuffer) {
     return val;
   }
-  warn(`getArrayBuffer - unexpected data format: ${val}`);
-  return new Uint8Array(val).buffer;
+  throw new Error(`getArrayBuffer - unexpected data: ${val}`);
 }
 
 class PDFFetchStream extends BasePDFStream {
@@ -194,4 +193,4 @@ class PDFFetchStreamRangeReader extends BasePDFStreamRangeReader {
   }
 }
 
-export { PDFFetchStream };
+export { getArrayBuffer, PDFFetchStream };

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -14,13 +14,14 @@
  */
 /* globals process */
 
-import { AbortException, assert, warn } from "../shared/util.js";
+import { AbortException, assert } from "../shared/util.js";
 import {
   BasePDFStream,
   BasePDFStreamRangeReader,
   BasePDFStreamReader,
 } from "../shared/base_pdf_stream.js";
 import { createResponseError } from "./network_utils.js";
+import { getArrayBuffer } from "./fetch_stream.js";
 
 if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   throw new Error(
@@ -42,17 +43,6 @@ function getReadableStream(readStream) {
 
   const polyfill = require("node-readable-to-web-readable-stream");
   return polyfill.makeDefaultReadableStreamFromNodeReadable(readStream);
-}
-
-function getArrayBuffer(val) {
-  if (val instanceof Uint8Array) {
-    return val.buffer;
-  }
-  if (val instanceof ArrayBuffer) {
-    return val;
-  }
-  warn(`getArrayBuffer - unexpected data format: ${val}`);
-  return new Uint8Array(val).buffer;
 }
 
 class PDFNodeStream extends BasePDFStream {

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -187,6 +187,14 @@ class PDFDataTransportStreamReader extends BasePDFStreamReader {
 
   progressiveDone() {
     this._done ||= true;
+
+    if (this._queuedChunks.length > 0) {
+      return;
+    }
+    for (const capability of this._requests) {
+      capability.resolve({ value: undefined, done: true });
+    }
+    this._requests.length = 0;
   }
 }
 

--- a/src/display/transport_stream.js
+++ b/src/display/transport_stream.js
@@ -29,6 +29,13 @@ function getArrayBuffer(val) {
     : new Uint8Array(val).buffer;
 }
 
+function endRequests() {
+  for (const capability of this._requests) {
+    capability.resolve({ value: undefined, done: true });
+  }
+  this._requests.length = 0;
+}
+
 class PDFDataTransportStream extends BasePDFStream {
   _progressiveDone = false;
 
@@ -112,6 +119,8 @@ class PDFDataTransportStream extends BasePDFStream {
 }
 
 class PDFDataTransportStreamReader extends BasePDFStreamReader {
+  #endRequests = endRequests.bind(this);
+
   _done = false;
 
   _queuedChunks = null;
@@ -179,26 +188,21 @@ class PDFDataTransportStreamReader extends BasePDFStreamReader {
 
   cancel(reason) {
     this._done = true;
-    for (const capability of this._requests) {
-      capability.resolve({ value: undefined, done: true });
-    }
-    this._requests.length = 0;
+    this.#endRequests();
   }
 
   progressiveDone() {
     this._done ||= true;
 
-    if (this._queuedChunks.length > 0) {
-      return;
+    if (this._queuedChunks.length === 0) {
+      this.#endRequests();
     }
-    for (const capability of this._requests) {
-      capability.resolve({ value: undefined, done: true });
-    }
-    this._requests.length = 0;
   }
 }
 
 class PDFDataTransportStreamRangeReader extends BasePDFStreamRangeReader {
+  #endRequests = endRequests.bind(this);
+
   onDone = null;
 
   _begin = -1;
@@ -221,13 +225,10 @@ class PDFDataTransportStreamRangeReader extends BasePDFStreamRangeReader {
     if (this._requests.length === 0) {
       this._queuedChunk = chunk;
     } else {
-      const firstCapability = this._requests.shift();
-      firstCapability.resolve({ value: chunk, done: false });
+      const capability = this._requests.shift();
+      capability.resolve({ value: chunk, done: false });
 
-      for (const capability of this._requests) {
-        capability.resolve({ value: undefined, done: true });
-      }
-      this._requests.length = 0;
+      this.#endRequests();
     }
     this._done = true;
     this.onDone?.();
@@ -249,12 +250,9 @@ class PDFDataTransportStreamRangeReader extends BasePDFStreamRangeReader {
 
   cancel(reason) {
     this._done = true;
-    for (const capability of this._requests) {
-      capability.resolve({ value: undefined, done: true });
-    }
-    this._requests.length = 0;
+    this.#endRequests();
     this.onDone?.();
   }
 }
 
-export { PDFDataTransportStream };
+export { endRequests, PDFDataTransportStream };


### PR DESCRIPTION
Doing skip-cache reloading of https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#disableRange=true in the latest Firefox Nightly version I noticed an *intermittent* bug, where the loadingBar would fill up but without the PDF ever rendering.
Initially I was quite worried that the changes in PR #20602 had somehow caused this, however after a bunch of testing in a slightly older Nightly I was able to reproduce the problem there as well.[1]

Instead I believe that this problem goes all the back to PR #10675, so still my fault, since the `progressiveDone` handling there was incomplete.
Note how we only set the `this._done` property, but don't actually resolve any still pending requests. For reference, compare with the handling in the `PDFDataTransportStreamRangeReader.prototype._enqueue` method.
Depending on the exact order in which the `PDFDataTransportStreamReader.prototype.{_enqueue, read, progressiveDone}` methods are invoked, which depends on how/when the PDF data arrives, the bug might occur.

The reason that this bug hasn't been caught before now is likely that `disableRange=true` isn't used by default and Firefox users are unlikely to manually set that in e.g. `about:config`.

---
[1] Possibly some timings changed to make it slightly more common, but given the intermittent nature of this it's difficult to tell.