### PR TITLE
Mark a couple of viewer, and editor, EventBus listeners as "internal"

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1231,7 +1231,7 @@ class AnnotationEditorUIManager {
         resolve();
       }
     };
-    this._eventBus.on("editorsrendered", onEditorsRendered);
+    this._eventBus.on("editorsrendered", onEditorsRendered, internalOpt);
     await promise;
   }
 
@@ -1248,6 +1248,7 @@ class AnnotationEditorUIManager {
     this._eventBus.on("annotationeditormodechanged", callback, {
       once: true,
       signal: this._signal,
+      ...internalOpt,
     });
     this._eventBus.dispatch("showannotationeditorui", {
       source: this,

--- a/web/app.js
+++ b/web/app.js
@@ -884,8 +884,10 @@ const PDFViewerApplication = {
     if (!this.supportsPrinting) {
       togglePrintingButtons(false);
     } else {
-      eventBus.on("printingallowed", ({ isAllowed }) =>
-        togglePrintingButtons(isAllowed)
+      eventBus.on(
+        "printingallowed",
+        ({ isAllowed }) => togglePrintingButtons(isAllowed),
+        internalOpt
       );
     }
 
@@ -1452,7 +1454,7 @@ const PDFViewerApplication = {
           }
           resolve(isAllowed);
         },
-        { once: true }
+        { once: true, ...internalOpt }
       );
     });
 

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -237,12 +237,12 @@ class PDFThumbnailViewer {
         this.#newBadge = newSpan;
       }
 
-      this.eventBus.on(
+      eventBus.on(
         "pagesloaded",
         () => {
           menuButton.disabled = false;
         },
-        { once: true }
+        { once: true, ...internalOpt }
       );
 
       this._manageMenu = new Menu(menu, menuButton, [
@@ -266,27 +266,31 @@ class PDFThumbnailViewer {
       this.#toggleMenuEntries(false);
       menuButton.disabled = true;
 
-      this.eventBus.on("editingaction", ({ name }) => {
-        switch (name) {
-          case "copyPage":
-            this.#copyPages();
-            break;
-          case "cutPage":
-            this.#cutPages();
-            break;
-          case "deletePage":
-            this.#deletePages("delete");
-            break;
-          case "savePage":
-            this.#saveExtractedPages();
-            break;
-        }
-      });
+      eventBus.on(
+        "editingaction",
+        ({ name }) => {
+          switch (name) {
+            case "copyPage":
+              this.#copyPages();
+              break;
+            case "cutPage":
+              this.#cutPages();
+              break;
+            case "deletePage":
+              this.#deletePages("delete");
+              break;
+            case "savePage":
+              this.#saveExtractedPages();
+              break;
+          }
+        },
+        internalOpt
+      );
 
       this.container.addEventListener(
         "contextmenu",
         e => {
-          this.eventBus.dispatch("editingstateschanged", {
+          eventBus.dispatch("editingstateschanged", {
             source: this,
             details: {
               thumbnailId:
@@ -1386,11 +1390,15 @@ class PDFThumbnailViewer {
   }
 
   #addEventListeners() {
-    this.eventBus.on("resize", ({ source }) => {
-      if (source.thumbnailsView === this.container) {
-        this.#computeThumbnailsPosition();
-      }
-    });
+    this.eventBus.on(
+      "resize",
+      ({ source }) => {
+        if (source.thumbnailsView === this.container) {
+          this.#computeThumbnailsPosition();
+        }
+      },
+      internalOpt
+    );
     this.container.addEventListener("keydown", e => {
       const { target } = e;
       const isCheckbox =


### PR DESCRIPTION
There's currently a few EventBus listeners that aren't marked as "internal", however I'm assuming that they probably should be (e.g. to reduce the risk of intermittent failures in the integration-tests).