### PR TITLE
Use the `MathClamp` helper function more

### DIFF
--- a/src/core/postscript/js_evaluator.js
+++ b/src/core/postscript/js_evaluator.js
@@ -19,6 +19,7 @@ import {
   PS_VALUE_TYPE,
   PSStackToTree,
 } from "./ast.js";
+import { MathClamp } from "../../shared/util.js";
 import { TOKEN } from "./lexer.js";
 
 // Consecutive integers for a dense jump table in _execute.
@@ -341,7 +342,7 @@ class PsJsCompiler {
           const slot = ir[ip++] | 0;
           const min = ir[ip++];
           const max = ir[ip++];
-          dest[destOffset + slot] = Math.max(Math.min(stack[--sp], max), min);
+          dest[destOffset + slot] = MathClamp(stack[--sp], min, max);
           break;
         }
         case OP.IF: {

--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { FeatureTest, Util } from "../shared/util.js";
+import { FeatureTest, MathClamp, Util } from "../shared/util.js";
 
 const FORCED_DEPENDENCY_LABEL = "__forcedDependency";
 
@@ -257,22 +257,11 @@ class CanvasBBoxTracker {
 
     const bbox = [Infinity, Infinity, -Infinity, -Infinity];
     Util.axialAlignedBoundingBox([minX, minY, maxX, maxY], transform, bbox);
-    this.#pendingBBox[0] = Math.min(
-      this.#pendingBBox[0],
-      Math.max(bbox[0], clipBox[0])
-    );
-    this.#pendingBBox[1] = Math.min(
-      this.#pendingBBox[1],
-      Math.max(bbox[1], clipBox[1])
-    );
-    this.#pendingBBox[2] = Math.max(
-      this.#pendingBBox[2],
-      Math.min(bbox[2], clipBox[2])
-    );
-    this.#pendingBBox[3] = Math.max(
-      this.#pendingBBox[3],
-      Math.min(bbox[3], clipBox[3])
-    );
+
+    this.#pendingBBox[0] = MathClamp(bbox[0], clipBox[0], this.#pendingBBox[0]);
+    this.#pendingBBox[1] = MathClamp(bbox[1], clipBox[1], this.#pendingBBox[1]);
+    this.#pendingBBox[2] = MathClamp(bbox[2], this.#pendingBBox[2], clipBox[2]);
+    this.#pendingBBox[3] = MathClamp(bbox[3], this.#pendingBBox[3], clipBox[3]);
     return this;
   }
 


### PR DESCRIPTION
The idea with this helper function is that once https://github.com/tc39/proposal-math-clamp/ becomes stable, all its call-sites should then be replaced by the native functionality.