### PR TITLE
Fix array type in CanvasBBoxTracker comment

### DIFF
--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -78,9 +78,10 @@ const ensureDebugMetadata = (map, key) =>
 class CanvasBBoxTracker {
   #baseTransformStack = [[1, 0, 0, 1, 0, 0]];
 
+  // minX, minY, maxX, maxY
   #clipBox = [-Infinity, -Infinity, Infinity, Infinity];
 
-  // Float32Array<minX, minY, maxX, maxY>
+  // minX, minY, maxX, maxY
   #pendingBBox = new Float64Array(BBOX_INIT);
 
   _pendingBBoxIdx = -1;


### PR DESCRIPTION
> **Fix array type in CanvasBBoxTracker comment**
>
> Remove the "Float32Array" mention in the comment, given that the implementation usesa  Float64Array.
>
> Actually using a Float32Array passes all the tests we currently have and reduces memory usage (by 16 bytes per op), however to be sure that it does not introduce rounding bugs we'd need to `Math.fround` all operations we do on the clipBox and pendingBBox. It reduces the readibilty of the code, but we can revisit if this memory usage becomes a problem.

Fixes https://github.com/mozilla/pdf.js/issues/21032