### PR TITLE
Hide the "Select pages" label, in the thumbnails sidebar, when split-merge is disabled

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -461,6 +461,7 @@ const PDFViewerApplication = {
           foreground: AppOptions.get("pageColorsForeground"),
         }
       : null;
+    const enableSplitMerge = AppOptions.get("enableSplitMerge");
 
     let altTextManager;
     if (AppOptions.get("enableUpdatedAddImage")) {
@@ -602,7 +603,7 @@ const PDFViewerApplication = {
         pageColors,
         abortSignal,
         enableHWA,
-        enableSplitMerge: AppOptions.get("enableSplitMerge"),
+        enableSplitMerge,
         manageMenu: appConfig.viewsManager.manageMenu,
         addFileButton: appConfig.viewsManager.viewsManagerAddFileButton,
       });
@@ -764,6 +765,7 @@ const PDFViewerApplication = {
         elements: appConfig.viewsManager,
         eventBus,
         l10n,
+        enableSplitMerge,
       });
       this.viewsManager.onToggled = this.forceRendering.bind(this);
       this.viewsManager.onUpdateThumbnails = () => {

--- a/web/views_manager.js
+++ b/web/views_manager.js
@@ -98,6 +98,7 @@ class ViewsManager extends Sidebar {
     },
     eventBus,
     l10n,
+    enableSplitMerge = false,
   }) {
     super(
       {
@@ -141,6 +142,11 @@ class ViewsManager extends Sidebar {
     this.viewsManagerStatus = viewsManagerStatus;
 
     this.eventBus = eventBus;
+
+    if (!enableSplitMerge) {
+      viewsManagerStatus.hidden = true;
+    }
+    this._enableSplitMerge = enableSplitMerge;
 
     this.menu = new Menu(
       viewsManagerSelectorOptions,
@@ -252,7 +258,9 @@ class ViewsManager extends Sidebar {
         return;
     }
 
-    this.viewsManagerStatus.hidden = view !== SidebarView.THUMBS;
+    if (this._enableSplitMerge) {
+      this.viewsManagerStatus.hidden = view !== SidebarView.THUMBS;
+    }
     this.viewsManagerAddFileButton.hidden = view !== SidebarView.THUMBS;
     this.viewsManagerCurrentOutlineButton.hidden = view !== SidebarView.OUTLINE;
     this.viewsManagerHeaderLabel.setAttribute(


### PR DESCRIPTION
Currently there's a "pointless" label displayed, thus taking up vertical space, when `enableSplitMerge = false` is set.

---

Since a picture is worth a thousand words, note how the demo viewer currently looks (with the element circled in red):

<img width="1278" height="1345" alt="select-pages" src="https://github.com/user-attachments/assets/33718ae5-8315-47a5-af5e-922a52b0b2be" />
