### PR TITLE
Update the position when calling `ChunkedStream.prototype.getBytes` without a length

### DIFF
--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -190,6 +190,7 @@ class ChunkedStream extends Stream {
       if (strEnd > this.progressiveDataLength) {
         this.ensureRange(pos, strEnd);
       }
+      this.pos = strEnd;
       return bytes.subarray(pos, strEnd);
     }
 


### PR DESCRIPTION
Currently the code only updates the position when the length is defined, and it seems that this has "always" been wrong. Originally I believe that the `ChunkedStream` class was essentially a copy of the `Stream` class, and that implementation had the same problem until PR #20593.

Hopefully there's no code that relies on the current incorrect behaviour[1], since testing every aspect of the `ChunkedStream` implementation can be tricky given that these things are timing dependant.

---

[1] If there are, fixing those call-sites may be as easy calling `ChunkedStream.prototype.reset`.