### PR TITLE
Remove unnecessary `Map.prototype.entries()` usage

### DIFF
--- a/src/core/default_appearance.js
+++ b/src/core/default_appearance.js
@@ -294,7 +294,7 @@ class FakeUnicodeFont {
     descendantFont.set("DW", 1000);
 
     const widths = [];
-    const chars = [...this.widths.entries()].sort();
+    const chars = [...this.widths].sort();
     let currentChar = null;
     let currentWidths = null;
     for (const [char, width] of chars) {

--- a/src/core/xfa/fonts.js
+++ b/src/core/xfa/fonts.js
@@ -105,14 +105,14 @@ class FontFinder {
     name = name.toLowerCase();
 
     const maybe = [];
-    for (const [family, pdfFont] of this.fonts.entries()) {
+    for (const [family, pdfFont] of this.fonts) {
       if (family.replaceAll(pattern, "").toLowerCase().startsWith(name)) {
         maybe.push(pdfFont);
       }
     }
 
     if (maybe.length === 0) {
-      for (const [, pdfFont] of this.fonts.entries()) {
+      for (const pdfFont of this.fonts.values()) {
         if (
           pdfFont.regular.name
             ?.replaceAll(pattern, "")
@@ -126,7 +126,7 @@ class FontFinder {
 
     if (maybe.length === 0) {
       name = name.replaceAll(/psmt|mt/gi, "");
-      for (const [family, pdfFont] of this.fonts.entries()) {
+      for (const [family, pdfFont] of this.fonts) {
         if (family.replaceAll(pattern, "").toLowerCase().startsWith(name)) {
           maybe.push(pdfFont);
         }

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -841,7 +841,7 @@ class XmlObject extends XFAObject {
     const utf8TagName = utf8StringToString(tagName);
     const prefix = this[$namespaceId] === NS_DATASETS ? "xfa:" : "";
     buf.push(`<${prefix}${utf8TagName}`);
-    for (const [name, value] of this[_attributes].entries()) {
+    for (const [name, value] of this[_attributes]) {
       const utf8Name = utf8StringToString(name);
       buf.push(` ${utf8Name}="${encodeToXmlString(value[$content])}"`);
     }

--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -951,7 +951,7 @@ class Doc extends PDFObject {
       cName = parts[0];
     }
 
-    for (const [name, field] of this._fields.entries()) {
+    for (const [name, field] of this._fields) {
       if (name.endsWith(cName)) {
         if (!isNaN(childIndex)) {
           const children = this._getChildren(name);
@@ -985,7 +985,7 @@ class Doc extends PDFObject {
     const len = fieldName.length;
     const children = [];
     const pattern = /^\.[^.]+$/;
-    for (const [name, field] of this._fields.entries()) {
+    for (const [name, field] of this._fields) {
       if (name.startsWith(fieldName)) {
         const finalPart = name.slice(len);
         if (pattern.test(finalPart)) {
@@ -1000,7 +1000,7 @@ class Doc extends PDFObject {
     // Get all the descendants which have a value.
     const children = [];
     const len = fieldName.length;
-    for (const [name, field] of this._fields.entries()) {
+    for (const [name, field] of this._fields) {
       if (name.startsWith(fieldName)) {
         const finalPart = name.slice(len);
         if (


### PR DESCRIPTION
A `Map` instance can be iterated directly with a `for...of` loop, hence using its `entries` method is not actually necessary.