### PR TITLE
Fixed OOM issue when reading partially corrupted PDFs

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -430,8 +430,7 @@ class XRef {
       if (offset - startOffset > MAX_TOKEN_LENGTH) {
         offset = startOffset + MAX_TOKEN_LENGTH;
       }
-      const asciiDecoder = new TextDecoder("ascii");
-      return asciiDecoder.decode(data.subarray(startOffset, offset));
+      return bytesToString(data.subarray(startOffset, offset));
     }
     function skipUntil(data, offset, what) {
       const length = what.length,

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -417,6 +417,10 @@ class XRef {
       LT = 0x3c;
 
     function readToken(data, offset) {
+      // The maximum length of a PDF token.
+      // For now it is set to max string length according to
+      // Node.js buffer.constants.MAX_STRING_LENGTH,
+      // but seems to be working for browsers as well.
       const MAX_TOKEN_LENGTH = 0x1fffffe8;
       const dataLen = data.length;
       const startOffset = offset;

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -417,16 +417,20 @@ class XRef {
       LT = 0x3c;
 
     function readToken(data, offset) {
-      let token = "",
-        ch = data[offset];
-      while (ch !== LF && ch !== CR && ch !== LT) {
-        if (++offset >= data.length) {
+      const MAX_TOKEN_LENGTH = 0x1fffffe8;
+      const dataLen = data.length;
+      const startOffset = offset;
+      while (offset < dataLen) {
+        const ch = data[offset];
+        if (ch === LF || ch === CR || ch === LT) {
           break;
         }
-        token += String.fromCharCode(ch);
-        ch = data[offset];
+        offset++;
       }
-      return token;
+      if (offset - startOffset > MAX_TOKEN_LENGTH) {
+        offset = startOffset + MAX_TOKEN_LENGTH;
+      }
+      return data.subarray(startOffset, offset).toString("ascii");
     }
     function skipUntil(data, offset, what) {
       const length = what.length,

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -430,7 +430,8 @@ class XRef {
       if (offset - startOffset > MAX_TOKEN_LENGTH) {
         offset = startOffset + MAX_TOKEN_LENGTH;
       }
-      return data.subarray(startOffset, offset).toString("ascii");
+      const asciiDecoder = new TextDecoder("ascii");
+      return asciiDecoder.decode(data.subarray(startOffset, offset));
     }
     function skipUntil(data, offset, what) {
       const length = what.length,


### PR DESCRIPTION
I encountered multiple PDFs that appeared to be partially corrupted. As a result, PDF.js was unable to load them due to an out‑of‑memory (OOM) error.

This PR fixes the issue, and I can confirm that with this change in place I am now able to successfully load those PDFs.

Unfortunately, I can’t include or share the affected PDFs due to NDA restrictions. However, I suspect they may have been generated using one of the online “PDF combine” services. In terms of content, the PDFs each contain around 10–15 pages with a mix of scanned images and text.