### PR TITLE
Add one more unit-test case for invalid email domains in the `Autolinker` class

### DIFF
--- a/test/unit/autolinker_spec.js
+++ b/test/unit/autolinker_spec.js
@@ -149,6 +149,7 @@ describe("autolinker", function () {
         "abc.example.com", // URL without scheme.
         "JD?M$0QP)lKn06l1apKDC@\\qJ4B!!(5m+j.7F790m", // Not a valid email.
         "262@0.302304", // Invalid domain.
+        "foo@123.456", // Invalid domain.
       ].join("\n")
     );
     expect(matches.length).toEqual(0);


### PR DESCRIPTION
This improves coverage for a branch of the `Autolinker` class that wasn't previously tested.