### PR TITLE
Download linked PDFs when running `gulp unittestcli`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1981,6 +1981,23 @@ gulp.task(
     setTestEnv,
     "generic-legacy",
     "lib-legacy",
+    function downloadPDFs(done) {
+      console.log("\n### Downloading PDFs");
+
+      const PDF_TEST = process.env.PDF_TEST || "test_manifest.json";
+      const args = ["test.mjs", "--manifestFile=" + PDF_TEST, "--downloadOnly"];
+
+      const testProcess = startNode(args, {
+        cwd: TEST_DIR,
+        stdio: "inherit",
+      });
+      testProcess.on("close", function (code) {
+        if (code !== 0) {
+          done(new Error(`Downloading PDFs failed.`));
+        }
+        done();
+      });
+    },
     function runUnitTestCli(done) {
       const useCoverage = process.argv.includes("--coverage");
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1372,9 +1372,6 @@ describe("api", function () {
     });
 
     it("gets a destination, from out-of-order /Names (NameTree) dictionary (issue 10272)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const loadingTask = getDocument(buildGetDocumentParams("issue10272.pdf"));
       const pdfDoc = await loadingTask.promise;
       const destination = await pdfDoc.getDestination("link_1");
@@ -1421,9 +1418,6 @@ describe("api", function () {
     });
 
     it("gets a destination, from /Dests dictionary with keys using PDFDocEncoding", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const loadingTask = getDocument(buildGetDocumentParams("issue19835.pdf"));
       const pdfDoc = await loadingTask.promise;
 
@@ -1443,9 +1437,6 @@ describe("api", function () {
     });
 
     it("gets a destination containing Unicode escape sequence (\x1b), from /Dests dictionary with keys using PDFDocEncoding", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const loadingTask = getDocument(buildGetDocumentParams("issue19835.pdf"));
       const pdfDoc = await loadingTask.promise;
 
@@ -1814,10 +1805,6 @@ describe("api", function () {
     });
 
     it("gets fieldObjects with missing /P-entries", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("bug1847733.pdf"));
       const pdfDoc = await loadingTask.promise;
       const fieldObjects = await pdfDoc.getFieldObjects();
@@ -1851,10 +1838,6 @@ describe("api", function () {
     });
 
     it("gets fieldObjects and skipping LinkAnnotations", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("issue19281.pdf"));
       const pdfDoc = await loadingTask.promise;
       const fieldObjects = await pdfDoc.getFieldObjects();
@@ -1870,9 +1853,6 @@ describe("api", function () {
     });
 
     it("gets calculationOrder", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const loadingTask = getDocument(buildGetDocumentParams("issue13132.pdf"));
       const pdfDoc = await loadingTask.promise;
       const calculationOrder = await pdfDoc.getCalculationOrderIds();
@@ -1955,9 +1935,6 @@ describe("api", function () {
     });
 
     it("gets outline, with missing title (issue 17856)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const loadingTask = getDocument(buildGetDocumentParams("issue17856.pdf"));
       const pdfDoc = await loadingTask.promise;
       const outline = await pdfDoc.getOutline();
@@ -1985,9 +1962,6 @@ describe("api", function () {
     });
 
     it("gets outline, with dest-strings using PDFDocEncoding (issue 14864)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const loadingTask = getDocument(buildGetDocumentParams("issue14864.pdf"));
       const pdfDoc = await loadingTask.promise;
       const outline = await pdfDoc.getOutline();
@@ -2426,10 +2400,6 @@ describe("api", function () {
     });
 
     it("write a value in an annotation, save the pdf and check the value in xfa datasets (1)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       let loadingTask = getDocument(buildGetDocumentParams("issue16081.pdf"));
       let pdfDoc = await loadingTask.promise;
       const value = "Hello World";
@@ -2465,10 +2435,6 @@ describe("api", function () {
     });
 
     it("write a value in an annotation, save the pdf and check the value in xfa datasets (2)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       // In this file the path to the fields are wrong but the last path element
       // is unique so we can guess what the node is.
       let loadingTask = getDocument(buildGetDocumentParams("f1040_2022.pdf"));
@@ -2500,10 +2466,6 @@ describe("api", function () {
     });
 
     it("write a new annotation, save the pdf and check that the prev entry in xref stream is correct", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       let loadingTask = getDocument(buildGetDocumentParams("bug1823296.pdf"));
       let pdfDoc = await loadingTask.promise;
       let page = await pdfDoc.getPage(1);
@@ -3693,10 +3655,6 @@ page 1 / 3`);
     });
 
     it("gets text content, with no extra spaces (issue 16119)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("issue16119.pdf"));
       const pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(1);
@@ -3824,10 +3782,6 @@ sources, for full support with Dvips.`;
     });
 
     it("gets text content, with negative spaces (bug 931481)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("bug931481.pdf"));
       const pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(1);
@@ -3854,10 +3808,6 @@ sozialökonomische Gerechtigkeit.`)
     });
 
     it("gets text content, with invisible text marks (issue 9186)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("issue9186.pdf"));
       const pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(1);
@@ -3912,10 +3862,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
     });
 
     it("gets text content, and check that out-of-page text is not present (bug 1755201)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("bug1755201.pdf"));
       const pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(6);
@@ -3930,10 +3876,6 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
     });
 
     it("gets text content with or without includeMarkedContent, and compare (issue 15094)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("pdf.pdf"));
       const pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(568);
@@ -4177,10 +4119,6 @@ have written that much by now. So, here’s to squashing bugs.`);
     });
 
     it("gets corrupt structure tree with non-dictionary nodes (issue 18503)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
-
       const loadingTask = getDocument(buildGetDocumentParams("issue18503.pdf"));
       const pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(1);
@@ -4917,9 +4855,6 @@ have written that much by now. So, here’s to squashing bugs.`);
     });
 
     it("caches image resources at the document/page level, with main-thread copying of complex images (issue 11518)", async function () {
-      if (isNodeJS) {
-        pending("Linked test-cases are not supported in Node.js.");
-      }
       const { NUM_PAGES_THRESHOLD } = GlobalImageCache;
 
       const loadingTask = getDocument(buildGetDocumentParams("issue11518.pdf"));

--- a/test/unit/pdf_find_controller_spec.js
+++ b/test/unit/pdf_find_controller_spec.js
@@ -723,10 +723,6 @@ describe("pdf_find_controller", function () {
   });
 
   it("performs a search in a text containing diacritics before -\\n", async function () {
-    if (isNodeJS) {
-      pending("Linked test-cases are not supported in Node.js.");
-    }
-
     const { eventBus, pdfFindController } =
       await initPdfFindController("issue14562.pdf");
 
@@ -858,10 +854,6 @@ describe("pdf_find_controller", function () {
   });
 
   it("performs a search in a text containing combining diacritics", async function () {
-    if (isNodeJS) {
-      pending("Linked test-cases are not supported in Node.js.");
-    }
-
     const { eventBus, pdfFindController } =
       await initPdfFindController("issue12909.pdf");
 
@@ -930,10 +922,6 @@ describe("pdf_find_controller", function () {
   });
 
   it("performs a search in a text with some UTF-32 chars", async function () {
-    if (isNodeJS) {
-      pending("Linked test-cases are not supported in Node.js.");
-    }
-
     const { eventBus, pdfFindController } =
       await initPdfFindController("bug1820909.pdf");
 


### PR DESCRIPTION
Currently a fair number of unit-tests are disabled in Node.js not because of missing functionality, but only because they use linked PDFs.

---

*Please note:* This patch was thrown together quickly just to see if this even works, but obviously caching of test PDFs must be implemented *before* this could actually be considered.