### PR TITLE
Remove unnecessary class constructors in the `src` folder

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1051,9 +1051,7 @@ class CFFHeader {
 }
 
 class CFFStrings {
-  constructor() {
-    this.strings = [];
-  }
+  strings = [];
 
   get(index) {
     if (index >= 0 && index <= NUM_STANDARD_CFF_STRINGS - 1) {
@@ -1087,10 +1085,9 @@ class CFFStrings {
 }
 
 class CFFIndex {
-  constructor() {
-    this.objects = [];
-    this.length = 0;
-  }
+  objects = [];
+
+  length = 0;
 
   add(data) {
     this.length += data.length;
@@ -1323,9 +1320,7 @@ class CFFFDSelect {
 // Helper class to keep track of where an offset is within the data and helps
 // filling in that offset once it's known.
 class CFFOffsetTracker {
-  constructor() {
-    this.offsets = Object.create(null);
-  }
+  offsets = Object.create(null);
 
   isTracking(key) {
     return key in this.offsets;

--- a/src/core/dataset_reader.js
+++ b/src/core/dataset_reader.js
@@ -27,10 +27,7 @@ function decodeString(str) {
 }
 
 class DatasetXMLParser extends SimpleXMLParser {
-  constructor(options) {
-    super(options);
-    this.node = null;
-  }
+  node = null;
 
   onEndElement(name) {
     const node = super.onEndElement(name);

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -5042,21 +5042,31 @@ class StateManager {
 }
 
 class TextState {
-  constructor() {
-    this.ctm = new Float32Array(IDENTITY_MATRIX);
-    this.fontName = null;
-    this.fontSize = 0;
-    this.loadedName = null;
-    this.font = null;
-    this.fontMatrix = FONT_IDENTITY_MATRIX;
-    this.textMatrix = IDENTITY_MATRIX.slice();
-    this.textLineMatrix = IDENTITY_MATRIX.slice();
-    this.charSpacing = 0;
-    this.wordSpacing = 0;
-    this.leading = 0;
-    this.textHScale = 1;
-    this.textRise = 0;
-  }
+  ctm = new Float32Array(IDENTITY_MATRIX);
+
+  fontName = null;
+
+  fontSize = 0;
+
+  loadedName = null;
+
+  font = null;
+
+  fontMatrix = FONT_IDENTITY_MATRIX;
+
+  textMatrix = IDENTITY_MATRIX.slice();
+
+  textLineMatrix = IDENTITY_MATRIX.slice();
+
+  charSpacing = 0;
+
+  wordSpacing = 0;
+
+  leading = 0;
+
+  textHScale = 1;
+
+  textRise = 0;
 
   setTextMatrix(a, b, c, d, e, f) {
     const m = this.textMatrix;
@@ -5105,24 +5115,28 @@ class TextState {
 }
 
 class EvalState {
-  constructor() {
-    this.ctm = new Float32Array(IDENTITY_MATRIX);
-    this.font = null;
-    this.textRenderingMode = TextRenderingMode.FILL;
-    this._fillColorSpace = this._strokeColorSpace = ColorSpaceUtils.gray;
-    this.patternFillColorSpace = null;
-    this.patternStrokeColorSpace = null;
+  ctm = new Float32Array(IDENTITY_MATRIX);
 
-    // Path stuff.
-    this.currentPointX = this.currentPointY = 0;
-    this.pathMinMax = new Float32Array([
-      Infinity,
-      Infinity,
-      -Infinity,
-      -Infinity,
-    ]);
-    this.pathBuffer = [];
-  }
+  font = null;
+
+  textRenderingMode = TextRenderingMode.FILL;
+
+  _fillColorSpace = ColorSpaceUtils.gray;
+
+  _strokeColorSpace = ColorSpaceUtils.gray;
+
+  patternFillColorSpace = null;
+
+  patternStrokeColorSpace = null;
+
+  // Path stuff.
+  currentPointX = 0;
+
+  currentPointY = 0;
+
+  pathMinMax = new Float32Array([Infinity, Infinity, -Infinity, -Infinity]);
+
+  pathBuffer = [];
 
   get fillColorSpace() {
     return this._fillColorSpace;

--- a/src/core/function.js
+++ b/src/core/function.js
@@ -836,9 +836,7 @@ class AstVariableDefinition extends AstNode {
 }
 
 class ExpressionBuilderVisitor {
-  constructor() {
-    this.parts = [];
-  }
+  parts = [];
 
   visitArgument(arg) {
     this.parts.push(

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -398,9 +398,7 @@ class RefSet {
 }
 
 class RefSetCache {
-  constructor() {
-    this._map = new Map();
-  }
+  _map = new Map();
 
   get size() {
     return this._map.size;

--- a/src/scripting_api/color.js
+++ b/src/scripting_api/color.js
@@ -17,21 +17,32 @@ import { ColorConverters } from "../shared/scripting_utils.js";
 import { PDFObject } from "./pdf_object.js";
 
 class Color extends PDFObject {
+  transparent = ["T"];
+
+  black = ["G", 0];
+
+  white = ["G", 1];
+
+  red = ["RGB", 1, 0, 0];
+
+  green = ["RGB", 0, 1, 0];
+
+  blue = ["RGB", 0, 0, 1];
+
+  cyan = ["CMYK", 1, 0, 0, 0];
+
+  magenta = ["CMYK", 0, 1, 0, 0];
+
+  yellow = ["CMYK", 0, 0, 1, 0];
+
+  dkGray = ["G", 0.25];
+
+  gray = ["G", 0.5];
+
+  ltGray = ["G", 0.75];
+
   constructor() {
     super({});
-
-    this.transparent = ["T"];
-    this.black = ["G", 0];
-    this.white = ["G", 1];
-    this.red = ["RGB", 1, 0, 0];
-    this.green = ["RGB", 0, 1, 0];
-    this.blue = ["RGB", 0, 0, 1];
-    this.cyan = ["CMYK", 1, 0, 0, 0];
-    this.magenta = ["CMYK", 0, 1, 0, 0];
-    this.yellow = ["CMYK", 0, 0, 1, 0];
-    this.dkGray = ["G", 0.25];
-    this.gray = ["G", 0.5];
-    this.ltGray = ["G", 0.75];
   }
 
   static _isValidSpace(cColorSpace) {

--- a/src/scripting_api/fullscreen.js
+++ b/src/scripting_api/fullscreen.js
@@ -17,20 +17,25 @@ import { Cursor } from "./constants.js";
 import { PDFObject } from "./pdf_object.js";
 
 class FullScreen extends PDFObject {
-  constructor(data) {
-    super(data);
+  _backgroundColor = [];
 
-    this._backgroundColor = [];
-    this._clickAdvances = true;
-    this._cursor = Cursor.hidden;
-    this._defaultTransition = "";
-    this._escapeExits = true;
-    this._isFullScreen = true;
-    this._loop = false;
-    this._timeDelay = 3600;
-    this._usePageTiming = false;
-    this._useTimer = false;
-  }
+  _clickAdvances = true;
+
+  _cursor = Cursor.hidden;
+
+  _defaultTransition = "";
+
+  _escapeExits = true;
+
+  _isFullScreen = true;
+
+  _loop = false;
+
+  _timeDelay = 3600;
+
+  _usePageTiming = false;
+
+  _useTimer = false;
 
   get backgroundColor() {
     return this._backgroundColor;

--- a/src/scripting_api/proxy.js
+++ b/src/scripting_api/proxy.js
@@ -14,12 +14,10 @@
  */
 
 class ProxyHandler {
-  constructor() {
-    // Don't dispatch an event for those properties.
-    //  - delay: allow to delay field redraw until delay is set to false.
-    //    Likely it's useless to implement that stuff.
-    this.nosend = new Set(["delay"]);
-  }
+  // Don't dispatch an event for those properties.
+  //  - delay: allow to delay field redraw until delay is set to false.
+  //    Likely it's useless to implement that stuff.
+  nosend = new Set(["delay"]);
 
   get(obj, prop) {
     // script may add some properties to the object

--- a/src/scripting_api/thermometer.js
+++ b/src/scripting_api/thermometer.js
@@ -16,14 +16,13 @@
 import { PDFObject } from "./pdf_object.js";
 
 class Thermometer extends PDFObject {
-  constructor(data) {
-    super(data);
+  _cancelled = false;
 
-    this._cancelled = false;
-    this._duration = 100;
-    this._text = "";
-    this._value = 0;
-  }
+  _duration = 100;
+
+  _text = "";
+
+  _value = 0;
 
   get cancelled() {
     return this._cancelled;


### PR DESCRIPTION
There's a number of classes where the constructors can be removed completely by instead using class fields, which help to slightly shorten the code.

It seems that `unicorn/prefer-class-fields` ESLint plugin, see PR #20657, unfortunately isn't able to detect all of these cases.