### PR TITLE
fix: remove color-scheme for :root selector which affects the host website

### DIFF
--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -26,8 +26,6 @@
 /* Ignored in GECKOVIEW: end */
 
 :root {
-  color-scheme: light dark;
-
   --viewer-container-height: 0;
   --pdfViewer-padding-bottom: 0;
   --page-margin: 1px auto -8px;


### PR DESCRIPTION
Resolving https://github.com/mozilla/pdf.js/issues/19886

Simply remove the CSS style applied to the :root selector.