### PR TITLE
Improve the `validateRangeRequestCapabilities` unit-tests

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -107,7 +107,7 @@ class PDFFetchStreamReader extends BasePDFStreamReader {
 
         const responseHeaders = response.headers;
 
-        const { allowRangeRequests, suggestedLength } =
+        const { contentLength, isRangeSupported } =
           validateRangeRequestCapabilities({
             responseHeaders,
             isHttp: true,
@@ -115,9 +115,9 @@ class PDFFetchStreamReader extends BasePDFStreamReader {
             disableRange,
           });
 
-        this._isRangeSupported = allowRangeRequests;
+        this._isRangeSupported = isRangeSupported;
         // Setting right content length.
-        this._contentLength = suggestedLength || this._contentLength;
+        this._contentLength = contentLength || this._contentLength;
 
         this._filename = extractFilenameFromHeader(responseHeaders);
 

--- a/src/display/network.js
+++ b/src/display/network.js
@@ -222,7 +222,7 @@ class PDFNetworkStreamReader extends BasePDFStreamReader {
         : []
     );
 
-    const { allowRangeRequests, suggestedLength } =
+    const { contentLength, isRangeSupported } =
       validateRangeRequestCapabilities({
         responseHeaders,
         isHttp: stream.isHttp,
@@ -230,11 +230,11 @@ class PDFNetworkStreamReader extends BasePDFStreamReader {
         disableRange,
       });
 
-    if (allowRangeRequests) {
+    if (isRangeSupported) {
       this._isRangeSupported = true;
     }
     // Setting right content length.
-    this._contentLength = suggestedLength || this._contentLength;
+    this._contentLength = contentLength || this._contentLength;
 
     this._filename = extractFilenameFromHeader(responseHeaders);
 

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -49,38 +49,34 @@ function validateRangeRequestCapabilities({
       "rangeChunkSize must be an integer larger than zero."
     );
   }
-  const returnValues = {
-    allowRangeRequests: false,
-    suggestedLength: undefined,
+  const rv = {
+    contentLength: undefined,
+    isRangeSupported: false,
   };
 
   const length = parseInt(responseHeaders.get("Content-Length"), 10);
   if (!Number.isInteger(length)) {
-    return returnValues;
+    return rv;
   }
-
-  returnValues.suggestedLength = length;
+  rv.contentLength = length;
 
   if (length <= 2 * rangeChunkSize) {
     // The file size is smaller than the size of two chunks, so it does not
     // make any sense to abort the request and retry with a range request.
-    return returnValues;
+    return rv;
   }
-
   if (disableRange || !isHttp) {
-    return returnValues;
+    return rv;
   }
   if (responseHeaders.get("Accept-Ranges") !== "bytes") {
-    return returnValues;
+    return rv;
   }
 
   const contentEncoding = responseHeaders.get("Content-Encoding") || "identity";
-  if (contentEncoding !== "identity") {
-    return returnValues;
+  if (contentEncoding === "identity") {
+    rv.isRangeSupported = true;
   }
-
-  returnValues.allowRangeRequests = true;
-  return returnValues;
+  return rv;
 }
 
 function extractFilenameFromHeader(responseHeaders) {

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -81,13 +81,13 @@ describe("network_utils", function () {
           disableRange: true,
           isHttp: true,
           responseHeaders: new Headers({
-            "Content-Length": 8,
+            "Content-Length": 1024,
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: false,
-        suggestedLength: 8,
+        isRangeSupported: false,
+        contentLength: 1024,
       });
 
       expect(
@@ -95,13 +95,13 @@ describe("network_utils", function () {
           disableRange: false,
           isHttp: false,
           responseHeaders: new Headers({
-            "Content-Length": 8,
+            "Content-Length": 1024,
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: false,
-        suggestedLength: 8,
+        isRangeSupported: false,
+        contentLength: 1024,
       });
     });
 
@@ -112,13 +112,13 @@ describe("network_utils", function () {
           isHttp: true,
           responseHeaders: new Headers({
             "Accept-Ranges": "none",
-            "Content-Length": 8,
+            "Content-Length": 1024,
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: false,
-        suggestedLength: 8,
+        isRangeSupported: false,
+        contentLength: 1024,
       });
     });
 
@@ -130,13 +130,13 @@ describe("network_utils", function () {
           responseHeaders: new Headers({
             "Accept-Ranges": "bytes",
             "Content-Encoding": "gzip",
-            "Content-Length": 8,
+            "Content-Length": 1024,
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: false,
-        suggestedLength: 8,
+        isRangeSupported: false,
+        contentLength: 1024,
       });
     });
 
@@ -147,13 +147,13 @@ describe("network_utils", function () {
           isHttp: true,
           responseHeaders: new Headers({
             "Accept-Ranges": "bytes",
-            "Content-Length": "eight",
+            "Content-Length": "one thousand and twenty four",
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: false,
-        suggestedLength: undefined,
+        isRangeSupported: false,
+        contentLength: undefined,
       });
     });
 
@@ -164,13 +164,13 @@ describe("network_utils", function () {
           isHttp: true,
           responseHeaders: new Headers({
             "Accept-Ranges": "bytes",
-            "Content-Length": 8,
+            "Content-Length": 128,
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: false,
-        suggestedLength: 8,
+        isRangeSupported: false,
+        contentLength: 128,
       });
     });
 
@@ -181,13 +181,13 @@ describe("network_utils", function () {
           isHttp: true,
           responseHeaders: new Headers({
             "Accept-Ranges": "bytes",
-            "Content-Length": 8192,
+            "Content-Length": 1024,
           }),
           rangeChunkSize: 64,
         })
       ).toEqual({
-        allowRangeRequests: true,
-        suggestedLength: 8192,
+        isRangeSupported: true,
+        contentLength: 1024,
       });
     });
   });


### PR DESCRIPTION
A number of these unit-tests didn't actually cover the intended code-paths, since many of them *accidentally* matched the "file size is smaller than two range requests"-check.

The patch also updates `validateRangeRequestCapabilities` to use return-value names that are consistent with the class fields used in the various stream implementations.

---

*Edit:* Looking at the coverage results the `src/display/network_utils.js` file went from 96.80% to 100.00%, confirming that the tests were indeed subtly "wrong" before.