### PR TITLE
[api-major] Remove support for calling `getDocument` without  a parameter object, and remove the `PDFDocumentProxy.prototype.destroy` method

### DIFF
--- a/docs/contents/examples/index.md
+++ b/docs/contents/examples/index.md
@@ -18,13 +18,13 @@ This tutorial shows how PDF.js can be used as a library in a web browser.
 The object structure of PDF.js loosely follows the structure of an actual PDF. At the top level there is a document object. From the document, more information and individual pages can be fetched. To get the document:
 
 ```js
-pdfjsLib.getDocument('helloworld.pdf')
+pdfjsLib.getDocument({ url: "helloworld.pdf" })
 ```
 
 Remember though that PDF.js uses promises, and the above will return a `PDFDocumentLoadingTask` instance that has a `promise` property which is resolved with the document object.
 
 ```js
-var loadingTask = pdfjsLib.getDocument('helloworld.pdf');
+var loadingTask = pdfjsLib.getDocument({ url: "helloworld.pdf" });
 loadingTask.promise.then(function(pdf) {
   // you can now use *pdf* here
 });
@@ -48,8 +48,8 @@ var viewport = page.getViewport({ scale: scale, });
 // Support HiDPI-screens.
 var outputScale = window.devicePixelRatio || 1;
 
-var canvas = document.getElementById('the-canvas');
-var context = canvas.getContext('2d');
+var canvas = document.getElementById("the-canvas");
+var context = canvas.getContext("2d");
 
 canvas.width = Math.floor(viewport.width * outputScale);
 canvas.height = Math.floor(viewport.height * outputScale);

--- a/examples/learning/helloworld.html
+++ b/examples/learning/helloworld.html
@@ -26,7 +26,7 @@
       //
       // Asynchronous download PDF
       //
-      const loadingTask = pdfjsLib.getDocument(url);
+      const loadingTask = pdfjsLib.getDocument({ url });
       const pdf = await loadingTask.promise;
       //
       // Fetch the first page

--- a/examples/learning/prevnext.html
+++ b/examples/learning/prevnext.html
@@ -123,7 +123,7 @@
       /**
        * Asynchronously downloads PDF.
        */
-      var loadingTask = pdfjsLib.getDocument(url);
+      var loadingTask = pdfjsLib.getDocument({ url });
       pdfDoc = await loadingTask.promise;
       document.getElementById("page_count").textContent = pdfDoc.numPages;
 

--- a/examples/node/getinfo.mjs
+++ b/examples/node/getinfo.mjs
@@ -14,7 +14,7 @@ const pdfPath =
 
 // Will be using promises to load document, pages and misc data instead of
 // callback.
-const loadingTask = getDocument(pdfPath);
+const loadingTask = getDocument({ url: pdfPath });
 loadingTask.promise
   .then(function (doc) {
     const numPages = doc.numPages;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1027,13 +1027,6 @@ class PDFDocumentProxy {
   }
 
   /**
-   * Destroys the current document instance and terminates the worker.
-   */
-  destroy() {
-    return this.loadingTask.destroy();
-  }
-
-  /**
    * @param {RefProxy} ref - The page reference.
    * @returns {number | null} The page number, if it's cached.
    */

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -221,19 +221,10 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
  * XHR as fallback) is used, which means it must follow same origin rules,
  * e.g. no cross-domain requests without CORS.
  *
- * @param {string | URL | TypedArray | ArrayBuffer | DocumentInitParameters}
- *   src - Can be a URL where a PDF file is located, a typed array (Uint8Array)
- *         already populated with data, or a parameter object.
+ * @param {DocumentInitParameters} src - Parameter object.
  * @returns {PDFDocumentLoadingTask}
  */
 function getDocument(src = {}) {
-  if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-    if (typeof src === "string" || src instanceof URL) {
-      src = { url: src };
-    } else if (src instanceof ArrayBuffer || ArrayBuffer.isView(src)) {
-      src = { data: src };
-    }
-  }
   const task = new PDFDocumentLoadingTask();
   const { docId } = task;
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -969,7 +969,7 @@ class Driver {
     // Wipe out the link to the pdfdoc so it can be GC'ed.
     for (const task of [this.currentTask, ...this.taskQueue]) {
       if (task?.pdfDoc) {
-        destroyedPromises.push(task.pdfDoc.destroy());
+        destroyedPromises.push(task.pdfDoc.loadingTask.destroy());
         delete task.pdfDoc;
       }
     }

--- a/test/driver.js
+++ b/test/driver.js
@@ -866,7 +866,7 @@ class Driver {
             await loadingTask.destroy();
             delete task.annotationStorage;
 
-            return getDocument(data).promise;
+            return getDocument({ data }).promise;
           });
         }
 

--- a/test/types/legacy.ts
+++ b/test/types/legacy.ts
@@ -10,7 +10,7 @@ class MainTest {
   }
 
   loadPdf() {
-    this.task = getDocument("file://" + this.file);
+    this.task = getDocument({ url: "file://" + this.file });
     return this.task.promise;
   }
 }

--- a/test/types/modern.ts
+++ b/test/types/modern.ts
@@ -10,7 +10,7 @@ class MainTest {
   }
 
   loadPdf() {
-    this.task = getDocument("file://" + this.file);
+    this.task = getDocument({ url: "file://" + this.file });
     return this.task.promise;
   }
 }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -121,7 +121,7 @@ describe("api", function () {
   describe("getDocument", function () {
     it("creates pdf doc from URL-string", async function () {
       const urlStr = TEST_PDFS_PATH + basicApiFileName;
-      const loadingTask = getDocument(urlStr);
+      const loadingTask = getDocument({ url: urlStr });
       expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
       const pdfDocument = await loadingTask.promise;
 
@@ -135,7 +135,7 @@ describe("api", function () {
     it("creates pdf doc from URL-object", async function () {
       const urlObj = TestPdfsServer.resolveURL(basicApiFileName);
 
-      const loadingTask = getDocument(urlObj);
+      const loadingTask = getDocument({ url: urlObj });
       expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
       const pdfDocument = await loadingTask.promise;
 
@@ -210,7 +210,7 @@ describe("api", function () {
       expect(typedArrayPdf).toBeInstanceOf(Uint8Array);
       expect(typedArrayPdf.length).toEqual(basicApiFileLength);
 
-      const loadingTask = getDocument(typedArrayPdf);
+      const loadingTask = getDocument({ data: typedArrayPdf });
       expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
 
       const progressReportedCapability = Promise.withResolvers();
@@ -245,7 +245,7 @@ describe("api", function () {
       expect(arrayBufferPdf).toBeInstanceOf(ArrayBuffer);
       expect(arrayBufferPdf.byteLength).toEqual(basicApiFileLength);
 
-      const loadingTask = getDocument(arrayBufferPdf);
+      const loadingTask = getDocument({ data: arrayBufferPdf });
       expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
 
       const progressReportedCapability = Promise.withResolvers();
@@ -516,7 +516,7 @@ describe("api", function () {
     );
 
     it("creates pdf doc from empty TypedArray", async function () {
-      const loadingTask = getDocument(new Uint8Array(0));
+      const loadingTask = getDocument({ data: new Uint8Array(0) });
       expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
 
       try {
@@ -850,7 +850,7 @@ describe("api", function () {
       expect(typedArrayPdf).toBeInstanceOf(Uint8Array);
       expect(typedArrayPdf.length).toEqual(1116);
 
-      const loadingTask = getDocument(typedArrayPdf.slice());
+      const loadingTask = getDocument({ data: typedArrayPdf.slice() });
       expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
 
       let passwordData = null;
@@ -2407,7 +2407,7 @@ describe("api", function () {
       expect(typedArrayPdf).toBeInstanceOf(Uint8Array);
       expect(typedArrayPdf.length).toEqual(10719);
 
-      const loadingTask = getDocument(typedArrayPdf.slice());
+      const loadingTask = getDocument({ data: typedArrayPdf.slice() });
       const pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       // Trigger parsing of the JPEG image.
@@ -2463,7 +2463,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const pdfPage = await pdfDoc.getPage(1);
       const annotations = await pdfPage.getAnnotations();
@@ -2486,7 +2486,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const datasets = await pdfDoc.getXFADatasets();
 
@@ -2522,7 +2522,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const datasets = await pdfDoc.getXFADatasets();
 
@@ -2559,7 +2559,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       page = await pdfDoc.getPage(1);
       const newStructTree = await page.getStructTree();
@@ -2594,7 +2594,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const annotations = await pdfDoc.getAnnotArray(0);
 
@@ -2673,7 +2673,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       // Ensure that the Annotation text-content was actually compressed.
       typedArray = await pdfDoc.getData();
@@ -2714,7 +2714,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const opList = await page.getOperatorList();
@@ -2772,7 +2772,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const tree = await page.getStructTree();
@@ -2867,7 +2867,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const tree = await page.getStructTree();
@@ -2935,11 +2935,11 @@ describe("api", function () {
       const blob = await getImageBlob("firefox_logo.png");
 
       let loadingTask, pdfDoc;
-      let data = buildGetDocumentParams("empty.pdf");
+      let docParams = buildGetDocumentParams("empty.pdf");
 
       for (let i = 1; i <= 2; i++) {
         const bitmap = await createImageBitmap(blob);
-        loadingTask = getDocument(data);
+        loadingTask = getDocument(docParams);
         pdfDoc = await loadingTask.promise;
         pdfDoc.annotationStorage.setValue("pdfjs_internal_editor_0", {
           annotationType: AnnotationEditorType.STAMP,
@@ -2955,11 +2955,11 @@ describe("api", function () {
           },
         });
 
-        data = await pdfDoc.saveDocument();
+        docParams = { data: await pdfDoc.saveDocument() };
         await loadingTask.destroy();
       }
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument(docParams);
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const tree = await page.getStructTree();
@@ -3018,7 +3018,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const tree = await page.getStructTree();
@@ -3081,7 +3081,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const tree = await page.getStructTree();
@@ -3119,7 +3119,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const annotations = await page.getAnnotations();
@@ -3163,7 +3163,7 @@ describe("api", function () {
       const data = await pdfDoc.saveDocument();
       await loadingTask.destroy();
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       const page = await pdfDoc.getPage(1);
       const tree = await page.getStructTree();
@@ -5597,7 +5597,7 @@ small scripts as well as for`);
         return;
       }
 
