### PR TITLE
Ignore abstract methods when reporting test coverage

### DIFF
--- a/external/builder/babel-plugin-pdfjs-preprocessor.mjs
+++ b/external/builder/babel-plugin-pdfjs-preprocessor.mjs
@@ -69,7 +69,8 @@ function babelPluginPDFJSPreprocessor(babel, ctx) {
   return {
     name: "babel-plugin-pdfjs-preprocessor",
     manipulateOptions({ parserOpts }) {
-      parserOpts.attachComment = false;
+      // Keep "istanbul ignore ..." comments when collecting coverage.
+      parserOpts.attachComment = ctx.defines.COVERAGE === true;
     },
     visitor: {
       "ExportNamedDeclaration|ImportDeclaration": ({ node }) => {

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1392,6 +1392,7 @@ class Annotation {
       this.appearance &&
       !this._streams.includes(this.appearance)
     ) {
+      /* istanbul ignore next */
       unreachable("The appearance stream should always be reset.");
     }
 
@@ -3369,6 +3370,7 @@ class ButtonWidgetAnnotation extends WidgetAnnotation {
       };
       char = "\x6C";
     } else {
+      /* istanbul ignore next */
       unreachable(`_getDefaultCheckedAppearance - unsupported type: ${type}`);
     }
 

--- a/src/core/base_stream.js
+++ b/src/core/base_stream.js
@@ -21,17 +21,20 @@ class BaseStream {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BaseStream
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BaseStream.");
     }
   }
 
   // eslint-disable-next-line getter-return
   get length() {
+    /* istanbul ignore next */
     unreachable("Abstract getter `length` accessed");
   }
 
   // eslint-disable-next-line getter-return
   get isEmpty() {
+    /* istanbul ignore next */
     unreachable("Abstract getter `isEmpty` accessed");
   }
 
@@ -40,10 +43,12 @@ class BaseStream {
   }
 
   getByte() {
+    /* istanbul ignore next */
     unreachable("Abstract method `getByte` called");
   }
 
   getBytes(length) {
+    /* istanbul ignore next */
     unreachable("Abstract method `getBytes` called");
   }
 
@@ -57,6 +62,7 @@ class BaseStream {
   }
 
   async asyncGetBytes() {
+    /* istanbul ignore next */
     unreachable("Abstract method `asyncGetBytes` called");
   }
 
@@ -112,6 +118,7 @@ class BaseStream {
   }
 
   getByteRange(begin, end) {
+    /* istanbul ignore next */
     unreachable("Abstract method `getByteRange` called");
   }
 
@@ -124,14 +131,17 @@ class BaseStream {
   }
 
   reset() {
+    /* istanbul ignore next */
     unreachable("Abstract method `reset` called");
   }
 
   moveStart() {
+    /* istanbul ignore next */
     unreachable("Abstract method `moveStart` called");
   }
 
   makeSubStream(start, length, dict = null) {
+    /* istanbul ignore next */
     unreachable("Abstract method `makeSubStream` called");
   }
 

--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -387,18 +387,22 @@ class IdentityCMap extends CMap {
   }
 
   mapCidRange(low, high, dstLow) {
+    /* istanbul ignore next */
     unreachable("should not call mapCidRange");
   }
 
   mapBfRange(low, high, dstLow) {
+    /* istanbul ignore next */
     unreachable("should not call mapBfRange");
   }
 
   mapBfRangeToArray(low, high, array) {
+    /* istanbul ignore next */
     unreachable("should not call mapBfRangeToArray");
   }
 
   mapOne(src, dst) {
+    /* istanbul ignore next */
     unreachable("should not call mapCidOne");
   }
 
@@ -435,6 +439,7 @@ class IdentityCMap extends CMap {
 
   // eslint-disable-next-line getter-return
   get isIdentityCMap() {
+    /* istanbul ignore next */
     unreachable("should not access .isIdentityCMap");
   }
 }

--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -141,6 +141,7 @@ class ColorSpace {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === ColorSpace
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize ColorSpace.");
     }
     this.name = name;
@@ -167,6 +168,7 @@ class ColorSpace {
    * The result placed into the dest array starting from the destOffset.
    */
   getRgbItem(src, srcOffset, dest, destOffset) {
+    /* istanbul ignore next */
     unreachable("Should not call ColorSpace.getRgbItem");
   }
 
@@ -180,6 +182,7 @@ class ColorSpace {
    * array).
    */
   getRgbBuffer(src, srcOffset, count, dest, destOffset, bits, alpha01) {
+    /* istanbul ignore next */
     unreachable("Should not call ColorSpace.getRgbBuffer");
   }
 
@@ -189,6 +192,7 @@ class ColorSpace {
    * |alpha01| is either 0 (RGB output) or 1 (RGBA output).
    */
   getOutputLength(inputLength, alpha01) {
+    /* istanbul ignore next */
     unreachable("Should not call ColorSpace.getOutputLength");
   }
 
@@ -438,6 +442,7 @@ class PatternCS extends ColorSpace {
   }
 
   isDefaultDecode(decode, bpc) {
+    /* istanbul ignore next */
     unreachable("Should not call PatternCS.isDefaultDecode");
   }
 }

--- a/src/core/colorspace_utils.js
+++ b/src/core/colorspace_utils.js
@@ -45,6 +45,7 @@ class ColorSpaceUtils {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       (!globalColorSpaceCache || !localColorSpaceCache)
     ) {
+      /* istanbul ignore next */
       unreachable(
         'ColorSpaceUtils.parse - expected "globalColorSpaceCache"/"localColorSpaceCache" argument.'
       );

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -197,6 +197,7 @@ class AESBaseCipher {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === AESBaseCipher
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize AESBaseCipher.");
     }
     this.buffer = new Uint8Array(16);
@@ -204,6 +205,7 @@ class AESBaseCipher {
   }
 
   _expandKey(cipherKey) {
+    /* istanbul ignore next */
     unreachable("Cannot call `_expandKey` on the base class");
   }
 
@@ -640,11 +642,13 @@ class PDFBase {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === PDFBase
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize PDFBase.");
     }
   }
 
   _hash(password, input, userBytes) {
+    /* istanbul ignore next */
     unreachable("Abstract method `_hash` called");
   }
 

--- a/src/core/decode_stream.js
+++ b/src/core/decode_stream.js
@@ -48,6 +48,7 @@ class DecodeStream extends BaseStream {
   }
 
   readBlock() {
+    /* istanbul ignore next */
     unreachable("Abstract method `readBlock` called");
   }
 

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1039,10 +1039,12 @@ class PDFDocument {
       }
 
       static createObjId() {
+        /* istanbul ignore next */
         unreachable("Abstract method `createObjId` called.");
       }
 
       static getPageObjId() {
+        /* istanbul ignore next */
         unreachable("Abstract method `getPageObjId` called.");
       }
     };

--- a/src/core/font_renderer.js
+++ b/src/core/font_renderer.js
@@ -789,6 +789,7 @@ class CompiledFont {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === CompiledFont
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize CompiledFont.");
     }
     this.fontMatrix = fontMatrix;
@@ -858,6 +859,7 @@ class CompiledFont {
   }
 
   compileGlyphImpl() {
+    /* istanbul ignore next */
     unreachable("Children classes should implement this.");
   }
 

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -22,6 +22,7 @@ class BaseLocalCache {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BaseLocalCache
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BaseLocalCache.");
     }
     this._onlyRefs = options?.onlyRefs === true;
@@ -35,6 +36,7 @@ class BaseLocalCache {
 
   getByName(name) {
     if (this._onlyRefs) {
+      /* istanbul ignore next */
       unreachable("Should not call `getByName` method.");
     }
     const ref = this._nameRefMap.get(name);
@@ -49,6 +51,7 @@ class BaseLocalCache {
   }
 
   set(name, ref, data) {
+    /* istanbul ignore next */
     unreachable("Abstract method `set` called.");
   }
 }

--- a/src/core/name_number_tree.js
+++ b/src/core/name_number_tree.js
@@ -27,6 +27,7 @@ class NameOrNumberTree {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === NameOrNumberTree
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize NameOrNumberTree.");
     }
     this.root = root;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -51,6 +51,7 @@ class Pattern {
   static #hasGPU = false;
 
   constructor() {
+    /* istanbul ignore next */
     unreachable("Cannot initialize Pattern.");
   }
 
@@ -125,11 +126,13 @@ class BaseShading {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BaseShading
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BaseShading.");
     }
   }
 
   getIR() {
+    /* istanbul ignore next */
     unreachable("Abstract method `getIR` called.");
   }
 }
@@ -321,6 +324,7 @@ class RadialAxialShading extends BaseShading {
       r1 = coordsArr[5];
       type = "radial";
     } else {
+      /* istanbul ignore next */
       unreachable(`getPattern type unknown: ${shadingType}`);
     }
 
@@ -765,6 +769,7 @@ class MeshShading extends BaseShading {
         patchMesh = true;
         break;
       default:
+        /* istanbul ignore next */
         unreachable("Unsupported mesh type.");
         break;
     }

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -59,6 +59,7 @@ class BasePdfManager {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePdfManager
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePdfManager.");
     }
     this._docBaseUrl = parseDocBaseUrl(docBaseUrl);
@@ -125,18 +126,22 @@ class BasePdfManager {
   }
 
   async ensure(obj, prop, args) {
+    /* istanbul ignore next */
     unreachable("Abstract method `ensure` called");
   }
 
   requestRange(begin, end) {
+    /* istanbul ignore next */
     unreachable("Abstract method `requestRange` called");
   }
 
   requestLoadedStream(noFetch = false) {
+    /* istanbul ignore next */
     unreachable("Abstract method `requestLoadedStream` called");
   }
 
   sendProgressiveData(chunk) {
+    /* istanbul ignore next */
     unreachable("Abstract method `sendProgressiveData` called");
   }
 
@@ -145,6 +150,7 @@ class BasePdfManager {
   }
 
   terminate(reason) {
+    /* istanbul ignore next */
     unreachable("Abstract method `terminate` called");
   }
 }

--- a/src/core/to_unicode_map.js
+++ b/src/core/to_unicode_map.js
@@ -96,6 +96,7 @@ class IdentityToUnicodeMap {
   }
 
   amend(map) {
+    /* istanbul ignore next */
     unreachable("Should not call amend()");
   }
 }

