### PR TITLE
Simplify the `applyOpacity` helper function

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -794,13 +794,10 @@ class CSSConstants {
   }
 }
 
-function applyOpacity(r, g, b, opacity) {
+function applyOpacity(color, opacity) {
   opacity = MathClamp(opacity ?? 1, 0, 1);
   const white = 255 * (1 - opacity);
-  r = Math.round(r * opacity + white);
-  g = Math.round(g * opacity + white);
-  b = Math.round(b * opacity + white);
-  return [r, g, b];
+  return color.map(c => Math.round(c * opacity + white));
 }
 
 function RGBToHSL(rgb, output) {

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -323,7 +323,7 @@ describe("display_utils", function () {
       ctx.globalAlpha = 0.8;
       ctx.fillRect(0, 0, 1, 1);
       const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
-      expect(applyOpacity(123, 45, 67, ctx.globalAlpha)).toEqual([r, g, b]);
+      expect(applyOpacity([123, 45, 67], ctx.globalAlpha)).toEqual([r, g, b]);
     });
   });
 

--- a/web/comment_manager.js
+++ b/web/comment_manager.js
@@ -132,7 +132,7 @@ class CommentManager {
     return this.#hasForcedColors
       ? null
       : findContrastColor(
-          applyOpacity(...color, opacity ?? 1),
+          applyOpacity(color, opacity ?? 1),
           CSSConstants.commentForegroundColor
         );
   }


### PR DESCRIPTION
This function only has a single call-site (if we ignore the unit-tests), where the colors are split into separate parameters.
Given that all the color components are modified in the exact same way, it seems easier (and shorter) to pass the colors as-is to `applyOpacity` and have it use `Array.prototype.map()` instead.