### PR TITLE
[Firefox] Ensure that worker-thread fetching is used for built-in CMap, standard font, and wasm data

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -408,6 +408,9 @@ class PartialEvaluator {
         isCompressed: true,
       };
     } else {
+      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+        throw new Error("Only worker-thread fetching supported.");
+      }
       // Get the data on the main-thread instead.
       data = await this.handler.sendWithPromise("FetchBinaryData", {
         type: "cMapReaderFactory",
@@ -446,6 +449,9 @@ class PartialEvaluator {
           `${this.options.standardFontDataUrl}${filename}`
         );
       } else {
+        if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+          throw new Error("Only worker-thread fetching supported.");
+        }
         // Get the data on the main-thread instead.
         data = await this.handler.sendWithPromise("FetchBinaryData", {
           type: "standardFontDataFactory",

--- a/src/core/jbig2_ccittFax_wasm.js
+++ b/src/core/jbig2_ccittFax_wasm.js
@@ -48,6 +48,9 @@ class JBig2CCITTFaxWasmImage {
         if (this.#useWorkerFetch) {
           this.#buffer = await fetchBinaryData(`${this.#wasmUrl}${filename}`);
         } else {
+          if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+            throw new Error("Only worker-thread fetching supported.");
+          }
           this.#buffer = await this.#handler.sendWithPromise(
             "FetchBinaryData",
             { type: "wasmFactory", filename }

--- a/src/core/jpx.js
+++ b/src/core/jpx.js
@@ -72,6 +72,9 @@ class JpxImage {
         if (this.#useWorkerFetch) {
           this.#buffer = await fetchBinaryData(`${this.#wasmUrl}${filename}`);
         } else {
+          if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+            throw new Error("Only worker-thread fetching supported.");
+          }
           this.#buffer = await this.#handler.sendWithPromise(
             "FetchBinaryData",
             { type: "wasmFactory", filename }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2468,16 +2468,17 @@ class WorkerTransport {
 
     this.canvasFactory = factory.canvasFactory;
     this.filterFactory = factory.filterFactory;
-    this.cMapReaderFactory = factory.cMapReaderFactory;
-    this.standardFontDataFactory = factory.standardFontDataFactory;
-    this.wasmFactory = factory.wasmFactory;
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      this.cMapReaderFactory = factory.cMapReaderFactory;
+      this.standardFontDataFactory = factory.standardFontDataFactory;
+      this.wasmFactory = factory.wasmFactory;
+    }
+    this.pagesMapper = pagesMapper;
 
     this.destroyed = false;
     this.destroyCapability = null;
 
     this.setupMessageHandler();
-
-    this.pagesMapper = pagesMapper;
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
       // For testing purposes.
@@ -2925,22 +2926,21 @@ class WorkerTransport {
       this.#onProgress(data);
     });
 
-    messageHandler.on("FetchBinaryData", async data => {
-      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
-        throw new Error("Not implemented: FetchBinaryData");
-      }
-      if (this.destroyed) {
-        throw new Error("Worker was destroyed.");
-      }
-      const factory = this[data.type];
+    if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
+      messageHandler.on("FetchBinaryData", async data => {
+        if (this.destroyed) {
+          throw new Error("Worker was destroyed.");
+        }
+        const factory = this[data.type];
 
-      if (!factory) {
-        throw new Error(
-          `${data.type} not initialized, see the \`useWorkerFetch\` parameter.`
-        );
-      }
-      return factory.fetch(data);
-    });
+        if (!factory) {
+          throw new Error(
+            `${data.type} not initialized, see the \`useWorkerFetch\` parameter.`
+          );
+        }
+        return factory.fetch(data);
+      });
+    }
   }
 
   getData() {


### PR DESCRIPTION
Given that we "forcibly" set `useWorkerFetch = true` for the MOZCENTRAL build-target there's a small amount of dead code as a result, which we can thus remove during building.