### PR TITLE
Start using `Response.prototype.bytes()` in the code-base

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -129,7 +129,7 @@ async function fetchBinaryData(url) {
       `Failed to fetch file "${url}" with "${response.statusText}".`
     );
   }
-  return new Uint8Array(await response.arrayBuffer());
+  return response.bytes();
 }
 
 /**

--- a/src/display/cmap_reader_factory.js
+++ b/src/display/cmap_reader_factory.js
@@ -64,11 +64,9 @@ class DOMCMapReaderFactory extends BaseCMapReaderFactory {
   async _fetch(url) {
     const data = await fetchData(
       url,
-      /* type = */ this.isCompressed ? "arraybuffer" : "text"
+      /* type = */ this.isCompressed ? "bytes" : "text"
     );
-    return data instanceof ArrayBuffer
-      ? new Uint8Array(data)
-      : stringToBytes(data);
+    return data instanceof Uint8Array ? data : stringToBytes(data);
   }
 }
 

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -48,6 +48,8 @@ async function fetchData(url, type = "text") {
         return response.arrayBuffer();
       case "blob":
         return response.blob();
+      case "bytes":
+        return response.bytes();
       case "json":
         return response.json();
     }
@@ -58,7 +60,7 @@ async function fetchData(url, type = "text") {
   return new Promise((resolve, reject) => {
     const request = new XMLHttpRequest();
     request.open("GET", url, /* async = */ true);
-    request.responseType = type;
+    request.responseType = type === "bytes" ? "arraybuffer" : type;
 
     request.onreadystatechange = () => {
       if (request.readyState !== XMLHttpRequest.DONE) {
@@ -66,6 +68,9 @@ async function fetchData(url, type = "text") {
       }
       if (request.status === 200 || request.status === 0) {
         switch (type) {
+          case "bytes":
+            resolve(new Uint8Array(request.response));
+            return;
           case "arraybuffer":
           case "blob":
           case "json":

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -44,8 +44,6 @@ async function fetchData(url, type = "text") {
       throw new Error(response.statusText);
     }
     switch (type) {
-      case "arraybuffer":
-        return response.arrayBuffer();
       case "blob":
         return response.blob();
       case "bytes":
@@ -71,7 +69,6 @@ async function fetchData(url, type = "text") {
           case "bytes":
             resolve(new Uint8Array(request.response));
             return;
-          case "arraybuffer":
           case "blob":
           case "json":
             resolve(request.response);

--- a/src/display/standard_fontdata_factory.js
+++ b/src/display/standard_fontdata_factory.js
@@ -57,8 +57,7 @@ class DOMStandardFontDataFactory extends BaseStandardFontDataFactory {
    * @ignore
    */
   async _fetch(url) {
-    const data = await fetchData(url, /* type = */ "arraybuffer");
-    return new Uint8Array(data);
+    return fetchData(url, /* type = */ "bytes");
   }
 }
 

--- a/src/display/wasm_factory.js
+++ b/src/display/wasm_factory.js
@@ -55,8 +55,7 @@ class DOMWasmFactory extends BaseWasmFactory {
    * @ignore
    */
   async _fetch(url) {
-    const data = await fetchData(url, /* type = */ "arraybuffer");
-    return new Uint8Array(data);
+    return fetchData(url, /* type = */ "bytes");
   }
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1248,6 +1248,18 @@ if (
   };
 }
 
+// See https://developer.mozilla.org/en-US/docs/Web/API/Response/bytes#browser_compatibility
+if (
+  typeof PDFJSDev !== "undefined" &&
+  !PDFJSDev.test("SKIP_BABEL") &&
+  typeof Response.prototype.bytes !== "function"
+) {
+  Response.prototype.bytes = async function () {
+    return new Uint8Array(await this.arrayBuffer());
+  };
+}
+
+// TODO: Remove this once Safari 17.4 is the lowest supported version.
 if (
   typeof PDFJSDev !== "undefined" &&
   !PDFJSDev.test("SKIP_BABEL") &&

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -41,8 +41,7 @@ class DefaultFileReaderFactory {
     if (isNodeJS) {
       return fetchDataNode(params.path);
     }
-    const data = await fetchDataDOM(params.path, /* type = */ "arraybuffer");
-    return new Uint8Array(data);
+    return fetchDataDOM(params.path, /* type = */ "bytes");
   }
 }
 


### PR DESCRIPTION
In all cases where we currently use `Response.prototype.arrayBuffer()` the result is immediately wrapped in a `Uint8Array`, which can be avoided by instead using the newer `Response.prototype.bytes()` method; see https://developer.mozilla.org/en-US/docs/Web/API/Response/bytes