### PR TITLE
Bug 2035251 - Use toolkit's pdf icon as favicon

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -37,6 +37,7 @@ See https://github.com/adobe-type-tools/cmap-resources
       Inline style="…" attributes stay blocked via style-src (no fallback).
     -->
     <!--#if MOZCENTRAL-->
+    <!--<link rel="icon" type="image/svg+xml" href="chrome://global/skin/icons/pdf.svg" />-->
     <!--<meta
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; script-src resource: 'wasm-unsafe-eval'; worker-src resource:; style-src resource:; style-src-elem resource: 'unsafe-inline'; img-src resource: blob: data:; font-src resource:; connect-src resource:; base-uri 'none'; form-action 'none';"


### PR DESCRIPTION
Should follow https://phabricator.services.mozilla.com/D303238 which will hopefully land land the new pdf.svg icon