### PR TITLE
Remove the unused `HighlightOutline.prototype.classNamesForOutlining` getter

### DIFF
--- a/src/display/editor/drawers/highlight.js
+++ b/src/display/editor/drawers/highlight.js
@@ -343,10 +343,6 @@ class HighlightOutline extends Outline {
   get box() {
     return this.#box;
   }
-
-  get classNamesForOutlining() {
-    return ["highlightOutline"];
-  }
 }
 
 class FreeHighlightOutliner extends FreeDrawOutliner {


### PR DESCRIPTION
This was added in PR #18972 and it became unused in PR #19085, however it was accidentally left behind.