### PR TITLE
Replace individual AI/ML disabling preferences with the single killswitch preference in the tests

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -928,11 +928,7 @@ async function startBrowser({
       // Disable logging for remote settings.
       "services.settings.loglevel": "off",
       // Disable AI/ML functionality.
-      "browser.ml.enable": false,
-      "browser.ml.chat.enabled": false,
-      "browser.ml.linkPreview.enabled": false,
-      "browser.tabs.groups.smart.enabled": false,
-      "browser.tabs.groups.smart.userEnabled": false,
+      "browser.ai.control.default": "blocked",
       "privacy.baselineFingerprintingProtection": false,
       ...extraPrefsFirefox,
     };


### PR DESCRIPTION
Firefox 148 shipped with a single killswitch to disable current and future AI/ML functionality. This can be controlled in the GUI via `Settings -> AI Controls -> Block AI enhancements`, but can also be controlled programmatically via the `browser.ai.control.default` preference.

This commit uses this single preference to replace the multiple preferences we had to use for this purpose before.

Extends 844681a.