### PR TITLE
Fix an intermittent failure in the reorganize pages integration tests

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -117,6 +117,10 @@ async function drawInkLine(page, pageNumber) {
 }
 
 async function waitForHavingContents(page, expected) {
+  // Only visible pages render their text layer: enlarge the viewport so that,
+  // once shrunk to the minimum scale in WRAPPED mode below, all the pages fit
+  // on screen even for documents with many pages.
+  await page.setViewport({ width: 1500, height: 1500 });
   await page.evaluate(() => {
     // Make sure all the pages will be visible.
     window.PDFViewerApplication.pdfViewer.scrollMode = 2 /* = ScrollMode.WRAPPED = */;


### PR DESCRIPTION
`waitForHavingContents` shrinks to the minimum scale in WRAPPED mode so that every page is visible and renders its text layer. Since tests run with `defaultViewport: null` the window size is OS-dependent, so for the cut/copy tests (15-17 pages) some pages could stay outside the viewport and never render, making the helper wait forever.

It fixes #21403.