-      loadingTask = getDocument(data);
+      loadingTask = getDocument({ data });
       pdfDoc = await loadingTask.promise;
       expect(pdfDoc.numPages).toEqual(expected.length);
 
@@ -5631,7 +5631,7 @@ small scripts as well as for`);
           { document: pdfData2 },
           { document: pdfData3 },
         ]);
-        let newLoadingTask = getDocument(data);
+        let newLoadingTask = getDocument({ data });
         let newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(9);
 
@@ -5649,7 +5649,7 @@ small scripts as well as for`);
           { document: pdfData2 },
           { document: null },
         ]);
-        newLoadingTask = getDocument(data);
+        newLoadingTask = getDocument({ data });
         newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(9);
         for (let i = 1; i <= 9; i++) {
@@ -5666,7 +5666,7 @@ small scripts as well as for`);
           { document: pdfData2, includePages: [0] },
           { document: pdfData3, includePages: [0] },
         ]);
-        newLoadingTask = getDocument(data);
+        newLoadingTask = getDocument({ data });
         newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(3);
         for (let i = 1; i <= 3; i++) {
@@ -5681,7 +5681,7 @@ small scripts as well as for`);
           { document: pdfData2, excludePages: [0] },
           { document: pdfData3, excludePages: [0] },
         ]);
