### PR TITLE
Remove the unused `bbox` setter in the `FontFaceObject` class (PR 20427 follow-up)

### DIFF
--- a/src/display/font_loader.js
+++ b/src/display/font_loader.js
@@ -507,10 +507,6 @@ class FontFaceObject {
     return this.#fontData.bbox;
   }
 
-  set bbox(bbox) {
-    shadow(this, "bbox", bbox);
-  }
-
   get fontMatrix() {
     return this.#fontData.fontMatrix;
   }


### PR DESCRIPTION
The commit message for the patch in PR #20427 is pretty non-descriptive, being only a single line, however there's a bit more context in https://github.com/mozilla/pdf.js/pull/20427#issue-3597370951 but unfortunately the details there don't really make sense.
Note that the PR only changed main-thread code, but all the links are to worker-thread code!?

The `FontFaceObject` class is only used on the main-thread, and when encountering a broken font we fallback to the built-in font renderer; see https://github.com/mozilla/pdf.js/blob/820b70eb25b1c6bf74f916e002d11afc49e929cf/src/display/font_loader.js#L135-L143 Hence the `FontFaceObject` class *only* needs a way to set the `disableFontFace` property, however nowhere on the main-thread do we ever update the `bbox` of a font.