### PR TITLE
[api-minor] Remove the unused `convertToViewportRectangle` method in the `PageViewport` class

### DIFF
--- a/src/display/page_viewport.js
+++ b/src/display/page_viewport.js
@@ -190,27 +190,11 @@ class PageViewport {
    * @returns {Array} Array containing `x`- and `y`-coordinates of the
    *   point in the viewport coordinate space.
    * @see {@link convertToPdfPoint}
-   * @see {@link convertToViewportRectangle}
    */
   convertToViewportPoint(x, y) {
     const p = [x, y];
     Util.applyTransform(p, this.transform);
     return p;
-  }
-
-  /**
-   * Converts PDF rectangle to the viewport coordinates.
-   * @param {Array} rect - The xMin, yMin, xMax and yMax coordinates.
-   * @returns {Array} Array containing corresponding coordinates of the
-   *   rectangle in the viewport coordinate space.
-   * @see {@link convertToViewportPoint}
-   */
-  convertToViewportRectangle(rect) {
-    const topLeft = [rect[0], rect[1]];
-    Util.applyTransform(topLeft, this.transform);
-    const bottomRight = [rect[2], rect[3]];
-    Util.applyTransform(bottomRight, this.transform);
-    return [topLeft[0], topLeft[1], bottomRight[0], bottomRight[1]];
   }
 
   /**


### PR DESCRIPTION
This method has been completely unused for many years, possibly as far back as PR #8030, hence we can avoid shipping a little bit of dead code.

*Note:* If there's any third-party code depending on it, updating it ought to be as simple as changing
```javascript
const r = viewport.convertToViewportRectangle(rect);
```
into
```javascript
const r = [
  ...viewport.convertToViewportPoint(rect[0], rect[1]),
  ...viewport.convertToViewportPoint(rect[2], rect[3])
];
```