### PR TITLE
Reduce allocations in the `FontInfo.prototype.#readString` method (PR 20197 follow-up)

### DIFF
--- a/src/display/obj_bin_transform_display.js
+++ b/src/display/obj_bin_transform_display.js
@@ -247,9 +247,9 @@ class FontInfo {
       offset += this.#view.getUint32(offset) + 4;
     }
     const length = this.#view.getUint32(offset);
-    const stringData = new Uint8Array(length);
-    stringData.set(new Uint8Array(this.#buffer, offset + 4, length));
-    return this.#decoder.decode(stringData);
+    return this.#decoder.decode(
+      new Uint8Array(this.#buffer, offset + 4, length)
+    );
   }
 
   get fallbackName() {


### PR DESCRIPTION
Looking at the very similar `CssFontInfo.prototype.#readString` and `SystemFontInfo.prototype.#readString` methods they decode using the data as-is, but the `FontInfo.prototype.#readString` method for some reason copies the data into a new `Uint8Array` first; fixes yet another bug/inefficiency in PR #20197.