### PR TITLE
Restore editor layer state during page mutations

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -355,9 +355,6 @@ class PDFPageView extends BasePDFPageView {
   }
 
   updatePageNumber(newPageNumber) {
-    if (this.id === newPageNumber) {
-      return;
-    }
     const oldPageNumber = this.id;
     this.id = newPageNumber;
     this.renderingId = `page${newPageNumber}`;


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/issues/21240

After page deletion, the [updatePageIndex()](https://github.com/mozilla/pdf.js/blob/25c7d9eaace0438316714aff7033dd5f4c1a542e/src/display/editor/tools.js#L1847) is syncing layers' enable/disable state but this happens _only_ for pages which indices changed. The index check happens here:

https://github.com/mozilla/pdf.js/blob/25c7d9eaace0438316714aff7033dd5f4c1a542e/web/pdf_page_view.js#L358-L360

The fix was to just remove this condition.

Another approach (my initial) was to sync the layers of the "hanging" pages when calling `endUpdatePages()` but I thought syncing needs to happen anyway for all pages, so it would be better to do it at once for all pages. The current solution is also much cleaner.