### PR TITLE
fix typo in bit flag value for suppressCropClip

### DIFF
--- a/src/scripting_api/print_params.js
+++ b/src/scripting_api/print_params.js
@@ -87,7 +87,7 @@ class PrintParams {
       suppressBG: 1 << 8,
       suppressCenter: 1 << 9,
       suppressCJKFontSubst: 1 << 10,
-      suppressCropClip: 1 << 1,
+      suppressCropClip: 1 << 11,
       suppressRotate: 1 << 12,
       suppressTransfer: 1 << 13,
       suppressUCR: 1 << 14,


### PR DESCRIPTION
suppressCropClip was assigned 1 << 1 instead of 1 << 11, which causes a collision with applySoftProofSettings. Any PDF script setting either of these flags would effectively set both.