### PR TITLE
Convert the `PDFObjects` class to use a `Map` internally

### DIFF
--- a/web/base_download_manager.js
+++ b/web/base_download_manager.js
@@ -64,11 +64,10 @@ class BaseDownloadManager {
     const contentType = isPdfData ? "application/pdf" : "";
 
     if (isPdfData) {
-      let blobUrl;
+      const blobUrl = this.#openBlobUrls.getOrInsertComputed(data, () =>
+        URL.createObjectURL(new Blob([data], { type: contentType }))
+      );
       try {
-        blobUrl = this.#openBlobUrls.getOrInsertComputed(data, () =>
-          URL.createObjectURL(new Blob([data], { type: contentType }))
-        );
         const viewerUrl = this._getOpenDataUrl(blobUrl, filename, dest);
 
         window.open(viewerUrl);


### PR DESCRIPTION
This patch also adds unconditional `Map.prototype.getOrInsertComputed()` usage, which should be fine since it's [supported in the latest browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsertComputed#browser_compatibility) and it'll be polyfilled (via core-js) in the `legacy` builds.