### PR TITLE
Run various test-suite when the `external/` folder is modified

### DIFF
--- a/.github/workflows/coverage_browser_tests.yml
+++ b/.github/workflows/coverage_browser_tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - 'gulpfile.mjs'
-      - 'external/builder/**'
+      - 'external/**'
       - 'src/**'
       - 'test/images/**'
       - 'test/pdfs/**'
@@ -20,7 +20,7 @@ on:
   pull_request:
     paths:
       - 'gulpfile.mjs'
-      - 'external/builder/**'
+      - 'external/**'
       - 'src/**'
       - 'test/images/**'
       - 'test/pdfs/**'

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'gulpfile.mjs'
+      - 'external/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/font/**'
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - 'gulpfile.mjs'
+      - 'external/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/font/**'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - 'gulpfile.mjs'
-      - 'external/builder/**'
+      - 'external/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/integration/**'
@@ -14,7 +14,7 @@ on:
   pull_request:
     paths:
       - 'gulpfile.mjs'
-      - 'external/builder/**'
+      - 'external/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/integration/**'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - 'gulpfile.mjs'
-      - 'external/builder/**'
+      - 'external/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/unit/**'
@@ -14,7 +14,7 @@ on:
   pull_request:
     paths:
       - 'gulpfile.mjs'
-      - 'external/builder/**'
+      - 'external/**'
       - 'src/**'
       - 'test/test.mjs'
       - 'test/unit/**'


### PR DESCRIPTION
Given that the `external/` folder contains various imported code/resources, all of which could affect functionality and/or rendering, it seems safest to simply run browser/font/integration/unit tests whenever any part of that folder is touched.