### PR TITLE
Set the `annotationType` automatically in the `Annotation` constructor

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -179,7 +179,7 @@ class AnnotationFactory {
 
     if (
       collectByType &&
-      !collectByType.has(AnnotationType[subtype.toUpperCase()])
+      !collectByType.has(AnnotationType[subtype?.toUpperCase()])
     ) {
       return null;
     }
@@ -660,7 +660,8 @@ function getTransformMatrix(rect, bbox, matrix) {
 
 class Annotation {
   constructor(params) {
-    const { dict, xref, annotationGlobals, ref, orphanFields } = params;
+    const { annotationGlobals, dict, orphanFields, ref, subtype, xref } =
+      params;
     const parentRef = orphanFields?.get(ref);
     if (parentRef) {
       dict.set("Parent", parentRef);
@@ -694,6 +695,7 @@ class Annotation {
 
     // Expose public properties using a data object.
     this.data = {
+      annotationType: AnnotationType[subtype?.toUpperCase()],
       annotationFlags: this.flags,
       borderStyle: this.borderStyle,
       color: this.color,
@@ -705,7 +707,7 @@ class Annotation {
       id: params.id,
       modificationDate: this.modificationDate,
       rect: this.rectangle,
-      subtype: params.subtype,
+      subtype,
       hasOwnCanvas: false,
       noRotate: !!(this.flags & AnnotationFlag.NOROTATE),
       noHTML: isLocked && isContentLocked,
@@ -1873,7 +1875,6 @@ class WidgetAnnotation extends Annotation {
     const data = this.data;
     this._needAppearances = params.needAppearances;
 
-    data.annotationType = AnnotationType.WIDGET;
     if (data.fieldName === undefined) {
       data.fieldName = this._constructFieldName(dict);
     }
@@ -3856,7 +3857,6 @@ class TextAnnotation extends MarkupAnnotation {
     this.data.noHTML = false;
 
     const { dict } = params;
-    this.data.annotationType = AnnotationType.TEXT;
 
     if (this.data.hasAppearance) {
       this.data.name = "NoIcon";
@@ -3881,7 +3881,6 @@ class LinkAnnotation extends Annotation {
     super(params);
 
     const { dict, annotationGlobals } = params;
-    this.data.annotationType = AnnotationType.LINK;
 
     // A link is never rendered on the main canvas so we must render its HTML
     // version.
@@ -3913,7 +3912,6 @@ class PopupAnnotation extends Annotation {
     super(params);
 
     const { dict } = params;
-    this.data.annotationType = AnnotationType.POPUP;
 
     // A pop-up is never rendered on the main canvas so we must render its HTML
     // version.
@@ -4006,7 +4004,6 @@ class FreeTextAnnotation extends MarkupAnnotation {
     this.data.noHTML = false;
 
     const { annotationGlobals, evaluatorOptions, xref } = params;
-    this.data.annotationType = AnnotationType.FREETEXT;
     this.setDefaultAppearance(params);
     this._hasAppearance = !!this.appearance;
 
@@ -4235,7 +4232,6 @@ class LineAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.LINE;
     this.data.hasOwnCanvas = this.data.noRotate;
     this.data.noHTML = false;
 
@@ -4303,7 +4299,6 @@ class SquareAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.SQUARE;
     this.data.hasOwnCanvas = this.data.noRotate;
     this.data.noHTML = false;
 
@@ -4352,7 +4347,6 @@ class CircleAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.CIRCLE;
 
     if (!this.appearance) {
       // The default stroke color is black.
@@ -4416,7 +4410,6 @@ class PolylineAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.POLYLINE;
     this.data.hasOwnCanvas = this.data.noRotate;
     this.data.noHTML = false;
     this.data.vertices = null;
@@ -4502,22 +4495,10 @@ class PolylineAnnotation extends MarkupAnnotation {
   }
 }
 
-class PolygonAnnotation extends PolylineAnnotation {
-  constructor(params) {
-    // Polygons are specific forms of polylines, so reuse their logic.
-    super(params);
+// Polygons are specific forms of polylines, so reuse their logic.
+class PolygonAnnotation extends PolylineAnnotation {}
 
-    this.data.annotationType = AnnotationType.POLYGON;
-  }
-}
-
-class CaretAnnotation extends MarkupAnnotation {
-  constructor(params) {
-    super(params);
-
-    this.data.annotationType = AnnotationType.CARET;
-  }
-}
+class CaretAnnotation extends MarkupAnnotation {}
 
 class InkAnnotation extends MarkupAnnotation {
   constructor(params) {
@@ -4527,7 +4508,6 @@ class InkAnnotation extends MarkupAnnotation {
     this.data.noHTML = false;
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.INK;
     this.data.inkLists = [];
     this.data.isEditable = !this.data.noHTML;
     // We want to be able to add mouse listeners to the annotation.
@@ -4805,7 +4785,6 @@ class HighlightAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.HIGHLIGHT;
     this.data.isEditable = !this.data.noHTML;
     // We want to be able to add mouse listeners to the annotation.
     this.data.noHTML = false;
@@ -4949,7 +4928,6 @@ class UnderlineAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.UNDERLINE;
 
     const quadPoints = (this.data.quadPoints = getQuadPoints(dict, null));
     if (quadPoints) {
@@ -4989,7 +4967,6 @@ class SquigglyAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.SQUIGGLY;
 
     const quadPoints = (this.data.quadPoints = getQuadPoints(dict, null));
     if (quadPoints) {
@@ -5035,7 +5012,6 @@ class StrikeOutAnnotation extends MarkupAnnotation {
     super(params);
 
     const { dict, xref } = params;
-    this.data.annotationType = AnnotationType.STRIKEOUT;
 
     const quadPoints = (this.data.quadPoints = getQuadPoints(dict, null));
     if (quadPoints) {
@@ -5077,7 +5053,6 @@ class StampAnnotation extends MarkupAnnotation {
   constructor(params) {
     super(params);
 
-    this.data.annotationType = AnnotationType.STAMP;
     this.data.hasOwnCanvas = this.data.noRotate;
     this.data.isEditable = !this.data.noHTML;
     // We want to be able to add mouse listeners to the annotation.
@@ -5296,7 +5271,6 @@ class FileAttachmentAnnotation extends MarkupAnnotation {
     const { dict } = params;
     const file = new FileSpec(dict.get("FS"));
 
-    this.data.annotationType = AnnotationType.FILEATTACHMENT;
     this.data.hasOwnCanvas = this.data.noRotate;
     this.data.noHTML = false;
     this.data.file = file.serializable;


### PR DESCRIPTION
Rather than assigning it manually in every extending class, we can utilize the fact that the `AnnotationType`-entries are simply the upper-case version of the `/Subtype` (when it exists) in the Annotation dictionary.