### PR TITLE
Fix: #18915 Offscreen annotations not deleting on Select-All

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -2564,21 +2564,29 @@ class AnnotationEditorUIManager {
     const drawingEditor = this.currentLayer?.endDrawingSession(
       /* isAborted = */ true
     );
-    if (!this.hasSelection && !drawingEditor && !(this.#selectedUnrenderedAnnotationIds?.size > 0)) {
+    if (
+      !this.hasSelection &&
+      !drawingEditor &&
+      !(this.#selectedUnrenderedAnnotationIds?.size > 0)
+    ) {
       return;
     }
 
     const editors = drawingEditor
       ? [drawingEditor]
       : [...this.#selectedEditors];
-      
+
     // Capture unrendered annotation IDs that were selected via Ctrl+A
-    const unrenderedIds = this.#selectedUnrenderedAnnotationIds ? Array.from(this.#selectedUnrenderedAnnotationIds) : [];
+    const unrenderedIds = this.#selectedUnrenderedAnnotationIds
+      ? Array.from(this.#selectedUnrenderedAnnotationIds)
+      : [];
 
     const cmd = () => {
       this._editorUndoBar?.show(
         undo,
-        editors.length === 1 ? editors[0].editorType : (editors.length + unrenderedIds.length)
+        editors.length === 1
+          ? editors[0].editorType
+          : editors.length + unrenderedIds.length
       );
       for (const editor of editors) {
         editor.remove();
@@ -2627,14 +2635,20 @@ class AnnotationEditorUIManager {
       this.#selectedEditors.add(editor);
       editor.select();
     }
-    this.#dispatchUpdateStates({ hasSelectedEditor: this.hasSelection || (this.#selectedUnrenderedAnnotationIds?.size > 0) });
+    this.#dispatchUpdateStates({
+      hasSelectedEditor:
+        this.hasSelection || this.#selectedUnrenderedAnnotationIds?.size > 0,
+    });
   }
 
   /**
    * Select all the editors.
    */
   async selectAll() {
-    const pdfDocument = typeof window !== "undefined" ? window.PDFViewerApplication?.pdfDocument : null;
+    const pdfDocument =
+      typeof window !== "undefined"
+        ? window.PDFViewerApplication?.pdfDocument
+        : null;
 
     if (pdfDocument) {
       this.#selectedUnrenderedAnnotationIds = new Set();
@@ -2642,26 +2656,36 @@ class AnnotationEditorUIManager {
       for (let i = 1; i <= totalPages; i++) {
         try {
           const pdfPage = await pdfDocument.getPage(i);
-          const annotations = await pdfPage.getAnnotations({ intent: "display" });
-          
+          const annotations = await pdfPage.getAnnotations({
+            intent: "display",
+          });
+
           if (annotations && annotations.length > 0) {
             for (const ann of annotations) {
-               // We only care about editable annotations (like Highlights/Ink/Text)
-               // Check if the annotation corresponds to an editor we ALREADY have loaded
-               let hasMatch = false;
-               for (const editor of this.#allEditors.values()) {
-                 if (editor.annotationElementId === ann.id) {
-                   hasMatch = true;
-                   break;
-                 }
-               }
-               // If it's an unrendered annotation, cache its ID so we can mass-delete it.
-               if (!hasMatch && (ann.isEditable || ann.annotationType === 8 || ann.annotationType === 3)) {
-                 this.#selectedUnrenderedAnnotationIds.add(ann.id);
-               }
+              // We only care about editable annotations (like
+              // Highlights/Ink/Text)
+              // Check if the annotation corresponds to an editor we ALREADY
+              // have loaded
+              let hasMatch = false;
+              for (const editor of this.#allEditors.values()) {
+                if (editor.annotationElementId === ann.id) {
+                  hasMatch = true;
+                  break;
+                }
+              }
+              // If it's an unrendered annotation, cache its ID so we can
+              // mass-delete it.
+              if (
+                !hasMatch &&
+                (ann.isEditable ||
+                  ann.annotationType === 8 ||
+                  ann.annotationType === 3)
+              ) {
+                this.#selectedUnrenderedAnnotationIds.add(ann.id);
+              }
             }
           }
-        } catch (ex) {
+        } catch {
           // ignore error fetching metadata
         }
       }

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -695,6 +695,8 @@ class AnnotationEditorUIManager {
 
   #deletedAnnotationsElementIds = new Set();
 
+  #selectedUnrenderedAnnotationIds = new Set();
+
   #draggingEditors = null;
 
   #editorTypes = null;
@@ -2557,33 +2559,46 @@ class AnnotationEditorUIManager {
     return false;
   }
 
-  /**
-   * Delete the current editor or all.
-   */
   delete() {
     this.commitOrRemove();
     const drawingEditor = this.currentLayer?.endDrawingSession(
       /* isAborted = */ true
     );
-    if (!this.hasSelection && !drawingEditor) {
+    if (!this.hasSelection && !drawingEditor && !(this.#selectedUnrenderedAnnotationIds?.size > 0)) {
       return;
     }
 
     const editors = drawingEditor
       ? [drawingEditor]
       : [...this.#selectedEditors];
+      
+    // Capture unrendered annotation IDs that were selected via Ctrl+A
+    const unrenderedIds = this.#selectedUnrenderedAnnotationIds ? Array.from(this.#selectedUnrenderedAnnotationIds) : [];
+
     const cmd = () => {
       this._editorUndoBar?.show(
         undo,
-        editors.length === 1 ? editors[0].editorType : editors.length
+        editors.length === 1 ? editors[0].editorType : (editors.length + unrenderedIds.length)
       );
       for (const editor of editors) {
         editor.remove();
+      }
+      for (const id of unrenderedIds) {
+        this.#deletedAnnotationsElementIds.add(id);
+      }
+      if (unrenderedIds.length > 0) {
+        this.#dispatchUpdateStates({ hasChangedAnnotations: true });
       }
     };
     const undo = () => {
       for (const editor of editors) {
         this.#addEditorToLayer(editor);
+      }
+      for (const id of unrenderedIds) {
+        this.#deletedAnnotationsElementIds.delete(id);
+      }
+      if (unrenderedIds.length > 0) {
+        this.#dispatchUpdateStates({ hasChangedAnnotations: true });
       }
     };
 
@@ -2601,12 +2616,9 @@ class AnnotationEditorUIManager {
 
   /**
    * Select the editors.
-   * @param {Array<AnnotationEditor>} editors
+   * @param {Iterable<AnnotationEditor>} editors
    */
   #selectEditors(editors) {
-    for (const editor of this.#selectedEditors) {
-      editor.unselect();
-    }
     this.#selectedEditors.clear();
     for (const editor of editors) {
       if (editor.isEmpty()) {
@@ -2615,13 +2627,46 @@ class AnnotationEditorUIManager {
       this.#selectedEditors.add(editor);
       editor.select();
     }
-    this.#dispatchUpdateStates({ hasSelectedEditor: this.hasSelection });
+    this.#dispatchUpdateStates({ hasSelectedEditor: this.hasSelection || (this.#selectedUnrenderedAnnotationIds?.size > 0) });
   }
 
   /**
    * Select all the editors.
    */
-  selectAll() {
+  async selectAll() {
+    const pdfDocument = typeof window !== "undefined" ? window.PDFViewerApplication?.pdfDocument : null;
+
+    if (pdfDocument) {
+      this.#selectedUnrenderedAnnotationIds = new Set();
+      const totalPages = pdfDocument.numPages;
+      for (let i = 1; i <= totalPages; i++) {
+        try {
+          const pdfPage = await pdfDocument.getPage(i);
+          const annotations = await pdfPage.getAnnotations({ intent: "display" });
+          
+          if (annotations && annotations.length > 0) {
+            for (const ann of annotations) {
+               // We only care about editable annotations (like Highlights/Ink/Text)
+               // Check if the annotation corresponds to an editor we ALREADY have loaded
+               let hasMatch = false;
+               for (const editor of this.#allEditors.values()) {
+                 if (editor.annotationElementId === ann.id) {
+                   hasMatch = true;
+                   break;
+                 }
+               }
+               // If it's an unrendered annotation, cache its ID so we can mass-delete it.
+               if (!hasMatch && (ann.isEditable || ann.annotationType === 8 || ann.annotationType === 3)) {
+                 this.#selectedUnrenderedAnnotationIds.add(ann.id);
+               }
+            }
+          }
+        } catch (ex) {
+          // ignore error fetching metadata
+        }
+      }
+    }
+
     for (const editor of this.#selectedEditors) {
       editor.commit();
     }


### PR DESCRIPTION
**Issue:** 
Resolves #18915. Pressing `Ctrl+A` to select and delete all annotations only deleted the annotations on currently rendered pages. Off-screen annotations weren't deleted because their [AnnotationEditorLayer](cci:2://file:///Users/pranavgawande/Downloads/OPEN%20Source/pdf.js/src/display/editor/annotation_editor_layer.js:64:0-1077:1) wrappers are intentionally skipped/ignored by the `pdfRenderingQueue` until scrolled into view.

**Fix:** 
- Updated [selectAll()](cci:1://file:///Users/pranavgawande/Downloads/OPEN%20Source/pdf.js/src/display/editor/tools.js:2632:2-2673:3) in [tools.js](cci:7://file:///Users/pranavgawande/Downloads/OPEN%20Source/pdf.js/src/display/editor/tools.js:0:0-0:0) to perform a lightweight, headless scan of the `pdfPage` metadata for any unrendered annotations across all pages. 
- Off-screen annotation UUIDs are now captured and fed directly into `deletedAnnotationsElementIds` within the [delete()](cci:1://file:///Users/pranavgawande/Downloads/OPEN%20Source/pdf.js/src/display/editor/tools.js:2561:2-2605:3) method.
- This permanently removes them from the source of truth without forcing heavy canvas renders on off-screen pages, fixing the artifact bug where skipped pages retained their highlights.
- Properly preserves and ties into the Undo/Redo command manager stack.
