### PR TITLE
Fix intermittent failure in the `must check that the comment sidebar is resizable` comment integration test

### DIFF
--- a/test/integration/comment_spec.mjs
+++ b/test/integration/comment_spec.mjs
@@ -537,7 +537,11 @@ describe("Comment", () => {
             await page.mouse.down();
 
             const steps = 20;
-            await page.mouse.move(startX - extraWidth, startY, { steps });
+            for (let i = 1; i <= steps; i++) {
+              const x = Math.round(startX - (extraWidth * i) / steps);
+              await page.mouse.move(x, startY);
+              await waitForBrowserTrip(page);
+            }
             await page.mouse.up();
 
             const rectAfter = await getRect(page, sidebarSelector);


### PR DESCRIPTION
We use the generic `page.mouse.move(x, y, { steps }` API, but that purely performs the mouse move steps without having knowledge about if/how the application handles any events caused by it, so it doesn't wait for the sidebar to render before moving on. This causes intermittent failures if the sidebar didn't get enough time to render before the next mouse move is initiated (which can happen in slower environments).

This commit fixes the issue by doing the mouse move steps ourselves and by waiting for a browser trip between each of them to make sure that the sidebar got a chance to render.

Fixes #21447.
Relates to #21044 / #21045 / 24e5377.