### PR TITLE
Normalize the font name in `getBaseFontMetrics` (issue 20246)

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -31,7 +31,11 @@ import {
 } from "../shared/util.js";
 import { CMapFactory, IdentityCMap } from "./cmap.js";
 import { Cmd, Dict, EOF, isName, Name, Ref, RefSet } from "./primitives.js";
-import { compileType3Glyph, FontFlags } from "./fonts_utils.js";
+import {
+  compileType3Glyph,
+  FontFlags,
+  normalizeFontName,
+} from "./fonts_utils.js";
 import { ErrorFont, Font } from "./fonts.js";
 import {
   fetchBinaryData,
@@ -4238,16 +4242,17 @@ class PartialEvaluator {
     let defaultWidth = 0;
     let widths = Object.create(null);
     let monospace = false;
+
+    let fontName = normalizeFontName(name);
     const stdFontMap = getStdFontMap();
-    let lookupName = stdFontMap[name] || name;
+    fontName = stdFontMap[fontName] || fontName;
     const Metrics = getMetrics();
 
-    if (!(lookupName in Metrics)) {
+    const glyphWidths =
+      Metrics[fontName] ??
       // Use default fonts for looking up font metrics if the passed
       // font is not a base font
-      lookupName = this.isSerifFont(name) ? "Times-Roman" : "Helvetica";
-    }
-    const glyphWidths = Metrics[lookupName];
+      Metrics[this.isSerifFont(name) ? "Times-Roman" : "Helvetica"];
 
     if (typeof glyphWidths === "number") {
       defaultWidth = glyphWidths;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4463,7 +4463,7 @@ class PartialEvaluator {
         }
 
         // Using base font name as a font name.
-        baseFontName = baseFontName.name.replaceAll(/[,_]/g, "-");
+        baseFontName = normalizeFontName(baseFontName.name);
         const metrics = this.getBaseFontMetrics(baseFontName);
 
         // Simulating descriptor flags attribute

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -992,7 +992,7 @@ class Font {
         nonStdFontMap = getNonStdFontMap(),
         serifFonts = getSerifFonts();
       for (const namePart of name.split("+")) {
-        let fontName = namePart.replaceAll(/[,_]/g, "-");
+        let fontName = normalizeFontName(namePart);
         fontName = stdFontMap[fontName] || nonStdFontMap[fontName] || fontName;
         fontName = fontName.split("-", 1)[0];
         if (serifFonts[fontName]) {

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -873,3 +873,4 @@
 !Brotli-Prototype-FileA.pdf
 !bug2013793.pdf
 !bug2014080.pdf
+!issue20246.pdf

--- a/test/pdfs/issue20246.pdf.link
+++ b/test/pdfs/issue20246.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/22213611/SFM305474INV1574654.PDF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -13936,5 +13936,14 @@
     "md5": "9113370932798776ba91c807ce95082e",
     "rounds": 1,
     "type": "eq"
+  },
+  {
+    "id": "issue20246",
+    "file": "pdfs/issue20246.pdf",
+    "md5": "4ec1d6b41c7a919ca2de8174ba300233",
+    "rounds": 1,
+    "link": true,
+    "lastPage": 1,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
We tried to lookup the font metrics using the font name as-is, which didn't work since the PDF file in question has non-embedded fonts with names that include commas.
Hence the font names need to be normalized here as well, similar to elsewhere in the font code.