### PR TITLE
Avoid parsing skipped range requests in `ChunkedStreamManager` (PR 10694 follow-up)

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -301,7 +301,11 @@ class ChunkedStreamManager {
       const readChunk = ({ value, done }) => {
         try {
           if (done) {
-            resolve(arrayBuffersToBytes(chunks));
+            resolve(
+              chunks.length > 0 || !this.disableAutoFetch
+                ? arrayBuffersToBytes(chunks)
+                : null
+            );
             chunks = null;
             return;
           }
@@ -321,6 +325,11 @@ class ChunkedStreamManager {
     }).then(data => {
       if (this.aborted) {
         return; // Ignoring any data after abort.
+      }
+      if (!data) {
+        // The range request wasn't dispatched, see the "GetRangeReader" handler
+        // in the `src/display/api.js` file.
+        return;
       }
       this.onReceiveData({ chunk: data.buffer, begin });
     });


### PR DESCRIPTION
While we don't dispatch the actual range request after PR #10694 we still parse the returned data, which ends up being an *empty* `ArrayBuffer` and thus cannot affect the `ChunkedStream.prototype._loadedChunks` property.
Given that no actual data arrived, it's thus pointless[1] to invoke the `ChunkedStreamManager.prototype.onReceiveData` method in this case (and it also avoids sending effectively duplicate "DocProgress" messages).

---
[1] With the *possible* exception of `disableAutoFetch === false` being set, see https://github.com/mozilla/pdf.js/blob/f24768d7b4ef0f64976a7f9e80e15ef50c759356/src/core/chunked_stream.js#L499-L517 however that never happens when streaming is being used; note https://github.com/mozilla/pdf.js/blob/f24768d7b4ef0f64976a7f9e80e15ef50c759356/src/core/worker.js#L237-L238