### PR TITLE
Move the `SVG_NS` definition into `src/shared/util.js`

### DIFF
--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -102,13 +102,12 @@ import {
   getStringOption,
   HTMLResult,
 } from "./utils.js";
-import { Util, warn } from "../../shared/util.js";
+import { SVG_NS, Util, warn } from "../../shared/util.js";
 import { getMetrics } from "./fonts.js";
 import { recoverJsURL } from "../core_utils.js";
 import { searchNode } from "./som.js";
 
 const TEMPLATE_NS_ID = NamespaceIds.template.id;
-const SVG_NS = "http://www.w3.org/2000/svg";
 
 // In case of lr-tb (and rl-tb) layouts, we try:
 //  - to put the container at the end of a line

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -38,6 +38,7 @@ import {
   LINE_FACTOR,
   makeArr,
   shadow,
+  SVG_NS,
   unreachable,
   Util,
   warn,
@@ -666,8 +667,7 @@ class AnnotationElement {
       style.borderWidth = 0;
       svgBuffer = [
         "url('data:image/svg+xml;utf8,",
-        `<svg xmlns="http://www.w3.org/2000/svg"`,
-        ` preserveAspectRatio="none" viewBox="0 0 1 1">`,
+        `<svg xmlns="${SVG_NS}" preserveAspectRatio="none" viewBox="0 0 1 1">`,
         `<g fill="transparent" stroke="${borderColor}" stroke-width="${borderWidth}">`,
       ];
       this.container.classList.add("hasBorder");

--- a/src/display/display_utils.js
+++ b/src/display/display_utils.js
@@ -25,8 +25,6 @@ import { MathClamp } from "../shared/math_clamp.js";
 import { PageViewport } from "./page_viewport.js";
 import { XfaLayer } from "./xfa_layer.js";
 
-const SVG_NS = "http://www.w3.org/2000/svg";
-
 class PixelsPerInch {
   static CSS = 96.0;
 
@@ -844,5 +842,4 @@ export {
   StatTimer,
   stopEvent,
   SupportedImageMimeTypes,
-  SVG_NS,
 };

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -24,6 +24,7 @@ import {
   FeatureTest,
   getUuid,
   shadow,
+  SVG_NS,
   Util,
   warn,
 } from "../../shared/util.js";
@@ -170,7 +171,7 @@ class ImageManager {
     // The "workaround" is to append "svgView(preserveAspectRatio(none))" to the
     // url, but according to comment #15, it seems that it leads to unexpected
     // behavior in Safari.
-    const svg = `data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 1 1" width="1" height="1" xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1" style="fill:red;"/></svg>`;
+    const svg = `data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 1 1" width="1" height="1" xmlns="${SVG_NS}"><rect width="1" height="1" style="fill:red;"/></svg>`;
     const canvas = new OffscreenCanvas(1, 3);
     const ctx = canvas.getContext("2d", { willReadFrequently: true });
     const image = new Image();

--- a/src/display/filter_factory.js
+++ b/src/display/filter_factory.js
@@ -13,8 +13,14 @@
  * limitations under the License.
  */
 
-import { getRGB, isDataScheme, SVG_NS } from "./display_utils.js";
-import { unreachable, updateUrlHash, Util, warn } from "../shared/util.js";
+import { getRGB, isDataScheme } from "./display_utils.js";
+import {
+  SVG_NS,
+  unreachable,
+  updateUrlHash,
+  Util,
+  warn,
+} from "../shared/util.js";
 
 class BaseFilterFactory {
   constructor() {

--- a/src/display/svg_factory.js
+++ b/src/display/svg_factory.js
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import { SVG_NS } from "./display_utils.js";
-import { unreachable } from "../shared/util.js";
+import { SVG_NS, unreachable } from "../shared/util.js";
 
 class BaseSVGFactory {
   constructor() {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -36,6 +36,8 @@ const LINE_FACTOR = 1.35;
 const LINE_DESCENT_FACTOR = 0.35;
 const BASELINE_FACTOR = LINE_DESCENT_FACTOR / LINE_FACTOR;
 
+const SVG_NS = "http://www.w3.org/2000/svg";
+
 /**
  * Refer to the `WorkerTransport.getRenderingIntent`-method in the API, to see
  * how these flags are being used:
@@ -1237,6 +1239,7 @@ export {
   stringToBytes,
   stringToUTF8String,
   stripPath,
+  SVG_NS,
   TextRenderingMode,
   UnknownErrorException,
   unreachable,


### PR DESCRIPTION
This constant is already defined in both the `src/core/` and `src/display/` folders, and in a few spots the same string was also inlined.