### PR TITLE
Remove unused `preInit` parameter from the `CanvasExtraState` constructor (PR 19043 follow-up)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -333,11 +333,10 @@ class CanvasExtraState {
 
   transferMaps = "none";
 
-  constructor(width, height, preInit) {
-    preInit?.(this);
+  minMax = MIN_MAX_INIT.slice();
 
+  constructor(width, height) {
     this.clipBox = new Float32Array([0, 0, width, height]);
-    this.minMax = MIN_MAX_INIT.slice();
   }
 
   clone() {


### PR DESCRIPTION
This parameter was added in PR #19043, however it never actually appears to have been used.