### PR TITLE
Fix broken `enableSelectionRendering: false`

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1067,6 +1067,9 @@ class PDFPageView extends BasePDFPageView {
         },
         abortSignal: this.#abortSignal,
       });
+      if (this.enableSelectionRendering) {
+        this.textLayer.div.classList.add("selectionRendering");
+      }
     }
 
     if (

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -118,7 +118,18 @@
   }
 
   ::selection {
-    background: transparent;
+    /* stylelint-disable declaration-block-no-duplicate-properties */
+    /*#if !MOZCENTRAL*/
+    background: rgba(0 0 255 / 0.25);
+    /*#endif*/
+    /* stylelint-enable declaration-block-no-duplicate-properties */
+    background: color-mix(in srgb, AccentColor, transparent 50%);
+  }
+
+  &.selectionRendering {
+    ::selection {
+      background: transparent;
+    }
   }
 
   /* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */


### PR DESCRIPTION
This PR restores the CSS that was there before (https://github.com/mozilla/pdf.js/pull/20981/changes#diff-90b9c7e02c41b4051095250577f8dd385455429d67abe6bf360e13ef17d7fe19). And applies the new CSS, through a class, based on the option.

Closes GH-21374.
Related-to GH-20981.