### PR TITLE
Update l10n related information in various READMEs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,6 @@ The issue tracking system is designed to record a single technical problem. A bu
 
 If you are developing a custom solution, first check the examples at https://github.com/mozilla/pdf.js#learning and search existing issues. If this does not help, please prepare a short well-documented example that demonstrates the problem and make it accessible online on your website, JS Bin, GitHub, etc. before opening a new issue or contacting us in the Matrix room -- keep in mind that just code snippets won't help us troubleshoot the problem.
 
-Note that the translations for PDF.js in the `l10n` folder are imported from the Nightly channel of Mozilla Firefox, such that we don't have to maintain them ourselves. This means that we will not accept pull requests that add new languages and/or modify existing translations, unless the corresponding changes have been made in Mozilla Firefox first.
-
 See also:
 - https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions
 - https://github.com/mozilla/pdf.js/wiki/Contributing

--- a/l10n/README.md
+++ b/l10n/README.md
@@ -1,5 +1,3 @@
-Most of the files in this folder (except for the `en-US` folder) have been
-imported from the Firefox Nightly branch;
-please see https://hg.mozilla.org/l10n-central. Some of the files are
-licensed under the MPL license. You can obtain a copy of the license at
-https://mozilla.org/MPL/2.0.
+ + Only the translations for the `en-US` locale are maintained here.
+
+ + The translations for all other locales are imported automatically from Firefox. Please see https://mozilla-l10n.github.io/introduction/ for information about contributing.


### PR DESCRIPTION
In practice we've not accepted PRs with "manual" changes of any non `en-US` locales for many years, however some (older) README/FAQ entries can perhaps be seen as actually inviting such PRs.

Now that l10n updates are running automatically via GitHub Actions, see PR #20749, we're definitely not going to accept any "manual" translation patches so it cannot hurt to de-emphasize localization in various README files.

(Also, since all relevant Fluent files have license headers it doesn't seem meaningful to mention that in the l10n README.)