### PR TITLE
Fix saveDocument JSDoc return type

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -967,8 +967,9 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @returns {Promise<Uint8Array>} A promise that is resolved with a
-   *   {Uint8Array} containing the full data of the saved document.
+   * @returns {Promise<Uint8Array<ArrayBuffer>>} A promise that is
+   *   resolved with a {Uint8Array<ArrayBuffer>} containing the
+   *   full data of the saved document.
    */
   saveDocument() {
     return this._transport.saveDocument();


### PR DESCRIPTION
Fixes #21106.

saveDocument JSDoc declared `Promise<Uint8Array>` which is generic, so TS 5.7+ widens the buffer to `ArrayBufferLike` (can include `SharedArrayBuffer`). That breaks passing the result into a `Blob` with a type error.

Narrowed the return to `Promise<Uint8Array<ArrayBuffer>>` to match what's actually returned. Ran typecheck + generation locally, both pass.

More background in the issue.

Some references:
- https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#lib.d.ts-changes
- https://github.com/microsoft/TypeScript/issues/62546#issuecomment-3371313647
- https://github.com/microsoft/TypeScript/issues/62324
- https://github.com/microsoft/TypeScript/issues/62240#issuecomment-3208310715