### PR TITLE
Start using `Blob.prototype.bytes()` in the code-base

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -5105,9 +5105,9 @@ class StampAnnotation extends MarkupAnnotation {
       ctx.drawImage(bitmap, 0, 0);
     }
 
-    const jpegBufferPromise = canvas
+    const jpegBytesPromise = canvas
       .convertToBlob({ type: "image/jpeg", quality: 1 })
-      .then(blob => blob.arrayBuffer());
+      .then(blob => blob.bytes());
 
     const xobjectName = Name.get("XObject");
     const imageName = Name.get("Image");
@@ -5144,7 +5144,7 @@ class StampAnnotation extends MarkupAnnotation {
 
       smaskStream = new Stream(alphaBuffer, 0, 0, smask);
     }
-    const imageStream = new Stream(await jpegBufferPromise, 0, 0, image);
+    const imageStream = new Stream(await jpegBytesPromise, 0, 0, image);
 
     return {
       imageStream,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1259,6 +1259,17 @@ if (
   };
 }
 
+// See https://developer.mozilla.org/en-US/docs/Web/API/Blob/bytes#browser_compatibility
+if (
+  typeof PDFJSDev !== "undefined" &&
+  !PDFJSDev.test("SKIP_BABEL") &&
+  typeof Blob.prototype.bytes !== "function"
+) {
+  Blob.prototype.bytes = async function () {
+    return new Uint8Array(await this.arrayBuffer());
+  };
+}
+
 // See https://developer.mozilla.org/en-US/docs/Web/API/Response/bytes#browser_compatibility
 if (
   typeof PDFJSDev !== "undefined" &&


### PR DESCRIPTION
Note that this isn't motivated by the miniscule reduction in code-size, but rather by wanting to unblock using this newer feature; see https://developer.mozilla.org/en-US/docs/Web/API/Blob/bytes