### PR TITLE
Use `Map.prototype.getOrInsert()` in the `_addField` method

### DIFF
--- a/src/scripting_api/doc.js
+++ b/src/scripting_api/doc.js
@@ -213,26 +213,15 @@ class Doc extends PDFObject {
     const pc = field.obj._actions.get("PageClose");
     if (po || pc) {
       this._otherPageActions ||= new Map();
-      let actions = this._otherPageActions.get(field.obj._page + 1);
-      if (!actions) {
-        actions = new Map();
-        this._otherPageActions.set(field.obj._page + 1, actions);
-      }
+      const actions = this._otherPageActions.getOrInsertComputed(
+        field.obj._page + 1,
+        () => new Map()
+      );
       if (po) {
-        let poActions = actions.get("PageOpen");
-        if (!poActions) {
-          poActions = [];
-          actions.set("PageOpen", poActions);
-        }
-        poActions.push(...po);
+        actions.getOrInsert("PageOpen", []).push(...po);
       }
       if (pc) {
-        let pcActions = actions.get("PageClose");
-        if (!pcActions) {
-          pcActions = [];
-          actions.set("PageClose", pcActions);
-        }
-        pcActions.push(...pc);
+        actions.getOrInsert("PageClose", []).push(...pc);
       }
     }
   }


### PR DESCRIPTION
Also, use `Map.prototype.getOrInsertComputed()` in one spot to avoid creating `Map`-instances unconditionally.

---

Given that even the latest QuickJS version doesn't support this functionality, it would require manually bundling polyfills in non-`legacy` and non-MOZCENTRAL builds of the scripting-code. Let's just avoid that complication for now.