### PR TITLE
Remove the `CompilerOutput.prototype.finalData` getter, and a few other font improvements (PR 21053 follow-up)

### DIFF
--- a/src/core/cff_font.js
+++ b/src/core/cff_font.js
@@ -28,11 +28,12 @@ class CFFFont {
     this.seacs = this.cff.seacs;
     try {
       this.data = compiler.compile();
-    } catch {
-      warn("Failed to compile font " + properties.loadedName);
+    } catch (ex) {
+      warn(`Failed to compile font "${properties.loadedName}": "${ex}".`);
       // There may have just been an issue with the compiler, set the data
       // anyway and hope the font loaded.
-      this.data = file;
+      file.reset();
+      this.data = file.getBytes();
     }
     this._createBuiltInEncoding();
   }

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1400,12 +1400,6 @@ class CompilerOutput {
     return this.#buf.subarray(0, this.#pos);
   }
 
-  get finalData() {
-    const data = this.#buf.slice(0, this.#pos);
-    this.#buf = null;
-    return data;
-  }
-
   get length() {
     return this.#pos;
   }
@@ -1534,7 +1528,7 @@ class CFFCompiler {
     // the sanitizer will bail out. Add a dummy byte to avoid that.
     output.add([0]);
 
-    return output.finalData;
+    return output.data;
   }
 
   encodeNumber(value) {

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1519,6 +1519,12 @@ class Font {
         data[8] = data[9] = data[10] = data[11] = 0;
         data[17] |= 0x20; // Set font optimized for cleartype flag.
       }
+      // The "CFF " table may be replaced completely, hence its data shouldn't
+      // need to be read and/or modified piecewise through a `DataView`.
+      const view =
+        tag === "CFF "
+          ? null
+          : new DataView(data.buffer, data.byteOffset, data.byteLength);
 
       return {
         tag,
@@ -1526,7 +1532,7 @@ class Font {
         length,
         offset,
         data,
-        view: new DataView(data.buffer, data.byteOffset, data.byteLength),
+        view,
       };
     }
 


### PR DESCRIPTION
 - **Remove the `CompilerOutput.prototype.finalData` getter (PR 21053 follow-up)**

   Return the data as-is from the `CFFCompiler.prototype.compile` method, rather than making a copy of it first.
   The reason that it was implemented this way in PR 21053 was to avoid keeping a potentially large `ArrayBuffer` alive, see https://github.com/mozilla/pdf.js/pull/21053#discussion_r3045402988

   Having traced all the call-sites in the font-code that directly or indirectly invoke that code, I've now managed to conclude that the compiled CFF-data is never stored on the `Font` instance and using the data as-is thus shouldn't increase permanent memory usage.

 - **Set the correct data if compilation fails in the `CFFFont` constructor**

   The `CFFFont.prototype.data` should contain a `Uint8Array`, however if compilation failed it was being set to a `Stream` instance which will thus fail elsewhere in the font-code.

   *Please note:* This was found by code inspection, since I don't have a PDF document that's fixed by this change.

 - **Don't create a `DataView` for the "CFF " TrueType table in `readTableEntry`**

   Given that the "CFF " table may be replaced completely, during font-parsing, it shouldn't make sense to read and/or modify it piecewise.