### PR TITLE
Fix editor page index after page deletion

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1276,12 +1276,12 @@ class AnnotationEditorUIManager {
     this.#currentPageIndex = pageNumber - 1;
   }
 
-  deletePage(id) {
-    for (const editor of this.getEditors(id)) {
+  deletePage(pageIndex) {
+    for (const editor of this.getEditors(pageIndex)) {
       editor.remove();
     }
-    this.#allLayers.delete(id);
-    if (this.#currentPageIndex === id) {
+    this.#allLayers.delete(pageIndex);
+    if (this.#currentPageIndex === pageIndex) {
       this.#currentPageIndex = 0;
     }
   }

--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -34,6 +34,7 @@ import {
   waitAndClick,
   waitForBrowserTrip,
   waitForDOMMutation,
+  waitForPageRendered,
   waitForPointerUp,
   waitForSerialized,
   waitForStorageEntries,
@@ -2826,6 +2827,90 @@ describe("Reorganize Pages View", () => {
           expect(parseInt(pageCountAfterSecondDelete, 10))
             .withContext(`In ${browserName} after second delete`)
             .toBe(16);
+        })
+      );
+    });
+  });
+
+  describe("Annotation editor after deleting the current page", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "page_with_number.pdf",
+        ".annotationEditorLayer",
+        "1",
+        null,
+        { enableSplitMerge: true }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("should keep the ink editor usable on previous pages", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const pageCount = await page.$eval("#pageNumber", el =>
+            parseInt(el.max, 10)
+          );
+          const handlePageRendered = await waitForPageRendered(page, pageCount);
+          await page.evaluate(lastPage => {
+            window.PDFViewerApplication.pdfViewer.currentPageNumber = lastPage;
+          }, pageCount);
+          await awaitPromise(handlePageRendered);
+
+          await waitForThumbnailVisible(page, pageCount);
+
+          await waitAndClick(
+            page,
+            `.thumbnail:has(${getThumbnailSelector(pageCount)}) input`
+          );
+          const handlePagesEdited = await waitForPagesEdited(page);
+          await waitAndClick(page, "#viewsManagerStatusActionButton");
+          await waitAndClick(page, "#viewsManagerStatusActionDelete");
+          await awaitPromise(handlePagesEdited);
+
+          await page.waitForFunction(
+            expectedCount =>
+              parseInt(document.getElementById("pageNumber").max, 10) ===
+              expectedCount,
+            {},
+            pageCount - 1
+          );
+
+          await page.evaluate(() => {
+            window.PDFViewerApplication.pdfViewer.currentPageNumber = 1;
+          });
+          await page.waitForFunction(
+            () => window.PDFViewerApplication.page === 1
+          );
+
+          await switchToEditor("Ink", page);
+          const rect = await getRect(
+            page,
+            ".page[data-page-number='1'] .annotationEditorLayer"
+          );
+          const x = rect.x + rect.width * 0.3;
+          const y = rect.y + rect.height * 0.3;
+          const pointerUp = await waitForPointerUp(page);
+          await page.mouse.move(x, y);
+          await page.mouse.down();
+          await page.mouse.move(x + 50, y + 50);
+          await page.mouse.up();
+          await awaitPromise(pointerUp);
+
+          await page.keyboard.press("Escape");
+          await waitForSerialized(page, 1);
+          await page.waitForSelector(".page[data-page-number='1'] .inkEditor", {
+            visible: true,
+          });
+
+          const inkEditors = await page.$$(
+            ".page[data-page-number='1'] .inkEditor"
+          );
+          expect(inkEditors.length).withContext(`In ${browserName}`).toBe(1);
         })
       );
     });

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -430,7 +430,7 @@ class PDFPageView extends BasePDFPageView {
       return;
     }
     this.destroy();
-    this.#layerProperties.annotationEditorUIManager?.deletePage(this.id);
+    this.#layerProperties.annotationEditorUIManager?.deletePage(this.id - 1);
   }
 
   hasEditableAnnotations() {


### PR DESCRIPTION
## Problem

After deleting the current page in the reorganize-pages view, annotation tools can stop working on earlier pages. In #21240 this shows up after deleting the last page and then trying to use the Draw tool on previous pages.

## Root cause

`AnnotationEditorUIManager` tracks pages by zero-based page index. `PDFPageView.updatePageNumber()` already updates editor state with zero-based indexes, but `PDFPageView.deleteMe()` passed the one-based page id to `deletePage()`. When the deleted page was current, the editor manager could keep its current page index pointing at the removed page.

## Solution

Pass `this.id - 1` when deleting the editor page state, and rename the manager parameter to `pageIndex` so the zero-based contract is explicit. Added an integration regression that deletes the current last page, switches to Ink, and verifies drawing still works on page 1.

Fixes #21240

## Tests

- `npx prettier --check web\pdf_page_view.js src\display\editor\tools.js test\integration\reorganize_pages_spec.mjs`
- `npx eslint web\pdf_page_view.js src\display\editor\tools.js test\integration\reorganize_pages_spec.mjs`
- `npx gulp generic`
- `git diff --check`