### PR TITLE
Don't download Puppeteer browsers on `npm install`

### DIFF
--- a/.puppeteerrc.json
+++ b/.puppeteerrc.json
@@ -1,13 +1,13 @@
 {
   "chrome": {
-    "skipDownload": false,
+    "skipDownload": true,
     "version": "stable"
   },
   "chrome-headless-shell": {
     "skipDownload": true
   },
   "firefox": {
-    "skipDownload": false,
+    "skipDownload": true,
     "version": "nightly"
   }
 }

--- a/.puppeteerrc.json
+++ b/.puppeteerrc.json
@@ -2,6 +2,9 @@
   "chrome": {
     "skipDownload": false
   },
+  "chrome-headless-shell": {
+    "skipDownload": true
+  },
   "firefox": {
     "skipDownload": false,
     "version": "nightly"

--- a/.puppeteerrc.json
+++ b/.puppeteerrc.json
@@ -1,6 +1,7 @@
 {
   "chrome": {
-    "skipDownload": false
+    "skipDownload": false,
+    "version": "stable"
   },
   "chrome-headless-shell": {
     "skipDownload": true

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -28,6 +28,7 @@ import {
   downloadManifestFiles,
   verifyManifestFiles,
 } from "./downloadutils.mjs";
+import { execSync } from "child_process";
 import fs from "fs";
 import istanbulCoverage from "istanbul-lib-coverage";
 import istanbulReportGenerator from "istanbul-reports";
@@ -1095,9 +1096,13 @@ async function startBrowser({
 }
 
 async function startBrowsers({ baseUrl, initializeSession, numSessions = 1 }) {
-  // Remove old browser revisions from Puppeteer's cache. Updating Puppeteer can
-  // cause new browser revisions to be downloaded, so trimming the cache will
-  // prevent the disk from filling up over time.
+  // Install the browsers.
+  for (const browser of ["firefox@nightly", "chrome@stable"]) {
+    execSync(`npx puppeteer browsers install ${browser}`, { stdio: "inherit" });
+  }
+
+  // Remove old browser revisions from Puppeteer's cache. The commands above can
+  // download new browser revisions, so this prevents the disk from filling up.
   await puppeteer.trimCache();
 
   const browserNames = ["firefox", "chrome"];


### PR DESCRIPTION
The commit messages contain more information about the individual changes.

Fixes #19211.