### PR TITLE
Enable the `must check that an existing highlight is ignored on hovering` integration test on Windows

### DIFF
--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1726,10 +1726,6 @@ describe("Highlight Editor", () => {
     it("must check that an existing highlight is ignored on hovering", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          if (navigator.platform.includes("Win")) {
-            pending("Fails consistently on Windows (issue #20136).");
-          }
-
           await switchToHighlight(page);
 
           const rect = await getSpanRectFromText(


### PR DESCRIPTION
It looks like this test passes consistently again, most likely after a combination of browser/Puppeteer/configuration updates and the completed switch to the WebDriver BiDi protocol.

Fixes #20136.