### PR TITLE
[Debugger] Allow debugging page-rendering from the /Ref, in addition to the page number

### DIFF
--- a/web/internal/debugger.js
+++ b/web/internal/debugger.js
@@ -230,6 +230,15 @@ gotoInput.addEventListener("keydown", async ({ key, target }) => {
     return;
   }
   target.removeAttribute("aria-invalid");
+
+  // Allow debugging via references, as well as page numbers.
+  if (result.page === undefined) {
+    try {
+      result.page =
+        pdfDoc.cachedPageNumber(result.ref) ??
+        (await pdfDoc.getPageIndex(result.ref)) + 1;
+    } catch {}
+  }
   // If we're in debug view and navigating to a page, stay in debug view
   // without switching to the tree at all.
   if (!debugViewEl.hidden && result.page !== undefined) {


### PR DESCRIPTION
Currently it's only possible to trigger page-render debugging through the page number, but when looking at the /Pages tree it's often not immediately obvious what the page number actually is.
However, the /Ref of the page is directly available and it's thus handy to be able to use that one instead to enable page-render debugging.