### PR TITLE
Fix unhandled promise rejections, memory leak, and null dereference

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -691,7 +691,7 @@ class PDFDataRangeTransport {
       for (const listener of this.#progressiveReadListeners) {
         listener(chunk);
       }
-    });
+    }).catch(() => {});
   }
 
   onDataProgressiveDone() {
@@ -699,7 +699,7 @@ class PDFDataRangeTransport {
       for (const listener of this.#progressiveDoneListeners) {
         listener();
       }
-    });
+    }).catch(() => {});
   }
 
   transportReady() {

--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -152,7 +152,7 @@ class MessageHandler {
       this.#createStreamSink(data);
       return;
     }
-    action(data.data);
+    Promise.try(action, data.data);
   }
 
   on(actionName, handler) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1156,6 +1156,9 @@ class PDFFindController {
     }
 
     if (type === "cancelDelete") {
+      if (!this.#savedPageData) {
+        return;
+      }
       this._extractTextPromises = this.#savedPageData.promises;
       this._pageContents = this.#savedPageData.contents;
       this._pageDiffs = this.#savedPageData.diffs;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -416,12 +416,16 @@ class PDFViewer {
 
     // Trigger API-cleanup, once thumbnail rendering has finished,
     // if the relevant pageView is *not* cached in the buffer.
-    this.eventBus._on("thumbnailrendered", ({ pageNumber, pdfPage }) => {
-      const pageView = this._pages[pageNumber - 1];
-      if (!this.#buffer.has(pageView)) {
-        pdfPage?.cleanup();
-      }
-    });
+    this.eventBus._on(
+      "thumbnailrendered",
+      ({ pageNumber, pdfPage }) => {
+        const pageView = this._pages[pageNumber - 1];
+        if (!this.#buffer.has(pageView)) {
+          pdfPage?.cleanup();
+        }
+      },
+      { signal: abortSignal }
+    );
 
     if (
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) &&


### PR DESCRIPTION
## Summary

- **`src/display/api.js`**: `PDFDataRangeTransport.onDataProgressiveRead` and `onDataProgressiveDone` attach `.then()` to `#capability.promise` without a `.catch()`. If the capability rejects (e.g. transport destroyed mid-read) an unhandled rejection surfaces in the console. Added `.catch(() => {})` to silence it.

- **`src/shared/message_handler.js`**: The fire-and-forget action dispatch path (`action(data.data)`) did not use `Promise.try`, unlike the `callbackId` (line 129) and `streamId` (line 371) paths. An async handler that throws here produces an unhandled rejection. Changed to `Promise.try(action, data.data)` for consistency.

- **`web/pdf_viewer.js`**: The `'thumbnailrendered'` `eventBus` listener registered in the `PDFViewer` constructor was never removed. In applications that create multiple `PDFViewer` instances over their lifetime the listener accumulates, keeping each instance alive and preventing garbage collection. Fixed by forwarding the existing `abortSignal` constructor option to the `_on` call.

- **`web/pdf_find_controller.js`**: In `#onDocumentManagerUpdated`, the `'cancelDelete'` branch unconditionally reads `this.#savedPageData.promises` etc. `#savedPageData` starts as `null` and is only assigned during a `'delete'` event. If `'cancelDelete'` fires first (possible depending on caller order) a `TypeError` is thrown and the entire find controller breaks. Added an early-return guard.

## Test plan

- [ ] Run `npx gulp unittest` — all existing unit tests should pass
- [ ] Run `npx gulp lint` — no new lint errors
- [ ] Open the viewer (`npx gulp server` → `http://localhost:8888/web/viewer.html`) and verify text search, thumbnail rendering, and PDF loading still work correctly
- [ ] For the find controller fix: open a PDF, trigger a text edit deletion then cancel it — no console errors should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)