### PR TITLE
Remove the unused `compilePostScriptToIR` function (PR 21023 follow-up)

### DIFF
--- a/src/core/postscript/js_evaluator.js
+++ b/src/core/postscript/js_evaluator.js
@@ -517,18 +517,6 @@ class PsJsCompiler {
 }
 
 /**
- * @param {string}   source
- * @param {number[]} domain  – flat [min0,max0, …]
- * @param {number[]} range   – flat [min0,max0, …]
- * @returns {Float64Array|null}
- */
-function compilePostScriptToIR(source, domain, range) {
-  return new PsJsCompiler(domain, range).compile(
-    parsePostScriptFunction(source)
-  );
-}
-
-/**
  * Direct stack-based interpreter for a parsed PsProgram.
  * Used when PSStackToTree fails to optimize the AST.
  */
@@ -829,8 +817,4 @@ function buildPostScriptProgramFunction(program, domain, range) {
   return PSStackBasedInterpreter.build(program, domain, range);
 }
 
-export {
-  buildPostScriptJsFunction,
-  buildPostScriptProgramFunction,
-  compilePostScriptToIR,
-};
+export { buildPostScriptJsFunction, buildPostScriptProgramFunction };


### PR DESCRIPTION
This function was added in PR #21010, and it became unused in PR #21023.