### PR TITLE
Remove `Object.hasOwn` usage from the `src/core/xref.js` file

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -683,10 +683,10 @@ class XRef {
       // iterate over empty entries so we use the `in` operator instead of
       // using for..of on entries() or a for with the array length.
       for (const num in this.entries) {
-        if (!Object.hasOwn(this.entries, num)) {
+        const entry = this.entries[num];
+        if (!entry) {
           continue;
         }
-        const entry = this.entries[num];
         const ref = Ref.get(parseInt(num), entry.gen);
         let obj;
 
@@ -695,7 +695,6 @@ class XRef {
         } catch {
           continue;
         }
-
         if (obj instanceof BaseStream) {
           obj = obj.dict;
         }


### PR DESCRIPTION
This should not be necessary, given the following checks done early during the worker initialization: https://github.com/mozilla/pdf.js/blob/c5746949acd8d64636683c2da733e5426535728e/src/core/worker.js#L124-L141