### PR TITLE
Fix the l10n-id for the sidebar toggleButton, in the `ViewsManager` class

### DIFF
--- a/web/views_manager.js
+++ b/web/views_manager.js
@@ -162,7 +162,7 @@ class ViewsManager extends Sidebar {
       attachmentsTitle: "pdfjs-views-manager-attachments-title",
       layersTitle: "pdfjs-views-manager-layers-title1",
       notificationButton: "pdfjs-toggle-views-manager-notification-button",
-      toggleButton: "pdfjs-toggle-views-manager-button",
+      toggleButton: "pdfjs-toggle-views-manager-button1",
     });
 
     this.#addEventListeners();


### PR DESCRIPTION
Steps to reproduce:
 1. Open http://localhost:8888/web/viewer.html
 2. Open the console, and run: `PDFViewerApplication.close();`
 3. Note the warning: `[fluent] Missing translations in en-us: pdfjs-toggle-views-manager-button`