### PR TITLE
Fix the broken regular expression in the `decode` helper in the `getPdfFilenameFromUrl` function (issue 20664)

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -377,10 +377,9 @@ function getPdfFilenameFromUrl(url, defaultFilename = "document.pdf") {
       let decoded = decodeURIComponent(name);
       if (decoded.includes("/")) {
         decoded = stripPath(decoded);
-        if (decoded.test(/^\.pdf$/i)) {
-          return decoded;
+        if (/^\.pdf$/i.test(decoded)) {
+          return name;
         }
-        return name;
       }
       return decoded;
     } catch {


### PR DESCRIPTION
This will ignore filenames that become effectively empty, i.e. ones that are only ".pdf" and nothing more.

*Please note:* While this passes all existing unit-tests, I don't know if this is necessarily the "correct" solution here.