### PR TITLE
Move the `NetworkStream` choice from `src/display/api.js` and into a separate file

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -196,9 +196,7 @@ function createWebpackAlias(defines) {
   };
   const libraryAlias = {
     "display-binary_data_factory": "src/display/stubs.js",
-    "display-fetch_stream": "src/display/stubs.js",
-    "display-network": "src/display/stubs.js",
-    "display-node_stream": "src/display/stubs.js",
+    "display-network_stream": "src/display/stubs.js",
     "display-node_utils": "src/display/stubs.js",
   };
   const viewerAlias = {
@@ -227,8 +225,7 @@ function createWebpackAlias(defines) {
   if (defines.CHROME) {
     libraryAlias["display-binary_data_factory"] =
       "src/display/binary_data_factory.js";
-    libraryAlias["display-fetch_stream"] = "src/display/fetch_stream.js";
-    libraryAlias["display-network"] = "src/display/network.js";
+    libraryAlias["display-network_stream"] = "src/display/network_stream.js";
 
     viewerAlias["web-download_manager"] = "web/chromecom.js";
     viewerAlias["web-external_services"] = "web/chromecom.js";
@@ -241,9 +238,7 @@ function createWebpackAlias(defines) {
     // In the tsconfig.json files, the .js extension must be omitted.
     libraryAlias["display-binary_data_factory"] =
       "src/display/binary_data_factory.js";
-    libraryAlias["display-fetch_stream"] = "src/display/fetch_stream.js";
-    libraryAlias["display-network"] = "src/display/network.js";
-    libraryAlias["display-node_stream"] = "src/display/node_stream.js";
+    libraryAlias["display-network_stream"] = "src/display/network_stream.js";
     libraryAlias["display-node_utils"] = "src/display/node_utils.js";
 
     viewerAlias["web-download_manager"] = "web/download_manager.js";
@@ -1540,9 +1535,7 @@ function buildLibHelper(bundleDefines, inputStream, outputDir) {
     map: {
       "pdfjs-lib": "../pdf.js",
       "display-binary_data_factory": "./binary_data_factory.js",
-      "display-fetch_stream": "./fetch_stream.js",
-      "display-network": "./network.js",
-      "display-node_stream": "./node_stream.js",
+      "display-network_stream": "./network_stream.js",
       "display-node_utils": "./node_utils.js",
       "fluent-bundle": "../../../node_modules/@fluent/bundle/esm/index.js",
       "fluent-dom": "../../../node_modules/@fluent/dom/esm/index.js",

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -74,15 +74,13 @@ import { CanvasGraphics } from "./canvas.js";
 import { DOMBinaryDataFactory } from "display-binary_data_factory";
 import { DOMCanvasFactory } from "./canvas_factory.js";
 import { DOMFilterFactory } from "./filter_factory.js";
+import { getNetworkStream } from "display-network_stream";
 import { GlobalWorkerOptions } from "./worker_options.js";
 import { initWebGPUMesh } from "./webgpu_mesh.js";
 import { Metadata } from "./metadata.js";
 import { OptionalContentConfig } from "./optional_content_config.js";
 import { PagesMapper } from "./pages_mapper.js";
 import { PDFDataTransportStream } from "./transport_stream.js";
-import { PDFFetchStream } from "display-fetch_stream";
-import { PDFNetworkStream } from "display-network";
-import { PDFNodeStream } from "display-node_stream";
 import { PDFObjects } from "./pdf_objects.js";
 import { TextLayer } from "./text_layer.js";
 import { XfaText } from "./xfa_text.js";
@@ -454,14 +452,7 @@ function getDocument(src = {}) {
         if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
           throw new Error("Not implemented: NetworkStream");
         }
-        // eslint-disable-next-line no-nested-ternary
-        const NetworkStream = isValidFetchUrl(url)
-          ? PDFFetchStream
-          : typeof PDFJSDev !== "undefined" &&
-              PDFJSDev.test("GENERIC") &&
-              isNodeJS
-            ? PDFNodeStream
-            : PDFNetworkStream;
+        const NetworkStream = getNetworkStream(url);
 
         networkStream = new NetworkStream({
           url,

--- a/src/display/network_stream.js
+++ b/src/display/network_stream.js
@@ -1,0 +1,31 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isNodeJS } from "../shared/util.js";
+import { isValidFetchUrl } from "./display_utils.js";
+import { PDFFetchStream } from "./fetch_stream.js";
+import { PDFNetworkStream } from "./network.js";
+import { PDFNodeStream } from "./node_stream.js";
+
+function getNetworkStream(url) {
+  // eslint-disable-next-line no-nested-ternary
+  return isValidFetchUrl(url)
+    ? PDFFetchStream
+    : typeof PDFJSDev !== "undefined" && PDFJSDev.test("GENERIC") && isNodeJS
+      ? PDFNodeStream
+      : PDFNetworkStream;
+}
+
+export { getNetworkStream };

--- a/src/display/stubs.js
+++ b/src/display/stubs.js
@@ -14,19 +14,15 @@
  */
 
 const DOMBinaryDataFactory = null;
+const getNetworkStream = null;
 const NodeBinaryDataFactory = null;
 const NodeCanvasFactory = null;
 const NodeFilterFactory = null;
-const PDFFetchStream = null;
-const PDFNetworkStream = null;
-const PDFNodeStream = null;
 
 export {
   DOMBinaryDataFactory,
+  getNetworkStream,
   NodeBinaryDataFactory,
   NodeCanvasFactory,
   NodeFilterFactory,
-  PDFFetchStream,
-  PDFNetworkStream,
-  PDFNodeStream,
 };

--- a/test/components/simple-viewer.html
+++ b/test/components/simple-viewer.html
@@ -44,9 +44,7 @@ limitations under the License.
           "pdfjs-lib": "../../src/pdf.js",
 
           "display-binary_data_factory": "../../src/display/binary_data_factory.js",
-          "display-fetch_stream": "../../src/display/fetch_stream.js",
-          "display-network": "../../src/display/network.js",
-          "display-node_stream": "../../src/display/stubs.js",
+          "display-network_stream": "../../src/display/network_stream.js",
           "display-node_utils": "../../src/display/stubs.js",
 
           "fluent-bundle": "../../node_modules/@fluent/bundle/esm/index.js",

--- a/test/unit/unit_test.html
+++ b/test/unit/unit_test.html
@@ -21,9 +21,7 @@
           "cached-iterable": "../../node_modules/cached-iterable/src/index.mjs",
 
           "display-binary_data_factory": "../../src/display/binary_data_factory.js",
-          "display-fetch_stream": "../../src/display/fetch_stream.js",
-          "display-network": "../../src/display/network.js",
-          "display-node_stream": "../../src/display/stubs.js",
+          "display-network_stream": "../../src/display/network_stream.js",
           "display-node_utils": "../../src/display/stubs.js",
 
           "web-alt_text_manager": "../../web/alt_text_manager.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,7 @@
     "paths": {
       "pdfjs-lib": ["./src/pdf"],
       "display-binary_data_factory": ["./src/display/binary_data_factory"],
-      "display-fetch_stream": ["./src/display/fetch_stream"],
-      "display-network": ["./src/display/network"],
-      "display-node_stream": ["./src/display/node_stream"],
+      "display-network_stream": ["./src/display/network_stream.js"],
       "display-node_utils": ["./src/display/node_utils"],
       "fluent-bundle": ["./node_modules/@fluent/bundle/esm/index.js"],
       "fluent-dom": ["./node_modules/@fluent/dom/esm/index.js"],

--- a/web/internal/debugger.html
+++ b/web/internal/debugger.html
@@ -127,9 +127,7 @@ limitations under the License.
           "pdfjs-lib": "../../src/pdf.js",
 
           "display-binary_data_factory": "../../src/display/binary_data_factory.js",
-          "display-fetch_stream": "../../src/display/fetch_stream.js",
-          "display-network": "../../src/display/network.js",
-          "display-node_stream": "../../src/display/stubs.js",
+          "display-network_stream": "../../src/display/network_stream.js",
           "display-node_utils": "../../src/display/stubs.js"
         }
       }

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -60,9 +60,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
 
           "display-binary_data_factory": "../src/display/binary_data_factory.js",
-          "display-fetch_stream": "../src/display/fetch_stream.js",
-          "display-network": "../src/display/network.js",
-          "display-node_stream": "../src/display/stubs.js",
+          "display-network_stream": "../src/display/network_stream.js",
           "display-node_utils": "../src/display/stubs.js",
 
           "web-alt_text_manager": "./stubs-geckoview.js",

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -63,9 +63,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "cached-iterable": "../node_modules/cached-iterable/src/index.mjs",
 
           "display-binary_data_factory": "../src/display/binary_data_factory.js",
-          "display-fetch_stream": "../src/display/fetch_stream.js",
-          "display-network": "../src/display/network.js",
-          "display-node_stream": "../src/display/stubs.js",
+          "display-network_stream": "../src/display/network_stream.js",
           "display-node_utils": "../src/display/stubs.js",
 
           "web-alt_text_manager": "./alt_text_manager.js",


### PR DESCRIPTION
This code already isn't used (or even bundled) in the Firefox PDF Viewer, and it also slightly reduces the number of import maps that need to be maintained.