### PR TITLE
Automatically remove unmaintained locales when running `gulp importl10n`

### DIFF
--- a/external/importL10n/locales.mjs
+++ b/external/importL10n/locales.mjs
@@ -91,7 +91,7 @@ async function downloadL10n(root) {
     await downloadLanguageFiles(root, langCode);
   }
 
-  const removeCodes = [];
+  const rmCodes = [];
   for (const entry of fs.readdirSync(root)) {
     const dirPath = path.join(root, entry),
       stat = fs.lstatSync(dirPath);
@@ -101,14 +101,13 @@ async function downloadL10n(root) {
       entry !== DEFAULT_LOCALE &&
       !langCodes.includes(entry)
     ) {
-      removeCodes.push(entry);
+      fs.rmSync(dirPath, { recursive: true, force: true });
+      rmCodes.push(entry);
     }
   }
-  if (removeCodes.length) {
+  if (rmCodes.length) {
     console.log(
-      "\nConsider removing the following unmaintained locales:\n" +
-        removeCodes.join(", ") +
-        "\n"
+      `\nRemoved the following unmaintained locales: ${rmCodes.join(", ")}\n`
     );
   }
 }


### PR DESCRIPTION
It's not particularly common for locales to be removed from Firefox, but it has happened occasionally in the past.
Currently the `downloadL10n` function logs a message about any unmaintained locales, but after PR #20749 that code is running in GitHub Actions (rather than locally by a contributor) which makes it much less likely for the message to be seen.