### PR TITLE
Add a simple API unit-test for /BrotliDecode

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4590,6 +4590,27 @@ have written that much by now. So, here’s to squashing bugs.`);
       await loadingTask.destroy();
     });
 
+    it("gets operatorList, from PDF with /BrotliDecode", async function () {
+      const loadingTask = getDocument(
+        buildGetDocumentParams("Brotli-Prototype-FileA.pdf")
+      );
+      expect(loadingTask).toBeInstanceOf(PDFDocumentLoadingTask);
+
+      const pdfDoc = await loadingTask.promise;
+      expect(pdfDoc.numPages).toEqual(25);
+
+      const pdfPage = await pdfDoc.getPage(1);
+      expect(pdfPage).toBeInstanceOf(PDFPageProxy);
+
+      const opList = await pdfPage.getOperatorList();
+      expect(opList.fnArray.length).toBeGreaterThan(9800);
+      expect(opList.argsArray.length).toBeGreaterThan(9800);
+      expect(opList.lastChunk).toBeTrue();
+      expect(opList.separateAnnots).toBeNull();
+
+      await loadingTask.destroy();
+    });
+
     it("gets page stats after parsing page, without `pdfBug` set", async function () {
       await page.getOperatorList();
       expect(page.stats).toEqual(null);


### PR DESCRIPTION
This is a new feature in PDF documents, hence it shouldn't hurt to complement the existing ref-test with a simple unit-test as well.
This should also improve test coverage for the `external/` folder, which can't hurt since the other external decoders are already fairly well covered.