### PR TITLE
Remove explicit `name`/`filename` validation in the `BaseCMapReaderFactory`, `BaseStandardFontDataFactory`, and `BaseWasmFactory` classes

### DIFF
--- a/src/display/cmap_reader_factory.js
+++ b/src/display/cmap_reader_factory.js
@@ -34,17 +34,12 @@ class BaseCMapReaderFactory {
         "Ensure that the `cMapUrl` and `cMapPacked` API parameters are provided."
       );
     }
-    if (!name) {
-      throw new Error("CMap name must be specified.");
-    }
     const url = this.baseUrl + name + (this.isCompressed ? ".bcmap" : "");
 
     return this._fetch(url)
       .then(cMapData => ({ cMapData, isCompressed: this.isCompressed }))
       .catch(reason => {
-        throw new Error(
-          `Unable to load ${this.isCompressed ? "binary " : ""}CMap at: ${url}`
-        );
+        throw new Error(`Unable to load CMap data at: ${url}`);
       });
   }
 

--- a/src/display/standard_fontdata_factory.js
+++ b/src/display/standard_fontdata_factory.js
@@ -33,9 +33,6 @@ class BaseStandardFontDataFactory {
         "Ensure that the `standardFontDataUrl` API parameter is provided."
       );
     }
-    if (!filename) {
-      throw new Error("Font filename must be specified.");
-    }
     const url = `${this.baseUrl}${filename}`;
 
     return this._fetch(url).catch(reason => {

--- a/src/display/wasm_factory.js
+++ b/src/display/wasm_factory.js
@@ -31,9 +31,6 @@ class BaseWasmFactory {
     if (!this.baseUrl) {
       throw new Error("Ensure that the `wasmUrl` API parameter is provided.");
     }
-    if (!filename) {
-      throw new Error("Wasm filename must be specified.");
-    }
     const url = `${this.baseUrl}${filename}`;
 
     return this._fetch(url).catch(reason => {

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -247,7 +247,7 @@ describe("cmap", function () {
     } catch (reason) {
       expect(reason).toBeInstanceOf(Error);
       const message = reason.message;
-      expect(message.startsWith("Unable to load CMap at: ")).toEqual(true);
+      expect(message.startsWith("Unable to load CMap data at: ")).toEqual(true);
       expect(message.endsWith("/external/bcmaps/Adobe-Japan1-1")).toEqual(true);
     }
   });


### PR DESCRIPTION
Given that these classes are only used from the "FetchBinaryData" message handler, the `name`/`filename` parameters should never actually be missing and if they are that's a bug elsewhere in the code-base.
Furthermore a missing `name`/`filename` parameter would result in a "nonsense" URL and the actual data fetching would then fail instead, hence keeping this old validation code just doesn't seem necessary.