### PR TITLE
Use a non-zero exit code if the tests failed

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -743,6 +743,7 @@ function onAllSessionsClosedAfterTests(name) {
     }
     var runtime = (Date.now() - startTime) / 1000;
     console.log(name + " tests runtime was " + runtime.toFixed(1) + " seconds");
+    process.exit(numErrors > 0 ? 1 : 0);
   };
 }
 


### PR DESCRIPTION
The bots currently detect if the tests failed or not by checking the output text, but this is error-prone as it would break if the text gets changed (which is rather unexpected) and it's non-standard as usually processes report success/failure via their exit code.

This commit makes sure that the test process fails with a non-zero exit code if the tests failed, and a zero exit code otherwise. Note that we keep the same output text as before, so this change should not impact the bots, but it does form another step to unlock usage in GitHub Actions (which uses the exit code of commands to determine the status of the workflow run).

Related to #11851.