### PR TITLE
Include the `web/` folder in the coverage report for `gulp unittestcli`

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -3,7 +3,8 @@
   "include": [
     "build/lib-legacy/core/**/*.js",
     "build/lib-legacy/display/**/*.js",
-    "build/lib-legacy/shared/**/*.js"
+    "build/lib-legacy/shared/**/*.js",
+    "build/lib-legacy/web/**/*.js"
   ],
   "exclude": ["build/lib-legacy/test/**"],
   "all": false,


### PR DESCRIPTION
Given that there's a few unit-tests for `web/` code that runs in Node.js, it seems reasonable to include that folder in the coverage report.