### PR TITLE
[Node.js] Remove the `node-readable-to-web-readable-stream` polyfill

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2487,7 +2487,6 @@ function packageJson() {
     license: DIST_LICENSE,
     optionalDependencies: {
       "@napi-rs/canvas": "^0.1.96",
-      "node-readable-to-web-readable-stream": "^0.4.2",
     },
     browser: {
       canvas: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "jstransformer-nunjucks": "^1.2.0",
         "metalsmith": "^2.7.0",
         "metalsmith-html-relative": "^2.0.9",
-        "node-readable-to-web-readable-stream": "^0.4.2",
         "ordered-read-streams": "^2.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.8",
@@ -8678,13 +8677,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/node-readable-to-web-readable-stream": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
-      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.36",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "jstransformer-nunjucks": "^1.2.0",
     "metalsmith": "^2.7.0",
     "metalsmith-html-relative": "^2.0.9",
-    "node-readable-to-web-readable-stream": "^0.4.2",
     "ordered-read-streams": "^2.0.0",
     "pngjs": "^7.0.0",
     "postcss": "^8.5.8",

--- a/src/display/node_stream.js
+++ b/src/display/node_stream.js
@@ -29,20 +29,12 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   );
 }
 
-function getReadableStream(readStream) {
+function getReadableStream(url, opts = null) {
+  const fs = process.getBuiltinModule("fs");
   const { Readable } = process.getBuiltinModule("stream");
 
-  if (typeof Readable.toWeb === "function") {
-    // See https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options
-    return Readable.toWeb(readStream);
-  }
-  // Fallback to support Node.js versions older than `24.0.0` and `22.17.0`.
-  const require = process
-    .getBuiltinModule("module")
-    .createRequire(import.meta.url);
-
-  const polyfill = require("node-readable-to-web-readable-stream");
-  return polyfill.makeDefaultReadableStreamFromNodeReadable(readStream);
+  const readStream = fs.createReadStream(url, opts);
+  return Readable.toWeb(readStream);
 }
 
 class PDFNodeStream extends BasePDFStream {
@@ -66,13 +58,10 @@ class PDFNodeStreamReader extends BasePDFStreamReader {
 
     this._isStreamingSupported = !disableStream;
 
-    const fs = process.getBuiltinModule("fs");
-    fs.promises
-      .lstat(url)
+    const fs = process.getBuiltinModule("fs/promises");
+    fs.lstat(url)
       .then(stat => {
-        const readStream = fs.createReadStream(url);
-        const readableStream = getReadableStream(readStream);
-
+        const readableStream = getReadableStream(url);
         this._reader = readableStream.getReader();
 
         const { size } = stat;
@@ -123,14 +112,11 @@ class PDFNodeStreamRangeReader extends BasePDFStreamRangeReader {
     super(stream, begin, end);
     const { url } = stream._source;
 
-    const fs = process.getBuiltinModule("fs");
     try {
-      const readStream = fs.createReadStream(url, {
+      const readableStream = getReadableStream(url, {
         start: begin,
         end: end - 1,
       });
-      const readableStream = getReadableStream(readStream);
-
       this._reader = readableStream.getReader();
 
       this._readCapability.resolve();

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -76,8 +76,8 @@ if (isNodeJS) {
 }
 
 async function fetchData(url) {
-  const fs = process.getBuiltinModule("fs");
-  const data = await fs.promises.readFile(url);
+  const fs = process.getBuiltinModule("fs/promises");
+  const data = await fs.readFile(url);
   return new Uint8Array(data);
 }
 

--- a/test/unit/bidi_spec.js
+++ b/test/unit/bidi_spec.js
@@ -14,6 +14,7 @@
  */
 
 import { bidi } from "../../src/core/bidi.js";
+import { fetchData } from "../../src/display/display_utils.js";
 import { isNodeJS } from "../../src/shared/util.js";
 
 const BIDI_TEST_DATA_PATH = isNodeJS ? "./test/bidi/" : "../bidi/";
@@ -21,11 +22,10 @@ const BIDI_TEST_DATA_PATH = isNodeJS ? "./test/bidi/" : "../bidi/";
 async function readTestFile(filename) {
   const path = BIDI_TEST_DATA_PATH + filename;
   if (isNodeJS) {
-    const fs = process.getBuiltinModule("fs");
-    return fs.promises.readFile(path, "utf8");
+    const fs = process.getBuiltinModule("fs/promises");
+    return fs.readFile(path, "utf8");
   }
-  const response = await fetch(new URL(path, window.location));
-  return response.text();
+  return fetchData(new URL(path, window.location), /* type = */ "text");
 }
 
 // Unicode Bidirectional Algorithm tests.


### PR DESCRIPTION
While `Readable.toWeb` wasn't marked as stable until more recently, the functionality itself has existed since Node.js version `17.0.0`; note https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options

Hence the polyfill shouldn't actually be necessary, which is confirmed by the unit-tests passing in Node.js version `20` in GitHub Actions.