### PR TITLE
Replace the `getStatIndex` helper, in `web/debugger.mjs`, with native functionality

### DIFF
--- a/web/debugger.mjs
+++ b/web/debugger.mjs
@@ -677,14 +677,6 @@ const Stats = (function Stats() {
   function clear(node) {
     node.textContent = ""; // Remove any `node` contents from the DOM.
   }
-  function getStatIndex(pageNumber) {
-    for (const [i, stat] of stats.entries()) {
-      if (stat.pageNumber === pageNumber) {
-        return i;
-      }
-    }
-    return false;
-  }
   return {
     // Properties/functions needed by PDFBug.
     id: "Stats",
@@ -699,8 +691,8 @@ const Stats = (function Stats() {
       if (!stat) {
         return;
       }
-      const statsIndex = getStatIndex(pageNumber);
-      if (statsIndex !== false) {
+      const statsIndex = stats.findIndex(s => s.pageNumber === pageNumber);
+      if (statsIndex !== -1) {
         stats[statsIndex].div.remove();
         stats.splice(statsIndex, 1);
       }


### PR DESCRIPTION
This code is old enough that it predates the existence of `Array.prototype.findIndex()`, hence why a helper function was originally needed.