### PR TITLE
Fix intermittent failure in the "must check that a freetext is still here after having updated it and scroll the doc" freetext editor integration test

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -3204,16 +3204,13 @@ describe("FreeText Editor", () => {
             .toEqual("Hello World and edited in Firefox");
 
           // Check that the canvas has nothing drawn at the annotation position.
-          await page.$eval(selector, el => (el.hidden = true));
-          let editorPng = await page.screenshot({
-            clip: editorRect,
-            type: "png",
-          });
-          await page.$eval(selector, el => (el.hidden = false));
-          let editorImage = PNG.sync.read(Buffer.from(editorPng));
-          expect(editorImage.data.every(x => x === 0xff))
-            .withContext(`In ${browserName}`)
-            .toBeTrue();
+          let isWhite = await isCanvasMonochrome(
+            page,
+            1,
+            editorRect,
+            0xffffffff
+          );
+          expect(isWhite).withContext(`In ${browserName}`).toBeTrue();
 
           const oneToThirteen = Array.from(new Array(13).keys(), n => n + 2);
           for (const pageNumber of oneToThirteen) {
@@ -3253,14 +3250,8 @@ describe("FreeText Editor", () => {
 
           await awaitPromise(handlePromise);
 
-          editorPng = await page.screenshot({
-            clip: editorRect,
-            type: "png",
-          });
-          editorImage = PNG.sync.read(Buffer.from(editorPng));
-          expect(editorImage.data.every(x => x === 0xff))
-            .withContext(`In ${browserName}`)
-            .toBeFalse();
+          isWhite = await isCanvasMonochrome(page, 1, editorRect, 0xffffffff);
+          expect(isWhite).withContext(`In ${browserName}`).toBeFalse();
         })
       );
     });


### PR DESCRIPTION
The problem is that we screenshot the page itself rather than the canvas, even though we specifically care about the latter according to the comment, which means that we manually have to take care of hiding and showing the annotation editor. This is problematic because even though we signal that the annotation editor should be hidden, we don't wait until that is actually done, which leads to a situation where we can take the screenshot before the annotation editor is actually invisible in the view.

This commit fixes the issue by screenshotting the canvas instead, which avoids the need for manually hiding/showing the annotation editor. This makes the test less fragile, and matches other tests better.

Fixes #21362.