### PR TITLE
Add configurable MIN_SCALE and MAX_SCALE zoom limits via preferences (DUPLICATE)

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -1784,4 +1784,61 @@ describe("PDF viewer", () => {
       );
     });
   });
+
+  describe("Configurable zoom limits", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "empty.pdf",
+        ".textLayer .endOfContent",
+        100,
+        null,
+        { minScale: 50, maxScale: 200 }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must apply configured minScale and maxScale", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const { minScale, maxScale } = await page.evaluate(() => ({
+            minScale: window.PDFViewerApplication.pdfViewer.minScale,
+            maxScale: window.PDFViewerApplication.pdfViewer.maxScale,
+          }));
+          expect(minScale).withContext(`In ${browserName}`).toBe(0.5);
+          expect(maxScale).withContext(`In ${browserName}`).toBe(2.0);
+
+          for (let i = 0; i < 20; i++) {
+            await page.evaluate(() => window.PDFViewerApplication.zoomOut());
+          }
+          const scaleAtMin = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+          expect(scaleAtMin)
+            .withContext(`In ${browserName}`)
+            .toBeGreaterThanOrEqual(0.5);
+          expect(await page.$eval("#zoomOutButton", el => el.disabled))
+            .withContext(`In ${browserName}`)
+            .toBe(true);
+
+          for (let i = 0; i < 20; i++) {
+            await page.evaluate(() => window.PDFViewerApplication.zoomIn());
+          }
+          const scaleAtMax = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+          expect(scaleAtMax)
+            .withContext(`In ${browserName}`)
+            .toBeLessThanOrEqual(2.0);
+          expect(await page.$eval("#zoomInButton", el => el.disabled))
+            .withContext(`In ${browserName}`)
+            .toBe(true);
+        })
+      );
+    });
+  });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -379,6 +379,8 @@ const PDFViewerApplication = {
         highlightEditorColors: x => x,
         imagesRightClickMinSize: x => parseInt(x),
         maxCanvasPixels: x => parseInt(x),
+        maxScale: x => parseInt(x),
+        minScale: x => parseInt(x),
         spreadModeOnLoad: x => parseInt(x),
         supportsCaretBrowsingMode: x => x === "true",
         viewerCssTheme: x => parseInt(x),
@@ -567,6 +569,8 @@ const PDFViewerApplication = {
       ),
       imageResourcesPath: AppOptions.get("imageResourcesPath"),
       enablePrintAutoRotate: AppOptions.get("enablePrintAutoRotate"),
+      minScale: AppOptions.get("minScale") / 100,
+      maxScale: AppOptions.get("maxScale") / 100,
       maxCanvasPixels,
       maxCanvasDim,
       capCanvasAreaFactor,
@@ -687,12 +691,20 @@ const PDFViewerApplication = {
         const nimbusData = JSON.parse(
           AppOptions.get("nimbusDataStr") || "null"
         );
-        this.toolbar = new Toolbar(appConfig.toolbar, eventBus, nimbusData);
+        this.toolbar = new Toolbar(
+          appConfig.toolbar,
+          eventBus,
+          nimbusData,
+          pdfViewer.minScale,
+          pdfViewer.maxScale
+        );
       } else {
         this.toolbar = new Toolbar(
           appConfig.toolbar,
           eventBus,
-          AppOptions.get("toolbarDensity")
+          AppOptions.get("toolbarDensity"),
+          pdfViewer.minScale,
+          pdfViewer.maxScale
         );
       }
     }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+const DEFAULT_MIN_SCALE = 0.1;
+const DEFAULT_MAX_SCALE = 25.0;
+
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
   // eslint-disable-next-line no-var
   var compatParams = new Map();
@@ -347,10 +350,20 @@ const defaultOptions = {
     value: 2 ** 25,
     kind: OptionKind.VIEWER,
   },
