### PR TITLE
Fix the `disableFontFace` and `fontExtraProperties` asserts in the `FontFaceObject` constructor (PR 20197 follow-up)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -355,19 +355,22 @@ class FontLoader {
 }
 
 class FontFaceObject {
+  compiledGlyphs = Object.create(null);
+
   #fontData;
 
   constructor(translatedData, inspectFont = null, extra, charProcOperatorList) {
-    this.compiledGlyphs = Object.create(null);
-    this.#fontData = translatedData;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
-      if (typeof this.disableFontFace !== "boolean") {
-        unreachable("disableFontFace must be available.");
-      }
-      if (typeof this.fontExtraProperties !== "boolean") {
-        unreachable("fontExtraProperties must be available.");
-      }
+      assert(
+        typeof translatedData.disableFontFace === "boolean",
+        "disableFontFace must be available."
+      );
+      assert(
+        typeof translatedData.fontExtraProperties === "boolean",
+        "fontExtraProperties must be available."
+      );
     }
+    this.#fontData = translatedData;
     this._inspectFont = inspectFont;
     if (extra) {
       Object.assign(this, extra);
@@ -453,7 +456,7 @@ class FontFaceObject {
   }
 
   get disableFontFace() {
-    return this.#fontData.disableFontFace ?? false;
+    return this.#fontData.disableFontFace;
   }
 
   set disableFontFace(value) {
@@ -461,7 +464,7 @@ class FontFaceObject {
   }
 
   get fontExtraProperties() {
-    return this.#fontData.fontExtraProperties ?? false;
+    return this.#fontData.fontExtraProperties;
   }
 
   get isInvalidPDFjsFont() {


### PR DESCRIPTION
In PR #19548 these checks were added to ensure that the font-data sent from the worker-thread *always* include correct `disableFontFace` and `fontExtraProperties` data.

For some reason PR #20197 then changed the code such that these checks became effectively pointless, since these properties are now checked after the fact *and* the new getters provide fallback values.