### PR TITLE
Run browser tests to collect code coverage data

### DIFF
--- a/.github/workflows/coverage_browser_tests.yml
+++ b/.github/workflows/coverage_browser_tests.yml
@@ -1,0 +1,99 @@
+name: Coverage (Browser tests)
+on:
+  push:
+    paths:
+      - 'gulpfile.mjs'
+      - 'external/builder/**'
+      - 'src/**'
+      - 'test/images/**'
+      - 'test/pdfs/**'
+      - 'test/resources/**'
+      - 'test/*.css'
+      - 'test/driver.js'
+      - 'test/test.mjs'
+      - 'test/test_manifest.json'
+      - 'test/test_slave.html'
+      - 'web/**'
+      - '.github/workflows/coverage_browser_tests.yml'
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'gulpfile.mjs'
+      - 'external/builder/**'
+      - 'src/**'
+      - 'test/images/**'
+      - 'test/pdfs/**'
+      - 'test/resources/**'
+      - 'test/*.css'
+      - 'test/driver.js'
+      - 'test/test.mjs'
+      - 'test/test_manifest.json'
+      - 'test/test_slave.html'
+      - 'web/**'
+      - '.github/workflows/coverage_browser_tests.yml'
+    branches:
+      - master
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / firefox
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [lts/*]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    environment: code-coverage
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Restore cached PDF files
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: test/pdfs/*.pdf
+          key: cached-pdf-files-${{ hashFiles('test/pdfs/*.pdf') }}
+          restore-keys: |
+            cached-pdf-files-
+          enableCrossOsArchive: true
+
+      - name: Run browser tests with code coverage
+        run: npx gulp botbrowsertest --headless -j$(nproc) --coverage --coverage-output build/coverage/browser --noChrome
+
+      - name: Save cached PDF files
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: test/pdfs/*.pdf
+          key: cached-pdf-files-${{ hashFiles('test/pdfs/*.pdf') }}
+          enableCrossOsArchive: true
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./build/coverage/browser/lcov.info
+          flags: browsertest
+          name: codecov-umbrella
+          disable_search: true
+          disable_telem: true
+          verbose: true


### PR DESCRIPTION
Obviously it's not yet possible to just migrate `gulp browsertest` to GitHub Actions, however it's already possible to at least run the browser tests there which allows collection of more code coverage data.
This should thus give us more realistic coverage numbers, since currently there's many `src/` files that have very low code coverage.

By taking advantage of the fact that the GitHub Actions runners provide multiple cores, these tests are also fairly fast:
 - The ubuntu-latest/firefox job complete in ~9 minutes.
 - The windows-latest/firefox job complete in ~11 minutes.

---

*Please note:* I completely understand if this is deemed pointless since we still need to use the old bots for actual testing, but I figured that submitting this for consideration couldn't hurt.