### PR TITLE
Avoid to have stuck actions when running update_locales task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 name: CodeQL
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: Code Coverage
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/prefs_tests.yml
+++ b/.github/workflows/prefs_tests.yml
@@ -1,5 +1,5 @@
 name: Prefs tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/types_tests.yml
+++ b/.github/workflows/types_tests.yml
@@ -1,5 +1,5 @@
 name: Types tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -47,3 +48,8 @@ jobs:
             --title "l10n: Update locale files" \
             --body "Automated weekly update of locale files from mozilla-central." \
             --label l10n || true
+          # GITHUB_TOKEN-initiated pushes/PRs don't trigger other workflows.
+          # Explicitly dispatch them so CI runs on the update-locales branch.
+          for workflow in ci.yml lint.yml codeql.yml; do
+            gh workflow run "$workflow" --ref update-locales
+          done


### PR DESCRIPTION
The task update_locales is using the GITHUB_TOKEN to push the changes to the update-locales branch, but this token doesn't trigger other workflows (see [1]), so we need to explicitly dispatch the required ones.

[1] https://github.com/orgs/community/discussions/26970#discussioncomment-3254152