### PR TITLE
Remove the deprecated `PDFWorker.fromPort` method (PR 19943 follow-up)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2099,16 +2099,6 @@ class PDFWorker {
           new Blob([wrapper], { type: "text/javascript" })
         );
       };
-
-      this.fromPort = params => {
-        deprecated(
-          "`PDFWorker.fromPort` - please use `PDFWorker.create` instead."
-        );
-        if (!params?.port) {
-          throw new Error("PDFWorker.fromPort - invalid method signature.");
-        }
-        return this.create(params);
-      };
     }
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {


### PR DESCRIPTION
This has been deprecated in ten releases, so let's just remove it now.