### PR TITLE
Prevent inherited spacing from affecting text layer

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -473,7 +473,8 @@ class TextLayer {
       // OffscreenCanvas.
       const canvas = document.createElement("canvas");
       canvas.style.cssText =
-        "position:absolute;top:0;left:0;width:0;height:0;display:none";
+        "position:absolute;top:0;left:0;width:0;height:0;display:none;" +
+        "letter-spacing:normal;word-spacing:normal";
       canvas.lang = lang;
       document.body.append(canvas);
       ctx = canvas.getContext("2d", {

--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -49,6 +49,61 @@ import { startBrowser } from "../test.mjs";
  */
 
 describe("Text layer", () => {
+  describe("Text layout", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        ".textLayer .endOfContent",
+        100,
+        {
+          postPageSetup: async page => {
+            await page.evaluate(() => {
+              const style = document.createElement("style");
+              style.textContent = `
+                body,
+                #mainContainer {
+                  letter-spacing: 5px;
+                  word-spacing: 5px;
+                }
+              `;
+              document.documentElement.append(style);
+            });
+          },
+        }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must ignore inherited text spacing styles", async () => {
+      await Promise.all(
+        pages.map(async ([_, page]) => {
+          const spacing = await page.evaluate(() => {
+            const textLayer = document.querySelector(".textLayer");
+            const span = textLayer.querySelector("span");
+            const textLayerStyle = getComputedStyle(textLayer);
+            const spanStyle = getComputedStyle(span);
+            return {
+              textLayerLetterSpacing: textLayerStyle.letterSpacing,
+              textLayerWordSpacing: textLayerStyle.wordSpacing,
+              spanLetterSpacing: spanStyle.letterSpacing,
+              spanWordSpacing: spanStyle.wordSpacing,
+            };
+          });
+
+          expect(spacing.textLayerLetterSpacing).toEqual("normal");
+          expect(spacing.spanLetterSpacing).toEqual("normal");
+          expect(["0px", "normal"]).toContain(spacing.textLayerWordSpacing);
+          expect(["0px", "normal"]).toContain(spacing.spanWordSpacing);
+        })
+      );
+    });
+  });
+
   describe("Text selection", () => {
     // page.mouse.move(x, y, { steps: ... }) doesn't work in Firefox, because
     // puppeteer will send fractional intermediate positions and Firefox doesn't

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -22,6 +22,8 @@
   overflow: clip;
   opacity: 1;
   line-height: 1;
+  letter-spacing: normal;
+  word-spacing: normal;
   text-size-adjust: none;
   forced-color-adjust: none;
   transform-origin: 0 0;


### PR DESCRIPTION
## Summary

Fixes #21259.

This prevents inherited `letter-spacing` and `word-spacing` from affecting the text layer. External page styles can otherwise change the rendered width/positioning of text-layer spans while the PDF canvas remains unchanged, causing text selection/highlight alignment issues.

The fix resets spacing on:

- `.textLayer`
- the hidden measurement canvas used by the text layer

A regression test was added to cover inherited spacing from the viewer container.

## Testing

- `npx eslint src/display/text_layer.js test/integration/text_layer_spec.mjs`
- `npx stylelint web/text_layer_builder.css`
- `npx gulp generic`
- Manual verification in the local viewer:
  - applied `letter-spacing: 5px` and `word-spacing: 5px` to `body` / `#mainContainer`
  - confirmed `body` had inherited spacing
  - confirmed `.textLayer` and text-layer spans stayed at neutral computed spacing
  - confirmed text selection remained aligned

Note: I also tried `npx gulp integrationtest --headless --noFirefox -t text_layer`, but it did not stay limited to the text-layer test and started running unrelated integration tests, so I stopped it locally.