### PR TITLE
Fix missing non-zero exit code for failure cases in `test.mjs`

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1148,6 +1148,7 @@ async function startBrowsers({ baseUrl, initializeSession, numSessions = 1 }) {
         })
         .catch(function (ex) {
           console.log(`Error while starting ${browserName}: ${ex.message}`);
+          session.numErrors = 1;
           closeSession(sessionName);
         });
     }
@@ -1395,6 +1396,7 @@ async function main() {
     // because the teardown logic of the tests did not get a chance to run.
     console.error(e);
     await Promise.all(sessions.map(session => closeSession(session.name)));
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
The two affected code paths caught and logged errors, but that wasn't reflected in the exit code of the process, and that is what GitHub Actions (and other tools) to determine if process execution was successful or not. This commit fixes the issue by making sure we consistently exit with code 1 in case of errors so that GitHub Actions pipelines correctly reflect the outcome of the test run.

Fixes #21356.

_Note that this fixes the immediate issue, but I'm planning to revisit error handling in this file altogether in a follow-up to simplify and centralize it, to reduce fragility due to having to handle this in multiple places now._

_Before this patch:_

```
$ npx gulp unittest --noFirefox
[snip]
### Running unit tests
Server running at http://127.0.0.1:45883/
Error while starting chrome: Could not find Chrome (ver. 148.0.7778.97). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
 2. your cache path is incorrectly configured (which is: /home/timvandermeij/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.

Run NaN tests
OHNOES!  No unit tests ran!
unit tests runtime was 0.1 seconds
[17:14:30] Finished 'runUnitTest' after 1.23 s
[17:14:30] Finished 'unittest' after 5.39 s

$ echo $?
0
```

_After this patch:_

```
$ npx gulp unittest --noFirefox
[snip]
### Running unit tests
Server running at http://127.0.0.1:33545/
Error while starting chrome: Could not find Chrome (ver. 148.0.7778.97). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
 2. your cache path is incorrectly configured (which is: /home/timvandermeij/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.

Run NaN tests
OHNOES!  No unit tests ran!
unit tests runtime was 0.1 seconds
[17:15:49] 'runUnitTest' errored after 1.24 s
[17:15:49] Error: Running unit tests failed.
    at ChildProcess.<anonymous> (file:///home/timvandermeij/Documenten/Ontwikkeling/pdf.js/Code/gulpfile.mjs:828:16)
    at ChildProcess.emit (node:events:509:20)
    at ChildProcess.emit (node:domain:536:15)
    at maybeClose (node:internal/child_process:1108:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
    at Process.callbackTrampoline (node:internal/async_hooks:131:14)
[17:15:49] 'unittest' errored after 5.48 s

$ echo $?
1
```