-        newLoadingTask = getDocument(data);
+        newLoadingTask = getDocument({ data });
         newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(6);
         for (let i = 1; i <= 6; i++) {
@@ -5709,7 +5709,7 @@ small scripts as well as for`);
           { document: pdfData1, includePages: [[0, 0], 2] },
           { document: null, includePages: [[2, 4], 7] },
         ]);
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(6);
 
@@ -5756,7 +5756,7 @@ small scripts as well as for`);
             ],
           },
         ]);
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(6);
 
@@ -5796,7 +5796,7 @@ small scripts as well as for`);
           { document: null, includePages: [0] },
           { document: pdfData1, password: "asdfasdf" },
         ]);
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(2);
 
@@ -5845,7 +5845,7 @@ small scripts as well as for`);
           includePages: [0, 1, 5, 7, 10],
         });
         await loadingTask.destroy();
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         const newPdfDoc = await loadingTask.promise;
         labels = await newPdfDoc.getPageLabels();
         expect(labels).toEqual(["i", "ii", "1", "a", "5"]);
@@ -5869,7 +5869,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         destinations = await pdfDoc.getDestinations();
@@ -5905,7 +5905,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(4);
@@ -5932,7 +5932,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(8);
@@ -5973,7 +5973,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(3);
@@ -6010,7 +6010,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(4);
@@ -6089,7 +6089,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(2);
@@ -6192,7 +6192,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(3);
@@ -6283,7 +6283,7 @@ small scripts as well as for`);
           { document: null, includePages: [1, 3, 5], pageIndices: [1, 2, 0] },
         ]);
         await loadingTask.destroy();
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(3);
@@ -6365,7 +6365,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(2);
@@ -6404,7 +6404,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(3);
 
@@ -6449,7 +6449,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(6);
 
@@ -6503,7 +6503,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(5);
 
@@ -6533,7 +6533,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(3);
@@ -6574,7 +6574,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         const attachments = await pdfDoc.getAttachments();
@@ -6601,7 +6601,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         const attachments = await pdfDoc.getAttachments();
@@ -6649,7 +6649,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(1);
@@ -6701,7 +6701,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         expect(pdfDoc.numPages).toEqual(2);
@@ -6747,7 +6747,7 @@ small scripts as well as for`);
         const data = await pdfDoc.extractPages([{ document: null }]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
 
         const calculationOrder = await pdfDoc.getCalculationOrderIds();
@@ -6778,7 +6778,7 @@ small scripts as well as for`);
         expect(data).not.toBeNull();
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(2);
         await newLoadingTask.destroy();
@@ -6810,7 +6810,7 @@ small scripts as well as for`);
         const data = await pdfDoc.extractPages([{ document: null }]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         const outline = await newPdfDoc.getOutline();
 
@@ -6890,7 +6890,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         const outline = await newPdfDoc.getOutline();
 
@@ -6928,7 +6928,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         const outline = await newPdfDoc.getOutline();
 
@@ -6996,7 +6996,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(2);
 
@@ -7056,7 +7056,7 @@ small scripts as well as for`);
         const data = await pdfDoc.extractPages([{ document: null }]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         const outline = await newPdfDoc.getOutline();
 
@@ -7084,7 +7084,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(2);
 
@@ -7133,7 +7133,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(1);
 
@@ -7165,7 +7165,7 @@ small scripts as well as for`);
         const data = await pdfDoc.extractPages([{ document: null }]);
         await loadingTask.destroy();
 
