### PR TITLE
Don't use "internal" `EventBus` methods in the integration-tests

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -3066,7 +3066,7 @@ describe("Reorganize Pages View", () => {
           await waitAndClick(page, getThumbnailSelector(2));
 
           const handleMerged = await createPromise(page, resolve => {
-            window.PDFViewerApplication.eventBus._on(
+            window.PDFViewerApplication.eventBus.on(
               "thumbnailsloaded",
               resolve,
               { once: true }
@@ -3125,7 +3125,7 @@ describe("Reorganize Pages View", () => {
           await waitAndClick(page, getThumbnailSelector(1));
 
           const handleMerged = await createPromise(page, resolve => {
-            window.PDFViewerApplication.eventBus._on(
+            window.PDFViewerApplication.eventBus.on(
               "thumbnailsloaded",
               resolve,
               { once: true }
@@ -3161,7 +3161,7 @@ describe("Reorganize Pages View", () => {
           await waitForThumbnailVisible(page, 1);
 
           const handleMerged = await createPromise(page, resolve => {
-            window.PDFViewerApplication.eventBus._on(
+            window.PDFViewerApplication.eventBus.on(
               "thumbnailsloaded",
               resolve,
               { once: true }
@@ -3197,7 +3197,7 @@ describe("Reorganize Pages View", () => {
           await waitForTextToBe(page, labelSelector, `${FSI}1${PDI} selected`);
 
           const handleMerged = await createPromise(page, resolve => {
-            window.PDFViewerApplication.eventBus._on(
+            window.PDFViewerApplication.eventBus.on(
               "thumbnailsloaded",
               resolve,
               { once: true }


### PR DESCRIPTION
This way *guarantees* that any and all internal viewer state has been updated first, before any test-specific code runs.