### PR TITLE
Prevent URL.parse crashes when passing non-string objects

### DIFF
--- a/src/display/api_utils.js
+++ b/src/display/api_utils.js
@@ -42,7 +42,7 @@ function getUrlProp(val) {
     }
 
     // The full path is required in the 'url' field.
-    const url = URL.parse(val, window.location);
+    const url = URL.parse(val, window.location.href);
     if (url) {
       return url;
     }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -449,7 +449,9 @@ function createValidAbsoluteUrl(url, baseUrl = null, options = null) {
     }
   }
 
-  const absoluteUrl = baseUrl ? URL.parse(url, baseUrl) : URL.parse(url);
+  const absoluteUrl = baseUrl
+    ? URL.parse(url?.href || url, baseUrl?.href || baseUrl)
+    : URL.parse(url?.href || url);
   return _isValidProtocol(absoluteUrl) ? absoluteUrl : null;
 }
 
@@ -462,7 +464,7 @@ function createValidAbsoluteUrl(url, baseUrl = null, options = null) {
  * @returns {string} The resulting URL string.
  */
 function updateUrlHash(url, hash, allowRel = false) {
-  const res = URL.parse(url);
+  const res = URL.parse(url?.href || url);
   if (res) {
     res.hash = hash;
     return res.href;

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -22,6 +22,7 @@ import {
   string32,
   stringToBytes,
   stringToPDFString,
+  updateUrlHash,
 } from "../../src/shared/util.js";
 
 describe("util", function () {
@@ -216,6 +217,31 @@ describe("util", function () {
         new URL("tel:+0123456789")
       );
       expect(createValidAbsoluteUrl("/foo", "tel:0123456789")).toEqual(null);
+    });
+
+    it("handles URL objects as arguments", function () {
+      const baseUrl = new URL("http://www.mozilla.org");
+      expect(createValidAbsoluteUrl("/foo", baseUrl)).toEqual(
+        new URL("http://www.mozilla.org/foo")
+      );
+      expect(createValidAbsoluteUrl(baseUrl, null)).toEqual(baseUrl);
+    });
+  });
+
+  describe("updateUrlHash", function () {
+    it("should correctly update the hash of a URL", function () {
+      const url = "http://www.example.com/foo#bar";
+      expect(updateUrlHash(url, "baz")).toEqual(
+        "http://www.example.com/foo#baz"
+      );
+      expect(updateUrlHash(url, "")).toEqual("http://www.example.com/foo");
+    });
+
+    it("handles URL objects as arguments", function () {
+      const url = new URL("http://www.example.com/foo#bar");
+      expect(updateUrlHash(url, "baz")).toEqual(
+        "http://www.example.com/foo#baz"
+      );
     });
   });
 


### PR DESCRIPTION
The recent transition to the URL.parse API introduced a regression where passing non-string objects (such as URL or window.location) as arguments causes a TypeError. Unlike the new URL() constructor, the static URL.parse() method strictly requires string arguments according to the specification. This PR ensures that URL and Location objects are correctly converted to strings via their .href property before being passed to URL.parse, preventing crashes in modern browsers (Chrome 126+, Safari 17.4+, etc.) and Node.js.