### PR TITLE
Slighty improve codecov stuff in gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,6 @@ jobs:
           files: ./build/coverage/unitcli/lcov.info
           flags: unittestcli
           name: codecov-umbrella
+          disable_search: true
+          disable_telem: true
           verbose: true

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -78,4 +78,6 @@ jobs:
           files: ./build/coverage/font/lcov.info
           flags: fonttest
           name: codecov-umbrella
+          disable_search: true
+          disable_telem: true
           verbose: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -86,4 +86,6 @@ jobs:
           files: ./build/coverage/unit/lcov.info
           flags: unittest
           name: codecov-umbrella
+          disable_search: true
+          disable_telem: true
           verbose: true


### PR DESCRIPTION
disable_search == true, will avoid useless search especially because we already provide the path to the info file.
disable_telem == true, disable sending telemetry to codecov.