### PR TITLE
Let `BinaryCMapStream` extend the `Stream` class

### DIFF
--- a/src/core/binary_cmap.js
+++ b/src/core/binary_cmap.js
@@ -14,6 +14,7 @@
  */
 
 import { FormatError } from "../shared/util.js";
+import { Stream } from "./stream.js";
 
 function hexToInt(a, size) {
   let n = 0;
@@ -56,26 +57,23 @@ function incHex(a, size) {
 const MAX_NUM_SIZE = 16;
 const MAX_ENCODED_NUM_SIZE = 19; // ceil(MAX_NUM_SIZE * 7 / 8)
 
-class BinaryCMapStream {
-  constructor(data) {
-    this.buffer = data;
-    this.pos = 0;
-    this.end = data.length;
-    this.tmpBuf = new Uint8Array(MAX_ENCODED_NUM_SIZE);
-  }
+class BinaryCMapStream extends Stream {
+  tmpBuf = new Uint8Array(MAX_ENCODED_NUM_SIZE);
 
-  readByte() {
-    if (this.pos >= this.end) {
-      return -1;
-    }
-    return this.buffer[this.pos++];
+  constructor(data) {
+    super(
+      /* arrayBuffer = */ data,
+      /* start = */ 0,
+      /* length = */ data.length,
+      /* dict = */ null
+    );
   }
 
   readNumber() {
     let n = 0;
     let last;
     do {
-      const b = this.readByte();
+      const b = this.getByte();
       if (b < 0) {
         throw new FormatError("unexpected EOF in bcmap");
       }
@@ -91,8 +89,7 @@ class BinaryCMapStream {
   }
 
   readHex(num, size) {
-    num.set(this.buffer.subarray(this.pos, this.pos + size + 1));
-    this.pos += size + 1;
+    num.set(this.getBytes(size + 1));
   }
 
   readHexNumber(num, size) {
@@ -100,7 +97,7 @@ class BinaryCMapStream {
     const stack = this.tmpBuf;
     let sp = 0;
     do {
-      const b = this.readByte();
+      const b = this.getByte();
       if (b < 0) {
         throw new FormatError("unexpected EOF in bcmap");
       }
@@ -145,7 +142,7 @@ class BinaryCMapStream {
 class BinaryCMapReader {
   async process(data, cMap, extend) {
     const stream = new BinaryCMapStream(data);
-    const header = stream.readByte();
+    const header = stream.getByte();
     cMap.vertical = !!(header & 1);
 
     let useCMap = null;
@@ -157,7 +154,7 @@ class BinaryCMapReader {
     let code;
 
     let b;
-    while ((b = stream.readByte()) >= 0) {
+    while ((b = stream.getByte()) >= 0) {
       const type = b >> 5;
       if (type === 7) {
         // metadata, e.g. comment or usecmap


### PR DESCRIPTION
Looking at the `BinaryCMapStream` implementation, it's basically a "regular" `Stream` but with added functionality for reading compressed CMap data.
Hence, by letting `BinaryCMapStream` extend `Stream`, we can remove an effectively duplicate method and simplify/shorten the code a tiny bit.