### PR TITLE
Bundle the necessary files and set the correct `cMapUrl`, `iccUrl`, and `standardFontDataUrl` when building `gulp internal-viewer`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2403,6 +2403,9 @@ function buildInternalViewer(defines, dir) {
         ])
       )
       .pipe(gulp.dest(dir + "web")),
+    createCMapBundle().pipe(gulp.dest(dir + "web/cmaps")),
+    createICCBundle().pipe(gulp.dest(dir + "web/iccs")),
+    createStandardFontBundle().pipe(gulp.dest(dir + "web/standard_fonts")),
     createWasmBundle().pipe(gulp.dest(dir + "web/wasm")),
   ]);
 }

--- a/web/pdf_internal_viewer.js
+++ b/web/pdf_internal_viewer.js
@@ -851,10 +851,15 @@ async function openDocument(source, name) {
 
   const loadingTask = getDocument({
     ...source,
-    cMapUrl: "../external/bcmaps/",
+    cMapUrl:
+      typeof PDFJSDev === "undefined" ? "../external/bcmaps/" : "../web/cmaps/",
+    iccUrl:
+      typeof PDFJSDev === "undefined" ? "../external/iccs/" : "../web/iccs/",
+    standardFontDataUrl:
+      typeof PDFJSDev === "undefined"
+        ? "../external/standard_fonts/"
+        : "../web/standard_fonts/",
     wasmUrl: "../web/wasm/",
-    iccUrl: "../external/iccs/",
-    standardFontDataUrl: "../external/standard_fonts/",
     useWorkerFetch: true,
     pdfBug: true,
     CanvasFactory: DebugCanvasFactory,


### PR DESCRIPTION
Without these changes none of the relevant functionality would work in the *built* internal-viewer.