### PR TITLE
Enable the `unicorn/prefer-class-fields` ESLint plugin rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -148,6 +148,7 @@ export default [
       "unicorn/prefer-array-index-of": "error",
       "unicorn/prefer-array-some": "error",
       "unicorn/prefer-at": "error",
+      "unicorn/prefer-class-fields": "error",
       "unicorn/prefer-classlist-toggle": "error",
       "unicorn/prefer-date-now": "error",
       "unicorn/prefer-dom-node-append": "error",

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1462,14 +1462,17 @@ class Annotation {
  * Contains all data regarding an annotation's border style.
  */
 class AnnotationBorderStyle {
-  constructor() {
-    this.width = 1;
-    this.rawWidth = 1;
-    this.style = AnnotationBorderStyleType.SOLID;
-    this.dashArray = [3];
-    this.horizontalCornerRadius = 0;
-    this.verticalCornerRadius = 0;
-  }
+  width = 1;
+
+  rawWidth = 1;
+
+  style = AnnotationBorderStyleType.SOLID;
+
+  dashArray = [3];
+
+  horizontalCornerRadius = 0;
+
+  verticalCornerRadius = 0;
 
   /**
    * Set the width.

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -991,24 +991,31 @@ class CFFParser {
 
 // Compact Font Format
 class CFF {
-  constructor() {
-    this.header = null;
-    this.names = [];
-    this.topDict = null;
-    this.strings = new CFFStrings();
-    this.globalSubrIndex = null;
+  header = null;
 
-    // The following could really be per font, but since we only have one font
-    // store them here.
-    this.encoding = null;
-    this.charset = null;
-    this.charStrings = null;
-    this.fdArray = [];
-    this.fdSelect = null;
+  names = [];
 
-    this.isCIDFont = false;
-    this.charStringCount = 0;
-  }
+  topDict = null;
+
+  strings = new CFFStrings();
+
+  globalSubrIndex = null;
+
+  // The following could really be per font, but since we only have one font
+  // store them here.
+  encoding = null;
+
+  charset = null;
+
+  charStrings = null;
+
+  fdArray = [];
+
+  fdSelect = null;
+
+  isCIDFont = false;
+
+  charStringCount = 0;
 
   duplicateFirstGlyph() {
     // Browsers will not display a glyph at position 0. Typically glyph 0 is

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -32,9 +32,11 @@ import { calculateSHA256 } from "./calculate_sha256.js";
 import { DecryptStream } from "./decrypt_stream.js";
 
 class ARCFourCipher {
+  a = 0;
+
+  b = 0;
+
   constructor(key) {
-    this.a = 0;
-    this.b = 0;
     const s = new Uint8Array(256);
     const keyLength = key.length;
 

--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -74,33 +74,52 @@ class XRefWrapper {
 }
 
 class PDFEditor {
+  hasSingleFile = false;
+
+  currentDocument = null;
+
+  oldPages = [];
+
+  newPages = [];
+
+  xref = [null];
+
+  xrefWrapper = new XRefWrapper(this.xref);
+
+  newRefCount = 1;
+
+  namesDict = null;
+
+  version = "1.7";
+
+  pageLabels = null;
+
+  namedDestinations = new Map();
+
+  parentTree = new Map();
+
+  structTreeKids = [];
+
+  idTree = new Map();
+
+  classMap = new Dict();
+
+  roleMap = new Dict();
+
+  namespaces = new Map();
+
+  structTreeAF = [];
+
+  structTreePronunciationLexicon = [];
+
   constructor({ useObjectStreams = true, title = "", author = "" } = {}) {
-    this.hasSingleFile = false;
-    this.currentDocument = null;
-    this.oldPages = [];
-    this.newPages = [];
-    this.xref = [null];
-    this.xrefWrapper = new XRefWrapper(this.xref);
-    this.newRefCount = 1;
     [this.rootRef, this.rootDict] = this.newDict;
     [this.infoRef, this.infoDict] = this.newDict;
     [this.pagesRef, this.pagesDict] = this.newDict;
-    this.namesDict = null;
     this.useObjectStreams = useObjectStreams;
     this.objStreamRefs = useObjectStreams ? new Set() : null;
-    this.version = "1.7";
     this.title = title;
     this.author = author;
-    this.pageLabels = null;
-    this.namedDestinations = new Map();
-    this.parentTree = new Map();
-    this.structTreeKids = [];
-    this.idTree = new Map();
-    this.classMap = new Dict();
-    this.roleMap = new Dict();
-    this.namespaces = new Map();
-    this.structTreeAF = [];
-    this.structTreePronunciationLexicon = [];
   }
 
   /**

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -79,13 +79,15 @@ const COMMAND_MAP = {
  *  the charStrings.
  */
 class Type1CharString {
-  constructor() {
-    this.width = 0;
-    this.lsb = 0;
-    this.flexing = false;
-    this.output = [];
-    this.stack = [];
-  }
+  width = 0;
+
+  lsb = 0;
+
+  flexing = false;
+
+  output = [];
+
+  stack = [];
 
   convert(encoded, subrs, seacAnalysisEnabled) {
     const count = encoded.length;

--- a/src/display/annotation_storage.js
+++ b/src/display/annotation_storage.js
@@ -35,15 +35,17 @@ class AnnotationStorage {
 
   #storage = new Map();
 
-  constructor() {
-    // Callbacks to signal when the modification state is set or reset.
-    // This is used by the viewer to only bind on `beforeunload` if forms
-    // are actually edited to prevent doing so unconditionally since that
-    // can have undesirable effects.
-    this.onSetModified = null;
-    this.onResetModified = null;
-    this.onAnnotationEditor = null;
+  // Callbacks to signal when the modification state is set or reset.
+  // This is used by the viewer to only bind on `beforeunload` if forms
+  // are actually edited to prevent doing so unconditionally since that
+  // can have undesirable effects.
+  onSetModified = null;
 
+  onResetModified = null;
+
+  onAnnotationEditor = null;
+
+  constructor() {
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.
       Object.defineProperty(this, "_setValues", {

--- a/src/scripting_api/print_params.js
+++ b/src/scripting_api/print_params.js
@@ -14,132 +14,165 @@
  */
 
 class PrintParams {
+  binaryOk = true;
+
+  bitmapDPI = 150;
+
+  booklet = {
+    binding: 0,
+    duplexMode: 0,
+    subsetFrom: 0,
+    subsetTo: -1,
+  };
+
+  colorOverride = 0;
+
+  colorProfile = "";
+
+  constants = Object.freeze({
+    bookletBindings: Object.freeze({
+      Left: 0,
+      Right: 1,
+      LeftTall: 2,
+      RightTall: 3,
+    }),
+    bookletDuplexMode: Object.freeze({
+      BothSides: 0,
+      FrontSideOnly: 1,
+      BasicSideOnly: 2,
+    }),
+    colorOverrides: Object.freeze({
+      auto: 0,
+      gray: 1,
+      mono: 2,
+    }),
+    fontPolicies: Object.freeze({
+      everyPage: 0,
+      jobStart: 1,
+      pageRange: 2,
+    }),
+    handling: Object.freeze({
+      none: 0,
+      fit: 1,
+      shrink: 2,
+      tileAll: 3,
+      tileLarge: 4,
+      nUp: 5,
+      booklet: 6,
+    }),
+    interactionLevel: Object.freeze({
+      automatic: 0,
+      full: 1,
+      silent: 2,
+    }),
+    nUpPageOrders: Object.freeze({
+      Horizontal: 0,
+      HorizontalReversed: 1,
+      Vertical: 2,
+    }),
+    printContents: Object.freeze({
+      doc: 0,
+      docAndComments: 1,
+      formFieldsOnly: 2,
+    }),
+    flagValues: Object.freeze({
+      applyOverPrint: 1,
+      applySoftProofSettings: 1 << 1,
+      applyWorkingColorSpaces: 1 << 2,
+      emitHalftones: 1 << 3,
+      emitPostScriptXObjects: 1 << 4,
+      emitFormsAsPSForms: 1 << 5,
+      maxJP2KRes: 1 << 6,
+      setPageSize: 1 << 7,
+      suppressBG: 1 << 8,
+      suppressCenter: 1 << 9,
+      suppressCJKFontSubst: 1 << 10,
+      suppressCropClip: 1 << 1,
+      suppressRotate: 1 << 12,
+      suppressTransfer: 1 << 13,
+      suppressUCR: 1 << 14,
+      useTrapAnnots: 1 << 15,
+      usePrintersMarks: 1 << 16,
+    }),
+    rasterFlagValues: Object.freeze({
+      textToOutline: 1,
+      strokesToOutline: 1 << 1,
+      allowComplexClip: 1 << 2,
+      preserveOverprint: 1 << 3,
+    }),
+    subsets: Object.freeze({
+      all: 0,
+      even: 1,
+      odd: 2,
+    }),
+    tileMarks: Object.freeze({
+      none: 0,
+      west: 1,
+      east: 2,
+    }),
+    usages: Object.freeze({
+      auto: 0,
+      use: 1,
+      noUse: 2,
+    }),
+  });
+
+  downloadFarEastFonts = false;
+
+  fileName = "";
+
+  firstPage = 0;
+
+  flags = 0;
+
+  fontPolicy = 0;
+
+  gradientDPI = 150;
+
+  interactive = 1;
+
+  npUpAutoRotate = false;
+
+  npUpNumPagesH = 2;
+
+  npUpNumPagesV = 2;
+
+  npUpPageBorder = false;
+
+  npUpPageOrder = 0;
+
+  pageHandling = 0;
+
+  pageSubset = 0;
+
+  printAsImage = false;
+
+  printContent = 0;
+
+  printerName = "";
+
+  psLevel = 0;
+
+  rasterFlags = 0;
+
+  reversePages = false;
+
+  tileLabel = false;
+
+  tileMark = 0;
+
+  tileOverlap = 0;
+
+  tileScale = 1.0;
+
+  transparencyLevel = 75;
+
+  usePrinterCRD = 0;
+
+  useT1Conversion = 0;
+
   constructor(data) {
-    this.binaryOk = true;
-    this.bitmapDPI = 150;
-    this.booklet = {
-      binding: 0,
-      duplexMode: 0,
-      subsetFrom: 0,
-      subsetTo: -1,
-    };
-    this.colorOverride = 0;
-    this.colorProfile = "";
-    this.constants = Object.freeze({
-      bookletBindings: Object.freeze({
-        Left: 0,
-        Right: 1,
-        LeftTall: 2,
-        RightTall: 3,
-      }),
-      bookletDuplexMode: Object.freeze({
-        BothSides: 0,
-        FrontSideOnly: 1,
-        BasicSideOnly: 2,
-      }),
-      colorOverrides: Object.freeze({
-        auto: 0,
-        gray: 1,
-        mono: 2,
-      }),
-      fontPolicies: Object.freeze({
-        everyPage: 0,
-        jobStart: 1,
-        pageRange: 2,
-      }),
-      handling: Object.freeze({
-        none: 0,
-        fit: 1,
-        shrink: 2,
-        tileAll: 3,
-        tileLarge: 4,
-        nUp: 5,
-        booklet: 6,
-      }),
-      interactionLevel: Object.freeze({
-        automatic: 0,
-        full: 1,
-        silent: 2,
-      }),
-      nUpPageOrders: Object.freeze({
-        Horizontal: 0,
-        HorizontalReversed: 1,
-        Vertical: 2,
-      }),
-      printContents: Object.freeze({
-        doc: 0,
-        docAndComments: 1,
-        formFieldsOnly: 2,
-      }),
-      flagValues: Object.freeze({
-        applyOverPrint: 1,
-        applySoftProofSettings: 1 << 1,
-        applyWorkingColorSpaces: 1 << 2,
-        emitHalftones: 1 << 3,
-        emitPostScriptXObjects: 1 << 4,
-        emitFormsAsPSForms: 1 << 5,
-        maxJP2KRes: 1 << 6,
-        setPageSize: 1 << 7,
-        suppressBG: 1 << 8,
-        suppressCenter: 1 << 9,
-        suppressCJKFontSubst: 1 << 10,
-        suppressCropClip: 1 << 1,
-        suppressRotate: 1 << 12,
-        suppressTransfer: 1 << 13,
-        suppressUCR: 1 << 14,
-        useTrapAnnots: 1 << 15,
-        usePrintersMarks: 1 << 16,
-      }),
-      rasterFlagValues: Object.freeze({
-        textToOutline: 1,
-        strokesToOutline: 1 << 1,
-        allowComplexClip: 1 << 2,
-        preserveOverprint: 1 << 3,
-      }),
-      subsets: Object.freeze({
-        all: 0,
-        even: 1,
-        odd: 2,
-      }),
-      tileMarks: Object.freeze({
-        none: 0,
-        west: 1,
-        east: 2,
-      }),
-      usages: Object.freeze({
-        auto: 0,
-        use: 1,
-        noUse: 2,
-      }),
-    });
-    this.downloadFarEastFonts = false;
-    this.fileName = "";
-    this.firstPage = 0;
-    this.flags = 0;
-    this.fontPolicy = 0;
-    this.gradientDPI = 150;
-    this.interactive = 1;
     this.lastPage = data.lastPage;
-    this.npUpAutoRotate = false;
-    this.npUpNumPagesH = 2;
-    this.npUpNumPagesV = 2;
-    this.npUpPageBorder = false;
-    this.npUpPageOrder = 0;
-    this.pageHandling = 0;
-    this.pageSubset = 0;
-    this.printAsImage = false;
-    this.printContent = 0;
-    this.printerName = "";
-    this.psLevel = 0;
-    this.rasterFlags = 0;
-    this.reversePages = false;
-    this.tileLabel = false;
-    this.tileMark = 0;
-    this.tileOverlap = 0;
-    this.tileScale = 1.0;
-    this.transparencyLevel = 75;
-    this.usePrinterCRD = 0;
-    this.useT1Conversion = 0;
   }
 }
 

--- a/web/pdf_find_bar.js
+++ b/web/pdf_find_bar.js
@@ -29,9 +29,9 @@ class PDFFindBar {
 
   #resizeObserver = new ResizeObserver(this.#resizeObserverCallback.bind(this));
 
-  constructor(options, mainContainer, eventBus) {
-    this.opened = false;
+  opened = false;
 
+  constructor(options, mainContainer, eventBus) {
     this.bar = options.bar;
     this.toggleButton = options.toggleButton;
     this.findField = options.findField;

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -172,8 +172,7 @@ class PDFPageView extends BasePDFPageView {
   constructor(options) {
     super(options);
 
-    const container = options.container;
-    const defaultViewport = options.defaultViewport;
+    const { container, defaultViewport } = options;
 
     this.renderingId = "page" + this.id;
     this.#layerProperties = options.layerProperties || DEFAULT_LAYER_PROPERTIES;


### PR DESCRIPTION
This leads to slightly shorter code[1] when initializing classes, and in some cases we can even remove the constructors, which shouldn't hurt; see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-class-fields.md

It's probably possible to also change a lot of these class fields to private ones[2], however it's often difficult to tell at a glance if that's safe hence this patch only does this for the `PDFRenderingQueue`.

---

[1] This reduces the size of the `gulp mozcentral` output by 999 bytes, for a mostly mechanical code change.

[2] That sort of re-factoring should generally be done separately, on a class-by-class basis, to reduce the risk of regressions.