### PR TITLE
Collect coverage data from "previous" workers when closing integration-tests

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -164,6 +164,11 @@ async function closeSinglePage(page) {
       } catch {}
     }
 
+    // Collect coverage data from "previous" workers, which happens if
+    // `PDFViewerApplication.open` was invoked more than once during the test
+    // (e.g. the "Merge PDF" tests).
+    const previousWorkerCoverage = globalThis._previousWorkerCoverage;
+
     // Close the viewer gracefully, and clear local storage to avoid state
     // leaking from one test to another.
     await window.PDFViewerApplication.testingClose();
@@ -176,6 +181,9 @@ async function closeSinglePage(page) {
     return {
       page: window.__coverage__ ? JSON.stringify(window.__coverage__) : null,
       worker: workerCoverage ? JSON.stringify(workerCoverage) : null,
+      previousWorker: previousWorkerCoverage
+        ? previousWorkerCoverage.map(c => JSON.stringify(c))
+        : null,
     };
   });
 
@@ -185,6 +193,7 @@ async function closeSinglePage(page) {
   if (coverage.worker) {
     mergeCoverageIntoGlobal(JSON.parse(coverage.worker));
   }
+  coverage.previousWorker?.map(c => mergeCoverageIntoGlobal(JSON.parse(c)));
 
   await page.close({ runBeforeUnload: false });
 }

--- a/web/app.js
+++ b/web/app.js
@@ -1219,6 +1219,22 @@ const PDFViewerApplication = {
    */
   async open(args) {
     if (this.pdfLoadingTask) {
+      if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("COVERAGE")) {
+        // Ensure that we don't miss collecting coverage data for
+        // e.g. the "Merge PDF" integration-tests.
+        let workerCoverage = null;
+        const handler = this.pdfDocument?._transport?.messageHandler;
+        if (handler) {
+          try {
+            workerCoverage = await handler.sendWithPromise(
+              "GetWorkerCoverage",
+              null
+            );
+          } catch {}
+        }
+        (globalThis._previousWorkerCoverage ??= []).push(workerCoverage);
+      }
+
       // We need to destroy already opened document.
       await this.close();
     }


### PR DESCRIPTION
The "Merge PDF" integration-tests will (indirectly) invoke `PDFViewerApplication.open` as part of loading the new PDF document, which will end up creating a new `PDFWorker` instance.
Currently worker coverage is only collected at the end of each integration-test, which means that in these cases we miss the coverage data from any "previous" workers.