### PR TITLE
A couple of small tweaks of the `getPdfFilenameFromUrl` helper

### DIFF
--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -347,22 +347,19 @@ function getPdfFilenameFromUrl(url, defaultFilename = "document.pdf") {
   const getURL = urlString => {
     try {
       return new URL(urlString);
-    } catch {
-      try {
-        return new URL(decodeURIComponent(urlString));
-      } catch {
-        try {
-          // Attempt to parse the URL using the document's base URI.
-          return new URL(urlString, "https://foo.bar");
-        } catch {
-          try {
-            return new URL(decodeURIComponent(urlString), "https://foo.bar");
-          } catch {
-            return null;
-          }
-        }
-      }
-    }
+    } catch {}
+    try {
+      return new URL(decodeURIComponent(urlString));
+    } catch {}
+    try {
+      // Attempt to parse the URL using the document's base URI.
+      return new URL(urlString, "https://foo.bar");
+    } catch {}
+    try {
+      return new URL(decodeURIComponent(urlString), "https://foo.bar");
+    } catch {}
+
+    return null;
   };
 
   const newURL = getURL(url);
@@ -376,7 +373,8 @@ function getPdfFilenameFromUrl(url, defaultFilename = "document.pdf") {
       let decoded = decodeURIComponent(name);
       if (decoded.includes("/")) {
         decoded = stripPath(decoded);
-        if (/^\.pdf$/i.test(decoded)) {
+        // Ignore the decoded name if it's identical to ".pdf".
+        if (decoded.length === 4 && pdfRegex.test(decoded)) {
           return name;
         }
       }


### PR DESCRIPTION
 - Shorten the `getURL` function slightly, by re-factoring the try-catch blocks.
 - Change how the `decode` function looks for a decoded ".pdf" name, to skip the regular expression matching when it's not needed and to allow re-using the already defined `pdfRegex`.

*Smaller diff with https://github.com/mozilla/pdf.js/pull/21222/changes?w=1*