### PR TITLE
Remove the `xfatest` command

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -680,7 +680,7 @@ function getTempFile(prefix, suffix) {
   return filePath;
 }
 
-function runTests(testsName, { bot = false, xfaOnly = false } = {}) {
+function runTests(testsName, { bot = false } = {}) {
   return new Promise((resolve, reject) => {
     console.log("\n### Running " + testsName + " tests");
 
@@ -695,9 +695,6 @@ function runTests(testsName, { bot = false, xfaOnly = false } = {}) {
           // The browser-tests are too slow in Google Chrome on the bots,
           // causing a timeout, hence disabling them for now.
           forceNoChrome = true;
-        }
-        if (xfaOnly) {
-          args.push("--xfaOnly");
         }
         args.push("--manifestFile=" + PDF_TEST);
         collectArgs(
@@ -1809,29 +1806,6 @@ gulp.task(
     await runTests("browser", { bot: true });
     await runTests("integration");
   })
-);
-
-gulp.task(
-  "xfatest",
-  gulp.series(setTestEnv, "generic", "components", async function runXfaTest() {
-    await runTests("unit");
-    await runTests("browser", { xfaOnly: true });
-    await runTests("integration");
-  })
-);
-
-gulp.task(
-  "botxfatest",
-  gulp.series(
-    setTestEnv,
-    "generic",
-    "components",
-    async function runBotXfaTest() {
-      await runTests("unit", { bot: true });
-      await runTests("browser", { bot: true, xfaOnly: true });
-      await runTests("integration");
-    }
-  )
 );
 
 gulp.task(

--- a/test/driver.js
+++ b/test/driver.js
@@ -505,7 +505,6 @@ class Driver {
     this.delay = params.get("delay") | 0;
     this.inFlightRequests = 0;
     this.testFilter = JSON.parse(params.get("testfilter") || "[]");
-    this.xfaOnly = params.get("xfaonly") === "true";
     this.masterMode = params.get("mastermode") === "true";
 
     // Create a working canvas
@@ -544,12 +543,9 @@ class Driver {
       this._log("done\n");
       this.manifest = await response.json();
 
-      if (this.testFilter?.length || this.xfaOnly) {
+      if (this.testFilter?.length) {
         this.manifest = this.manifest.filter(item => {
           if (this.testFilter.includes(item.id)) {
-            return true;
-          }
-          if (this.xfaOnly && item.enableXfa) {
             return true;
           }
           return false;

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -57,7 +57,6 @@ function parseOptions() {
       strictVerify: { type: "boolean", default: false },
       testfilter: { type: "string", short: "t", multiple: true, default: [] },
       unitTest: { type: "boolean", default: false },
-      xfaOnly: { type: "boolean", default: false },
     },
   });
 
@@ -83,8 +82,7 @@ function parseOptions() {
         "  --statsFile         File where to store stats.\n" +
         "  --strictVerify      Error if manifest file verification fails.\n" +
         "  --testfilter, -t    Run specific reftest(s), e.g. -t=issue5567.\n" +
-        "  --unitTest          Run the unit tests.\n" +
-        "  --xfaOnly           Only run the XFA reftest(s)."
+        "  --unitTest          Run the unit tests.\n"
     );
     process.exit(0);
   }
@@ -96,17 +94,6 @@ function parseOptions() {
     throw new Error(
       "--reftest, --unitTest, --fontTest, and --masterMode must not be specified together."
     );
-  }
-  if (
-    +values.unitTest + values.fontTest + values.integration + values.xfaOnly >
-    1
-  ) {
-    throw new Error(
-      "--unitTest, --fontTest, --integration, and --xfaOnly must not be specified together."
-    );
-  }
-  if (values.testfilter.length > 0 && values.xfaOnly) {
-    throw new Error("--testfilter and --xfaOnly cannot be used together.");
   }
   if (values.noDownload && values.downloadOnly) {
     throw new Error("--noDownload and --downloadOnly cannot be used together.");
@@ -347,16 +334,12 @@ function handleSessionTimeout(session) {
 function getTestManifest() {
   var manifest = JSON.parse(fs.readFileSync(options.manifestFile));
 
-  const testFilter = options.testfilter.slice(0),
-    xfaOnly = options.xfaOnly;
-  if (testFilter.length || xfaOnly) {
+  const testFilter = options.testfilter.slice(0);
+  if (testFilter.length) {
     manifest = manifest.filter(function (item) {
       var i = testFilter.indexOf(item.id);
       if (i !== -1) {
         testFilter.splice(i, 1);
-        return true;
-      }
-      if (xfaOnly && item.enableXfa) {
         return true;
       }
       return false;
@@ -968,7 +951,6 @@ async function startBrowsers({ baseUrl, initializeSession }) {
         `?browser=${encodeURIComponent(browserName)}` +
         `&manifestFile=${encodeURIComponent("/test/" + options.manifestFile)}` +
         `&testFilter=${JSON.stringify(options.testfilter)}` +
-        `&xfaOnly=${options.xfaOnly}` +
         `&delay=${options.statsDelay}` +
         `&masterMode=${options.masterMode}`;
       startUrl = baseUrl + queryParameters;


### PR DESCRIPTION
The XFA development work has been completed, with mostly regular maintance/bugfixing remaining, so while this special-casing for the tests made sense at the time we should now be able to remove it (see also https://github.com/mozilla/pdf.js/issues/11851#issuecomment-2419790237).

Fixes a part of #11851.
Related to https://github.com/mozilla/botio-files-pdfjs/pull/47.