### PR TITLE
Remove the unused `Outline._normalizePagePoint` method

### DIFF
--- a/src/display/editor/drawers/outline.js
+++ b/src/display/editor/drawers/outline.js
@@ -85,19 +85,6 @@ class Outline {
     }
   }
 
-  static _normalizePagePoint(x, y, rotation) {
-    switch (rotation) {
-      case 90:
-        return [1 - y, x];
-      case 180:
-        return [1 - x, 1 - y];
-      case 270:
-        return [y, 1 - x];
-      default:
-        return [x, y];
-    }
-  }
-
   static createBezierPoints(x1, y1, x2, y2, x3, y3) {
     return [
       (x1 + 5 * x2) / 6,


### PR DESCRIPTION
This method was added in PR #19093, back in 2024, however it never actually appears to have been used.