+  maxScale: {
+    /** @type {number} */
+    value: Math.round(DEFAULT_MAX_SCALE * 100) | 0,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   minDurationToUpdateCanvas: {
     /** @type {number} */
     value: 500, // ms
     kind: OptionKind.VIEWER,
+  },
+  minScale: {
+    /** @type {number} */
+    value: Math.round(DEFAULT_MIN_SCALE * 100) | 0,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   forcePageColors: {
     /** @type {boolean} */
@@ -753,4 +766,4 @@ class AppOptions {
   }
 }
 
-export { AppOptions, OptionKind };
+export { AppOptions, DEFAULT_MAX_SCALE, DEFAULT_MIN_SCALE, OptionKind };

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -28,7 +28,6 @@
 // eslint-disable-next-line max-len
 /** @typedef {import("./base_download_manager.js").BaseDownloadManager} BaseDownloadManager */
 /** @typedef {import("./l10n.js").L10n} L10n */
-
 import {
   AnnotationEditorType,
   AnnotationEditorUIManager,
@@ -41,6 +40,7 @@ import {
   stopEvent,
   version,
 } from "pdfjs-lib";
+import { DEFAULT_MAX_SCALE, DEFAULT_MIN_SCALE } from "./app_options.js";
 import {
   DEFAULT_SCALE,
   DEFAULT_SCALE_DELTA,
@@ -52,8 +52,6 @@ import {
   isValidScrollMode,
   isValidSpreadMode,
   MAX_AUTO_SCALE,
-  MAX_SCALE,
-  MIN_SCALE,
   PresentationModeState,
   removeNullCharacters,
   SCROLLBAR_PADDING,
@@ -257,7 +255,11 @@ class PDFViewer {
 
   #eventAbortController = null;
 
+  #maxScale = null;
+
   #minDurationToUpdateCanvas = 0;
+
+  #minScale = null;
 
   #mlManager = null;
 
@@ -373,7 +375,16 @@ class PDFViewer {
     this.#supportsPinchToZoom = options.supportsPinchToZoom !== false;
     this.#enableAutoLinking = options.enableAutoLinking !== false;
     this.#minDurationToUpdateCanvas = options.minDurationToUpdateCanvas ?? 500;
-
+    if (options.minScale <= 0 || options.maxScale < options.minScale) {
+      console.warn(
+        `Invalid scale options (minScale: ${options.minScale * 100}, maxScale: ${options.maxScale * 100}), using defaults (minScale: ${DEFAULT_MIN_SCALE * 100}, maxScale: ${DEFAULT_MAX_SCALE * 100}). Requirement: maxScale >= minScale > 0`
+      );
+      this.#minScale = DEFAULT_MIN_SCALE;
+      this.#maxScale = DEFAULT_MAX_SCALE;
+    } else {
+      this.#minScale = options.minScale;
+      this.#maxScale = options.maxScale;
+    }
     this.defaultRenderingQueue = !options.renderingQueue;
     if (
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&
@@ -590,6 +601,20 @@ class PDFViewer {
       return;
     }
     this.#setScale(val, { noScroll: false });
+  }
+
+  /**
+   * @type {number}
+   */
+  get minScale() {
+    return this.#minScale;
+  }
+
+  /**
+   * @type {number}
+   */
+  get maxScale() {
+    return this.#maxScale;
   }
 
   /**
@@ -2484,7 +2509,7 @@ class PDFViewer {
         newScale = round((newScale * delta).toFixed(2) * 10) / 10;
       } while (--steps > 0);
     }
-    newScale = MathClamp(newScale, MIN_SCALE, MAX_SCALE);
+    newScale = MathClamp(newScale, this.#minScale, this.#maxScale);
     this.#setScale(newScale, { noScroll: false, drawingDelay, origin });
   }
 

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -16,11 +16,10 @@
 /** @typedef {import("./event_utils.js").EventBus} EventBus */
 
 import { AnnotationEditorType, ColorPicker, noContextMenu } from "pdfjs-lib";
+import { DEFAULT_MAX_SCALE, DEFAULT_MIN_SCALE } from "./app_options.js";
 import {
   DEFAULT_SCALE,
   DEFAULT_SCALE_VALUE,
-  MAX_SCALE,
-  MIN_SCALE,
   toggleExpandedBtn,
 } from "./ui_utils.js";
 
@@ -56,10 +55,20 @@ class Toolbar {
    *    - 0 (default) - The regular toolbar size.
    *    - 1 (compact) - The small toolbar size.
    *    - 2 (touch) - The large toolbar size.
+   * @param {number} minScale - The minimum allowed zoom scale.
+   * @param {number} maxScale - The maximum allowed zoom scale.
    */
-  constructor(options, eventBus, toolbarDensity = 0) {
+  constructor(
+    options,
+    eventBus,
+    toolbarDensity = 0,
+    minScale = DEFAULT_MIN_SCALE,
+    maxScale = DEFAULT_MAX_SCALE
+  ) {
     this.#opts = options;
     this.eventBus = eventBus;
+    this.minScale = minScale;
+    this.maxScale = maxScale;
     const buttons = [
       { element: options.previous, eventName: "previouspage" },
       { element: options.next, eventName: "nextpage" },
@@ -385,8 +394,8 @@ class Toolbar {
     opts.previous.disabled = pageNumber <= 1;
     opts.next.disabled = pageNumber >= pagesCount;
 
-    opts.zoomOut.disabled = pageScale <= MIN_SCALE;
-    opts.zoomIn.disabled = pageScale >= MAX_SCALE;
+    opts.zoomOut.disabled = pageScale <= this.minScale;
+    opts.zoomIn.disabled = pageScale >= this.maxScale;
 
     let predefinedValueFound = false;
     for (const option of opts.scaleSelect.options) {

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -18,8 +18,6 @@ import { MathClamp } from "pdfjs-lib";
 const DEFAULT_SCALE_VALUE = "auto";
 const DEFAULT_SCALE = 1.0;
 const DEFAULT_SCALE_DELTA = 1.1;
-const MIN_SCALE = 0.1;
-const MAX_SCALE = 25.0;
 const UNKNOWN_SCALE = 0;
 const MAX_AUTO_SCALE = 1.25;
 const SCROLLBAR_PADDING = 40;
@@ -899,8 +897,6 @@ export {
   isValidScrollMode,
   isValidSpreadMode,
   MAX_AUTO_SCALE,
-  MAX_SCALE,
-  MIN_SCALE,
   normalizeWheelEventDelta,
   normalizeWheelEventDirection,
   parseQueryString,


### PR DESCRIPTION
**DUPLICATE of the PR #20843 which was closed accidentally** (PR justification and discussion can be found there)

Hello,

This is simple PR to make MIN_SCALE and MAX_SCALE zoom limits configurable via Firefox preferences.

## Summary
- Expose `pdfjs.minScale` and `pdfjs.maxScale` as `about:config` preferences (integer percentages, e.g. 10 = 10%, 1000 = 1000%) allowing advanced users to customize the PDF viewer's zoom range
- Values are validated in the `PDFViewer` constructor and fall back to the hardcoded defaults (`DEFAULT_MIN_SCALE`/`DEFAULT_MAX_SCALE`) if invalid (e.g. `maxScale < minScale` or non-positive values) + a console warning
- The `DEFAULT_MIN_SCALE` and `DEFAULT_MAX_SCALE` were added in `app_options.js`. **I need review on this point because it is new compared to the original PR**

## Test plan
- [X] Verify zoom-in button disables at the configured max and zoom-out button disables at the configured min
- [X] Setting invalid values (e.g. `minScale` > `maxScale`, or negative) --> fall back to defaults with a console warning
- [X] Without any preference changes, verify default behavior (10%-2500%) is unchanged
- [X] Linting checked
- [X] Added integration tests
- [X] Integration tests passed 