### PR TITLE
fix: keyboard shortcuts failing on non-Latin keyboard layouts

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -538,6 +538,22 @@ class KeyboardManager {
   }
 
   /**
+   * Normalize alphabetic keys for shortcut matching because `event.key`
+   * depends on the active keyboard layout (e.g. "я" instead of "z" on
+   * Russian layouts), while `event.code` represents the physical key.
+   */
+  #getNormalizedKey(event) {
+    const { code, key } = event;
+
+    // Normalize only A–Z physical keys
+    if (code && code.startsWith("Key") && code.length === 4) {
+      return code.slice(3).toLowerCase();
+    }
+
+    return key;
+  }
+
+  /**
    * Serialize an event into a string in order to match a
    * potential key for a callback.
    * @param {KeyboardEvent} event
@@ -556,7 +572,7 @@ class KeyboardManager {
     if (event.shiftKey) {
       this.buffer.push("shift");
     }
-    this.buffer.push(event.key);
+    this.buffer.push(this.#getNormalizedKey(event));
     const str = this.buffer.join("+");
     this.buffer.length = 0;
 
@@ -571,7 +587,9 @@ class KeyboardManager {
    * @returns
    */
   exec(self, event) {
-    if (!this.allKeys.has(event.key)) {
+    const key = this.#getNormalizedKey(event);
+
+    if (!this.allKeys.has(key)) {
       return;
     }
     const info = this.callbacks.get(this.#serialize(event));


### PR DESCRIPTION
Fixes #18856

Keyboard shortcuts in KeyboardManager were relying on 'event.key' for shortcut matching. This is layout-dependent and causes failures on non-Latin keyboard layouts (e.g. Russian), where alphabetic keys produce different values (e.g. "я" instead of "z").

This change introduces a normalized key extraction based on 'event.code' for alphabetic keys ('KeyA'-'KeyZ'), ensuring that shortcuts are matched using physical key positions rather than layout-dependent characters.

Changes:
- Added `#getNormalizedKey(event)` to normalize alphabetic keys using `event.code`
- Updated `exec()` early key check to use normalized key
- Updated `#serialize()` to use normalized key for consistent matching

This ensures keyboard shortcuts like Ctrl+Z, Ctrl+A, Ctrl+Y work correctly across all keyboard layouts while preserving existing behavior for non-alphabetic keys (Arrow keys, Enter, Delete, etc.).