### PR TITLE
Fix the intermittent test failure 'performs a search in a text containing some Hangul syllables'

### DIFF
--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -117,9 +117,8 @@ async function initializePDFJS(callback) {
       "The `gulp unittest` command cannot be used in Node.js environments."
     );
   }
-  // Configure the worker. Point at the raw source so the webserver can
-  // instrument it on request and the worker accumulates `__coverage__`.
-  GlobalWorkerOptions.workerSrc = "../../src/pdf.worker.js";
+  // Configure the worker.
+  GlobalWorkerOptions.workerSrc = "../../build/generic/build/pdf.worker.mjs";
 
   callback();
 }


### PR DESCRIPTION
The patch cb8055f0a changed the worker source so just set it as it was.