### PR TITLE
Fix the issue in the ref test tracemonkey-extract_0_2_12

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -666,7 +666,7 @@ class Driver {
           task.isOffscreenCanvasSupported === false ? false : undefined;
         const disableFontFace = task.disableFontFace === true;
 
-        const loadingTask = getDocument({
+        const documentOptions = {
           url: new URL(task.file, window.location),
           password: task.password,
           cMapUrl: CMAP_URL,
@@ -682,12 +682,15 @@ class Driver {
           isOffscreenCanvasSupported,
           styleElement: xfaStyleElement,
           disableFontFace,
-        });
+        };
+        const loadingTask = getDocument(documentOptions);
         let promise = loadingTask.promise;
 
         if (!this.masterMode && task.type === "extract") {
           promise = promise.then(async doc => {
-            const data = await doc.extractPages([
+            const extractedDocumentOptions = { ...documentOptions };
+            delete extractedDocumentOptions.url;
+            extractedDocumentOptions.data = await doc.extractPages([
               {
                 document: null,
                 includePages: task.includePages,
@@ -695,7 +698,7 @@ class Driver {
             ]);
             await loadingTask.destroy();
             delete task.includePages;
-            return getDocument(data).promise;
+            return getDocument(extractedDocumentOptions).promise;
           });
         }
 


### PR DESCRIPTION
When getting the extracted document, the url for the wasms wasn't passed and consequently the icc-based color wasn't rendered as expected because of the wasm for qcms.