### PR TITLE
Ensure that `TextLayerBuilder` works correctly without the `abortSignal` parameter (PR 20928 follow-up)

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -169,13 +169,14 @@ class TextLayerBuilder {
   #bindMouse(end) {
     const { div } = this;
     const abortSignal = this.#abortSignal;
+    const opts = abortSignal ? { signal: abortSignal } : null;
 
     div.addEventListener(
       "mousedown",
       () => {
         div.classList.add("selecting");
       },
-      { signal: abortSignal }
+      opts
     );
 
     div.addEventListener(
@@ -190,7 +191,7 @@ class TextLayerBuilder {
         }
         stopEvent(event);
       },
-      { signal: abortSignal }
+      opts
     );
 
     TextLayerBuilder.#textLayers.set(div, end);


### PR DESCRIPTION
After the changes in PR #20928 the code no longer works correctly unless the `abortSignal` parameter is provided, which completely breaks text-selection in e.g. the standalone viewer-components with errors such as:
```
 #renderTextLayer: TypeError: EventTarget.addEventListener: 'signal' member of AddEventListenerOptions is not an object.
    #bindMouse http://localhost:8888/web/text_layer_builder.js:173
    render http://localhost:8888/web/text_layer_builder.js:128
    #renderTextLayer http://localhost:8888/web/pdf_page_view.js:532
    resultPromise http://localhost:8888/web/pdf_page_view.js:1184
    promise callback*draw http://localhost:8888/web/pdf_page_view.js:1174
    renderView http://localhost:8888/web/pdf_rendering_queue.js:219
    forceRendering http://localhost:8888/web/pdf_viewer.js:2081
    promise callback*forceRendering http://localhost:8888/web/pdf_viewer.js:2080
    renderHighestPriority http://localhost:8888/web/pdf_rendering_queue.js:84
    update http://localhost:8888/web/pdf_viewer.js:1895
    onScaleChanging http://localhost:8888/web/app.js:2755
    dispatch http://localhost:8888/web/event_utils.js:115
    #setScaleUpdatePages http://localhost:8888/web/pdf_viewer.js:1555
    #setScale http://localhost:8888/web/pdf_viewer.js:1640
    set currentScaleValue http://localhost:8888/web/pdf_viewer.js:592
    setInitialView http://localhost:8888/web/app.js:1969
    load http://localhost:8888/web/app.js:1570
    promise callback*load/< http://localhost:8888/web/app.js:1518
    promise callback*load http://localhost:8888/web/app.js:1507
    open http://localhost:8888/web/app.js:1255
    promise callback*open http://localhost:8888/web/app.js:1253
    run http://localhost:8888/web/app.js:895
    webViewerLoad http://localhost:8888/web/viewer.js:366
    <anonymous> http://localhost:8888/web/viewer.js:377
pdf_page_view.js:547:15
```