### PR TITLE
Remove unneeded check in the "GetAnnotationsByType" worker-thread handler

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -510,20 +510,17 @@ class WorkerMessageHandler {
               startWorkerTask(task);
             }
             pagePromises.push(
-              pdfManager.getPage(i).then(async page => {
-                if (!page) {
-                  return [];
-                }
-                return (
+              pdfManager
+                .getPage(i)
+                .then(page =>
                   page.collectAnnotationsByType(
                     handler,
                     task,
                     types,
                     annotationPromises,
                     annotationGlobals
-                  ) || []
-                );
-              })
+                  )
+                )
             );
           }
           await Promise.all(pagePromises);


### PR DESCRIPTION
Given that the Promise returned by the `PDFDocument.prototype.getPage` method *always* resolves with a `Page` instance, checking that the page is defined isn't necessary; note https://github.com/mozilla/pdf.js/blob/3a093291135136f20babaf8d76c7dee3cc938515/src/core/document.js#L1702-L1723

Furthermore the `Page.prototype.collectAnnotationsByType` method is asynchronous, and thus it always returns a Promise, hence it's "pointless" to fallback to return an empty Array.