### PR TITLE
A couple of `internal-viewer` fixes

### DIFF
--- a/web/internal/debugger.css
+++ b/web/internal/debugger.css
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+@import url(../text_layer_builder.css);
 @import url(canvas_context_details_view.css);
 @import url(draw_ops_view.css);
 @import url(font_view.css);

--- a/web/internal/debugger.html
+++ b/web/internal/debugger.html
@@ -20,7 +20,6 @@ limitations under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>PDF.js — Debugging tools</title>
     <link rel="stylesheet" href="debugger.css" />
-    <link rel="stylesheet" href="../text_layer_builder.css" />
   </head>
   <body>
     <div id="header">

--- a/web/internal/split_view.js
+++ b/web/internal/split_view.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { MathClamp } from "pdfjs/shared/math_clamp.js";
+import { MathClamp } from "pdfjs-lib";
 
 /**
  * Wraps two elements with a drag-to-resize handle between them.


### PR DESCRIPTION
 - Bundle the `web/text_layer_builder.css` file correctly, to ensure that textLayer debugging works when the code is *built*.
   Note how loading https://mozilla.github.io/pdf.js/internal-viewer/web/debugger.html currently logs the following error: `GET https://mozilla.github.io/pdf.js/internal-viewer/text_layer_builder.css [HTTP/2 404  7ms]`.

 - Import the `MathClamp` helper function from the *built* library, rather than "manually", since that's more correct.