### PR TITLE
Remove a tiny bit of unnecessary "rgba" parsing in the `getRGB` function

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -604,9 +604,8 @@ function getRGB(color) {
   if (color.startsWith("rgba(")) {
     return color
       .slice(/* "rgba(".length */ 5, -1) // Strip out "rgba(" and ")".
-      .split(",")
-      .map(x => parseInt(x))
-      .slice(0, 3);
+      .split(",", 3)
+      .map(x => parseInt(x));
   }
 
   warn(`Not a valid color format: "${color}"`);


### PR DESCRIPTION
This obviously won't matter in practice, however it seems more "correct" to only extract the necessary number of color components rather than slicing off excess ones at the end.