--- a/src/core/wasm_image.js
+++ b/src/core/wasm_image.js
@@ -47,6 +47,7 @@ class WasmImage {
 
   // eslint-disable-next-line getter-return
   static get instance() {
+    /* istanbul ignore next */
     unreachable("Abstract getter `instance` accessed");
   }
 
@@ -61,6 +62,7 @@ class WasmImage {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === WasmImage
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize WasmImage.");
     }
 
@@ -131,6 +133,7 @@ class WasmImage {
   }
 
   async decode(bytes, _params) {
+    /* istanbul ignore next */
     unreachable("Abstract method `decode` called");
   }
 }

--- a/src/shared/base_pdf_stream.js
+++ b/src/shared/base_pdf_stream.js
@@ -35,6 +35,7 @@ class BasePDFStream {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePDFStream
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePDFStream.");
     }
     this._source = source;
@@ -123,6 +124,7 @@ class BasePDFStreamReader {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePDFStreamReader
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePDFStreamReader.");
     }
     this._stream = stream;
@@ -188,6 +190,7 @@ class BasePDFStreamReader {
    * @returns {Promise}
    */
   async read() {
+    /* istanbul ignore next */
     unreachable("Abstract method `read` called");
   }
 
@@ -196,6 +199,7 @@ class BasePDFStreamReader {
    * @param {Object} reason
    */
   cancel(reason) {
+    /* istanbul ignore next */
     unreachable("Abstract method `cancel` called");
   }
 }
@@ -211,6 +215,7 @@ class BasePDFStreamRangeReader {
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
       this.constructor === BasePDFStreamRangeReader
     ) {
+      /* istanbul ignore next */
       unreachable("Cannot initialize BasePDFStreamRangeReader.");
     }
     this._stream = stream;
@@ -225,6 +230,7 @@ class BasePDFStreamRangeReader {
    * @returns {Promise}
    */
   async read() {
+    /* istanbul ignore next */
     unreachable("Abstract method `read` called");
   }
 
@@ -233,6 +239,7 @@ class BasePDFStreamRangeReader {
    * @param {Object} reason
    */
   cancel(reason) {
+    /* istanbul ignore next */
     unreachable("Abstract method `cancel` called");
   }
 }


### PR DESCRIPTION
In the PDF.js code-base there's a fair number of base classes that contain abstract methods, that throw if invoked, which must be implemented fully in every extending class.
These abstract methods help catch developer mistakes, and also document the base classes, however their code will never actually run. Despite that these methods still contribute to the test coverage, which means that they essentially block many files from ever reaching 100 percent test coverage.