-        const newLoadingTask = getDocument(data);
+        const newLoadingTask = getDocument({ data });
         const newPdfDoc = await newLoadingTask.promise;
         expect(newPdfDoc.numPages).toEqual(1);
         await newLoadingTask.destroy();
@@ -7188,7 +7188,7 @@ small scripts as well as for`);
         // Opening the result without a password must fail.
         // Use a copy so the underlying ArrayBuffer is not detached before the
         // second getDocument call below.
-        const passwordNeededLoadingTask = getDocument(data.slice());
+        const passwordNeededLoadingTask = getDocument({ data: data.slice() });
         await passwordNeededLoadingTask.promise.then(
           function () {
             // Shouldn't get here.
@@ -7227,7 +7227,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(3);
 
@@ -7262,7 +7262,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(3);
 
@@ -7296,7 +7296,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(23);
 
@@ -7335,7 +7335,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(3);
 
@@ -7368,7 +7368,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(4);
 
@@ -7401,7 +7401,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(3);
 
@@ -7433,7 +7433,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(3);
 
@@ -7520,7 +7520,7 @@ small scripts as well as for`);
         ]);
         await loadingTask.destroy();
 
-        loadingTask = getDocument(data);
+        loadingTask = getDocument({ data });
         pdfDoc = await loadingTask.promise;
         expect(pdfDoc.numPages).toEqual(2);
 

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -3203,7 +3203,7 @@ describe("api", function () {
         params.url = url.href;
         loadingTask = getDocument(params);
         return loadingTask.promise
-          .then(pdf => pdf.destroy())
+          .then(() => loadingTask.destroy())
           .then(
             function () {
               expect(expectSuccess).toEqual(true);

--- a/web/internal/debugger.js
+++ b/web/internal/debugger.js
@@ -95,7 +95,7 @@ async function openDocument(source, name) {
 
   if (pdfDoc) {
     pageView.reset();
-    await pdfDoc.destroy();
+    await pdfDoc.loadingTask.destroy();
     pdfDoc = null;
   }
 


### PR DESCRIPTION
 - **[api-major] Remove support for calling `getDocument` without a parameter object**

   This is a left-over from very old code[1], before there were a lot of `getDocument` options and when most of the library configuration was done via the (since removed) `PDFJS` global.
   Given all the functionality added through the years, which require configuration[2], in practice it's now unlikely that calling `getDocument` without additional options will work except for the most trivial PDFs.

   ---

   [1] If the `getDocument` function was added today, there's no chance that it'd support anything other than a parameter object.

   [2] Note things such as CMaps, standard fonts, wasm-based image decoders, and ICC-based colour spaces.

 - **[api-major] Remove the `PDFDocumentProxy.prototype.destroy` method**

   This is a left-over from very old code, which pre-dates the introduction of the `PDFDocumentLoadingTask` and it's nothing more than an alias for its `destroy` method.
   Given that `PDFDocumentProxy` already provides a way to access the underlying `PDFDocumentLoadingTask` instance, it shouldn't be necessary to have an alias for one of its methods.

   *Please note:* For any existing code relying on the removed method, updating it should be as simple as replacing `pdfDocument.destroy()` with `pdfDocument.loadingTask.destroy()`.

   ---

   [1] If the `PDFDocumentProxy` class was added today, there's no chance that it'd include a `destroy` method.