### PR TITLE
Skip the "should reorder thumbnails after dropping two adjacent pages" integration test

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -258,6 +258,8 @@ describe("Reorganize Pages View", () => {
     it("should reorder thumbnails after dropping two adjacent pages", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
+          pending("Fails consistently (issue #20814).");
+
           await waitForThumbnailVisible(page, 1);
           const rect2 = await getRect(page, getThumbnailSelector(2));
           const rect4 = await getRect(page, getThumbnailSelector(4));


### PR DESCRIPTION
 This is a temporary measure to reduce noise until #20814 is fixed.