### PR TITLE
Shorten the `DrawLayerBuilder.prototype.cancel` method a tiny bit

### DIFF
--- a/web/draw_layer_builder.js
+++ b/web/draw_layer_builder.js
@@ -68,10 +68,7 @@ class DrawLayerBuilder {
   cancel() {
     this._cancelled = true;
 
-    if (!this.#drawLayer) {
-      return;
-    }
-    this.#drawLayer.destroy();
+    this.#drawLayer?.destroy();
     this.#drawLayer = null;
   }
 


### PR DESCRIPTION
By replacing the early return with optional chaining, a pattern that we already use in lots of places, the code becomes a tiny bit shorter and more importantly the code coverage for this file becomes 100 percent.