### PR TITLE
Fix intermittent failure in the "must check that the comment sidebar is resizable with the keyboard" comment integration test

### DIFF
--- a/test/integration/comment_spec.mjs
+++ b/test/integration/comment_spec.mjs
@@ -571,10 +571,10 @@ describe("Comment", () => {
             const rect = await getRect(page, sidebarSelector);
             const arrowKey = extraWidth > 0 ? "ArrowLeft" : "ArrowRight";
             for (let i = 0; i < Math.abs(extraWidth); i++) {
-              await waitForBrowserTrip(page);
               await kbModifierDown(page);
               await page.keyboard.press(arrowKey);
               await kbModifierUp(page);
+              await waitForBrowserTrip(page);
             }
 
             const rectAfter = await getRect(page, sidebarSelector);
@@ -592,6 +592,7 @@ describe("Comment", () => {
             const arrowKey = extraWidth > 0 ? "ArrowLeft" : "ArrowRight";
             for (let i = 0; i < Math.abs(extraWidth); i++) {
               await page.keyboard.press(arrowKey);
+              await waitForBrowserTrip(page);
             }
 
             const rectAfter = await getRect(page, sidebarSelector);


### PR DESCRIPTION
In PR #20887 the issue got fixed partly, but two issues remained that unintendedly left room for intermittent failres:

- in the "Ctrl+ArrowLeft/Right" loop the `waitForBrowserTrip` call was placed _before_ the actual keypresses, which means that for the final iteration of the loop the last key presses were not properly awaited;

- in the "ArrowLeft/ArrowRight" loop the `waitForBrowserTrip` call was absent, which means that we didn't wait for key presses at all.

This commit fixes the issues by consistently waiting to a browser trip _after_ each key press to make sure the sidebar got a chance to render.

Fixes #21044.