### PR TITLE
Remove the unused `AnnotationEditorUIManager.prototype.isSelected` method

### DIFF
--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -2545,14 +2545,6 @@ class AnnotationEditorUIManager {
     });
   }
 
-  /**
-   * Check if the editor is selected.
-   * @param {AnnotationEditor} editor
-   */
-  isSelected(editor) {
-    return this.#selectedEditors.has(editor);
-  }
-
   get firstSelectedEditor() {
     return this.#selectedEditors.values().next().value;
   }


### PR DESCRIPTION
According to the coverage data this method is unused, see https://app.codecov.io/gh/mozilla/pdf.js/commit/e20c810dd4edf6dceab4aca6dba41ec52e285741/blob/src/display/editor/tools.js?dropdown=coverage#L2552, and searching through the entire code-base reveals no call-site invoking an `isSelected` method.