### PR TITLE
Use `L10n.prototype.getDirection` rather than querying the DOM, when initializing the `CommentManager` instance

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -500,9 +500,6 @@ const PDFViewerApplication = {
           )
         : null;
 
-    const ltr = appConfig.viewerContainer
-      ? getComputedStyle(appConfig.viewerContainer).direction === "ltr"
-      : true;
     const commentManager =
       AppOptions.get("enableComment") && appConfig.editCommentDialog
         ? new CommentManager(
@@ -532,7 +529,7 @@ const PDFViewerApplication = {
             eventBus,
             linkService,
             overlayManager,
-            ltr,
+            /* ltr = */ l10n.getDirection() === "ltr",
             hasForcedColors
           )
         : null;


### PR DESCRIPTION
Hopefully I'm not misunderstanding why it was written like that, however using an existing method should be a tiny bit more efficient than querying the DOM.