### PR TITLE
Remove unused branches in the `src/display/canvas.js` file

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -3996,12 +3996,6 @@ class CanvasGraphics {
       const result = this.applyTransferMapsToBitmap(imgData);
       imgToPaint = result.img;
       inlineImgCanvas = result.canvasEntry;
-    } else if (
-      (typeof HTMLElement === "function" && imgData instanceof HTMLElement) ||
-      !imgData.data
-    ) {
-      // typeof check is needed due to node.js support, see issue #8489
-      imgToPaint = imgData;
     } else {
       const tmpCanvas = this.canvasFactory.create(width, height);
       putBinaryImageData(tmpCanvas.context, imgData);

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -320,11 +320,6 @@ class CanvasExtraState {
 }
 
 function putBinaryImageData(ctx, imgData) {
-  if (imgData instanceof ImageData) {
-    ctx.putImageData(imgData, 0, 0);
-    return;
-  }
-
   // Put the image data to the canvas in chunks, rather than putting the
   // whole image at once.  This saves JS memory, because the ImageData object
   // is smaller. It also possibly saves C++ memory within the implementation

--- a/src/display/node_utils.js
+++ b/src/display/node_utils.js
@@ -51,13 +51,6 @@ if (isNodeJS) {
         warn("Cannot polyfill `DOMMatrix`, rendering may be broken.");
       }
     }
-    if (!globalThis.ImageData) {
-      if (canvas?.ImageData) {
-        globalThis.ImageData = canvas.ImageData;
-      } else {
-        warn("Cannot polyfill `ImageData`, rendering may be broken.");
-      }
-    }
     if (!globalThis.Path2D) {
       if (canvas?.Path2D) {
         globalThis.Path2D = canvas.Path2D;


### PR DESCRIPTION
 - **Remove the unused `HTMLElement` branch in the `paintInlineImageXObject` method**

   This branch isn't covered by any tests, and as far as I can tell it's been unused ever since PR #11601 which simplified the JPEG image handling.
   Prior to that we'd create an `Image` instance in one case, see [this code](https://github.com/mozilla/pdf.js/pull/11601/changes#diff-082d6b37ad01db7ac97cc07c6ddb0dc52040484c5ef91b110b072f50144d9f39L2312-L2314), which is why that branch was necessary since `new Image()` creates a `HTMLImageElement` instance which in itself is an instance of `HTMLElement`; note [this](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image) respectively [this](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement).

 - **Remove the unused `ImageData` branch in the `putBinaryImageData` function**

   This branch isn't covered by any tests, and looking at the two existing call-sites we only ever pass in a `CanvasRenderingContext2D` interface to this function.
   Based on the git history this branch was added in PR #3312, however as far as I can tell it doesn't actually appear to have been necessary even back then!?