### PR TITLE
Don't expand/collapse the entire outline when shift-clicking on the triangles (PR 20508 follow-up)

### DIFF
--- a/web/base_tree_viewer.js
+++ b/web/base_tree_viewer.js
@@ -131,7 +131,7 @@ class BaseTreeViewer {
         target.classList.toggle("treeItemsHidden");
         if (e.shiftKey) {
           const shouldShowAll = !target.classList.contains("treeItemsHidden");
-          this._toggleTreeItem(this.container, shouldShowAll);
+          this._toggleTreeItem(target.parentNode, shouldShowAll);
         }
       });
     }


### PR DESCRIPTION
This probably fixes the bug described in https://github.com/mozilla/pdf.js/issues/20739#issuecomment-3966081239.