### PR TITLE
Revert "Avoid to have stuck actions when running update_locales task"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 name: CodeQL
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 permissions:
   contents: read
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: Code Coverage
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 permissions:
   contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 permissions:
   contents: read
 

--- a/.github/workflows/prefs_tests.yml
+++ b/.github/workflows/prefs_tests.yml
@@ -1,5 +1,5 @@
 name: Prefs tests
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 permissions:
   contents: read
 

--- a/.github/workflows/types_tests.yml
+++ b/.github/workflows/types_tests.yml
@@ -1,5 +1,5 @@
 name: Types tests
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 permissions:
   contents: read
 

--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -50,8 +49,3 @@ jobs:
             --title "l10n: Update locale files" \
             --body "Automated weekly update of locale files from mozilla-central." \
             --label l10n || true
-          # GITHUB_TOKEN-initiated pushes/PRs don't trigger other workflows.
-          # Explicitly dispatch them so CI runs on the update-locales branch.
-          for workflow in ci.yml lint.yml codeql.yml; do
-            gh workflow run "$workflow" --ref update-locales
-          done


### PR DESCRIPTION
This reverts commit d618a2bc7ebe550cfcef31df8ddd0c8a12cf6bf1. Unfortunately it did not fix the hanging actions for the locale update job; fixing the issue is tracked in #20813.