### PR TITLE
Only focus the undo bar when the focus isn't inside

### DIFF
--- a/web/editor_undo_bar.js
+++ b/web/editor_undo_bar.js
@@ -105,7 +105,9 @@ class EditorUndoBar {
     // Without the setTimeout, VoiceOver will read out the document title
     // instead of the popup label.
     this.#focusTimeout = setTimeout(() => {
-      this.#container.focus();
+      if (!this.#container.contains(document.activeElement)) {
+        this.#container.focus();
+      }
       this.#focusTimeout = null;
     }, 100);
   }


### PR DESCRIPTION
It should fix the test "must work properly when selecting undo by keyboard" which calls focus() but it can be steal by fixed callback in setTimeout.