### PR TITLE
Remove unused `CanvasGraphics` properties (PR 700 follow-up)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -667,8 +667,6 @@ class CanvasGraphics {
     this.stateStack = [];
     this.pendingClip = null;
     this.pendingEOFill = false;
-    this.res = null;
-    this.xobjs = null;
     this.commonObjs = commonObjs;
     this.objs = objs;
     this.canvasFactory = canvasFactory;


### PR DESCRIPTION
These are probably a copy-and-paste mistake, since they appear to have been unused already in PR #700 all the way back in 2011.