### PR TITLE
Fix the `gets text content, with correct properties (issue 8276)` unit test

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3723,9 +3723,25 @@ page 1 / 3`);
         vertical: false,
       });
 
-      // Wait for font data to be loaded so we can check that the font names
-      // match.
-      await pdfPage.getOperatorList();
+      // Render the page to make sure that the font data is loaded so we can
+      // check that the font name in `commonObjs` matches.
+      const { canvasFactory } = pdfDoc;
+      const viewport = pdfPage.getViewport({ scale: 1 });
+
+      const canvasAndCtx = canvasFactory.create(
+        viewport.width,
+        viewport.height
+      );
+      const renderTask = pdfPage.render({
+        canvas: canvasAndCtx.canvas,
+        viewport,
+      });
+
+      await renderTask.promise;
+      // The canvas is no longer necessary, since we only care about the
+      // `commonObjs` property being populated below.
+      canvasFactory.destroy(canvasAndCtx);
+
       expect(pdfPage.commonObjs.has(fontName)).toEqual(true);
 
       await loadingTask.destroy();


### PR DESCRIPTION
This unit test failed consistently in Firefox both locally and on GitHub Actions (but not in Chrome or on the bots), which suggests a timing issue.

Since all other unit tests that rely on `commonObjs` actually render the page, most likely to make sure that `commonObjs` is fully populated at the time of the check, this commit mirrors that approach to this test, which indeed fixes the issue.

Fixes #21122.
Related to #21121.
Related to #11851.