### PR TITLE
Remove the `Map.prototype.getOrInsertComputed` polyfill from the scripting implementation (PR 21399 follow-up)

### DIFF
--- a/src/scripting_api/app_utils.js
+++ b/src/scripting_api/app_utils.js
@@ -31,20 +31,6 @@ function serializeError(error) {
 const makeArr = () => [];
 const makeMap = () => new Map();
 
-if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-  // TODO: Remove this once `Map.prototype.getOrInsertComputed` is supported in
-  // QuickJS.
-  if (typeof Map.prototype.getOrInsertComputed !== "function") {
-    // eslint-disable-next-line no-extend-native
-    Map.prototype.getOrInsertComputed = function (key, callbackFn) {
-      if (!this.has(key)) {
-        this.set(key, callbackFn(key));
-      }
-      return this.get(key);
-    };
-  }
-}
-
 export {
   FORMS_VERSION,
   makeArr,


### PR DESCRIPTION
All unit- and integration-tests pass with this patch, and according to the QuickJS changelog this is supported now; note https://github.com/bellard/quickjs/blob/3d5e064e9dd67c70f7962836505a7fa067bf0a4e/Changelog#L10 and https://github.com/tc39/proposal-upsert.