### PR TITLE
Add a pref to postMessage when mozPrintCallback has completed (bug 2036265)

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -369,6 +369,11 @@ const defaultOptions = {
     value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  postMessageAfterPrintCallback: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
   printResolution: {
     /** @type {number} */
     value: 150,

--- a/web/firefox_print_service.js
+++ b/web/firefox_print_service.js
@@ -23,6 +23,7 @@ import {
   BasePrintServiceFactory,
   getXfaHtmlForPrinting,
 } from "./print_utils.js";
+import { AppOptions } from "./app_options.js";
 
 // Creates a placeholder with div and canvas with right size for the page.
 function composePage(
@@ -31,6 +32,7 @@ function composePage(
   size,
   printContainer,
   printResolution,
+  shouldPostMessageAfterPrintCallback,
   optionalContentConfigPromise,
   printAnnotationStoragePromise
 ) {
@@ -94,6 +96,9 @@ function composePage(
             currentRenderTask = null;
           }
           obj.done();
+          if (shouldPostMessageAfterPrintCallback) {
+            window.postMessage("ready", "*");
+          }
         },
         function (reason) {
           if (!(reason instanceof RenderingCancelledException)) {
@@ -111,6 +116,9 @@ function composePage(
             obj.abort();
           } else {
             obj.done();
+          }
+          if (shouldPostMessageAfterPrintCallback) {
+            window.postMessage("error", "*");
           }
         }
       );
@@ -171,6 +179,9 @@ class FirefoxPrintService {
       return;
     }
 
+    const shouldPostMessageAfterPrintCallback = AppOptions.get(
+      "postMessageAfterPrintCallback"
+    );
     for (let i = 0, ii = pagesOverview.length; i < ii; ++i) {
       composePage(
         pdfDocument,
@@ -178,6 +189,7 @@ class FirefoxPrintService {
         pagesOverview[i],
         printContainer,
         _printResolution,
+        shouldPostMessageAfterPrintCallback,
         _optionalContentConfigPromise,
         _printAnnotationStoragePromise
       );


### PR DESCRIPTION
## Summary

- Adds a new `postMessageAfterPrintCallback` browser option (default `false`).
- When enabled by Firefox via the `pdfjs.postMessageAfterPrintCallback` pref, `web/firefox_print_service.js` posts `"ready"` or `"error"` to the window after each page's `mozPrintCallback` resolves.
- Allows embedders (e.g. print-preview test harnesses) to observe when print rendering for a page has actually finished, instead of relying on `STATE_STOP`.

This upstreams the viewer-side portion of [Phabricator D297837](https://phabricator.services.mozilla.com/D297837) (original patch by @dholbert). The Firefox-side pref wiring (PdfJsDefaultPrefs.js, PdfStreamConverter.sys.mjs) lives in mozilla-central; only the PDF.js bits land here so they aren't overwritten at the next pdf.js import.

See [bug 2036265](https://bugzilla.mozilla.org/show_bug.cgi?id=2036265) for context.

## Test plan

- [ ] `npx gulp lint` passes.
- [ ] With `pdfjs.postMessageAfterPrintCallback` flipped on in Firefox, printing a PDF results in one `window.postMessage("ready", "*")` per page on success and `"error"` on failure.
- [ ] Default behavior (pref off) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)