### PR TITLE
Fix intermittent integration test failures related to checking the find count results text

### DIFF
--- a/test/integration/find_spec.mjs
+++ b/test/integration/find_spec.mjs
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { closePages, FSI, loadAndWait, PDI } from "./test_utils.mjs";
+import {
+  closePages,
+  FSI,
+  loadAndWait,
+  PDI,
+  waitForTextToBe,
+} from "./test_utils.mjs";
 
 function fuzzyMatch(a, b, browserName, pixelFuzz = 3) {
   expect(a)
@@ -105,12 +111,11 @@ describe("find bar", () => {
           await page.type("#findInput", "preferences");
           await page.waitForSelector("#findInput[data-status='']");
           await page.waitForSelector(".xfaLayer .highlight");
-          await page.waitForFunction(
-            () => !!document.querySelector("#findResultsCount")?.textContent
+          await waitForTextToBe(
+            page,
+            "#findResultsCount",
+            `${FSI}1${PDI} of ${FSI}1${PDI} match`
           );
-          const resultElement = await page.waitForSelector("#findResultsCount");
-          const resultText = await resultElement.evaluate(el => el.textContent);
-          expect(resultText).toEqual(`${FSI}1${PDI} of ${FSI}1${PDI} match`);
           const selectedElement = await page.waitForSelector(
             ".highlight.selected"
           );
@@ -208,14 +213,11 @@ describe("find bar", () => {
             }
 
             // Verify we are on the expected match number.
-            const resultElement =
-              await page.waitForSelector("#findResultsCount");
-            const resultText = await resultElement.evaluate(
-              el => el.textContent
+            await waitForTextToBe(
+              page,
+              "#findResultsCount",
+              `${FSI}${i + 1}${PDI} of ${FSI}5${PDI} matches`
             );
-            expect(resultText)
-              .withContext(`In ${browserName}, match ${i + 1}`)
-              .toEqual(`${FSI}${i + 1}${PDI} of ${FSI}5${PDI} matches`);
 
             // The selected highlight must be visible in the viewport.
             const selected = await page.waitForSelector(

--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -460,20 +460,20 @@ describe("Reorganize Pages View", () => {
 
           // Wait for the first result to be selected and the search to settle.
           await page.waitForSelector("#findInput[data-status='']");
-          let resultEl = await page.waitForSelector("#findResultsCount");
-          const firstResult = await resultEl.evaluate(el => el.textContent);
-          expect(firstResult)
-            .withContext(`In ${browserName}`)
-            .toEqual(`${FSI}1${PDI} of ${FSI}10${PDI} matches`);
+          await waitForTextToBe(
+            page,
+            "#findResultsCount",
+            `${FSI}1${PDI} of ${FSI}10${PDI} matches`
+          );
 
           // Navigate to the next match.
           await page.keyboard.press("Enter");
           await page.waitForSelector("#findInput[data-status='']");
-          resultEl = await page.waitForSelector("#findResultsCount");
-          const secondResult = await resultEl.evaluate(el => el.textContent);
-          expect(secondResult)
-            .withContext(`In ${browserName}`)
-            .toEqual(`${FSI}2${PDI} of ${FSI}10${PDI} matches`);
+          await waitForTextToBe(
+            page,
+            "#findResultsCount",
+            `${FSI}2${PDI} of ${FSI}10${PDI} matches`
+          );
 
           // Move a page: this previously blocked subsequent find navigation.
           await movePages(page, [3], 0);
@@ -484,11 +484,11 @@ describe("Reorganize Pages View", () => {
           // Navigate to the next match — must not be blocked.
           await page.keyboard.press("Enter");
           await page.waitForSelector("#findInput[data-status='']");
-          resultEl = await page.waitForSelector("#findResultsCount");
-          const resultAfterMove = await resultEl.evaluate(el => el.textContent);
-          expect(resultAfterMove)
-            .withContext(`In ${browserName}`)
-            .not.toEqual(secondResult);
+          await waitForTextToBe(
+            page,
+            "#findResultsCount",
+            `${FSI}3${PDI} of ${FSI}10${PDI} matches`
+          );
         })
       );
     });


### PR DESCRIPTION
There is generally a small amount of time between the find call being reported as finished and the find count results text being updated with the correct number in the DOM, so the integration tests will fail if we check the find results count text too soon.

This commit fixes the issue by using the `waitForTextToBe` helper function to wait until the find count results text is what we expect it to be. Note that we already use this helper function for this exact purpose in other integration tests (related to reorganizing pages), and it's also a little bit shorter/easier to read which cannot hurt.

Fixes #21042.