### PR TITLE
Replace all `Object.prototype.hasOwnProperty` usage with `Object.hasOwn`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -262,6 +262,7 @@ export default [
       "no-useless-concat": "error",
       "no-useless-escape": "error",
       "no-useless-return": "error",
+      "prefer-object-has-own": "error",
       "prefer-promise-reject-errors": "error",
       "prefer-spread": "error",
       "wrap-iife": ["error", "any"],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -300,6 +300,11 @@ export default [
           message: "Use `typeof` rather than `instanceof Object`.",
         },
         {
+          selector: "MemberExpression[property.name='hasOwnProperty']",
+          message:
+            "Use `Object.hasOwn` rather than `Object.prototype.hasOwnProperty`.",
+        },
+        {
           selector: "CallExpression[callee.name='assert'][arguments.length!=2]",
           message: "`assert()` must always be invoked with two arguments.",
         },

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -718,7 +718,7 @@ class Catalog {
 
   getDestination(id) {
     // Avoid extra lookup/parsing when all destinations are already available.
-    if (this.hasOwnProperty("destinations")) {
+    if (Object.hasOwn(this, "destinations")) {
       return this.destinations[id] ?? null;
     }
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -127,7 +127,7 @@ class WorkerMessageHandler {
       // the `{Object, Array}.prototype` has been *incorrectly* extended.
       //
       // PLEASE NOTE: We do *not* want to slow down font parsing by adding
-      //              `hasOwnProperty` checks all over the code-base.
+      //              `Object.hasOwn` checks all over the code-base.
       const buildMsg = (type, prop) =>
         `The \`${type}.prototype\` contains unexpected enumerable property ` +
         `"${prop}", thus breaking e.g. \`for...in\` iteration of ${type}s.`;

--- a/src/core/xfa/bind.js
+++ b/src/core/xfa/bind.js
@@ -180,7 +180,7 @@ class Binder {
     //   <setProperty ref="$data.Main.Help.LastName" target="assist.toolTip"/>
     // </field>
 
-    if (!formNode.hasOwnProperty("setProperty")) {
+    if (!Object.hasOwn(formNode, "setProperty")) {
       return;
     }
 
@@ -265,7 +265,7 @@ class Binder {
         continue;
       }
 
-      if (!targetNode.hasOwnProperty($content)) {
+      if (!Object.hasOwn(targetNode, $content)) {
         warn(`XFA - Invalid node to use in setProperty`);
         continue;
       }
@@ -285,8 +285,8 @@ class Binder {
     // </field>
 
     if (
-      !formNode.hasOwnProperty("items") ||
-      !formNode.hasOwnProperty("bindItems") ||
+      !Object.hasOwn(formNode, "items") ||
+      !Object.hasOwn(formNode, "bindItems") ||
       formNode.bindItems.isEmpty()
     ) {
       return;

--- a/src/core/xfa/builder.js
+++ b/src/core/xfa/builder.js
@@ -97,7 +97,7 @@ class Builder {
       this._addNamespacePrefix(prefixes);
     }
 
-    if (attributes.hasOwnProperty($nsAttributes)) {
+    if (Object.hasOwn(attributes, $nsAttributes)) {
       // Only support xfa-data namespace.
       const dataTemplate = NamespaceSetUp.datasets;
       const nsAttrs = attributes[$nsAttributes];

--- a/src/core/xfa/config.js
+++ b/src/core/xfa/config.js
@@ -1355,7 +1355,7 @@ class Zpl extends XFAObject {
 
 class ConfigNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (ConfigNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(ConfigNamespace, name)) {
       return ConfigNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/connection_set.js
+++ b/src/core/xfa/connection_set.js
@@ -144,7 +144,7 @@ class XsdConnection extends XFAObject {
 
 class ConnectionSetNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (ConnectionSetNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(ConnectionSetNamespace, name)) {
       return ConnectionSetNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/datasets.js
+++ b/src/core/xfa/datasets.js
@@ -57,7 +57,7 @@ class Datasets extends XFAObject {
 
 class DatasetsNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (DatasetsNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(DatasetsNamespace, name)) {
       return DatasetsNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/html_utils.js
+++ b/src/core/xfa/html_utils.js
@@ -383,7 +383,7 @@ function toStyle(node, ...names) {
     if (value === null) {
       continue;
     }
-    if (converters.hasOwnProperty(name)) {
+    if (Object.hasOwn(converters, name)) {
       converters[name](node, style);
       continue;
     }

--- a/src/core/xfa/locale_set.js
+++ b/src/core/xfa/locale_set.js
@@ -239,7 +239,7 @@ class TypeFaces extends XFAObject {
 
 class LocaleSetNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (LocaleSetNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(LocaleSetNamespace, name)) {
       return LocaleSetNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/signature.js
+++ b/src/core/xfa/signature.js
@@ -26,7 +26,7 @@ class Signature extends XFAObject {
 
 class SignatureNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (SignatureNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(SignatureNamespace, name)) {
       return SignatureNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/stylesheet.js
+++ b/src/core/xfa/stylesheet.js
@@ -26,7 +26,7 @@ class Stylesheet extends XFAObject {
 
 class StylesheetNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (StylesheetNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(StylesheetNamespace, name)) {
       return StylesheetNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -6132,7 +6132,7 @@ class Variables extends XFAObject {
 
 class TemplateNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (TemplateNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(TemplateNamespace, name)) {
       const node = TemplateNamespace[name](attributes);
       node[$setSetAttributes](attributes);
       return node;

--- a/src/core/xfa/xdp.js
+++ b/src/core/xfa/xdp.js
@@ -40,7 +40,7 @@ class Xdp extends XFAObject {
 
 class XdpNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (XdpNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(XdpNamespace, name)) {
       return XdpNamespace[name](attributes);
     }
     return undefined;

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -171,7 +171,7 @@ class XFAObject {
 
   [$onChildCheck](child) {
     return (
-      this.hasOwnProperty(child[$nodeName]) &&
+      Object.hasOwn(this, child[$nodeName]) &&
       child[$namespaceId] === this[$namespaceId]
     );
   }
@@ -240,7 +240,7 @@ class XFAObject {
   }
 
   [$hasSettableValue]() {
-    return this.hasOwnProperty("value");
+    return Object.hasOwn(this, "value");
   }
 
   [$setValue](_) {}
@@ -817,7 +817,7 @@ class XmlObject extends XFAObject {
       for (const [attrName, value] of Object.entries(attributes)) {
         map.set(attrName, new XFAAttribute(this, attrName, value));
       }
-      if (attributes.hasOwnProperty($nsAttributes)) {
+      if (Object.hasOwn(attributes, $nsAttributes)) {
         // XFA attributes.
         const dataNode = attributes[$nsAttributes].xfa.dataNode;
         if (dataNode !== undefined) {

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -530,7 +530,7 @@ class Ul extends XhtmlObject {
 
 class XhtmlNamespace {
   static [$buildXFAObject](name, attributes) {
-    if (XhtmlNamespace.hasOwnProperty(name)) {
+    if (Object.hasOwn(XhtmlNamespace, name)) {
       return XhtmlNamespace[name](attributes);
     }
     return undefined;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2575,7 +2575,7 @@ class WorkerTransport {
     this.#pagePromises.clear();
     this.#pageRefCache.clear();
     // Allow `AnnotationStorage`-related clean-up when destroying the document.
-    if (this.hasOwnProperty("annotationStorage")) {
+    if (Object.hasOwn(this, "annotationStorage")) {
       this.annotationStorage.resetModified();
     }
     // We also need to wait for the worker to finish its long running tasks.

--- a/src/display/xfa_layer.js
+++ b/src/display/xfa_layer.js
@@ -86,7 +86,7 @@ class XfaLayer {
           for (const option of element.children) {
             if (option.attributes.value === storedData.value) {
               option.attributes.selected = true;
-            } else if (option.attributes.hasOwnProperty("selected")) {
+            } else if (Object.hasOwn(option.attributes, "selected")) {
               delete option.attributes.selected;
             }
           }

--- a/src/scripting_api/field.js
+++ b/src/scripting_api/field.js
@@ -77,7 +77,7 @@ class Field extends PDFObject {
     this._fillColor = data.fillColor || ["T"];
     this._isChoice = Array.isArray(data.items);
     this._items = data.items || [];
-    this._hasValue = data.hasOwnProperty("value");
+    this._hasValue = Object.hasOwn(data, "value");
     this._page = data.page || 0;
     this._strokeColor = data.strokeColor || ["G", 0];
     this._textColor = data.textColor || ["G", 0];

--- a/web/internal/tree_view.js
+++ b/web/internal/tree_view.js
@@ -953,18 +953,15 @@ class TreeView {
       val !== null &&
       typeof val === "object" &&
       !Array.isArray(val) &&
-      Object.prototype.hasOwnProperty.call(val, "dict") &&
-      (Object.prototype.hasOwnProperty.call(val, "bytes") ||
-        Object.prototype.hasOwnProperty.call(val, "imageData") ||
+      Object.hasOwn(val, "dict") &&
+      (Object.hasOwn(val, "bytes") ||
+        Object.hasOwn(val, "imageData") ||
         val.contentStream === true)
     );
   }
 
   #isImageStream(val) {
-    return (
-      this.#isStream(val) &&
-      Object.prototype.hasOwnProperty.call(val, "imageData")
-    );
+    return this.#isStream(val) && Object.hasOwn(val, "imageData");
   }
 
   #isFormXObjectStream(val) {
@@ -977,7 +974,7 @@ class TreeView {
       val !== null &&
       typeof val === "object" &&
       !Array.isArray(val) &&
-      Object.prototype.hasOwnProperty.call(val, "dict") &&
+      Object.hasOwn(val, "dict") &&
       val.psFunction === true
     );
   }


### PR DESCRIPTION
 - **Enable the `prefer-object-has-own` ESLint rule**

   Please see https://eslint.org/docs/latest/rules/prefer-object-has-own

 - **Replace all `Object.prototype.hasOwnProperty` usage with `Object.hasOwn`**

   The newer `Object.hasOwn` method is intended as a replacement for `Object.prototype.hasOwnProperty`, since that one may be problematical; please see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#problematic_cases_for_hasownproperty

   To ensure that `Object.hasOwn` is used in the future, the ESLint "no-restricted-syntax" rule is extended to catch the old method.