### PR TITLE
Clear the full SMask scratch canvas in compose()

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -1850,17 +1850,13 @@ class CanvasGraphics {
       return;
     }
 
-    // Whatever was drawn has been moved to the suspended canvas, now clear it
-    // out of the current canvas. Only the dirty box region needs clearing;
-    // everything outside it is already transparent.
+    // Clear the full scratch canvas, not just the dirty box. Pixels left
+    // outside dirtyBox can leak into a later compose() whose destination-in
+    // pass doesn't overwrite them, producing stale output -- this is what
+    // breaks `firefox-issue17779-partial` (issue #21276).
     this.ctx.save();
     this.ctx.setTransform(1, 0, 0, 1, 0, 0);
-    this.ctx.clearRect(
-      dirtyBox[0],
-      dirtyBox[1],
-      dirtyBox[2] - dirtyBox[0],
-      dirtyBox[3] - dirtyBox[1]
-    );
+    this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
     this.ctx.restore();
   }
 


### PR DESCRIPTION
PR #21101 narrowed `compose()`'s `clearRect` from full canvas to the caller-supplied dirty box. That leaves pixels outside the current dirty box on the SMask scratch canvas between `compose()` calls; subsequent draws into scratch are then source-over-blended on top of those leftovers, so the output depends on the cumulative draw history rather than just the current draw.