### PR TITLE
Optimize runtime and memory usage of the integration tests

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -268,13 +268,8 @@ function getSelector(id) {
 }
 
 async function getRect(page, selector) {
-  // In Chrome something is wrong when serializing a `DomRect`,
-  // so we extract the values and return them ourselves.
   await page.waitForSelector(selector, { visible: true });
-  return page.$eval(selector, el => {
-    const { x, y, width, height } = el.getBoundingClientRect();
-    return { x, y, width, height };
-  });
+  return (await page.$(selector)).boundingBox();
 }
 
 function getQuerySelector(id) {

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -1403,6 +1403,10 @@ describe("PDF viewer", () => {
       );
     });
 
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
     it("keeps the content under the pinch centre fixed on the screen", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
@@ -1608,6 +1612,10 @@ describe("PDF viewer", () => {
         "tracemonkey_annotation_on_page_8.pdf",
         `.page[data-page-number = "1"] .endOfContent`
       );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
     });
 
     it("Check that the top right corner of the annotation is centered vertically", async () => {

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -992,7 +992,7 @@ async function startBrowser({
     // calls can run before events triggered by the previous protocol calls had
     // a chance to be processed (essentially causing events to get lost). This
     // value gives Chrome a more similar execution speed as Firefox.
-    options.slowMo = 5;
+    options.slowMo = 3;
 
     // avoid crash
     options.args = ["--no-sandbox", "--disable-setuid-sandbox"];


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

I have measured the total integration tests runtime before and after this changeset on my local machine, which resulted in the following overview that shows that Chrome particularly benefits from this change and that the runtime with coverage enabled is a lot more consistent between the two browsers now:

|                                               | Firefox      | Chrome      |
| -------------------------------------| ------------- | ------------- |
| Before, without coverage| 717.157 seconds | 851.043 seconds |
| Before, with coverage      | 888.631 seconds | 1143.479 seconds |
| After, without coverage    | 704.604 seconds **(-2%)** | 603.918 seconds **(-29%)** |
| After, with coverage          | 875.45 seconds **(-1.5%)** | 891.851 seconds **(-22%)** |

I have also obtained the following job metrics from GitHub Actions, comparing https://github.com/mozilla/pdf.js/actions/runs/25973188596 (the last `master` merge as of writing) to https://github.com/mozilla/pdf.js/actions/runs/25968399984?pr=21275 (this PR).

Before:

<img width="308" height="246" alt="afbeelding" src="https://github.com/user-attachments/assets/4ed0f2dc-b445-4a7e-ae9b-06e58ba8893e" />

After:

<img width="308" height="246" alt="afbeelding" src="https://github.com/user-attachments/assets/09f28a5b-4baf-4823-a420-9b812014b793" />

This shows that we reduce all jobs by multiple minutes.