### PR TITLE
Fix the Codecov token not being usable in the unit tests GitHub Actions workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,6 +35,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    environment: code-coverage
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The job's environment must be `code-coverage` before it has access to the `CODECOV_TOKEN` secret that's required for pushing coverage data to Codecov. Without it we get an HTTP 400 response with a `Token required because branch is protected` message if it's run from `master`.

Fixes f932a58d.