### PR TITLE
Extend unit-test coverage for the `getPdfFilenameFromUrl` helper function

### DIFF
--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -151,6 +151,9 @@ describe("display_utils", function () {
       expect(getPdfFilenameFromUrl("/pdfs/%AA.pdf")).toEqual("%AA.pdf");
 
       expect(getPdfFilenameFromUrl("/pdfs/%2F.pdf")).toEqual("%2F.pdf");
+
+      // A corrupt relative URL.
+      expect(getPdfFilenameFromUrl("//%%file.pdf")).toEqual("document.pdf");
     });
 
     it("gets PDF filename from (some) standard protocols", function () {


### PR DESCRIPTION
Currently there's a couple of branches, specifically for dealing with corrupt URLs, that are not covered by tests.