### PR TITLE
Split the unit/font tests into per-browser jobs

### DIFF
--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -24,13 +24,19 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: ${{ matrix.os }} / ${{ matrix.browser }}
 
     strategy:
       fail-fast: false
       matrix:
         node-version: [lts/*]
         os: [windows-latest, ubuntu-latest]
+        browser: [firefox, chrome]
+        include:
+          - browser: firefox
+            skip: --noChrome
+          - browser: chrome
+            skip: --noFirefox
 
     runs-on: ${{ matrix.os }}
     environment: code-coverage
@@ -62,7 +68,7 @@ jobs:
         run: pip install -r .github/font_tests_requirements.txt
 
       - name: Run font tests with code coverage
-        run: npx gulp fonttest --headless --coverage --coverage-output build/coverage/font
+        run: npx gulp fonttest --headless --coverage --coverage-output build/coverage/font ${{ matrix.skip }}
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,13 +26,19 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: ${{ matrix.os }} / ${{ matrix.browser }}
 
     strategy:
       fail-fast: false
       matrix:
         node-version: [lts/*]
         os: [windows-latest, ubuntu-latest]
+        browser: [firefox, chrome]
+        include:
+          - browser: firefox
+            skip: --noChrome
+          - browser: chrome
+            skip: --noFirefox
 
     runs-on: ${{ matrix.os }}
     environment: code-coverage
@@ -63,7 +69,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Run unit tests with code coverage
-        run: npx gulp unittest --headless --coverage --coverage-output build/coverage/unit
+        run: npx gulp unittest --headless --coverage --coverage-output build/coverage/unit ${{ matrix.skip }}
 
       - name: Save cached PDF files
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
This commit mirrors the approach from e656b833 to the other workflows that run multiple OS/browser combinations. This approach has multiple advantages:

- it improves performance because each job is run in its own environment so we don't have two browsers competing for resources in the same environment anymore;
- it improves monitoring because each job is shown separately, with its own runtime, in e.g. the pull request checks and actions overviews, which makes it easier to spot bottlenecks that are specific to a certain OS/browser combination and enable follow-up optimizations.