### PR TITLE
Ignore abstract methods when reporting test coverage

### DIFF
--- a/src/shared/base_pdf_stream.js
+++ b/src/shared/base_pdf_stream.js
@@ -35,6 +35,7 @@ class BasePDFStream {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePDFStream
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePDFStream.");
     }
     this._source = source;
@@ -123,6 +124,7 @@ class BasePDFStreamReader {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePDFStreamReader
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePDFStreamReader.");
     }
     this._stream = stream;
@@ -188,6 +190,7 @@ class BasePDFStreamReader {
    * @returns {Promise}
    */
   async read() {
+    /* istanbul ignore next */
     unreachable("Abstract method `read` called");
   }
 
@@ -196,6 +199,7 @@ class BasePDFStreamReader {
    * @param {Object} reason
    */
   cancel(reason) {
+    /* istanbul ignore next */
     unreachable("Abstract method `cancel` called");
   }
 }
@@ -211,6 +215,7 @@ class BasePDFStreamRangeReader {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePDFStreamRangeReader
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePDFStreamRangeReader.");
     }
     this._stream = stream;
@@ -225,6 +230,7 @@ class BasePDFStreamRangeReader {
    * @returns {Promise}
    */
   async read() {
+    /* istanbul ignore next */
     unreachable("Abstract method `read` called");
   }
 
@@ -233,6 +239,7 @@ class BasePDFStreamRangeReader {
    * @param {Object} reason
    */
   cancel(reason) {
+    /* istanbul ignore next */
     unreachable("Abstract method `cancel` called");
   }
 }


### PR DESCRIPTION
In the PDF.js code-base there's a fair number of base classes that contain abstract methods, that throw if invoked, which must be implemented fully in every extending class.
These abstract methods help catch developer mistakes, and also document the base classes, however their code will never actually run. Despite that these methods still contribute to the test coverage, which means that they essentially block many files from ever reaching 100 percent test coverage.

---

*Submitted as a draft, and updating just a single file at first, to check if this first of all works and secondly if this is even deemed a good idea.*