### PR TITLE
Fix superfluous trailing argument in `web/pdf_internal_viewer.js`

### DIFF
--- a/web/pdf_internal_viewer.js
+++ b/web/pdf_internal_viewer.js
@@ -2878,7 +2878,7 @@ function renderValue(value, doc) {
 
   // Content stream (Page Contents) → expandable with Parsed/Raw toggle
   if (isContentStream(value)) {
-    return renderContentStream(value, doc);
+    return renderContentStream(value);
   }
 
   // Stream → expandable showing dict entries + byte count or image preview


### PR DESCRIPTION
The `renderContentStream` function only takes the value as argument.

This commit resolves the new CodeQL warning from
https://github.com/mozilla/pdf.js/security/code-scanning/1443.