### PR TITLE
[api-minor] Update the minimum supported Google Chrome version to 118

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -13,9 +13,6 @@
     "color-no-invalid-hex": true,
     "declaration-block-no-duplicate-properties": true,
     "declaration-block-no-redundant-longhand-properties": true,
-    "declaration-property-value-disallowed-list": {
-      "float": ["inline-start", "inline-end"]
-    },
     "length-zero-no-unit": [true, {
       "ignore": ["custom-properties"]
     }],

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -82,7 +82,7 @@ const config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
 
 const ENV_TARGETS = [
   "last 2 versions",
-  "Chrome >= 110",
+  "Chrome >= 118",
   "Firefox ESR",
   "Safari >= 16.4",
   "Node >= 20",
@@ -1297,10 +1297,6 @@ function createDefaultPrefsFile() {
   return createStringSource(defaultFileName, buf.join("\n"));
 }
 
-function replaceMozcentralCSS() {
-  return replace(/var\(--(inline-(?:start|end))\)/g, "$1");
-}
-
 gulp.task(
   "mozcentral",
   gulp.series(
@@ -1376,7 +1372,6 @@ gulp.task(
               autoprefixer(MOZCENTRAL_AUTOPREFIXER_CONFIG),
             ])
           )
-          .pipe(replaceMozcentralCSS())
           .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),
 
         preprocessCSS("web/viewer-geckoview.css", gvDefines)
@@ -1386,7 +1381,6 @@ gulp.task(
               autoprefixer(MOZCENTRAL_AUTOPREFIXER_CONFIG),
             ])
           )
-          .pipe(replaceMozcentralCSS())
           .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + "web")),
 
         gulp

--- a/web/tree.css
+++ b/web/tree.css
@@ -46,7 +46,7 @@
       }
 
       position: relative;
-      float: var(--inline-start);
+      float: inline-start;
       height: 0;
       width: 0;
       color: rgb(255 255 255 / 0.5);

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -17,10 +17,6 @@
 
 :root {
   --dir-factor: 1;
-  /*#if !MOZCENTRAL*/
-  --inline-start: left;
-  --inline-end: right;
-  /*#endif*/
 
   --sidebar-width: 200px;
   --sidebar-transition-duration: 200ms;
@@ -132,10 +128,6 @@
 
 :root:dir(rtl) {
   --dir-factor: -1;
-  /*#if !MOZCENTRAL*/
-  --inline-start: right;
-  --inline-end: left;
-  /*#endif*/
 }
 
 @media screen and (forced-colors: active) {
@@ -417,7 +409,7 @@ body {
 }
 
 .splitToolbarButtonSeparator {
-  float: var(--inline-start);
+  float: inline-start;
   width: 0;
   height: 62%;
   border-left: 1px solid var(--separator-color);


### PR DESCRIPTION
This patch updates the minimum supported browsers as follows:
 - Google Chrome 118, which was released on 2023-10-10; see https://chromereleases.googleblog.com/2023/10/stable-channel-update-for-desktop_10.html

We haven't made any changes to the supported Google Chrome version for a year, and this change allows us to remove "hacks" needed to support `float: inline-start/inline-end` in old browsers; see https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/float#browser_compatibility.

Note that nowadays we usually try, where feasible and possible, to support browsers that are about two years old. By limiting support to only "recent" browsers we reduce the risk of holding back improvements of the *built-in* Firefox PDF Viewer, and also (significantly) reduce the maintenance/support burden for the PDF.js contributors.

*Please note:* As always, the minimum supported browser version assumes that a `legacy`-build of the PDF.js library is being used; see https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#faq-support