### PR TITLE
Shorten the `fontFile` lookup a tiny bit

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4666,18 +4666,11 @@ class PartialEvaluator {
 
     let fontFile, fontFileN, subtype, length1, length2, length3;
     try {
-      fontFile = descriptor.get("FontFile");
-      if (fontFile) {
-        fontFileN = 1;
-      } else {
-        fontFile = descriptor.get("FontFile2");
+      for (const n of ["FontFile", "FontFile2", "FontFile3"]) {
+        fontFile = descriptor.get(n);
         if (fontFile) {
-          fontFileN = 2;
-        } else {
-          fontFile = descriptor.get("FontFile3");
-          if (fontFile) {
-            fontFileN = 3;
-          }
+          fontFileN = n;
+          break;
         }
       }
 

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -2698,7 +2698,7 @@ class Font {
       if (
         (header.version === "OTTO" &&
           (!properties.composite ||
-            (properties.fontFileN === 3 && parsedCff?.isCIDFont))) ||
+            (properties.fontFileN === "FontFile3" && parsedCff?.isCIDFont))) ||
         !tables.head ||
         !tables.hhea ||
         !tables.maxp ||


### PR DESCRIPTION
Rather than effectively duplicating code, we can use a loop instead.