### PR TITLE
Round clamped BlueScale to a short, encodable operand (issue #21466)

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -908,7 +908,12 @@ class CFFParser {
         const maxBlueScale = 1 / maxZoneHeight;
         const clamped = MathClamp(blueScale, minBlueScale, maxBlueScale);
         if (clamped !== blueScale) {
-          privateDict.setByName("BlueScale", clamped);
+          // Clamping can yield a non-terminating decimal (e.g. `0.5 / 13`)
+          // whose full-precision real operand exceeds what some CFF parsers
+          // accept in the Private DICT. The over-long operand desyncs the
+          // DICT and drops almost every glyph (issue 21466), so round to a
+          // short, safely-encodable value before writing it back.
+          privateDict.setByName("BlueScale", Math.round(clamped * 1e5) / 1e5);
         }
       }
     }

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -318,6 +318,30 @@ describe("CFFParser", function () {
     );
   });
 
+  it("rounds a clamped BlueScale to a short, encodable value (issue 21466)", function () {
+    cff.topDict.privateDict = new CFFPrivateDict(cff.strings);
+    // maxZoneHeight = 13 -> minBlueScale = 0.5 / 13 = 0.0384615384615...,
+    // a non-terminating decimal. Writing it back at full precision produces a
+    // real operand long enough to desync the Private DICT in stricter CFF
+    // parsers (notably the browser's), dropping nearly every glyph.
+    cff.topDict.privateDict.setByName("BlueValues", [-13, 13, 530, 13]);
+    cff.topDict.privateDict.setByName("BlueScale", 0.01);
+    cff.topDict.setByName("Private", [0, 0]);
+    const fontDataWithClampedBlueScale = new CFFCompiler(cff).compile();
+
+    const reparsedCff = new CFFParser(
+      new Stream(fontDataWithClampedBlueScale),
+      {},
+      SEAC_ANALYSIS_ENABLED
+    ).parse();
+
+    // The clamped value is rounded to five decimals (0.5 / 13 -> 0.03846)
+    // rather than written as 0.038461538461538464.
+    expect(reparsedCff.topDict.privateDict.getByName("BlueScale")).toEqual(
+      0.03846
+    );
+  });
+
   it("preserves a BlueScale that is already inside the valid range", function () {
     cff.topDict.privateDict = new CFFPrivateDict(cff.strings);
     cff.topDict.privateDict.setByName(


### PR DESCRIPTION
Fixes #21466.

#21343 began clamping out-of-range `BlueScale` values into AFDKO's valid window. The clamp can produce a non-terminating decimal (e.g. `0.5 / 13 = 0.038461538461538464`), which the CFF compiler writes back to the Private DICT as a full-precision real operand. That operand (~12 bytes) is long enough that stricter CFF parsers — notably the browser's — misparse it, desyncing the Private DICT and dropping almost every glyph. Node-based rendering was unaffected since it reuses in-memory charstrings without reparsing.

This rounds the clamped value to five decimals before writing it back (only when a clamp actually occurred), keeping the operand short (5 bytes) while preserving the intended hinting. Added a regression test to the BlueScale clamp suite in `cff_parser_spec.js`; it fails before the change and passes after.

Thanks to the reporter for the precise root-cause analysis.