### PR TITLE
Ensure that `percent === NaN` is consistently reported by the `onProgress` callback

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -275,7 +275,7 @@ class WorkerMessageHandler {
           if (!fullReader.isStreamingSupported) {
             handler.send("DocProgress", {
               loaded,
-              total: Math.max(loaded, fullReader.contentLength || 0),
+              total: fullReader.contentLength,
             });
           }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2524,7 +2524,9 @@ class WorkerTransport {
     this.loadingTask.onProgress?.({
       loaded,
       total,
-      percent: MathClamp(Math.round((loaded / total) * 100), 0, 100),
+      percent: total
+        ? MathClamp(Math.round((loaded / total) * 100), 0, 100)
+        : NaN,
     });
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1255,6 +1255,10 @@ const PDFViewerApplication = {
         if (loadingTask !== this.pdfLoadingTask) {
           return undefined; // Ignore errors for previously opened PDF files.
         }
+        if (this.loadingBar) {
+          // Avoid the "indeterminate" loadingBar being displayed on error.
+          this.loadingBar.percent ||= 0;
+        }
 
         let key = "pdfjs-loading-error";
         if (reason instanceof InvalidPDFException) {

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -577,11 +577,9 @@ class ExternalServices extends BaseExternalServices {
           pdfDataRangeTransport?.onDataProgressiveDone();
           break;
         case "progress":
-          const percent = MathClamp(
-            Math.round((args.loaded / args.total) * 100),
-            0,
-            100
-          );
+          const percent = args.total
+            ? MathClamp(Math.round((args.loaded / args.total) * 100), 0, 100)
+            : NaN;
 
           viewerApp.progress(percent);
           break;


### PR DESCRIPTION
 - **Ensure that `percent === NaN` is consistently reported by the `onProgress` callback**

    With these changes `0`, `NaN`, `null`, and `undefined` in the `total`-property all result in `percent === NaN` being reported by the callback, since previously e.g. `0` would result in `percent === 100` being reported unconditionally which doesn't make a lot of sense.

    Also, remove the "indeterminate" loadingBar (in the viewer) if the `PDFDocumentLoadingTask` fails since there won't be any more data arriving and displaying the animation thus seems wrong.

 - **Remove the "DocProgress" `loaded` fallback from the `getPdfManager` function**

   Falling back to use the `loaded` byteLength if the server `contentLength` is unknown doesn't make a lot of sense, since it'd lead to the `onProgress` callback reporting `percent === 100` repeatedly while the document is loading despite that being obviously wrong.
   Instead we'll now report `percent === NaN` in that case, thus showing the indeterminate progressBar, which seems more correct if the `contentLength` is unknown.

   Please note that this code-path is normally not even reached, since streaming is enabled by default (applies e.g. to the Firefox PDF Viewer).