### PR TITLE
Use `Map.prototype.getOrInsertComputed()` in the `ensureDebugMetadata` helper

### DIFF
--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -1,3 +1,18 @@
+/* Copyright 2025 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Util } from "../shared/util.js";
 
 const FORCED_DEPENDENCY_LABEL = "__forcedDependency";

--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -50,17 +50,11 @@ class BBoxReader {
   }
 }
 
-const ensureDebugMetadata = (map, key) => {
-  if (!map) {
-    return undefined;
-  }
-  let value = map.get(key);
-  if (!value) {
-    value = { dependencies: new Set(), isRenderingOperation: false };
-    map.set(key, value);
-  }
-  return value;
-};
+const ensureDebugMetadata = (map, key) =>
+  map?.getOrInsertComputed(key, () => ({
+    dependencies: new Set(),
+    isRenderingOperation: false,
+  }));
 
 /**
  * @typedef {"lineWidth" | "lineCap" | "lineJoin" | "miterLimit" | "dash" |


### PR DESCRIPTION
Also, shorten the function by using optional chaining.