### PR TITLE
Copy webpack.mjs to legacy in dist task

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2545,6 +2545,11 @@ gulp.task(
           })
           .pipe(gulp.dest(DIST_DIR)),
         gulp
+          .src("external/dist/webpack.mjs", {
+            encoding: false,
+          })
+          .pipe(gulp.dest(DIST_DIR + "legacy/")),
+        gulp
           .src(GENERIC_DIR + "LICENSE", { encoding: false })
           .pipe(gulp.dest(DIST_DIR)),
         gulp


### PR DESCRIPTION
This supports using the legacy PDF.js with webpack.

Based on feedback from #18699.