### PR TITLE
Fix wrong values when sanitizing fonts

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2029,7 +2029,7 @@ class Font {
         data[3] = 0;
       }
 
-      const indexToLocFormat = int16(data[50], data[51]);
+      const indexToLocFormat = signedInt16(data[50], data[51]);
       if (indexToLocFormat < 0 || indexToLocFormat > 1) {
         info(
           "Attempting to fix invalid indexToLocFormat in head table: " +
@@ -2397,7 +2397,7 @@ class Font {
           } else {
             for (j = 0; j < n; j++) {
               b = data[i++];
-              stack.push((b << 8) | data[i++]);
+              stack.push(signedInt16(b, data[i++]));
             }
           }
         } else if ((op & 0xf8) === 0xb0) {


### PR DESCRIPTION
NPUSHW: push signed 16-bits integer: https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#push-n-words
indexToLocFormat: field in the 'head' table: https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6head.html#:~:text=indexToLocFormat,-0