### PR TITLE
Remove obsolete `pdfBug: true` flag in the image caching unit test

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4839,7 +4839,6 @@ have written that much by now. So, here’s to squashing bugs.`);
       const loadingTask = getDocument(
         buildGetDocumentParams("issue11878.pdf", {
           isOffscreenCanvasSupported: false,
-          pdfBug: true,
         })
       );
       const pdfDoc = await loadingTask.promise;


### PR DESCRIPTION
In a previous commit the time-based checks, which were based on statistics provided by the `pdfBug: true` flag, got replaced by test-only property checks that don't use said statistics anymore.

Fixes b01eeaf8.