### PR TITLE
[api-minor] Update the minimum supported Node.js version to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24, 25]
+        node-version: [22, 24, 25]
 
     steps:
       - name: Checkout repository

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -87,7 +87,7 @@ const ENV_TARGETS = [
   "Chrome >= 118",
   "Firefox ESR",
   "Safari >= 16.4",
-  "Node >= 20",
+  "Node >= 22",
   "> 1%",
   "not IE > 0",
   "not dead",
@@ -2500,7 +2500,7 @@ function packageJson() {
       url: `git+${DIST_GIT_URL}`,
     },
     engines: {
-      node: ">=20.19.0 || >=22.13.0 || >=24",
+      node: ">=22.13.0 || >=24",
     },
     scripts: {},
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "webpack-stream": "^7.0.0"
       },
       "engines": {
-        "node": ">=20.19.0 || >=22.13.0 || >=24"
+        "node": ">=22.13.0 || >=24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "url": "git://github.com/mozilla/pdf.js.git"
   },
   "engines": {
-    "node": ">=20.19.0 || >=22.13.0 || >=24"
+    "node": ">=22.13.0 || >=24"
   },
   "license": "Apache-2.0"
 }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -14,20 +14,7 @@
  */
 
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  // eslint-disable-next-line no-var
-  var compatParams = new Map();
-  if (
-    typeof PDFJSDev !== "undefined" &&
-    PDFJSDev.test("LIB") &&
-    !globalThis.navigator?.language
-  ) {
-    globalThis.navigator = {
-      language: "en-US",
-      maxTouchPoints: 1,
-      platform: "",
-      userAgent: "",
-    };
-  }
+  var compatParams = new Map(); // eslint-disable-line no-var
   const { maxTouchPoints, platform, userAgent } = navigator;
 
   const isAndroid = /Android/.test(userAgent);


### PR DESCRIPTION
This patch updates the minimum supported environments as follows:
 - Node.js 22, which was initially released on 2024-04-24 and has now entered the "Maintenance"-phase; see https://github.com/nodejs/release#release-schedule

Furthermore, note also that Node.js 20 will reach end-of-life on 2026-04-30 which coincides (approximately) with the next PDF.js release.