### PR TITLE
Fix the intermittent issue in reorganize_pages spec

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -142,7 +142,13 @@ describe("Reorganize Pages View", () => {
         "page_with_number.pdf",
         "#viewsManagerToggleButton",
         "page-fit",
-        null,
+        {
+          appSetup: () => {
+            document
+              .getElementById("thumbnailsView")
+              .style.setProperty("--thumbnail-width", "26px");
+          },
+        },
         { enableSplitMerge: true }
       );
     });

--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -31,7 +31,6 @@ import { AppOptions } from "./app_options.js";
 
 const DRAW_UPSCALE_FACTOR = 2; // See comment in `PDFThumbnailView.draw` below.
 const MAX_NUM_SCALING_STEPS = 3;
-const THUMBNAIL_WIDTH = 126; // px
 
 /**
  * @typedef {Object} PDFThumbnailViewOptions
@@ -79,6 +78,8 @@ class TempImageFactory {
 
 class PDFThumbnailView extends RenderableView {
   #renderingState = RenderingStates.INITIAL;
+
+  static #baseWidth = 0;
 
   /**
    * @param {PDFThumbnailViewOptions} options
@@ -150,6 +151,10 @@ class PDFThumbnailView extends RenderableView {
     this.#updateDims();
 
     container.append(thumbnailContainer);
+  }
+
+  static setThumbnailBaseWidth(width) {
+    this.#baseWidth ||= width;
   }
 
   clone(container, id) {
@@ -240,7 +245,7 @@ class PDFThumbnailView extends RenderableView {
     const { width, height } = this.viewport;
     const ratio = width / height;
 
-    const canvasWidth = (this.canvasWidth = THUMBNAIL_WIDTH);
+    const canvasWidth = (this.canvasWidth = PDFThumbnailView.#baseWidth);
     const canvasHeight = (this.canvasHeight = (canvasWidth / ratio) | 0);
     this.scale = canvasWidth / width;
 

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -193,6 +193,12 @@ class PDFThumbnailViewer {
     this.#undoButton = undoBar?.viewsManagerStatusUndoButton || null;
     this.#undoCloseButton = undoBar?.viewsManagerStatusUndoCloseButton || null;
 
+    PDFThumbnailView.setThumbnailBaseWidth(
+      parseFloat(
+        getComputedStyle(container).getPropertyValue("--thumbnail-width")
+      ) || 126
+    );
+
     // TODO: uncomment when the "add file" feature is implemented.
     // this.#addFileButton = addFileButton;
 


### PR DESCRIPTION
The intermittent problem is very likely because the thumbnail we want to dnd is not or partially visible.
So this patch helps to reduce enough the size of the thumbnails before starting to dnd them.