### PR TITLE
Fix transparent color of `::selection` in Firefox

### DIFF
--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -124,11 +124,13 @@
     /*#endif*/
     /* stylelint-enable declaration-block-no-duplicate-properties */
     background: color-mix(in srgb, AccentColor, transparent 50%);
+    color: transparent;
   }
 
   &.selectionRendering {
     ::selection {
       background: transparent;
+      color: transparent;
     }
   }
 


### PR DESCRIPTION
This forces `color: transparent` on selections.
In latest Firefox Nightly, this is no longer inherited on `::selection` from the normal element.

References: <https://github.com/mozilla-firefox/firefox/commit/753827d749820c3ebcf066e4356c502a91e6069d>