### PR TITLE
Move the `hexNumbers` Array into `Util`, to enable using it in the viewer

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -17,7 +17,6 @@ import {
   AnnotationEditorPrefix,
   assert,
   BaseException,
-  hexNumbers,
   makeArr,
   objectSize,
   stringToPDFString,
@@ -697,7 +696,7 @@ function stringToUTF16HexString(str) {
   const buf = [];
   for (let i = 0, ii = str.length; i < ii; i++) {
     const char = str.charCodeAt(i);
-    buf.push(hexNumbers[(char >> 8) & 0xff], hexNumbers[char & 0xff]);
+    buf.push(Util.hexNums[(char >> 8) & 0xff], Util.hexNums[char & 0xff]);
   }
   return buf.join("");
 }

--- a/src/core/icc_colorspace.js
+++ b/src/core/icc_colorspace.js
@@ -157,7 +157,7 @@ class IccColorSpace extends ColorSpace {
           });
           isUsable = !!this._module;
           QCMS._memory = this._module.memory;
-          QCMS._makeHexColor = Util.makeHexColor;
+          QCMS._makeHexColor = Util.makeHexColor.bind(Util);
         } catch (e) {
           warn(`ICCBased color space: "${e}".`);
         }

--- a/src/display/editor/color_picker.js
+++ b/src/display/editor/color_picker.js
@@ -355,9 +355,7 @@ class BasicColorPicker {
     input.type = "color";
     if (hasAlpha) {
       input.setAttribute("alpha", "");
-      const alphaHex = Math.round((opacity ?? 1) * 255)
-        .toString(16)
-        .padStart(2, "0");
+      const alphaHex = Util.hexNums[Math.round((opacity ?? 1) * 255)];
       input.value = (color || "#000000") + alphaHex;
     } else {
       input.value = color || "#000000";
@@ -399,9 +397,7 @@ class BasicColorPicker {
     }
     if (this.#hasAlpha) {
       // Reconstruct #RRGGBBAA using the editor's current opacity.
-      const alphaHex = Math.round(this.#editor.opacity * 255)
-        .toString(16)
-        .padStart(2, "0");
+      const alphaHex = Util.hexNums[Math.round(this.#editor.opacity * 255)];
       this.#input.value = value + alphaHex;
     } else {
       this.#input.value = value;
@@ -413,9 +409,7 @@ class BasicColorPicker {
       return;
     }
     // Reconstruct #RRGGBBAA using the editor's current color.
-    const alphaHex = Math.round(value * 255)
-      .toString(16)
-      .padStart(2, "0");
+    const alphaHex = Util.hexNums[Math.round(value * 255)];
     this.#input.value = this.#editor.color + alphaHex;
   }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -688,13 +688,17 @@ class FeatureTest {
   }
 }
 
-const hexNumbers = Array.from(Array(256).keys(), n =>
-  n.toString(16).padStart(2, "0")
-);
-
 class Util {
+  static get hexNums() {
+    return shadow(
+      this,
+      "hexNums",
+      Array.from(Array(256).keys(), n => n.toString(16).padStart(2, "0"))
+    );
+  }
+
   static makeHexColor(r, g, b) {
-    return `#${hexNumbers[r]}${hexNumbers[g]}${hexNumbers[b]}`;
+    return `#${this.hexNums[r]}${this.hexNums[g]}${this.hexNums[b]}`;
   }
 
   static domMatrixToTransform(dm) {
@@ -1316,7 +1320,6 @@ export {
   getModificationDate,
   getUuid,
   getVerbosityLevel,
-  hexNumbers,
   ImageKind,
   info,
   InvalidPDFException,

--- a/web/annotation_editor_params.js
+++ b/web/annotation_editor_params.js
@@ -91,11 +91,6 @@ class AnnotationEditorParams {
       let currentInkColor = "#000000";
       let currentInkOpacity = 1;
 
-      const toAlphaHex = opacity =>
-        Math.round(opacity * 255)
-          .toString(16)
-          .padStart(2, "0");
-
       editorInkColor.addEventListener("input", function () {
         // The returned value format varies by browser; normalize it.
         const rgba = getRGBA(this.value);
@@ -111,11 +106,13 @@ class AnnotationEditorParams {
 
       updateInkColor = value => {
         currentInkColor = value;
-        editorInkColor.value = currentInkColor + toAlphaHex(currentInkOpacity);
+        const alphaHex = Util.hexNums[Math.round(currentInkOpacity * 255)];
+        editorInkColor.value = currentInkColor + alphaHex;
       };
       updateInkOpacity = value => {
         currentInkOpacity = value;
-        editorInkColor.value = currentInkColor + toAlphaHex(currentInkOpacity);
+        const alphaHex = Util.hexNums[Math.round(currentInkOpacity * 255)];
+        editorInkColor.value = currentInkColor + alphaHex;
       };
     } else {
       editorInkColor.addEventListener("input", function () {


### PR DESCRIPTION
This reduces some code duplication, and the new `Util.hexNums` property is now computed lazily.