### PR TITLE
Remove unused `lastCode` property from the `LZWStream` class (PR 324 follow-up)

### DIFF
--- a/src/core/lzw_stream.js
+++ b/src/core/lzw_stream.js
@@ -56,7 +56,6 @@ class LZWStream extends DecodeStream {
     }
     this.bitsCached = bitsCached -= n;
     this.cachedData = cachedData;
-    this.lastCode = null;
     return (cachedData >>> bitsCached) & ((1 << n) - 1);
   }
 


### PR DESCRIPTION
This appear to have been unused already in PR #324 all the way back in 2011.