### PR TITLE
Make the `PDFDataRangeTransport` streaming unit-tests faster

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -5207,7 +5207,7 @@ have written that much by now. So, here’s to squashing bugs.`);
   describe("PDFDataRangeTransport", function () {
     async function streamDelay() {
       return new Promise(resolve => {
-        setTimeout(resolve, 250);
+        setTimeout(resolve, 100);
       });
     }
     let dataPromise;
@@ -5269,7 +5269,7 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(contentDispositionFilename).toEqual("aaa.pdf");
       expect(contentLength).toEqual(dataLength);
 
-      expect(fetches).toBeGreaterThan(4);
+      expect(fetches).toEqual(5);
 
       expect(initialProgress).toEqual({
         loaded: initialDataLength,
@@ -5428,7 +5428,7 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(contentDispositionFilename).toEqual(null);
       expect(contentLength).toEqual(dataLength);
 
-      expect(fetches).toBeGreaterThan(2);
+      expect(fetches).toEqual(3);
 
       expect(initialProgress.loaded).toBeGreaterThan(initialDataLength);
       expect(initialProgress.total).toEqual(dataLength);


### PR DESCRIPTION
The delay between chunks when testing streaming is necessary to avoid the entire PDF document arriving all at once, since that would render those unit-tests somewhat pointless.
However, the delay is unnecessarily large which causes these unit-tests to be slower than necessary.

Also, update the range unit-tests to check the expected number of fetches *exactly* since those values are not supposed to vary.

---

*Note:* This reduces the runtime of the `should fetch document info and page using only streaming` unit-test by `1200` ms.