### PR TITLE
fix: resolve #21119 — [Bug]: display look very broken when the window is very small

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -29,6 +29,61 @@ import {
 import { PNG } from "pngjs";
 
 describe("PDF viewer", () => {
+  describe("Toolbar layout", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait("empty.pdf", ".textLayer .endOfContent");
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("doesn't wrap find bar labels in a narrow window", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await page.setViewport({ width: 300, height: 800 });
+          await waitAndClick(page, "#viewFindButton");
+          await page.waitForSelector("#findbar:not(.hidden)");
+
+          const wrappedLabels = await page.evaluate(() => {
+            const range = document.createRange();
+
+            return Array.from(
+              document.querySelectorAll("#findbar .toolbarLabel")
+            )
+              .filter(label => {
+                const walker = document.createTreeWalker(
+                  label,
+                  NodeFilter.SHOW_TEXT
+                );
+                const tops = new Set();
+                let node;
+
+                while ((node = walker.nextNode())) {
+                  if (!node.nodeValue.trim()) {
+                    continue;
+                  }
+                  range.selectNodeContents(node);
+                  for (const { top } of range.getClientRects()) {
+                    tops.add(Math.round(top));
+                  }
+                }
+
+                return tops.size > 1;
+              })
+              .map(label => label.textContent.trim());
+          });
+
+          expect(wrappedLabels)
+            .withContext(`In ${browserName}`)
+            .toEqual([]);
+        })
+      );
+    });
+  });
+
   describe("Zoom origin", () => {
     let pages;
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -112,7 +112,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                   aria-haspopup="true"
                   aria-controls="viewsManager"
                 >
-                  <span data-l10n-id="pdfjs-toggle-views-manager-button1-label"></span>
+                  <span class="toolbarLabel" data-l10n-id="pdfjs-toggle-views-manager-button1-label"></span>
                 </button>
                 <div
                   id="viewsManager"
@@ -135,7 +135,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                           aria-haspopup="listbox"
                           aria-controls="viewsManagerSelectorOptions"
                         >
-                          <span data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
+                          <span class="toolbarLabel" data-l10n-id="pdfjs-views-manager-view-selector-button-label"></span>
                         </button>
                         <menu id="viewsManagerSelectorOptions" role="listbox" class="popupMenu withMark">
                           <button id="thumbnailsViewMenu" role="option" type="button" tabindex="-1">


### PR DESCRIPTION
## Summary

fix: resolve #21119 — [Bug]: display look very broken when the window is very small

## Problem

**Severity**: `Medium` | **File**: `web/viewer.html`

The CSS fix depends on labels being contained in elements that can receive overflow handling. If `#viewsManagerHeaderLabel` or doorhanger menu labels are bare text nodes or nested in containers that cannot shrink, CSS ellipsis/nowrap may not work reliably. The markup should be checked and only minimally adjusted if necessary.

## Solution

|

## Changes

- `web/viewer.html` (modified)
- `test/integration/viewer_spec.mjs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Contributed by Lê Thành Chỉnh*