### PR TITLE
Upgrade `eslint-plugin-unicorn` to version 66.0.0

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1030,10 +1030,7 @@ function createBuildNumber(done) {
       const version = config.versionPrefix + buildNumber;
 
       exec('git log --format="%h" -n 1', function (err2, stdout2, stderr2) {
-        let buildCommit = "";
-        if (!err2) {
-          buildCommit = stdout2.replace("\n", "");
-        }
+        const buildCommit = !err2 ? stdout2.replace("\n", "") : "";
 
         createStringSource(
           "version.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-perfectionist": "^5.9.0",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-regexp": "^3.1.0",
-        "eslint-plugin-unicorn": "^65.0.1",
+        "eslint-plugin-unicorn": "^66.0.0",
         "globals": "^17.6.0",
         "gulp": "^5.0.1",
         "gulp-cli": "^3.1.0",
@@ -5282,42 +5282,43 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "65.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-65.0.1.tgz",
-      "integrity": "sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==",
+      "version": "66.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-66.0.0.tgz",
+      "integrity": "sha512-+ywdy8T3foyZ2t3nRBujGa3vfOVMobHIi5iLB0L+fogdVO3EiUJ4BAyIacogWytnweLw3hgT70LQL9KoKTY/kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "@eslint-community/eslint-utils": "^4.9.1",
+        "browserslist": "^4.28.2",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
         "core-js-compat": "^3.49.0",
         "detect-indent": "^7.0.2",
         "find-up-simple": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.6.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
         "jsesc": "^3.1.0",
         "pluralize": "^8.0.0",
-        "regjsparser": "^0.13.0",
-        "semver": "^7.7.4",
+        "regjsparser": "^0.13.1",
+        "semver": "^7.8.4",
         "strip-indent": "^4.1.1"
       },
       "engines": {
-        "node": "^20.10.0 || >=21.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=9.38.0"
+        "eslint": ">=10.4"
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8779,9 +8780,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-perfectionist": "^5.9.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-regexp": "^3.1.0",
-    "eslint-plugin-unicorn": "^65.0.1",
+    "eslint-plugin-unicorn": "^66.0.0",
     "globals": "^17.6.0",
     "gulp": "^5.0.1",
     "gulp-cli": "^3.1.0",

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -4265,10 +4265,7 @@ class FreeTextAnnotation extends MarkupAnnotation {
       totalWidth = Math.max(totalWidth, lineWidth);
     }
 
-    let hscale = 1;
-    if (totalWidth > w) {
-      hscale = w / totalWidth;
-    }
+    const hscale = totalWidth > w ? w / totalWidth : 1;
     let vscale = 1;
     const lineHeight = LINE_FACTOR * fontSize;
     const lineAscent = (LINE_FACTOR - LINE_DESCENT_FACTOR) * fontSize;

--- a/src/core/default_appearance.js
+++ b/src/core/default_appearance.js
@@ -418,10 +418,7 @@ class FakeUnicodeFont {
       [w, h] = [h, w];
     }
 
-    let hscale = 1;
-    if (maxWidth > w) {
-      hscale = w / maxWidth;
-    }
+    const hscale = maxWidth > w ? w / maxWidth : 1;
     let vscale = 1;
     const lineHeight = LINE_FACTOR * fontSize;
     const lineDescent = LINE_DESCENT_FACTOR * fontSize;

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -3535,10 +3535,7 @@ class PartialEvaluator {
             if (includeMarkedContent) {
               markedContentData.level++;
 
-              let mcid = null;
-              if (args[1] instanceof Dict) {
-                mcid = args[1].get("MCID");
-              }
+              const mcid = args[1] instanceof Dict ? args[1].get("MCID") : null;
               textContent.items.push({
                 type: "beginMarkedContentProps",
                 id: Number.isInteger(mcid)

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3171,10 +3171,7 @@ class Font {
     // there isn't enough room to duplicate, the glyph id is left the same. In
     // this case, glyph 0 may not work correctly, but that is better than
     // having the whole font fail.
-    let glyphZeroId = numGlyphsOut - 1;
-    if (!dupFirstEntry) {
-      glyphZeroId = 0;
-    }
+    const glyphZeroId = dupFirstEntry ? numGlyphsOut - 1 : 0;
 
     // When `cssFontInfo` is set, the font is used to render text in the HTML
     // view (e.g. with Xfa) so nothing must be moved in the private use area.
@@ -3248,10 +3245,7 @@ class Font {
     // Type 1 fonts have a notdef inserted at the beginning, so glyph 0
     // becomes glyph 1. In a CFF font glyph 0 is appended to the end of the
     // char strings.
-    let glyphZeroId = 1;
-    if (font instanceof CFFFont) {
-      glyphZeroId = font.numGlyphs - 1;
-    }
+    const glyphZeroId = font instanceof CFFFont ? font.numGlyphs - 1 : 1;
     const mapping = font.getGlyphMapping(properties);
     let newMapping = null;
     let newCharCodeToGlyphId = mapping;

--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -285,10 +285,9 @@ class RadialAxialShading extends BaseShading {
     }
     colorStops.push([1, Util.makeHexColor(rPrev, gPrev, bPrev)]);
 
-    let background = "transparent";
-    if (dict.has("Background")) {
-      background = cs.getRgbHex(dict.get("Background"), 0);
-    }
+    const background = dict.has("Background")
+      ? cs.getRgbHex(dict.get("Background"), 0)
+      : "transparent";
 
     if (!extendStart) {
       // Insert a color stop at the front and offset the first real color stop

--- a/src/core/type1_parser.js
+++ b/src/core/type1_parser.js
@@ -691,13 +691,10 @@ class Type1Parser {
         subrs,
         this.seacAnalysisEnabled
       );
-      let output = charString.output;
-      if (error) {
-        // It seems when FreeType encounters an error while evaluating a glyph
-        // that it completely ignores the glyph so we'll mimic that behaviour
-        // here and put an endchar to make the validator happy.
-        output = [14];
-      }
+      // It seems when FreeType encounters an error while evaluating a glyph
+      // that it completely ignores the glyph so we'll mimic that behaviour
+      // here and put an endchar to make the validator happy.
+      const output = !error ? charString.output : [14];
       const charStringObject = {
         glyphName: glyph,
         charstring: output,

--- a/src/core/xfa/factory.js
+++ b/src/core/xfa/factory.js
@@ -101,7 +101,6 @@ class XFAFactory {
     const missingFonts = [];
     for (let typeface of this.form[$globalData].usedTypefaces) {
       typeface = stripQuotes(typeface);
-      // eslint-disable-next-line unicorn/prefer-array-some
       const font = this.form[$globalData].fontFinder.find(typeface);
       if (!font) {
         missingFonts.push(typeface);

--- a/src/core/xml_parser.js
+++ b/src/core/xml_parser.js
@@ -51,7 +51,7 @@ class XMLParserBase {
     return s.replaceAll(/&([^;]+);/g, (all, entity) => {
       if (entity.substring(0, 2) === "#x") {
         return String.fromCodePoint(parseInt(entity.substring(2), 16));
-      } else if (entity.substring(0, 1) === "#") {
+      } else if (entity.at(0) === "#") {
         return String.fromCodePoint(parseInt(entity.substring(1), 10));
       }
       switch (entity) {

--- a/src/scripting_api/event.js
+++ b/src/scripting_api/event.js
@@ -255,11 +255,9 @@ class EventDispatcher {
       this.runCalculate(source, event);
 
       const savedValue = (event.value = source.obj._getValue());
-      let formattedValue = null;
-
-      if (this.runActions(source, source, event, "Format")) {
-        formattedValue = event.value?.toString?.();
-      }
+      const formattedValue = this.runActions(source, source, event, "Format")
+        ? event.value?.toString?.()
+        : null;
 
       source.obj._send({
         id: source.obj._id,
@@ -365,10 +363,9 @@ class EventDispatcher {
       }
 
       savedValue = target.obj._getValue();
-      let formattedValue = null;
-      if (this.runActions(target, target, event, "Format")) {
-        formattedValue = event.value?.toString?.();
-      }
+      const formattedValue = this.runActions(target, target, event, "Format")
+        ? event.value?.toString?.()
+        : null;
 
       target.obj._send({
         id: target.obj._id,

--- a/test/resources/reftest-analyzer.js
+++ b/test/resources/reftest-analyzer.js
@@ -555,10 +555,11 @@ window.onload = function () {
   window.addEventListener("keydown", function keydown(event) {
     if (event.which === 84) {
       // 't' switch test/ref images
-      let val = 0;
-      if (document.querySelector('input[name="which"][value="0"]:checked')) {
-        val = 1;
-      }
+      const val = document.querySelector(
+        'input[name="which"][value="0"]:checked'
+      )
+        ? 1
+        : 0;
       document
         .querySelector('input[name="which"][value="' + val + '"]')
         .click();


### PR DESCRIPTION
This is a major version bump, but the changelog at https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v66.0.0 doesn't indicate any breaking changes that should impact us.

However, improved rules do require a small number of changes here:

- The `prefer-array-some` rule no longer reports a false positive after https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3198 got fixed, so the ignore line that was added in commit 68a5ec1 is removed.

- The `prefer-ternary` rule triggers on more cases now, in particular `let` declarations with `if` reassignments, so a number of changes are made to make it pass again.

- The `prefer-at` rule triggers on more cases now, in particular `substring` calls that just extract a single character, so one change is made to make it pass again.