### PR TITLE
Add `alternativeText` to getFieldObject return

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3084,6 +3084,7 @@ class TextWidgetAnnotation extends WidgetAnnotation {
       datetimeFormat: this.data.datetimeFormat,
       hasDatetimeHTML: !!this.data.datetimeType,
       type: "text",
+      alternativeText: this.data.alternativeText,
     };
   }
 }
@@ -3539,6 +3540,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
       fillColor: this.data.backgroundColor,
       rotation: this.rotation,
       type,
+      alternativeText: this.data.alternativeText,
     };
   }
 
@@ -3653,6 +3655,7 @@ class ChoiceWidgetAnnotation extends WidgetAnnotation {
       fillColor: this.data.backgroundColor,
       rotation: this.rotation,
       type,
+      alternativeText: this.data.alternativeText,
     };
   }
 
@@ -3841,6 +3844,7 @@ class SignatureWidgetAnnotation extends WidgetAnnotation {
       value: null,
       page: this.data.pageIndex,
       type: "signature",
+      alternativeText: this.data.alternativeText,
     };
   }
 }


### PR DESCRIPTION
The property is necessary for accessibility in some circumstances.