### PR TITLE
Simplify compilation of font paths (PR 20346 follow-up)

### DIFF
--- a/src/core/obj_bin_transform_core.js
+++ b/src/core/obj_bin_transform_core.js
@@ -389,20 +389,15 @@ function compilePatternInfo(ir) {
 }
 
 function compileFontPathInfo(path) {
-  let data;
-  let buffer;
-  if (
-    (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) ||
-    FeatureTest.isFloat16ArraySupported
-  ) {
-    buffer = new ArrayBuffer(path.length * 2);
-    data = new Float16Array(buffer);
-  } else {
-    buffer = new ArrayBuffer(path.length * 4);
-    data = new Float32Array(buffer);
+  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+    assert(
+      FeatureTest.isFloat16ArraySupported
+        ? path instanceof Float16Array
+        : path instanceof Float32Array,
+      "compileFontPathInfo: Unexpected path format."
+    );
   }
-  data.set(path);
-  return buffer;
+  return path.slice().buffer;
 }
 
 export {


### PR DESCRIPTION
Given that `CompiledFont.prototype.getPathJs` already returns data in the desired TypedArray format, we should be able to directly copy the font-path data which helps shorten the code a little bit (rather than the "manual" handling in PR #20346).

To ensure that this keeps working as expected, a non-production `assert` is added to prevent any future surprises.