### PR TITLE
perf: Avoid multi-second getDestinations stalls for PDFs with many named destinations

### DIFF
--- a/src/core/name_number_tree.js
+++ b/src/core/name_number_tree.js
@@ -46,8 +46,8 @@ class NameOrNumberTree {
       processed.put(this.root);
     }
     const queue = [this.root];
-    while (queue.length > 0) {
-      const obj = xref.fetchIfRef(queue.shift());
+    for (const node of queue) {
+      const obj = xref.fetchIfRef(node);
       if (!(obj instanceof Dict)) {
         continue;
       }


### PR DESCRIPTION
Replace the `queue.shift()` traversal in `NameOrNumberTree.getAll()` with an index-based queue loop. This keeps traversal order and duplicate-reference handling, but avoids copying the remaining queue for every node.

This matters for callers that materialize full name/number trees: `getDestinations()`, embedded-file name trees, JavaScript name trees, XFA image name trees, and tagged-PDF parent/id trees.

End-user impact:

For small PDFs, no visible change. With 100 named destinations the run stays about 0.29 ms; with 1,000 destinations the result is noise-level because parsing/worker overhead dominates. With large destination trees, the UI/API avoids a quadratic traversal pause. In the 50,000-destination case, `getDestinations()` went from 5570.5 ms to 715.5 ms, saving about 4.9 s.

Benchmark:

I generated synthetic one-page PDFs with `/Names << /Dests ... >>` trees where the root has one leaf per named destination, then measured `pdfDocument.getDestinations()` in Node using the `generic-legacy` build.

```
Named destinations   master median/one-run   patched median/one-run   impact
100                  0.296 ms median         0.286 ms median          no visible change
1,000                6.78 ms median          7.13 ms median           no visible change/noise
20,000               388.6 ms median         211.7 ms median          ~1.8x faster, ~177 ms saved
50,000               5570.5 ms one run       715.5 ms one run         ~7.8x faster, ~4.9 s saved
```

Isolated `NameTree.getAll()` micro-benchmark on the same flat tree shape:

```
Tree entries   master median   patched median   speedup
100            0.0053 ms       0.0041 ms        ~1.3x
1,000          0.0550 ms       0.0305 ms        ~1.8x
50,000         152.9 ms        2.42 ms          ~63x
```