### PR TITLE
Add knockout_inner_backdrop ref test

### DIFF
--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -17,6 +17,7 @@
 !issue18408_reduced.pdf
 !bug1907000_reduced.pdf
 !knockout_blend_multiply.pdf
+!knockout_inner_backdrop.pdf
 !knockout_isolated_overlap.pdf
 !knockout_nested.pdf
 !knockout_nested_group_alpha.pdf

--- a/test/pdfs/knockout_inner_backdrop.pdf
+++ b/test/pdfs/knockout_inner_backdrop.pdf
@@ -1,0 +1,58 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /XObject << /OuterGroup 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 19 >>
+stream
+q
+/OuterGroup Do
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 200 200] /Group << /Type /Group /S /Transparency /K true /I true >> /Resources << /XObject << /InnerGroup 6 0 R >> >> /Length 41 >>
+stream
+0 0 1 rg
+0 0 200 200 re f
+/InnerGroup Do
+
+endstream
+endobj
+6 0 obj
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 200 200] /Group << /Type /Group /S /Transparency /K false /I false >> /Resources << /ExtGState << /GSM 7 0 R >> >> /Length 64 >>
+stream
+/GSM gs
+1 0 0 rg
+20 20 130 130 re f
+0 1 0 rg
+50 50 130 130 re f
+
+endstream
+endobj
+7 0 obj
+<< /Type /ExtGState /BM /Multiply >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000258 00000 n 
+0000000327 00000 n 
+0000000589 00000 n 
+0000000871 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+923
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -6833,6 +6833,14 @@
     "about": "Non-isolated knockout group with a Multiply blend mode element on a yellow backdrop; the element must blend against the backdrop, not against a transparent temp canvas."
   },
   {
+    "id": "knockout_inner_backdrop",
+    "file": "pdfs/knockout_inner_backdrop.pdf",
+    "md5": "4b3b77319b9b2c6e6f1836c121f488c7",
+    "rounds": 1,
+    "type": "eq",
+    "about": "Non-isolated, non-knockout subgroup that needs isolation (Multiply blend mode in its content) nested inside a knockout group; the subgroup's elements must blend against its own initial backdrop while its transparent areas leave the parent untouched."
+  },
+  {
     "id": "issue6010_1",
     "file": "pdfs/issue6010_1.pdf",
     "md5": "b58adce5dbb08936ddb0d904f0da8716",


### PR DESCRIPTION
Non-isolated subgroup needing isolation (Multiply BM) nested in a KO group, exercising the inner-backdrop blend path.