### PR TITLE
fix: resolve #21009 — [Bug]: PDF completely black after computer idling overnight.

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -29,6 +29,45 @@ import {
 import { PNG } from "pngjs";
 
 describe("PDF viewer", () => {
+  describe("Force redraw after long idle", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        ".textLayer .endOfContent",
+        "page-width"
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("redraws visible pages when focus returns after a long idle", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const redrawPromise = await createPromise(page, resolve => {
+            window.PDFViewerApplication.pdfViewer.forceRedrawVisiblePages =
+              resolve;
+          });
+
+          await page.evaluate(() => {
+            const originalNow = performance.now.bind(performance);
+            let now = originalNow();
+            performance.now = () => now;
+            window.dispatchEvent(new Event("blur"));
+            now += 6 * 60 * 1000;
+            window.dispatchEvent(new Event("focus"));
+            performance.now = originalNow;
+          });
+
+          await awaitPromise(redrawPromise);
+        })
+      );
+    });
+  });
+
   describe("Zoom origin", () => {
     let pages;
 

--- a/web/app.js
+++ b/web/app.js
@@ -98,6 +98,7 @@ import { ViewHistory } from "./view_history.js";
 import { ViewsManager } from "web-views_manager";
 
 const FORCE_PAGES_LOADED_TIMEOUT = 10000; // ms
+const FORCE_REDRAW_VISIBLE_PAGES_TIMEOUT = 5 * 60 * 1000; // ms
 
 const ViewOnLoad = {
   UNKNOWN: -1,
@@ -174,6 +175,7 @@ const PDFViewerApplication = {
   _eventBusAbortController: null,
   _windowAbortController: null,
   _globalAbortController: new AbortController(),
+  _lastHiddenTime: 0,
   documentInfo: null,
   metadata: null,
   _contentDispositionFilename: null,
@@ -2090,6 +2092,13 @@ const PDFViewerApplication = {
     if (this.supportsPrinting && (await this._printPermissionPromise)) {
       window.print();
     }
+  },
+
+  _forceRedrawVisiblePages() {
+    if (!this.pdfDocument || !this.pdfViewer?.pagesCount) {
+      return;
+    }
+    this.pdfViewer.forceRedrawVisiblePages();
   },
 
   bindEvents() {


### PR DESCRIPTION
## Summary

fix: resolve #21009 — [Bug]: PDF completely black after computer idling overnight.

## Problem

**Severity**: `Medium` | **File**: `web/app.js`

Add viewer-level event handling for cases where the browser/OS resumes after a long idle, lock screen, sleep, or GPU device reset. The reported symptom is that already-rendered PDF canvases can become completely black while PDF.js still considers the pages successfully rendered, so normal rendering-queue logic does not repaint them until another action such as zooming resets the pages. The viewer should proactively invalidate/repaint currently visible pages when the document becomes visible/focused again after a significant idle interval.

## Solution

In `PDFViewerApplication.bindEvents()` or the nearby window-event setup code, register listeners for `visibilitychange`, `focus`, and possibly `pageshow`. Track the last time the viewer became hidden/blurred, e.g. `this._lastHiddenTime = performance.now()`. When the document becomes visible again or the window regains focus, compare elapsed time against a conservative threshold, for example 5–10 minutes, to avoid unnecessary redraws during quick tab switches. If the threshold is exceeded, call a new `PDFViewer` method such as `this.pdfViewer.forceRedrawVisiblePages()` or dispatch an internal event that causes visible pages to be reset and rendered again. Ensure the hook is guarded so it only runs when a PDF is loaded and the viewer is initialized.

## Changes

- `web/app.js` (modified)
- `test/integration/viewer_spec.mjs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Contributed by Lê Thành Chỉnh*