### PR TITLE
Remove unnecessary "flooring" of the components when setting the Annotation `borderColor`

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -465,11 +465,7 @@ class AnnotationElement {
       const borderColor = data.borderColor || null;
       if (borderColor) {
         this.#hasBorder = true;
-        style.borderColor = Util.makeHexColor(
-          borderColor[0] | 0,
-          borderColor[1] | 0,
-          borderColor[2] | 0
-        );
+        style.borderColor = Util.makeHexColor(...borderColor);
       } else {
         // Transparent (invisible) border, so do not draw it at all.
         style.borderWidth = 0;
@@ -1374,9 +1370,7 @@ class WidgetAnnotationElement extends AnnotationElement {
   _setBackgroundColor(element) {
     const color = this.data.backgroundColor || null;
     element.style.backgroundColor =
-      color === null
-        ? "transparent"
-        : Util.makeHexColor(color[0], color[1], color[2]);
+      color === null ? "transparent" : Util.makeHexColor(...color);
   }
 
   /**
@@ -1427,7 +1421,7 @@ class WidgetAnnotationElement extends AnnotationElement {
     }
     style.fontSize = `calc(${computedFontSize}px * var(--total-scale-factor))`;
 
-    style.color = Util.makeHexColor(fontColor[0], fontColor[1], fontColor[2]);
+    style.color = Util.makeHexColor(...fontColor);
 
     if (this.data.textAlignment !== null) {
       style.textAlign = TEXT_ALIGNMENT[this.data.textAlignment];


### PR DESCRIPTION
This looks like a leftover from much older code, since all colors are now parsed with the [`getRgbColor` helper](https://github.com/mozilla/pdf.js/blob/ca85d73335ea0ef67b686ee53609ee0115dc4187/src/core/annotation.js#L558-L583) which returns `Uint8ClampedArray` data when the color is valid.

Also, use spread syntax when calling `Util.makeHexColor` in a few more spots.