### PR TITLE
Add a `PDFViewer` helper method for setting `#printingAllowed` and dispatching the event

### DIFF
--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -720,6 +720,11 @@ class PDFViewer {
     });
   }
 
+  #setPrintingAllowed(isAllowed) {
+    this.#printingAllowed = isAllowed;
+    this.eventBus.dispatch("printingallowed", { source: this, isAllowed });
+  }
+
   /**
    * Currently only *some* permissions are supported.
    * @returns {Object}
@@ -731,22 +736,14 @@ class PDFViewer {
       textLayerMode: this.#textLayerMode,
     };
     if (!permissions) {
-      this.#printingAllowed = true;
-      this.eventBus.dispatch("printingallowed", {
-        source: this,
-        isAllowed: this.#printingAllowed,
-      });
-
+      this.#setPrintingAllowed(true);
       return params;
     }
 
-    this.#printingAllowed =
+    this.#setPrintingAllowed(
       permissions.includes(PermissionFlag.PRINT_HIGH_QUALITY) ||
-      permissions.includes(PermissionFlag.PRINT);
-    this.eventBus.dispatch("printingallowed", {
-      source: this,
-      isAllowed: this.#printingAllowed,
-    });
+        permissions.includes(PermissionFlag.PRINT)
+    );
 
     if (
       !permissions.includes(PermissionFlag.COPY) &&
@@ -922,7 +919,6 @@ class PDFViewer {
       this.#annotationEditorUIManager = null;
 
       this.#annotationEditorMode = AnnotationEditorType.NONE;
-
       this.#printingAllowed = true;
     }
 


### PR DESCRIPTION
This reduces a little bit of code duplication, which shouldn't hurt.