### PR TITLE
[api-minor] Update the supported Node.js "patch" versions

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2284,7 +2284,7 @@ function packageJson() {
       url: `git+${DIST_GIT_URL}`,
     },
     engines: {
-      node: ">=20.16.0 || >=22.3.0",
+      node: ">=20.19.0 || >=22.13.0 || >=24",
     },
     scripts: {},
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "yargs": "^18.0.0"
       },
       "engines": {
-        "node": ">=20.16.0 || >=22.3.0"
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "url": "git://github.com/mozilla/pdf.js.git"
   },
   "engines": {
-    "node": ">=20.16.0 || >=22.3.0"
+    "node": ">=20.19.0 || >=22.13.0 || >=24"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
We haven't made any changes to the supported Node.js versions for close to a year, however now seems like a good time to do so in order to unblock future (major version) package upgrades.

 - Babel version `8` is now close to release, since https://github.com/babel/babel/releases contain an 8-RC version and according to [this article](https://babel.dev/blog/2026/01/31/7.29.0) no new `7` releases are planned.
    See also https://babel.dev/blog/2025/05/30/babel-8-beta and note the supported Node.js versions in https://next.babeljs.io/docs/v8-migration/#nodejs-support

 - ESLint version `10` was just released, see https://eslint.org/blog/2026/02/eslint-v10.0.0-released/ and note the supported Node.js versions in https://eslint.org/docs/latest/use/migrate-to-10.0.0#-nodejs--v2019-v21-v23-are-no-longer-supported