### PR TITLE
Run unit-tests and integration-tests when the `external/builder/` folder is changed

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'gulpfile.mjs'
+      - 'external/builder/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/integration/**'
@@ -13,6 +14,7 @@ on:
   pull_request:
     paths:
       - 'gulpfile.mjs'
+      - 'external/builder/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/integration/**'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'gulpfile.mjs'
+      - 'external/builder/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/unit/**'
@@ -13,6 +14,7 @@ on:
   pull_request:
     paths:
       - 'gulpfile.mjs'
+      - 'external/builder/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/unit/**'


### PR DESCRIPTION
Given that changes to either the Babel plugin or the "old" builder could accidentally cause issues in the built files, it seems like a good idea to run all test-suites when the `external/builder/` folder is changed.