### PR TITLE
Remove duplicated font tests execution in the GitHub Actions workflow

### DIFF
--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -61,9 +61,6 @@ jobs:
       - name: Install requirements
         run: pip install -r .github/font_tests_requirements.txt
 
-      - name: Run font tests
-        run: npx gulp fonttest --headless
-
       - name: Run font tests with code coverage
         run: npx gulp fonttest --headless --coverage --coverage-output build/coverage/font
 


### PR DESCRIPTION
The font tests have run with coverage reporting enabled for quite some time now and the coverage information has proven to work and be stable, so we don't have to also run the font tests without coverage reporting anymore, thereby reducing the total runtime of the workflow.