### PR TITLE
Reduce duplication when parsing `searchParams` in the `getPdfFilenameFromUrl` function

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -395,19 +395,14 @@ function getPdfFilenameFromUrl(url, defaultFilename = "document.pdf") {
   }
 
   if (newURL.searchParams.size > 0) {
-    const values = Array.from(newURL.searchParams.values()).reverse();
-    for (const value of values) {
-      if (pdfRegex.test(value)) {
-        // If any of the search parameters ends with ".pdf", return it.
-        return decode(value);
-      }
-    }
-    const keys = Array.from(newURL.searchParams.keys()).reverse();
-    for (const key of keys) {
-      if (pdfRegex.test(key)) {
-        // If any of the search parameter keys ends with ".pdf", return it.
-        return decode(key);
-      }
+    const getLast = iterator => [...iterator].findLast(v => pdfRegex.test(v));
+
+    // If any of the search parameters ends with ".pdf", return it.
+    const name =
+      getLast(newURL.searchParams.values()) ??
+      getLast(newURL.searchParams.keys());
+    if (name) {
+      return decode(name);
     }
   }
 


### PR DESCRIPTION
Currently we essentially "duplicate" the same code for parsing the `values` and `keys` of the `searchParams`, which seems a little unnecessary.

To be able to parse the `searchParams` from the end, we currently create an Array (from the Iterator) and then reverse it before finally looping through it. Here the latter two steps can be replaced with the `Array.prototype.findLast()` method instead.

*Please note:* I completely understand if this patch is rejected, on account of being less readable than the current code.