### PR TITLE
Ensure TextLayer hiddenCanvasElement is layout-neutral by default

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -472,7 +472,8 @@ class TextLayer {
       // their replacements when they aren't embedded) and then we can use an
       // OffscreenCanvas.
       const canvas = document.createElement("canvas");
-      canvas.className = "hiddenCanvasElement";
+      canvas.style.cssText =
+        "position:absolute;top:0;left:0;width:0;height:0;display:none";
       canvas.lang = lang;
       document.body.append(canvas);
       ctx = canvas.getContext("2d", {

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -78,16 +78,6 @@
   transform: rotate(270deg) translateX(-100%);
 }
 
-#hiddenCopyElement,
-.hiddenCanvasElement {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 0;
-  height: 0;
-  display: none;
-}
-
 .pdfViewer {
   /* Define this variable here and not in :root to avoid to reflow all the UI
      when scaling (see #15929). */

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -967,6 +967,8 @@ class PDFViewer {
           const element = (this.#hiddenCopyElement =
             document.createElement("div"));
           element.id = "hiddenCopyElement";
+          element.style.cssText =
+            "position:absolute;top:0;left:0;width:0;height:0;display:none";
           viewer.before(element);
         }
 


### PR DESCRIPTION
`TextLayer` creates a helper canvas with class `hiddenCanvasElement` and appends it directly to `document.body`, which can adversely affect the host-page layout/scrolling behavior.

The stock viewer stylesheet `web/pdf_viewer.css` already makes this element layout-neutral via `.hiddenCanvasElement { ... display: none; }`, but direct `pdfjs-dist` / `TextLayer` consumers are not required to load `web/pdf_viewer.css`. Consumers that scope the viewer stylesheet to avoid global CSS leakage also lose this protection, since the helper canvas is appended outside the scoped viewer subtree.

This change applies the essential layout-neutralizing rule at the creation site, so the display-layer helper does not depend on viewer CSS to avoid participating in host-page layout.

Related context:
- #18086 discussed the same body-appended helper element from a lifecycle/cleanup perspective.
- `react-pdf` added the `.hiddenCanvasElement` CSS rule downstream in wojtekmaj/react-pdf#1815 to avoid layout side effects.