### PR TITLE
Ensure that `getDocument` is called with one of the `data`, `range`, or `url` parameters provided

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -469,18 +469,17 @@ function getDocument(src = {}) {
       );
 
       let networkStream;
-      if (rangeTransport) {
+      if (data) {
+        // The entire PDF was provided, no `networkStream` necessary.
+      } else if (rangeTransport) {
         networkStream = new PDFDataTransportStream({
           pdfDataRangeTransport: rangeTransport,
           disableRange,
           disableStream,
         });
-      } else if (!data) {
+      } else if (url) {
         if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
           throw new Error("Not implemented: NetworkStream");
-        }
-        if (!url) {
-          throw new Error("getDocument - no `url` parameter provided.");
         }
         // eslint-disable-next-line no-nested-ternary
         const NetworkStream = isValidFetchUrl(url)
@@ -499,6 +498,10 @@ function getDocument(src = {}) {
           disableRange,
           disableStream,
         });
+      } else {
+        throw new Error(
+          "getDocument - expected either `data`, `range`, or `url` parameter."
+        );
       }
 
       return workerIdPromise.then(workerId => {


### PR DESCRIPTION
Providing one of these parameters is necessary when calling `getDocument`, since otherwise there's nothing to actually load. However, we currently don't enforce that properly and if there's more than one of these parameters provided the behaviour isn't well defined.[1]

The new behaviour is thus, in order:
 1. Use the `data` parameter, since the PDF is already available and no additional loading is necessary.
 2. Use the `range` parameter, for custom PDF loading (e.g. the Firefox PDF Viewer).
 3. Use the `url` parameter, and have the PDF.js library load the PDF with a suitable `networkStream`.
 4. Throw an error, since there's no way to load the PDF.

---

[1] E.g. if both `data` and `range` is provided, we'd load the document directly (since it's available) and also initialize a pointless `PDFDataTransportStream` instance.