### PR TITLE
Handle Escape for active annotation tools

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1810,6 +1810,15 @@ class AnnotationEditorUIManager {
       this.#mode !== AnnotationEditorType.NONE &&
       !this.isEditorHandlingKeyboard
     ) {
+      if (
+        event.key === "Escape" &&
+        !this.hasSomethingToControl() &&
+        !this.#currentDrawingSession
+      ) {
+        this.updateToolbar({ mode: AnnotationEditorType.NONE });
+        stopEvent(event);
+        return;
+      }
       AnnotationEditorUIManager._keyboardManager.exec(this, event);
     }
   }

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -128,6 +128,28 @@ describe("FreeText Editor", () => {
       await closePages(pages);
     });
 
+    it("must turn off the active editor tool with Escape", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await switchToFreeText(page);
+
+          const modeChangedHandle = await waitForAnnotationModeChanged(page);
+          await page.keyboard.press("Escape");
+          await awaitPromise(modeChangedHandle);
+
+          await page.waitForSelector("#editorFreeTextButton:not(.toggled)");
+          await page.waitForSelector(
+            ".annotationEditorLayer:not(.freetextEditing)"
+          );
+
+          const mode = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.annotationEditorMode
+          );
+          expect(mode).withContext(`In ${browserName}`).toEqual(0);
+        })
+      );
+    });
+
     it("must write a string in a FreeText editor", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {


### PR DESCRIPTION
Problem
- The annotation toolbar can be enabled from the keyboard/mouse, but pressing Escape only unselects existing editors and does not turn off the active tool when no editor is selected.

Root cause
- The editor keyboard manager handles Escape for selected or active editors, but there was no Escape path for the active tool mode itself.

Solution
- When an annotation editor mode is active and there is no active editor, selection, or drawing session to handle, Escape switches the editor mode back to none.
- Added integration coverage for the FreeText toolbar state and viewer mode after Escape.

Tests run
- npx prettier --check src/display/editor/tools.js test/integration/freetext_editor_spec.mjs
- npx eslint src/display/editor/tools.js test/integration/freetext_editor_spec.mjs --report-unused-disable-directives
- git diff --check
- npx gulp generic
- Focused browser smoke test against the built generic viewer for Escape deselecting the active FreeText tool

Fixes #20199