### PR TITLE
Exclude page 12 from the "tracemonkey-extract_0_2_12" reference test

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -13073,16 +13073,15 @@
     }
   },
   {
-    "id": "tracemonkey-extract_0_2_12",
+    "id": "tracemonkey-extract_0_2",
     "file": "pdfs/tracemonkey.pdf",
     "md5": "9a192d8b1a7dc652a19835f6f08098bd",
     "rounds": 1,
     "type": "extract",
-    "includePages": [0, 2, 12],
+    "includePages": [0, 2],
     "pageMapping": {
       "1": 1,
-      "3": 2,
-      "13": 3
+      "3": 2
     }
   },
   {


### PR DESCRIPTION
This particular page is constantly reporting changes in the diagram area, even after recreating the reference images. It's not clear why, but it was checked that the actual file doesn't have an issue, so since this test is only interested in if extracting pages works and the resulting pages don't change it should be fine to just extract the two other (non-consecutive) pages for this purpose instead.