### PR TITLE
[Editor] Avoid "generating" the l10n-ids used for the `a11yAlert`

### DIFF
--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -113,7 +113,7 @@ class DrawingEditor extends AnnotationEditor {
     this.#drawOutlines = drawOutlines;
     this._drawingOptions ||= drawingOptions;
     if (!this.annotationElementId) {
-      this._uiManager.a11yAlert(`pdfjs-editor-${this.editorType}-added-alert`);
+      this._uiManager.a11yAlert(AnnotationEditor._l10nAlert[this.editorType]);
     }
 
     if (drawId >= 0) {

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -109,6 +109,8 @@ class AnnotationEditor {
 
   static _l10n = null;
 
+  static _l10nAlert = null;
+
   static _l10nResizer = null;
 
   #isDraggable = false;
@@ -247,7 +249,15 @@ class AnnotationEditor {
   static initialize(l10n, _uiManager) {
     AnnotationEditor._l10n ??= l10n;
 
-    AnnotationEditor._l10nResizer ||= Object.freeze({
+    AnnotationEditor._l10nAlert ??= Object.freeze({
+      highlight: "pdfjs-editor-highlight-added-alert",
+      freetext: "pdfjs-editor-freetext-added-alert",
+      ink: "pdfjs-editor-ink-added-alert",
+      stamp: "pdfjs-editor-stamp-added-alert",
+      signature: "pdfjs-editor-signature-added-alert",
+    });
+
+    AnnotationEditor._l10nResizer ??= Object.freeze({
       topLeft: "pdfjs-editor-resizer-top-left",
       topMiddle: "pdfjs-editor-resizer-top-middle",
       topRight: "pdfjs-editor-resizer-top-right",

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -133,7 +133,7 @@ class FreeTextEditor extends AnnotationEditor {
       AnnotationEditor._defaultLineColor;
     this.#fontSize = params.fontSize || FreeTextEditor._defaultFontSize;
     if (!this.annotationElementId) {
-      this._uiManager.a11yAlert("pdfjs-editor-freetext-added-alert");
+      this._uiManager.a11yAlert(AnnotationEditor._l10nAlert.freetext);
     }
     this.canAddComment = false;
   }

--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -128,7 +128,7 @@ class HighlightEditor extends AnnotationEditor {
     }
 
     if (!this.annotationElementId) {
-      this._uiManager.a11yAlert("pdfjs-editor-highlight-added-alert");
+      this._uiManager.a11yAlert(AnnotationEditor._l10nAlert.highlight);
     }
   }
 

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -483,7 +483,7 @@ class StampEditor extends AnnotationEditor {
       this.div.setAttribute("aria-description", this.#bitmapFileName);
     }
     if (!this.annotationElementId) {
-      this._uiManager.a11yAlert("pdfjs-editor-stamp-added-alert");
+      this._uiManager.a11yAlert(AnnotationEditor._l10nAlert.stamp);
     }
   }
 


### PR DESCRIPTION
In the `DrawingEditor.prototype.#createDrawOutlines` method the l10n-id was being "generated", which is bad for maintainability since searching for l10n-id becomes more difficult and the `gulp check_l10n` script actually warns about this.

Hence, similar to e.g. the resizer localization, let's define the `a11yAlert` l10n-ids *once* and provide shorthands for accessing them.