### PR TITLE
Remove the `Util.domMatrixToTransform` method

### DIFF
--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -14,6 +14,7 @@
  */
 
 import { BBOX_INIT, FeatureTest, Util } from "../shared/util.js";
+import { getCurrentTransform } from "./display_utils.js";
 import { MathClamp } from "../shared/math_clamp.js";
 
 const FORCED_DEPENDENCY_LABEL = "__forcedDependency";
@@ -1121,7 +1122,7 @@ class CanvasImagesTracker {
       this.#coords = newCoords;
     }
 
-    const transform = Util.domMatrixToTransform(ctx.getTransform());
+    const transform = getCurrentTransform(ctx);
 
     // We want top left, bottom left, top right.
     // (0, 0) is the bottom left corner.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -709,10 +709,6 @@ class Util {
     return `#${this.hexNums[r]}${this.hexNums[g]}${this.hexNums[b]}`;
   }
 
-  static domMatrixToTransform(dm) {
-    return [dm.a, dm.b, dm.c, dm.d, dm.e, dm.f];
-  }
-
   // Apply a scaling matrix to some min/max values.
   // If a scaling factor is negative then min and max must be
   // swapped.


### PR DESCRIPTION
This method is unused in the worker-thread and has only *a single* call-site in the main-thread, which can be trivially replaced with the `getCurrentTransform` helper function.