### PR TITLE
Add option allow external connections to `npx gulp server`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2210,8 +2210,17 @@ gulp.task(
         }
       }
 
+      let host;
+      const j = process.argv.indexOf("--host");
+      if (j >= 0 && j + 1 < process.argv.length) {
+        host = process.argv[j + 1];
+        if (host === "0") {
+          host = "0.0.0.0";
+        }
+      }
+
       const { WebServer } = await import("./test/webserver.mjs");
-      const server = new WebServer({ port });
+      const server = new WebServer({ host, port });
       server.start();
     }
   )


### PR DESCRIPTION
Using `0.0.0.0` instead of `localhost` allows connecting from other
devices, significantly simplifying testing on mobile devices.

This is controlled by the `--any-host` CLI flag and not enabled by
default, since allowing external connections comes with security
implications (e.g. when on a public network without a properly
configured firewall).