### PR TITLE
Add wheel zoom sensitivity option

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -135,6 +135,45 @@ describe("PDF viewer", () => {
         })
       );
     });
+
+    it("must respect custom mouse wheel zoom sensitivity", async () => {
+      const sensitivePages = await loadAndWait(
+        "empty.pdf",
+        ".textLayer .endOfContent",
+        1000,
+        null,
+        { wheelzoomsensitivity: 0.25 }
+      );
+
+      try {
+        await Promise.all(
+          sensitivePages.map(async ([browserName, page]) => {
+            await page.keyboard.down("Control");
+            try {
+              const zoomGetter = () =>
+                page.evaluate(
+                  () => window.PDFViewerApplication.pdfViewer.currentScale
+                );
+              const initialZoom = await zoomGetter();
+
+              await page.mouse.wheel({ deltaY: 100 });
+              expect(await zoomGetter())
+                .withContext(`In ${browserName}`)
+                .toEqual(initialZoom);
+
+              await page.mouse.wheel({ deltaY: 100 });
+              expect(await zoomGetter())
+                .withContext(`In ${browserName}`)
+                .toBeLessThan(initialZoom);
+            } finally {
+              await page.keyboard.up("Control");
+            }
+          })
+        );
+      } finally {
+        await closePages(sensitivePages);
+      }
+    });
   });
 
   describe("Zoom commands", () => {

--- a/web/app.js
+++ b/web/app.js
@@ -390,6 +390,7 @@ const PDFViewerApplication = {
         pageColorsBackground: x => x,
         pageColorsForeground: x => x,
         sidebarViewOnLoad: x => parseInt(x, 10),
+        wheelZoomSensitivity: x => parseFloat(x),
       });
     }
 
@@ -2888,6 +2889,8 @@ function onWheel(evt) {
       );
       this.updateZoom(null, scaleFactor, origin);
     } else {
+      const sensitivity = AppOptions.get("wheelZoomSensitivity");
+      const wheelZoomSensitivity = sensitivity > 0 ? sensitivity : 1;
       const delta = normalizeWheelEventDirection(evt);
 
       let ticks = 0;
@@ -2902,15 +2905,15 @@ function onWheel(evt) {
         //
         // If we're getting fractional lines (I can't think of a scenario
         // this might actually happen), be safe and use the accumulator.
-        ticks =
-          Math.abs(delta) >= 1
-            ? Math.sign(delta)
-            : this._accumulateTicks(delta, "_wheelUnusedTicks");
+        const ticksDelta =
+          (Math.abs(delta) >= 1 ? Math.sign(delta) : delta) *
+          wheelZoomSensitivity;
+        ticks = this._accumulateTicks(ticksDelta, "_wheelUnusedTicks");
       } else {
         // pixel-based devices
         const PIXELS_PER_LINE_SCALE = 30;
         ticks = this._accumulateTicks(
-          delta / PIXELS_PER_LINE_SCALE,
+          (delta * wheelZoomSensitivity) / PIXELS_PER_LINE_SCALE,
           "_wheelUnusedTicks"
         );
       }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -184,6 +184,11 @@ const defaultOptions = {
     value: "",
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  wheelZoomSensitivity: {
+    /** @type {number} */
+    value: 1,
+    kind: OptionKind.VIEWER,
+  },
   disableHistory: {
     /** @type {boolean} */
     value: false,


### PR DESCRIPTION
## Problem

Ctrl + mouse-wheel zoom currently converts the raw wheel delta directly into zoom ticks. On systems or embedders that produce large wheel deltas, one wheel notch can jump through several zoom levels.

## Root cause

The viewer has no way to scale the wheel delta before it is accumulated into zoom ticks. Pixel, line, and page wheel events all use the built-in sensitivity.

## Solution

Add a viewer-level `wheelZoomSensitivity` option with a default of `1`. The default keeps existing behavior, while embedders can set a smaller positive value to slow Ctrl + wheel zoom. Invalid non-positive values fall back to the default sensitivity. Pinch zoom stays on the existing scale-factor path.

Fixes mozilla/pdf.js#21297

## Tests

- `npx prettier --check web/app.js web/app_options.js test/integration/viewer_spec.mjs`
- `npx eslint web/app.js web/app_options.js test/integration/viewer_spec.mjs`
- `npx gulp generic`
- `git diff --check`
- Browser smoke: `wheelzoomsensitivity=0.25` keeps scale at `10` after one Ctrl-wheel event and zooms to `9` after the second accumulated event
- Browser smoke: default sensitivity zooms from `10` to `7.3` after one Ctrl-wheel event