### PR TITLE
Adjust the 'BaseException' unit-test for the 'Error.stack' changes in Firefox

### DIFF
--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -37,7 +37,6 @@ describe("util", function () {
       expect(exception.message).toEqual("Something went wrong");
       expect(exception.name).toEqual("DerivedException");
       expect(exception.foo).toEqual("bar");
-      expect(exception.stack).toContain("BaseExceptionClosure");
     });
   });
 


### PR DESCRIPTION
Firefox 154 no longer walks the prototype chain in the `Error.stack` getter, so `BaseException`-derived instances return an empty string rather than the prototype `Error`'s stack (see bug 1946559).