### PR TITLE
Pin canvas backing store to sRGB to fix magenta wash on Display P3 (fixes #21084)

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3295,6 +3295,14 @@ class InternalRenderTask {
       this._canvasContext ||
       this._canvas.getContext("2d", {
         alpha: false,
+        // Pin the canvas backing store to sRGB. Image pixels written via
+        // `putImageData` bypass color management, so on wide-gamut displays
+        // (e.g. Display P3 on Apple Silicon) the compositor otherwise
+        // reinterprets sRGB pixel values as P3 and shifts them toward
+        // magenta. Regressed in b1b728d47 (v5.4.54), when this getContext
+        // call moved from the caller (who previously supplied a pre-built
+        // context) into PDF.js itself.
+        colorSpace: "srgb",
         willReadFrequently: !this._enableHWA,
       });
 


### PR DESCRIPTION
Fixes #21084.

## What this changes

Adds `colorSpace: "srgb"` to the canvas 2D context created in `InternalRenderTask._next` (`src/display/api.js`). One line, no API surface change.

```diff
 const canvasContext =
   this._canvasContext ||
   this._canvas.getContext("2d", {
     alpha: false,
+    colorSpace: "srgb",
     willReadFrequently: !this._enableHWA,
   });
```

## Why

After [PR #20016](https://github.com/mozilla/pdf.js/pull/20016) ("[api-minor] Move `getContext` call to `InternalRenderTask`", merged in `v5.4.54`), PDF.js creates its own 2D context instead of accepting a caller-supplied one. That new internal `getContext` call doesn't specify a `colorSpace`, so on wide-gamut displays (Display P3 on Apple Silicon) Chromium's compositor gets to pick — and picks P3. PDF.js then writes sRGB pixels via `putImageData`, which is **not** color-managed, so the raw sRGB bytes get reinterpreted as P3 values at composition time. The result is a dramatic magenta / pink wash over any JPEG content, most visible on photo-heavy PDFs.

The regression is described in full detail — symptoms, bisect, root cause, affected environment — in #21084. This PR is the one-line fix from that issue's "Proposed fix" section.

## Test plan

- [x] Locally verified on `pdfjs-dist@5.7.119` (tip of main) against:
  - The minimal 1-page-JPEG repro PDF attached to #21084
  - A real-world production PDF with full-bleed photographic cover + multiple embedded JPEGs (shown in the issue's before/after screenshots)
- [x] Hardware: MacBook with Apple Silicon, Display P3 profile (default)
- [x] Browser: Chromium 130+
- [x] Rendered with both `react-pdf@10.3.0` and the standalone viewer at `mozilla.github.io/pdf.js/web/viewer.html`
- [x] Firefox rendering unchanged (it was never affected — Gecko handles canvas color management differently)

## Notes

- Pinning `colorSpace: "srgb"` is a no-op for users on sRGB displays (they were already getting an sRGB context), so this change is backward-compatible.
- I deliberately did **not** touch `src/display/canvas_factory.js:38` (the scratch-canvas factory), which has the same pattern — the rendering bug reproduces and fully resolves with just the `api.js` change, so I held off to keep the diff minimal. Happy to extend the fix there for defense-in-depth if you'd prefer, as discussed in open question (2) on the issue.
- I'd be glad to add a regression test. If you'd like, point me at the preferred spot in the reference test suite and I can follow up in a separate PR.
