### PR TITLE
Fix cursor-anchored zooming to prevent jumps to top-left

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1444,34 +1444,36 @@ class PDFViewer {
     this._currentScale = newScale;
 
     if (!noScroll) {
-      let page = this._currentPageNumber,
-        dest;
-      if (
-        this._location &&
-        !(this.isInPresentationMode || this.isChangingPresentationMode)
-      ) {
-        page = this._location.pageNumber;
-        dest = [
-          null,
-          { name: "XYZ" },
-          this._location.left,
-          this._location.top,
-          null,
-        ];
-      }
-      this.scrollPageIntoView({
-        pageNumber: page,
-        destArray: dest,
-        allowNegativeOffset: true,
-      });
       if (Array.isArray(origin)) {
-        // If the origin of the scaling transform is specified, preserve its
-        // location on screen. If not specified, scaling will fix the top-left
-        // corner of the visible PDF area.
-        const scaleDiff = newScale / previousScale - 1;
         const [top, left] = this.containerTopLeft;
-        this.container.scrollLeft += (origin[0] - left) * scaleDiff;
-        this.container.scrollTop += (origin[1] - top) * scaleDiff;
+        const scaleFactor = previousScale > 0 ? newScale / previousScale : 1;
+        this.container.scrollLeft =
+          (this.container.scrollLeft + origin[0] - left) * scaleFactor -
+          (origin[0] - left);
+        this.container.scrollTop =
+          (this.container.scrollTop + origin[1] - top) * scaleFactor -
+          (origin[1] - top);
+      } else {
+        let page = this._currentPageNumber,
+          dest;
+        if (
+          this._location &&
+          !(this.isInPresentationMode || this.isChangingPresentationMode)
+        ) {
+          page = this._location.pageNumber;
+          dest = [
+            null,
+            { name: "XYZ" },
+            this._location.left,
+            this._location.top,
+            null,
+          ];
+        }
+        this.scrollPageIntoView({
+          pageNumber: page,
+          destArray: dest,
+          allowNegativeOffset: true,
+        });
       }
     }
 


### PR DESCRIPTION
...fixes #20630
Vibecoded by Antigravity.
I have checked the fix by running `bun gulp server`, visiting localhost and reproducing the bug.

---

<details><summary>Slop explaination</summary>
<p>

### The Problem
When you zoom into a PDF with a mouse wheel (or pinch gesture), PDF.js attempts to keep the point under your cursor fixed. It previously did this in two discrete steps:

1. **Restoring the last viewed location**: It calls `scrollPageIntoView`  using a saved "location" (in PDF coordinates) which represents the top-left of the viewport before the current zoom step.
2. **Relative adjustment**: It then calculates a delta based on your mouse position and adjusts the scroll position further.
The bug occurs during the transition when the PDF first fills the display width and begins to overflow. At this threshold, the "centering margin" (created by margin: auto in CSS) disappears or changes size.

- Because browser scroll containers cannot have negative scrollLeft, attempting to restore a location that was previously in the "centered margin" leads to clamping at 0.
- This resets the view to the top-left of the page.
- The subsequent manual adjustment is then applied to the wrong base, causing a jump.
- Custom CSS filters (like the one you use) can exacerbate this in some browsers (especially Firefox) by causing delays in layout reporting or triggering unexpected reflows during the scale change.

#### The Fix
I have modified `web/pdf_viewer.js` to use a more robust, direct zooming formula when a zoom origin (mouse position) is provided. The new implementation:

- Skips the location-based restore step entirely when zooming with the mouse. Instead, it calculates the new scroll position directly from the current one.
- Uses the formula: `newScroll = (currentScroll + mouseOffset) * scaleRatio - mouseOffset`. This is the mathematically correct way to zoom around a point in the viewport.
- By avoiding `scrollPageIntoView` during mouse zooming, we bypass the clamping issue and the "stale location" race condition that occurs during rapid wheel zooming.
This should result in smooth, cursor-anchored zooming even as the PDF crosses the width of your display, regardless of your custom CSS filters.

</p>
</details> 
