### PR TITLE
Remove the `#externalHide` field from the `AnnotationLayerBuilder` class

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -72,8 +72,6 @@ class AnnotationLayerBuilder {
 
   #commentManager = null;
 
-  #externalHide = false;
-
   #onAppend = null;
 
   #eventAC = null;
@@ -226,8 +224,7 @@ class AnnotationLayerBuilder {
     this.#eventAC = null;
   }
 
-  hide(internal = false) {
-    this.#externalHide = !internal;
+  hide() {
     if (!this.div) {
       return;
     }
@@ -263,10 +260,6 @@ class AnnotationLayerBuilder {
     }
 
     await this.annotationLayer.addLinkAnnotations(newLinks);
-    // Don't show the annotation layer if it was explicitly hidden previously.
-    if (!this.#externalHide) {
-      this.div.hidden = false;
-    }
   }
 
   #updatePresentationModeState(state) {


### PR DESCRIPTION
Prior to PR #20321 the annotationLayer was hidden when there was no regular annotations on the page, which meant that if there were any inferred links (from the textLayer) the annotationLayer needed to be made visible but in such a way that it wouldn't override an explicit `hide`-call from the `PDFPageView` class.

With the changes in the aforementioned PR the annotationLayer is now always "visible", and this code can thus be simplified a little bit.