### PR TITLE
Improve error handling in the `PDFFindController.prototype.#extractText` method

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -909,6 +909,11 @@ class PDFFindController {
         try {
           const pdfPage = await pdfDoc.getPage(i + 1);
           const textContent = await pdfPage.getTextContent(textOptions);
+
+          if (pdfDoc !== this._pdfDocument) {
+            resolve();
+            return;
+          }
           const strBuf = [];
 
           for (const textItem of textContent.items) {
@@ -921,6 +926,10 @@ class PDFFindController {
           [this._pageContents[i], this._pageDiffs[i], this._hasDiacritics[i]] =
             normalize(strBuf.join(""));
         } catch (ex) {
+          if (pdfDoc !== this._pdfDocument) {
+            resolve();
+            return;
+          }
           console.error(`Unable to get text content for page ${i + 1}`, ex);
           // Page error -- assuming no text content.
           [this._pageContents[i], this._pageDiffs[i], this._hasDiacritics[i]] =

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -906,40 +906,27 @@ class PDFFindController {
           resolve();
           return;
         }
-        await pdfDoc
-          .getPage(i + 1)
-          .then(pdfPage => pdfPage.getTextContent(textOptions))
-          .then(
-            textContent => {
-              const strBuf = [];
+        try {
+          const pdfPage = await pdfDoc.getPage(i + 1);
+          const textContent = await pdfPage.getTextContent(textOptions);
+          const strBuf = [];
 
-              for (const textItem of textContent.items) {
-                strBuf.push(textItem.str);
-                if (textItem.hasEOL) {
-                  strBuf.push("\n");
-                }
-              }
-
-              // Store the normalized page content (text items) as one string.
-              [
-                this._pageContents[i],
-                this._pageDiffs[i],
-                this._hasDiacritics[i],
-              ] = normalize(strBuf.join(""));
-              resolve();
-            },
-            reason => {
-              console.error(
-                `Unable to get text content for page ${i + 1}`,
-                reason
-              );
-              // Page error -- assuming no text content.
-              this._pageContents[i] = "";
-              this._pageDiffs[i] = null;
-              this._hasDiacritics[i] = false;
-              resolve();
+          for (const textItem of textContent.items) {
+            strBuf.push(textItem.str);
+            if (textItem.hasEOL) {
+              strBuf.push("\n");
             }
-          );
+          }
+          // Store the normalized page content (text items) as one string.
+          [this._pageContents[i], this._pageDiffs[i], this._hasDiacritics[i]] =
+            normalize(strBuf.join(""));
+        } catch (ex) {
+          console.error(`Unable to get text content for page ${i + 1}`, ex);
+          // Page error -- assuming no text content.
+          [this._pageContents[i], this._pageDiffs[i], this._hasDiacritics[i]] =
+            ["", null, false];
+        }
+        resolve();
       });
     }
   }


### PR DESCRIPTION
 - **Improve error handling in the `PDFFindController.prototype.#extractText` method**

   This handles *all* errors correctly, if e.g. the document is closed in the middle of searching.
   Also, replacing the "promise chains" with more `await` helps simplify the code a little bit.

 - **Avoid setting page-content for a previous document in the  `PDFFindController.prototype.#extractText` method**

   Given that all of the relevant API methods are asynchronous it's possible, although quite unlikely, that the existing "is the document active" check won't catch all situations where the document was closed in the middle of searching.