### PR TITLE
Add an abstract `readBlock` method in the `DecodeStream` class

### DIFF
--- a/src/core/ccitt_stream.js
+++ b/src/core/ccitt_stream.js
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import { shadow, unreachable } from "../shared/util.js";
 import { DecodeStream } from "./decode_stream.js";
 import { Dict } from "./primitives.js";
 import { JBig2CCITTFaxImage } from "./jbig2_ccittFax.js";
+import { shadow } from "../shared/util.js";
 
 class CCITTFaxStream extends DecodeStream {
   constructor(str, maybeLength, params) {
@@ -44,10 +44,6 @@ class CCITTFaxStream extends DecodeStream {
   get bytes() {
     // If `this.maybeLength` is null, we'll get the entire stream.
     return shadow(this, "bytes", this.stream.getBytes(this.maybeLength));
-  }
-
-  readBlock() {
-    unreachable("CCITTFaxStream.readBlock");
   }
 
   get isImageStream() {

--- a/src/core/decode_stream.js
+++ b/src/core/decode_stream.js
@@ -15,6 +15,7 @@
 
 import { BaseStream } from "./base_stream.js";
 import { Stream } from "./stream.js";
+import { unreachable } from "../shared/util.js";
 
 // Lots of DecodeStreams are created whose buffers are never used.  For these
 // we share a single empty buffer. This is (a) space-efficient and (b) avoids
@@ -24,21 +25,30 @@ const emptyBuffer = new Uint8Array(0);
 
 // Super class for the decoding streams.
 class DecodeStream extends BaseStream {
+  buffer = emptyBuffer;
+
+  bufferLength = 0;
+
+  eof = false;
+
+  minBufferLength = 512;
+
+  pos = 0;
+
   constructor(maybeMinBufferLength) {
     super();
     this._rawMinBufferLength = maybeMinBufferLength || 0;
 
-    this.pos = 0;
-    this.bufferLength = 0;
-    this.eof = false;
-    this.buffer = emptyBuffer;
-    this.minBufferLength = 512;
     if (maybeMinBufferLength) {
       // Compute the first power of two that is as big as maybeMinBufferLength.
       while (this.minBufferLength < maybeMinBufferLength) {
         this.minBufferLength *= 2;
       }
     }
+  }
+
+  readBlock() {
+    unreachable("Abstract method `readBlock` called");
   }
 
   get isEmpty() {

--- a/src/core/jbig2_stream.js
+++ b/src/core/jbig2_stream.js
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-import { shadow, unreachable } from "../shared/util.js";
 import { BaseStream } from "./base_stream.js";
 import { DecodeStream } from "./decode_stream.js";
 import { Dict } from "./primitives.js";
 import { JBig2CCITTFaxImage } from "./jbig2_ccittFax.js";
+import { shadow } from "../shared/util.js";
 
 /**
  * For JBIG2's we use a library to decode these images and
@@ -41,10 +41,6 @@ class Jbig2Stream extends DecodeStream {
   ensureBuffer(requested) {
     // No-op, since `this.readBlock` will always parse the entire image and
     // directly insert all of its data into `this.buffer`.
-  }
-
-  readBlock() {
-    unreachable("Jbig2Stream.readBlock");
   }
 
   get isAsyncDecoder() {

--- a/src/core/jpx_stream.js
+++ b/src/core/jpx_stream.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { shadow, unreachable } from "../shared/util.js";
 import { DecodeStream } from "./decode_stream.js";
 import { JpxImage } from "./jpx.js";
+import { shadow } from "../shared/util.js";
 
 /**
  * For JPEG 2000's we use a library to decode these images and
@@ -39,10 +39,6 @@ class JpxStream extends DecodeStream {
   ensureBuffer(requested) {
     // No-op, since `this.readBlock` will always parse the entire image and
     // directly insert all of its data into `this.buffer`.
-  }
-
-  readBlock(decoderOptions) {
-    unreachable("JpxStream.readBlock");
   }
 
   get isAsyncDecoder() {


### PR DESCRIPTION
This avoids having to "duplicate" dummy `readBlock` methods in a couple of image-stream classes.
Also, move a few `DecodeStream` field definitions to (ever so slightly) shorten the code.