### PR TITLE
Disable WebGPU for Firefox tests

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1061,6 +1061,9 @@ async function startBrowser({
       // Disable hardware acceleration (fixes rendering issues, see #15168 and
       // #21272, and environments like GitHub Actions don't expose GPUs anyway).
       "gfx.canvas.accelerated": false,
+      // Disable WebGPU (prevents log spam on Windows, and environments like
+      // GitHub Actions don't expose GPUs anyway).
+      "dom.webgpu.enabled": false,
       // It's helpful to see where the caret is.
       "accessibility.browsewithcaret": true,
       // Disable the newtabpage stuff.


### PR DESCRIPTION
The GitHub Actions workflow for the integration tests on Windows logs the following line for every test:

`JavaScript warning: http://127.0.0.1:62313/build/generic/build/pdf.mjs,
line 134934: WebGPU is disabled by blocklist.`

On Linux WebGPU is disabled by default because of missing support, but on Windows it's enabled by default since bug 1972486, so we try to obtain a GPU adapter which fails (and logs) if there is no actual GPU like on GitHub Actions. Coverage data confirms that our own WebGPU code is already uncovered because of the lack of a GPU, so having WebGPU enabled or disabled doesn't change that, but if it causes log spam it seems better to disable it, which this commit does.

Note that Chrome doesn't seem to have a matching flag, but Chrome already doesn't log anything about this (which is the primary driver for this change), so that's not a problem.