### PR TITLE
Enable Codecov flag carryforward for accurate coverage badge

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
It fixes #21273.