### PR TITLE
Add fetch** functions in the XRefWrapper

### DIFF
--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -71,6 +71,18 @@ class XRefWrapper {
   fetch(ref) {
     return ref instanceof Ref ? this.entries[ref.num] : ref;
   }
+
+  fetchIfRefAsync(ref) {
+    return Promise.resolve(this.fetch(ref));
+  }
+
+  fetchIfRef(ref) {
+    return this.fetch(ref);
+  }
+
+  fetchAsync(ref) {
+    return Promise.resolve(this.fetch(ref));
+  }
 }
 
 class PDFEditor {


### PR DESCRIPTION
It could fail to not have them if they're used during writing.