### PR TITLE
Check every LinkAnnotation when testing if inferred links overlap (issue 21458)

### DIFF
--- a/test/integration/autolinker_spec.mjs
+++ b/test/integration/autolinker_spec.mjs
@@ -169,6 +169,43 @@ describe("autolinker", function () {
     });
   });
 
+  describe("issue21458.pdf", function () {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "issue21458.pdf",
+        ".page[data-page-number='1'] .annotationLayer",
+        null,
+        null,
+        { enableAutoLinking: true }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must not add links that overlap internal destinations", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await waitForLinkAnnotations(page);
+          const linkIds = await page.$$eval(
+            ".page[data-page-number='1'] .annotationLayer > .linkAnnotation > a",
+            annotations =>
+              annotations.map(a => a.getAttribute("data-element-id"))
+          );
+          expect(linkIds.length).withContext(`In ${browserName}`).toEqual(42);
+          linkIds.forEach(id =>
+            expect(id)
+              .withContext(`In ${browserName}`)
+              .not.toContain("inferred_link_")
+          );
+        })
+      );
+    });
+  });
+
   describe("PR 19470", function () {
     let pages;
 

--- a/test/pdfs/issue21458.pdf.link
+++ b/test/pdfs/issue21458.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/28985267/Gumbel.Distillation.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -32,6 +32,14 @@
     "type": "other"
   },
   {
+    "id": "issue21458",
+    "file": "pdfs/issue21458.pdf",
+    "md5": "875754beca276ab63568e06fd49e8375",
+    "rounds": 1,
+    "link": true,
+    "type": "other"
+  },
+  {
     "id": "filled-background-range",
     "file": "pdfs/filled-background.pdf",
     "md5": "2e3120255d9c3e79b96d2543b12d2589",

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -332,10 +332,7 @@ class AnnotationLayerBuilder {
       let linkAreaRects;
 
       for (const annotation of this.#annotations) {
-        if (
-          annotation.annotationType !== AnnotationType.LINK ||
-          !annotation.url
-        ) {
+        if (annotation.annotationType !== AnnotationType.LINK) {
           continue;
         }
         // TODO: Add a test case to verify that we can find the intersection


### PR DESCRIPTION
Currently we only check LinkAnnotations with URLs, but completely ignore e.g. internal destinations, named actions, attachments, SetOCGState actions, JS actions, and ResetForm actions when testing if inferred links overlap any existing annotation.
This seems conceptually wrong, since it may easily break intended functionality by overlaying the *correct* DOM element with an inferred link (as was the case in issue 21458).