### PR TITLE
Remove viewerContainer from keyboard tab order

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -228,7 +228,7 @@ describe("PDF viewer", () => {
     });
   });
 
-  describe("viewerContainer tabindex", () => {
+  describe("viewerContainer tabindex (bug 20674)", () => {
     let pages;
 
     beforeEach(async () => {
@@ -239,7 +239,26 @@ describe("PDF viewer", () => {
       await closePages(pages);
     });
 
-    it("uses tabindex -1 while still allowing programmatic focus", async () => {
+    it("must not appear in sequential keyboard navigation", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // Reproduce #20674: tab through the viewer UI and ensure the
+          // scroll container is never a silent tab stop between toolbar
+          // controls and page content.
+          for (let i = 0; i < 120; i++) {
+            await page.keyboard.press("Tab");
+            const activeId = await page.evaluate(
+              () => document.activeElement?.id ?? null,
+            );
+            expect(activeId)
+              .withContext(`Tab stop ${i} in ${browserName}`)
+              .not.toEqual("viewerContainer");
+          }
+        }),
+      );
+    });
+
+    it("must still allow programmatic focus for editor/viewer code paths", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
           const { tabIndex, focusWorks } = await page.evaluate(() => {
@@ -251,13 +270,9 @@ describe("PDF viewer", () => {
             };
           });
 
-          expect(tabIndex)
-            .withContext(`In ${browserName}`)
-            .toEqual(-1);
-          expect(focusWorks)
-            .withContext(`In ${browserName}`)
-            .toBeTrue();
-        })
+          expect(tabIndex).withContext(`In ${browserName}`).toEqual(-1);
+          expect(focusWorks).withContext(`In ${browserName}`).toBeTrue();
+        }),
       );
     });
   });

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -228,6 +228,40 @@ describe("PDF viewer", () => {
     });
   });
 
+  describe("viewerContainer tabindex", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait("tracemonkey.pdf", ".textLayer .endOfContent");
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("uses tabindex -1 while still allowing programmatic focus", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const { tabIndex, focusWorks } = await page.evaluate(() => {
+            const container = document.getElementById("viewerContainer");
+            container.focus();
+            return {
+              tabIndex: container.tabIndex,
+              focusWorks: document.activeElement === container,
+            };
+          });
+
+          expect(tabIndex)
+            .withContext(`In ${browserName}`)
+            .toEqual(-1);
+          expect(focusWorks)
+            .withContext(`In ${browserName}`)
+            .toBeTrue();
+        })
+      );
+    });
+  });
+
   describe("CSS-only zoom", () => {
     function createPromiseForFirstPageRendered(page) {
       return createPromise(page, (resolve, reject) => {

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -108,7 +108,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           </button>
         </div>
 
-        <div id="viewerContainer" tabindex="0">
+        <div id="viewerContainer" tabindex="-1">
           <div id="viewer" class="pdfViewer"></div>
         </div>
       </div>

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -858,7 +858,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </div>
 
-        <div id="viewerContainer" tabindex="0">
+        <div id="viewerContainer" tabindex="-1">
           <div id="viewer" class="pdfViewer"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes #20674 by removing `#viewerContainer` from sequential keyboard navigation while preserving programmatic focus used by the viewer and editor tests.

## Problem

With `tabindex="0"`, `#viewerContainer` is a silent tab stop between toolbar controls and page content — no visible focus ring, confusing keyboard users (#20674).

## Investigation (per @calixteman in #20674)

- `tabindex="0"` was added in #3447 (2013) so Chrome/Opera could scroll the container via keyboard.
- Maintainer guidance: confirm impact with **screen readers** before landing; `-1` may be sufficient vs removing the attribute entirely.
- We use `tabindex="-1"` (not removal) because editor/viewer code and integration tests call `viewerContainer.focus()` programmatically; a plain `<div>` without `tabindex` is not reliably programmatically focusable.

## Fix

- `web/viewer.html` / `web/viewer-geckoview.html`: `tabindex="0"` → `tabindex="-1"`

## Testing

**Automated (integration):** `test/integration/viewer_spec.mjs`
1. Tab through the loaded viewer 120 times — `document.activeElement` must never be `#viewerContainer`.
2. Call `viewerContainer.focus()` — must succeed with `tabIndex === -1`.

**Manual accessibility checklist (requested in issue thread):**
- [ ] NVDA (Windows) / VoiceOver (macOS): open demo viewer, read document — structure tree and text layer still reachable.
- [ ] Keyboard: Tab from right-most toolbar control (`Tools` / secondary toolbar) to page content without an extra silent stop on the scroll container.
- [ ] Keyboard scrolling: verify arrow/page scrolling still works when focus is on page content or toolbar (regression check for #3447 intent).

I have not completed manual screen-reader verification in this environment; posting for maintainer review of the approach and test plan before merge.
