### PR TITLE
Add Redline PDF editor tools

### DIFF
--- a/extensions/chromium/contentscript.js
+++ b/extensions/chromium/contentscript.js
@@ -23,6 +23,7 @@ function getViewerURL(pdf_url) {
 }
 
 document.addEventListener("animationstart", onAnimationStart, true);
+window.addEventListener("click", onPdfLinkClick, true);
 if (document.contentType === "application/pdf") {
   chrome.runtime.sendMessage({ action: "canRequestBody" }, maybeRenderPdfDoc);
 }
@@ -31,6 +32,50 @@ function onAnimationStart(event) {
   if (event.animationName === "pdfjs-detected-object-or-embed") {
     watchObjectOrEmbed(event.target);
   }
+}
+
+function onPdfLinkClick(event) {
+  if (
+    event.button !== 0 ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey
+  ) {
+    return;
+  }
+
+  const anchor = event
+    .composedPath()
+    .find(node => node instanceof HTMLAnchorElement && node.href);
+  if (!anchor || !isPdfAnchor(anchor)) {
+    return;
+  }
+  if (
+    anchor.download ||
+    (anchor.target && anchor.target.toLowerCase() !== "_self")
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  chrome.runtime.sendMessage({
+    action: "redlineOpenPdfInNewTab",
+    url: anchor.href,
+  });
+}
+
+function isPdfAnchor(anchor) {
+  const href = anchor.href;
+  if (!href || /^(?:blob|data|javascript):/i.test(href)) {
+    return false;
+  }
+  const type = anchor.getAttribute("type")?.trim().toLowerCase();
+  if (type === "application/pdf") {
+    return true;
+  }
+  return /\.pdf(?:$|[?#])/i.test(href);
 }
 
 // Called for every <object> or <embed> element in the page.

--- a/extensions/chromium/pdfHandler.js
+++ b/extensions/chromium/pdfHandler.js
@@ -360,6 +360,21 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     }
     return undefined;
   }
+  if (message && message.action === "redlineOpenPdfInNewTab") {
+    if (typeof message.url !== "string") {
+      return undefined;
+    }
+    const createProperties = {
+      url: getViewerURL(message.url),
+    };
+    if (sender.tab) {
+      createProperties.windowId = sender.tab.windowId;
+      createProperties.index = sender.tab.index + 1;
+      createProperties.openerTabId = sender.tab.id;
+    }
+    chrome.tabs.create(createProperties);
+    return undefined;
+  }
   if (message && message.action === "canRequestBody") {
     sendResponse(canRequestBody(sender.tab.id, sender.frameId));
     return undefined;

--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -309,6 +309,9 @@ pdfjs-editor-stamp-button-label = Add or edit images
 pdfjs-editor-highlight-button =
     .title = Highlight
 pdfjs-editor-highlight-button-label = Highlight
+pdfjs-editor-redaction-button =
+    .title = Permanently redact
+pdfjs-editor-redaction-button-label = Redact
 pdfjs-highlight-floating-button1 =
     .title = Highlight
     .aria-label = Highlight
@@ -342,6 +345,8 @@ pdfjs-editor-signature-editor1 =
 
 pdfjs-editor-stamp-editor =
     .aria-label = Image editor
+pdfjs-editor-redaction-editor =
+    .aria-label = Redaction area
 
 ## Remove button for the various kind of editor.
 
@@ -355,18 +360,53 @@ pdfjs-editor-remove-highlight-button =
     .title = Remove highlight
 pdfjs-editor-remove-signature-button =
     .title = Remove signature
+pdfjs-editor-remove-redaction-button =
+    .title = Remove redaction
 
 ##
 
 # Editor Parameters
 pdfjs-editor-free-text-color-input = Color
 pdfjs-editor-free-text-size-input = Size
+pdfjs-editor-free-text-font-family-input = Font
+pdfjs-editor-free-text-format-input = Format
+pdfjs-editor-free-text-alignment-input = Alignment
+pdfjs-editor-free-text-bold-button =
+    .title = Bold
+    .aria-label = Bold
+pdfjs-editor-free-text-italic-button =
+    .title = Italic
+    .aria-label = Italic
+pdfjs-editor-free-text-underline-button =
+    .title = Underline
+    .aria-label = Underline
+pdfjs-editor-free-text-align-left-button =
+    .title = Align left
+    .aria-label = Align left
+pdfjs-editor-free-text-align-center-button =
+    .title = Align center
+    .aria-label = Align center
+pdfjs-editor-free-text-align-right-button =
+    .title = Align right
+    .aria-label = Align right
 pdfjs-editor-ink-color-input = Color
 pdfjs-editor-ink-thickness-input = Thickness
 pdfjs-editor-ink-opacity-input = Opacity
 pdfjs-editor-stamp-add-image-button =
     .title = Add image
 pdfjs-editor-stamp-add-image-button-label = Add image
+pdfjs-editor-stamp-check-button =
+    .title = Select check mark symbol
+pdfjs-editor-stamp-x-button =
+    .title = Select X mark symbol
+pdfjs-editor-stamp-arrow-button =
+    .title = Select arrow symbol
+pdfjs-editor-stamp-circle-button =
+    .title = Select circle symbol
+pdfjs-editor-stamp-rectangle-button =
+    .title = Select rectangle symbol
+pdfjs-editor-stamp-triangle-button =
+    .title = Select triangle symbol
 # This refers to the thickness of the line used for free highlighting (not bound to text)
 pdfjs-editor-free-highlight-thickness-input = Thickness
 pdfjs-editor-free-highlight-thickness-title =
@@ -550,6 +590,7 @@ pdfjs-editor-freetext-added-alert = Text added
 pdfjs-editor-ink-added-alert = Drawing added
 pdfjs-editor-stamp-added-alert = Image added
 pdfjs-editor-signature-added-alert = Signature added
+pdfjs-editor-redaction-added-alert = Redaction added
 
 ## "Annotations removed" bar
 
@@ -559,6 +600,7 @@ pdfjs-editor-undo-bar-message-ink = Drawing removed
 pdfjs-editor-undo-bar-message-stamp = Image removed
 pdfjs-editor-undo-bar-message-signature = Signature removed
 pdfjs-editor-undo-bar-message-comment = Comment removed
+pdfjs-editor-undo-bar-message-redaction = Redaction removed
 # Variables:
 #   $count (Number) - the number of removed annotations.
 pdfjs-editor-undo-bar-message-multiple =
@@ -729,6 +771,10 @@ pdfjs-views-manager-pages-status-action-label =
     }
 pdfjs-views-manager-pages-status-none-action-label = Select pages
 pdfjs-views-manager-pages-status-action-button-label = Manage
+pdfjs-views-manager-pages-status-rotate-button-label = Rotate clockwise
+pdfjs-views-manager-pages-status-add-blank-button-label = Add blank page
+pdfjs-views-manager-pages-status-duplicate-button-label = Duplicate page
+pdfjs-views-manager-pages-status-remove-button-label = Remove page
 pdfjs-views-manager-pages-status-copy-button-label = Copy
 pdfjs-views-manager-pages-status-cut-button-label = Cut
 pdfjs-views-manager-pages-status-delete-button-label = Delete

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -25,10 +25,12 @@ import {
   BASELINE_FACTOR,
   BBOX_INIT,
   F32_BBOX_INIT,
+  FreeTextAnnotationPdfFontMap,
   info,
   isArrayEqual,
   LINE_DESCENT_FACTOR,
   LINE_FACTOR,
+  normalizeFreeTextAnnotationFontFamily,
   OPS,
   RenderingIntentFlag,
   shadow,
@@ -369,7 +371,7 @@ class AnnotationFactory {
     imagePromises,
     changes
   ) {
-    let baseFontRef;
+    const freeTextBaseFontRefs = new Map();
     const promises = [];
     const { isOffscreenCanvasSupported } = evaluator.options;
 
@@ -379,13 +381,20 @@ class AnnotationFactory {
       }
       switch (annotation.annotationType) {
         case AnnotationEditorType.FREETEXT:
+          const fontData = FreeTextAnnotation.getPdfFontData(
+            annotation.fontFamily,
+            annotation.bold,
+            annotation.italic
+          );
+          let baseFontRef = freeTextBaseFontRefs.get(fontData.pdfFontName);
           if (!baseFontRef) {
             const baseFont = new Dict(xref);
-            baseFont.setIfName("BaseFont", "Helvetica");
+            baseFont.setIfName("BaseFont", fontData.pdfFontName);
             baseFont.setIfName("Type", "Font");
             baseFont.setIfName("Subtype", "Type1");
             baseFont.setIfName("Encoding", "WinAnsiEncoding");
             baseFontRef = xref.getNewTemporaryRef();
+            freeTextBaseFontRefs.set(fontData.pdfFontName, baseFontRef);
             changes.put(baseFontRef, {
               data: baseFont,
             });
@@ -395,6 +404,7 @@ class AnnotationFactory {
               evaluator,
               task,
               baseFontRef,
+              fontData,
             })
           );
           break;
@@ -4250,16 +4260,25 @@ class FreeTextAnnotation extends MarkupAnnotation {
     this.data.noHTML = false;
 
     const { annotationGlobals, xref } = params;
+    const textAlignment = params.dict.get("Q");
+    this.data.textAlignment =
+      Number.isInteger(textAlignment) &&
+      textAlignment >= 0 &&
+      textAlignment <= 2
+        ? textAlignment
+        : 0;
+    this.data.underline = params.dict.get("RedlineUnderline") === true;
     this.setDefaultAppearance(params);
     this._hasAppearance = !!this.appearance;
 
     if (this._hasAppearance) {
-      const { fontColor, fontSize } = parseAppearanceStream(
+      const { fontColor, fontName, fontSize } = parseAppearanceStream(
         this.appearance,
         xref,
         annotationGlobals.globalColorSpaceCache
       );
       this.data.defaultAppearanceData.fontColor = fontColor;
+      this.data.defaultAppearanceData.fontName = fontName;
       this.data.defaultAppearanceData.fontSize = fontSize || 10;
     } else {
       this.data.defaultAppearanceData.fontSize ||= 10;
@@ -4299,17 +4318,58 @@ class FreeTextAnnotation extends MarkupAnnotation {
     return this._hasAppearance;
   }
 
+  static getPdfFontData(fontFamily, bold = false, italic = false) {
+    const normalized = normalizeFreeTextAnnotationFontFamily(fontFamily);
+    // PDF.js doesn't embed arbitrary system fonts for FreeText annotations
+    // here. Use deterministic Base-14 fallbacks instead.
+    const base =
+      FreeTextAnnotationPdfFontMap.get(normalized) ||
+      FreeTextAnnotationPdfFontMap.get("Helvetica");
+    if (!bold && !italic) {
+      return base;
+    }
+
+    let family = "Helvetica";
+    if (base.pdfFontName.startsWith("Times")) {
+      family = "Times";
+    } else if (base.pdfFontName.startsWith("Courier")) {
+      family = "Courier";
+    }
+    let suffix = "I";
+    let pdfStyle = family === "Times" ? "Italic" : "Oblique";
+    if (bold && italic) {
+      suffix = "BI";
+      pdfStyle = family === "Times" ? "BoldItalic" : "BoldOblique";
+    } else if (bold) {
+      suffix = "B";
+      pdfStyle = "Bold";
+    }
+    return {
+      pdfFontName: `${family}-${pdfStyle}`,
+      resourceName: `${base.resourceName}${suffix}`,
+    };
+  }
+
   static createNewDict(annotation, xref, { apRef, ap }) {
     const {
       color,
       date,
+      bold,
       fontSize,
+      italic,
       oldAnnotation,
       rect,
       rotation,
+      textAlign,
+      underline,
       user,
       value,
     } = annotation;
+    const { resourceName } = this.getPdfFontData(
+      annotation.fontFamily,
+      bold,
+      italic
+    );
     const freetext = oldAnnotation || new Dict(xref);
     freetext.setIfNotExists("Type", Name.get("Annot"));
     freetext.setIfNotExists("Subtype", Name.get("FreeText"));
@@ -4323,8 +4383,26 @@ class FreeTextAnnotation extends MarkupAnnotation {
       freetext.delete("RC");
     }
     freetext.setIfArray("Rect", rect);
-    const da = `/Helv ${fontSize} Tf ${getPdfColor(color, /* isFill */ true)}`;
+    const da = createDefaultAppearance({
+      fontSize,
+      fontName: resourceName,
+      fontColor: color,
+    });
     freetext.set("DA", da);
+    let alignment = 0;
+    if (textAlign === "center") {
+      alignment = 1;
+    } else if (textAlign === "right") {
+      alignment = 2;
+    }
+    if (textAlign) {
+      freetext.set("Q", alignment);
+    }
+    if (underline) {
+      freetext.set("RedlineUnderline", true);
+    } else {
+      freetext.delete("RedlineUnderline");
+    }
     freetext.setIfDefined("Contents", stringToAsciiOrUTF16BE(value));
     freetext.setIfNotExists("F", 4);
     freetext.setIfNotExists("Border", [0, 0, 0]);
@@ -4342,31 +4420,44 @@ class FreeTextAnnotation extends MarkupAnnotation {
 
   static async createNewAppearanceStream(annotation, xref, params) {
     const { baseFontRef, evaluator, task } = params;
-    const { color, fontSize, rect, rotation, value } = annotation;
+    const {
+      bold,
+      color,
+      fontFamily,
+      fontSize,
+      italic,
+      rect,
+      rotation,
+      textAlign,
+      underline,
+      value,
+    } = annotation;
     if (!color) {
       return null;
     }
+    const { pdfFontName, resourceName } =
+      params.fontData || this.getPdfFontData(fontFamily, bold, italic);
 
     const resources = new Dict(xref);
     const font = new Dict(xref);
 
     if (baseFontRef) {
-      font.set("Helv", baseFontRef);
+      font.set(resourceName, baseFontRef);
     } else {
       const baseFont = new Dict(xref);
-      baseFont.setIfName("BaseFont", "Helvetica");
+      baseFont.setIfName("BaseFont", pdfFontName);
       baseFont.setIfName("Type", "Font");
       baseFont.setIfName("Subtype", "Type1");
       baseFont.setIfName("Encoding", "WinAnsiEncoding");
-      font.set("Helv", baseFont);
+      font.set(resourceName, baseFont);
     }
     resources.set("Font", font);
 
-    const helv = await WidgetAnnotation._getFontData(
+    const pdfFont = await WidgetAnnotation._getFontData(
       evaluator,
       task,
       {
-        fontName: "Helv",
+        fontName: resourceName,
         fontSize,
       },
       resources
@@ -4384,8 +4475,9 @@ class FreeTextAnnotation extends MarkupAnnotation {
     const scale = fontSize / 1000;
     let totalWidth = -Infinity;
     const encodedLines = [];
+    const lineWidths = [];
     for (let line of lines) {
-      const encoded = helv.encodeString(line);
+      const encoded = pdfFont.encodeString(line);
       if (encoded.length > 1) {
         // The font doesn't contain all the chars.
         return null;
@@ -4393,10 +4485,11 @@ class FreeTextAnnotation extends MarkupAnnotation {
       line = encoded.join("");
       encodedLines.push(line);
       let lineWidth = 0;
-      const glyphs = helv.charsToGlyphs(line);
+      const glyphs = pdfFont.charsToGlyphs(line);
       for (const glyph of glyphs) {
         lineWidth += glyph.width * scale;
       }
+      lineWidths.push(lineWidth);
       totalWidth = Math.max(totalWidth, lineWidth);
     }
 
@@ -4434,13 +4527,24 @@ class FreeTextAnnotation extends MarkupAnnotation {
         break;
     }
 
+    let alignmentFactor = 0;
+    if (textAlign === "center") {
+      alignmentFactor = 0.5;
+    } else if (textAlign === "right") {
+      alignmentFactor = 1;
+    }
+    const lineOffsets = lineWidths.map(
+      lineWidth => Math.max(0, w - lineWidth * fscale) * alignmentFactor
+    );
+    firstPoint[0] += lineOffsets[0];
+
     const buffer = [
       "q",
       `${matrix.join(" ")} 0 0 cm`,
       `${clipBox.join(" ")} re W n`,
       `BT`,
       `${getPdfColor(color, /* isFill */ true)}`,
-      `0 Tc /Helv ${numberToString(newFontSize)} Tf`,
+      `0 Tc /${resourceName} ${numberToString(newFontSize)} Tf`,
     ];
 
     buffer.push(
@@ -4449,9 +4553,26 @@ class FreeTextAnnotation extends MarkupAnnotation {
     const vShift = numberToString(lineHeight);
     for (let i = 1, ii = encodedLines.length; i < ii; i++) {
       const line = encodedLines[i];
-      buffer.push(`0 -${vShift} Td (${escapeString(line)}) Tj`);
+      const xShift = numberToString(lineOffsets[i] - lineOffsets[i - 1]);
+      buffer.push(`${xShift} -${vShift} Td (${escapeString(line)}) Tj`);
     }
-    buffer.push("ET", "Q");
+    buffer.push("ET");
+    if (underline) {
+      buffer.push(
+        getPdfColor(color, /* isFill */ false),
+        `${numberToString(Math.max(0.5, newFontSize / 16))} w`
+      );
+      for (let i = 0; i < lineWidths.length; ++i) {
+        const x = firstPoint[0] - lineOffsets[0] + lineOffsets[i];
+        const y =
+          firstPoint[1] - i * lineHeight - Math.max(1, newFontSize * 0.12);
+        buffer.push(
+          `${numberToString(x)} ${numberToString(y)} m ` +
+            `${numberToString(x + lineWidths[i] * fscale)} ${numberToString(y)} l S`
+        );
+      }
+    }
+    buffer.push("Q");
     const appearance = buffer.join("\n");
 
     const appearanceStreamDict = new Dict(xref);

--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -55,6 +55,7 @@ class PageData {
     this.page = page;
     this.documentData = documentData;
     this.annotations = null;
+    this.rotationDelta = 0;
     // Named destinations which points to this page.
     this.pointingNamedDestinations = null;
 
@@ -745,6 +746,10 @@ class PDFEditor {
    * @property {PDFDocument} [document]
    * @property {ImageBitmap} [image]
    *  image to insert as a synthetic page.
+   * @property {{width: number, height: number}} [pageSize]
+   *  dimensions of an image-backed synthetic page in PDF points.
+   * @property {boolean} [fullPage]
+   *  whether the image fills the page without insertion margins.
    * @property {Array<Array<number>|number>} [includePages]
    *  included ranges (inclusive) or indices.
    * @property {Array<Array<number>|number>} [excludePages]
@@ -756,6 +761,8 @@ class PDFEditor {
    *  pages. When every contributing pageInfo has pageIndices, this is
    *  interpreted against that explicit layout. Cannot be combined with
    *  pageIndices on the same entry.
+   * @property {Array<number>} [rotationDeltas]
+   *  clockwise rotation added to each filtered page, in document order.
    */
 
   /**
@@ -992,8 +999,16 @@ class PDFEditor {
 
     const imageEntries = [];
     for (const pageInfo of pageInfos) {
-      const { document, image, includePages, excludePages, pageIndices } =
-        pageInfo;
+      const {
+        document,
+        image,
+        includePages,
+        excludePages,
+        fullPage,
+        pageIndices,
+        pageSize,
+        rotationDeltas,
+      } = pageInfo;
       if (image) {
         if (pageIndices) {
           newIndex = -1;
@@ -1019,7 +1034,7 @@ class PDFEditor {
           }
         }
         reservePageSlot(newPageIndex);
-        imageEntries.push({ image, slot: newPageIndex });
+        imageEntries.push({ fullPage, image, pageSize, slot: newPageIndex });
         continue;
       }
       if (!document) {
@@ -1040,7 +1055,9 @@ class PDFEditor {
       allDocumentData.push(documentData);
       promises.push(this.#collectDocumentData(documentData));
       let pageIndex = 0;
+      let filteredIndex = 0;
       for (const i of filteredPageIndices) {
+        const rotationDelta = rotationDeltas?.[filteredIndex++] || 0;
         let newPageIndex;
         if (pageIndices) {
           newPageIndex = pageIndices[pageIndex++];
@@ -1064,7 +1081,9 @@ class PDFEditor {
         reservePageSlot(newPageIndex);
         promises.push(
           document.getPage(i).then(page => {
-            this.oldPages[newPageIndex] = new PageData(page, documentData);
+            const pageData = new PageData(page, documentData);
+            pageData.rotationDelta = rotationDelta;
+            this.oldPages[newPageIndex] = pageData;
           })
         );
       }
@@ -1102,7 +1121,8 @@ class PDFEditor {
       if (imageEntry) {
         this.newPages[i] = await this.#makeImagePage(
           imageEntry.image,
-          modalPageSize
+          imageEntry.pageSize || modalPageSize,
+          imageEntry.fullPage
         );
       } else {
         this.newPages[i] = await this.#makePageCopy(i, null);
@@ -2354,8 +2374,13 @@ class PDFEditor {
    * @returns {Promise<Ref>} the page reference in the new PDF document.
    */
   async #makePageCopy(pageIndex) {
-    const { page, documentData, annotations, pointingNamedDestinations } =
-      this.oldPages[pageIndex];
+    const {
+      page,
+      documentData,
+      annotations,
+      pointingNamedDestinations,
+      rotationDelta,
+    } = this.oldPages[pageIndex];
     this.currentDocument = documentData;
     const { dedupNamedDestinations, oldRefMapping } = documentData;
     const { xref, rotate, mediaBox, resources, ref: oldPageRef } = page;
@@ -2390,7 +2415,7 @@ class PDFEditor {
     const lastRef = this.newRefCount;
     await this.#collectDependencies(pageDict, false, xref);
 
-    pageDict.set("Rotate", rotate);
+    pageDict.set("Rotate", (rotate + rotationDelta) % 360);
     pageDict.set("MediaBox", mediaBox);
     for (const boxName of ["CropBox", "BleedBox", "TrimBox", "ArtBox"]) {
       const box = page.getBoundingBox(boxName);
@@ -2516,18 +2541,20 @@ class PDFEditor {
 
   /**
    * Create a brand-new page that displays a single image, sized to the modal
-   * page dimensions with a margin equal to 10% of the page width on every
-   * side. The image is encoded as JPEG or lossless Flate depending on its
+   * page dimensions. Regular inserted images have a 10% margin; full-page
+   * images cover the entire page. The image is encoded as JPEG or lossless
+   * Flate depending on its
    * contents; when the source has transparency, an SMask carrying the alpha
    * channel is attached so the mask is preserved on render.
    * @param {ImageBitmap} bitmap
    * @param {{width: number, height: number}} pageSize
+   * @param {boolean} [fullPage]
    * @returns {Promise<Ref>}
    */
-  async #makeImagePage(bitmap, pageSize) {
+  async #makeImagePage(bitmap, pageSize, fullPage = false) {
     const { width: pageW, height: pageH } = pageSize;
     const DEFAULT_MARGIN_RATIO = 0.1;
-    const margin = pageW * DEFAULT_MARGIN_RATIO;
+    const margin = fullPage ? 0 : pageW * DEFAULT_MARGIN_RATIO;
     const availW = Math.max(1, pageW - 2 * margin);
     const availH = Math.max(1, pageH - 2 * margin);
 
@@ -2540,11 +2567,18 @@ class PDFEditor {
       height: imgH,
     } = await createImage(bitmap, this.xrefWrapper, { closeBitmap: true });
 
-    const scale = Math.min(availW / imgW, availH / imgH);
-    const drawW = imgW * scale;
-    const drawH = imgH * scale;
-    const tx = (pageW - drawW) / 2;
-    const ty = (pageH - drawH) / 2;
+    let drawW, drawH, tx, ty;
+    if (fullPage) {
+      drawW = pageW;
+      drawH = pageH;
+      tx = ty = 0;
+    } else {
+      const scale = Math.min(availW / imgW, availH / imgH);
+      drawW = imgW * scale;
+      drawH = imgH * scale;
+      tx = (pageW - drawW) / 2;
+      ty = (pageH - drawH) / 2;
+    }
 
     if (smaskStream) {
       const smaskRef = this.newRef;

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -43,6 +43,7 @@ import {
   FeatureTest,
   LINE_FACTOR,
   makeArr,
+  normalizeFreeTextAnnotationFontFamily,
   shadow,
   SVG_NS,
   unreachable,
@@ -3141,6 +3142,9 @@ class FreeTextAnnotationElement extends AnnotationElement {
       const content = (this.contentElement = document.createElement("div"));
       content.classList.add("annotationTextContent");
       content.setAttribute("role", "comment");
+      content.style.fontFamily = normalizeFreeTextAnnotationFontFamily(
+        this.data.defaultAppearanceData.fontName
+      );
       for (const line of this.textContent) {
         const lineSpan = document.createElement("span");
         lineSpan.textContent = line;
@@ -3149,10 +3153,8 @@ class FreeTextAnnotationElement extends AnnotationElement {
       this.container.append(content);
     }
 
-    if (!this.data.popupRef && this.hasPopupData) {
-      this.hasOwnCommentButton = true;
-      this._createPopup();
-    }
+    // /Contents is the visible FreeText value, not an implicit comment. An
+    // explicit /Popup annotation is still handled by AnnotationLayer.
 
     this._editOnDoubleClick();
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -981,6 +981,10 @@ class PDFDocumentProxy {
    * @typedef {Object} PageInfo
    * @property {null|Uint8Array} [document]
    * @property {ImageBitmap} [image] Image to insert as a synthetic page.
+   * @property {{width: number, height: number}} [pageSize] Dimensions of an
+   *  image-backed synthetic page in PDF points.
+   * @property {boolean} [fullPage] Whether the image fills the synthetic page
+   *  without the normal image-insertion margins.
    * @property {Array<Array<number>|number>} [includePages]
    *  included ranges or indices.
    * @property {Array<Array<number>|number>} [excludePages]
@@ -1005,6 +1009,8 @@ class PDFDocumentProxy {
    *  everything. Values beyond the current layout are clamped so the pages
    *  are appended at the end. Cannot be combined with `pageIndices` on the
    *  same entry.
+   * @property {Array<number>} [rotationDeltas] Clockwise rotation added to each
+   *  filtered page, in document order.
    */
 
   /**

--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -35,6 +35,7 @@ import { AnnotationEditor } from "./editor.js";
 import { FreeTextEditor } from "./freetext.js";
 import { HighlightEditor } from "./highlight.js";
 import { InkEditor } from "./ink.js";
+import { RedactionEditor } from "./redaction.js";
 import { SignatureEditor } from "./signature.js";
 import { StampEditor } from "./stamp.js";
 
@@ -104,6 +105,7 @@ class AnnotationEditorLayer {
       StampEditor,
       HighlightEditor,
       SignatureEditor,
+      RedactionEditor,
     ].map(type => [type._editorType, type])
   );
 
@@ -182,6 +184,11 @@ class AnnotationEditorLayer {
         this.enableClick();
         break;
       case AnnotationEditorType.HIGHLIGHT:
+        this.enableTextSelection();
+        this.togglePointerEvents(false);
+        this.disableClick();
+        break;
+      case AnnotationEditorType.REDACTION:
         this.enableTextSelection();
         this.togglePointerEvents(false);
         this.disableClick();
@@ -461,6 +468,9 @@ class AnnotationEditorLayer {
     // Unselect all the editors in order to let the user select some text
     // without being annoyed by an editor toolbar.
     this.#uiManager.unselectAll();
+    if (this.#uiManager.getMode() !== AnnotationEditorType.HIGHLIGHT) {
+      return;
+    }
     const { target } = event;
     if (
       target === this.#textLayer.div ||
@@ -850,8 +860,15 @@ class AnnotationEditorLayer {
     }
 
     const currentMode = this.#uiManager.getMode();
+    if (currentMode === AnnotationEditorType.STAMP) {
+      const data = this.#currentEditorType?.getDefaultCreationParams?.();
+      this.#uiManager.unselectAll();
+      if (data) {
+        this.createAndAddNewEditor(event, /* isCentered = */ true, data);
+      }
+      return;
+    }
     if (
-      currentMode === AnnotationEditorType.STAMP ||
       currentMode === AnnotationEditorType.POPUP ||
       currentMode === AnnotationEditorType.SIGNATURE
     ) {
@@ -859,7 +876,10 @@ class AnnotationEditorLayer {
       return;
     }
 
-    this.createAndAddNewEditor(event, /* isCentered = */ false);
+    this.createAndAddNewEditor(
+      event,
+      /* isCentered = */ currentMode === AnnotationEditorType.REDACTION
+    );
   }
 
   /**

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -183,7 +183,7 @@ class AnnotationEditor {
     this.annotationElementId = parameters.annotationElementId || null;
     this.creationDate = parameters.creationDate || new Date();
     this.modificationDate = parameters.modificationDate || null;
-    this.canAddComment = true;
+    this.canAddComment = false;
 
     const {
       rotation,
@@ -252,6 +252,7 @@ class AnnotationEditor {
       ink: "pdfjs-editor-ink-added-alert",
       stamp: "pdfjs-editor-stamp-added-alert",
       signature: "pdfjs-editor-signature-added-alert",
+      redaction: "pdfjs-editor-redaction-added-alert",
     });
 
     AnnotationEditor._l10nResizer ??= Object.freeze({
@@ -1232,6 +1233,9 @@ class AnnotationEditor {
   }
 
   set comment(value) {
+    if (!this.canAddComment) {
+      return;
+    }
     this.#comment ||= new Comment(this);
     if (typeof value === "object" && value !== null) {
       // Restore full comment data (used for undo).
@@ -1251,7 +1255,7 @@ class AnnotationEditor {
   }
 
   setCommentData({ comment, popupRef, richText }) {
-    if (!popupRef) {
+    if (!this.canAddComment || !popupRef) {
       return;
     }
     this.#comment ||= new Comment(this);
@@ -1283,6 +1287,9 @@ class AnnotationEditor {
   }
 
   async editComment(options) {
+    if (!this.canAddComment) {
+      return;
+    }
     this.#comment ||= new Comment(this);
     this.#comment.edit(options);
   }
@@ -1298,6 +1305,9 @@ class AnnotationEditor {
   }
 
   addComment(serialized) {
+    if (!this.canAddComment) {
+      return;
+    }
     if (this.hasEditedComment) {
       const DEFAULT_POPUP_WIDTH = 180;
       const DEFAULT_POPUP_HEIGHT = 100;

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -20,7 +20,10 @@ import {
   AnnotationEditorParamsType,
   AnnotationEditorType,
   assert,
+  FreeTextAnnotationFontFamily,
+  getFreeTextAnnotationFontStyle,
   LINE_FACTOR,
+  normalizeFreeTextAnnotationFontFamily,
   shadow,
   Util,
 } from "../../shared/util.js";
@@ -30,6 +33,7 @@ import { BasicColorPicker } from "./color_picker.js";
 import { FreeTextAnnotationElement } from "../annotation_layer.js";
 
 const EOL_PATTERN = /\r\n?|\n/g;
+const REDLINE_DEFAULT_FONT_FAMILY_KEY = "redlineDefaultFreeTextFontFamily";
 
 /**
  * Basic text editor in order to create a FreeTex annotation.
@@ -43,6 +47,16 @@ class FreeTextEditor extends AnnotationEditor {
 
   #fontSize;
 
+  #fontFamily;
+
+  #bold;
+
+  #italic;
+
+  #underline;
+
+  #textAlign;
+
   _colorPicker = null;
 
   static _freeTextDefaultContent = "";
@@ -52,6 +66,16 @@ class FreeTextEditor extends AnnotationEditor {
   static _defaultColor = null;
 
   static _defaultFontSize = 10;
+
+  static _defaultFontFamily = FreeTextAnnotationFontFamily.DEFAULT;
+
+  static _defaultBold = false;
+
+  static _defaultItalic = false;
+
+  static _defaultUnderline = false;
+
+  static _defaultTextAlign = "left";
 
   static get _keyboardManager() {
     const proto = FreeTextEditor.prototype;
@@ -130,6 +154,13 @@ class FreeTextEditor extends AnnotationEditor {
       FreeTextEditor._defaultColor ||
       AnnotationEditor._defaultLineColor;
     this.#fontSize = params.fontSize || FreeTextEditor._defaultFontSize;
+    this.#fontFamily = normalizeFreeTextAnnotationFontFamily(
+      params.fontFamily || FreeTextEditor._defaultFontFamily
+    );
+    this.#bold = params.bold ?? FreeTextEditor._defaultBold;
+    this.#italic = params.italic ?? FreeTextEditor._defaultItalic;
+    this.#underline = params.underline ?? FreeTextEditor._defaultUnderline;
+    this.#textAlign = params.textAlign || FreeTextEditor._defaultTextAlign;
     if (!this.annotationElementId) {
       this._uiManager.a11yAlert(AnnotationEditor._l10nAlert.freetext);
     }
@@ -154,6 +185,11 @@ class FreeTextEditor extends AnnotationEditor {
     this._internalPadding = parseFloat(
       style.getPropertyValue("--freetext-padding")
     );
+    try {
+      FreeTextEditor._defaultFontFamily = normalizeFreeTextAnnotationFontFamily(
+        localStorage.getItem(REDLINE_DEFAULT_FONT_FAMILY_KEY)
+      );
+    } catch {}
   }
 
   /** @inheritdoc */
@@ -164,6 +200,28 @@ class FreeTextEditor extends AnnotationEditor {
         break;
       case AnnotationEditorParamsType.FREETEXT_COLOR:
         FreeTextEditor._defaultColor = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_FONT_FAMILY:
+        FreeTextEditor._defaultFontFamily =
+          normalizeFreeTextAnnotationFontFamily(value);
+        try {
+          localStorage.setItem(
+            REDLINE_DEFAULT_FONT_FAMILY_KEY,
+            FreeTextEditor._defaultFontFamily
+          );
+        } catch {}
+        break;
+      case AnnotationEditorParamsType.FREETEXT_BOLD:
+        FreeTextEditor._defaultBold = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_ITALIC:
+        FreeTextEditor._defaultItalic = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_UNDERLINE:
+        FreeTextEditor._defaultUnderline = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_ALIGNMENT:
+        FreeTextEditor._defaultTextAlign = value;
         break;
     }
   }
@@ -176,6 +234,21 @@ class FreeTextEditor extends AnnotationEditor {
         break;
       case AnnotationEditorParamsType.FREETEXT_COLOR:
         this.#updateColor(value);
+        break;
+      case AnnotationEditorParamsType.FREETEXT_FONT_FAMILY:
+        this.#updateFontFamily(value);
+        break;
+      case AnnotationEditorParamsType.FREETEXT_BOLD:
+        this.#updateTextFormat(type, value);
+        break;
+      case AnnotationEditorParamsType.FREETEXT_ITALIC:
+        this.#updateTextFormat(type, value);
+        break;
+      case AnnotationEditorParamsType.FREETEXT_UNDERLINE:
+        this.#updateTextFormat(type, value);
+        break;
+      case AnnotationEditorParamsType.FREETEXT_ALIGNMENT:
+        this.#updateTextFormat(type, value);
         break;
     }
   }
@@ -191,6 +264,23 @@ class FreeTextEditor extends AnnotationEditor {
         AnnotationEditorParamsType.FREETEXT_COLOR,
         FreeTextEditor._defaultColor || AnnotationEditor._defaultLineColor,
       ],
+      [
+        AnnotationEditorParamsType.FREETEXT_FONT_FAMILY,
+        FreeTextEditor._defaultFontFamily,
+      ],
+      [AnnotationEditorParamsType.FREETEXT_BOLD, FreeTextEditor._defaultBold],
+      [
+        AnnotationEditorParamsType.FREETEXT_ITALIC,
+        FreeTextEditor._defaultItalic,
+      ],
+      [
+        AnnotationEditorParamsType.FREETEXT_UNDERLINE,
+        FreeTextEditor._defaultUnderline,
+      ],
+      [
+        AnnotationEditorParamsType.FREETEXT_ALIGNMENT,
+        FreeTextEditor._defaultTextAlign,
+      ],
     ];
   }
 
@@ -199,6 +289,11 @@ class FreeTextEditor extends AnnotationEditor {
     return [
       [AnnotationEditorParamsType.FREETEXT_SIZE, this.#fontSize],
       [AnnotationEditorParamsType.FREETEXT_COLOR, this.color],
+      [AnnotationEditorParamsType.FREETEXT_FONT_FAMILY, this.#fontFamily],
+      [AnnotationEditorParamsType.FREETEXT_BOLD, this.#bold],
+      [AnnotationEditorParamsType.FREETEXT_ITALIC, this.#italic],
+      [AnnotationEditorParamsType.FREETEXT_UNDERLINE, this.#underline],
+      [AnnotationEditorParamsType.FREETEXT_ALIGNMENT, this.#textAlign],
     ];
   }
 
@@ -230,6 +325,84 @@ class FreeTextEditor extends AnnotationEditor {
       post: this._uiManager.updateUI.bind(this._uiManager, this),
       mustExec: true,
       type: AnnotationEditorParamsType.FREETEXT_SIZE,
+      overwriteIfSameType: true,
+      keepUndo: true,
+    });
+  }
+
+  /**
+   * Update the font family and make this action undoable.
+   * @param {string} fontFamily
+   */
+  #updateFontFamily(fontFamily) {
+    const setFontFamily = family => {
+      this.#fontFamily = normalizeFreeTextAnnotationFontFamily(family);
+      this.#applyFontFamily();
+      this.#setEditorDimensions();
+    };
+    const savedFontFamily = this.#fontFamily;
+    this.addCommands({
+      cmd: setFontFamily.bind(this, fontFamily),
+      undo: setFontFamily.bind(this, savedFontFamily),
+      post: this._uiManager.updateUI.bind(this._uiManager, this),
+      mustExec: true,
+      type: AnnotationEditorParamsType.FREETEXT_FONT_FAMILY,
+      overwriteIfSameType: true,
+      keepUndo: true,
+    });
+  }
+
+  #applyFontFamily(element = this.editorDiv) {
+    if (element) {
+      element.style.fontFamily = this.#fontFamily;
+    }
+  }
+
+  #applyTextFormat(element = this.editorDiv) {
+    if (!element) {
+      return;
+    }
+    const { style } = element;
+    style.fontWeight = this.#bold ? "bold" : "normal";
+    style.fontStyle = this.#italic ? "italic" : "normal";
+    style.textDecoration = this.#underline ? "underline" : "none";
+    style.textAlign = this.#textAlign;
+  }
+
+  #setTextFormat(type, value) {
+    switch (type) {
+      case AnnotationEditorParamsType.FREETEXT_BOLD:
+        this.#bold = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_ITALIC:
+        this.#italic = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_UNDERLINE:
+        this.#underline = value;
+        break;
+      case AnnotationEditorParamsType.FREETEXT_ALIGNMENT:
+        this.#textAlign = value;
+        break;
+    }
+    this.#applyTextFormat();
+    this.#setEditorDimensions();
+  }
+
+  #updateTextFormat(type, value) {
+    let savedValue = this.#textAlign;
+    if (type === AnnotationEditorParamsType.FREETEXT_BOLD) {
+      savedValue = this.#bold;
+    } else if (type === AnnotationEditorParamsType.FREETEXT_ITALIC) {
+      savedValue = this.#italic;
+    } else if (type === AnnotationEditorParamsType.FREETEXT_UNDERLINE) {
+      savedValue = this.#underline;
+    }
+    this.addCommands({
+      cmd: this.#setTextFormat.bind(this, type, value),
+      undo: this.#setTextFormat.bind(this, type, savedValue),
+      post: this._uiManager.updateUI.bind(this._uiManager, this),
+      mustExec: true,
+      type,
       overwriteIfSameType: true,
       keepUndo: true,
     });
@@ -582,6 +755,8 @@ class FreeTextEditor extends AnnotationEditor {
     const { style } = this.editorDiv;
     style.fontSize = `calc(${this.#fontSize}px * var(--total-scale-factor))`;
     style.color = this.color;
+    this.#applyFontFamily();
+    this.#applyTextFormat();
 
     this.div.append(this.editorDiv);
 
@@ -782,7 +957,7 @@ class FreeTextEditor extends AnnotationEditor {
     if (data instanceof FreeTextAnnotationElement) {
       const {
         data: {
-          defaultAppearanceData: { fontSize, fontColor },
+          defaultAppearanceData,
           rect,
           rotation,
           id,
@@ -791,6 +966,8 @@ class FreeTextEditor extends AnnotationEditor {
           contentsObj,
           creationDate,
           modificationDate,
+          textAlignment,
+          underline,
         },
         textContent,
         textPosition,
@@ -798,6 +975,10 @@ class FreeTextEditor extends AnnotationEditor {
           page: { pageNumber },
         },
       } = data;
+      const { fontSize, fontColor } = defaultAppearanceData;
+      const { bold, italic } = getFreeTextAnnotationFontStyle(
+        defaultAppearanceData.fontName
+      );
       // textContent is supposed to be an array of strings containing each line
       // of text. However, it can be null or empty.
       if (!textContent || textContent.length === 0) {
@@ -807,7 +988,14 @@ class FreeTextEditor extends AnnotationEditor {
       initialData = data = {
         annotationType: AnnotationEditorType.FREETEXT,
         color: Array.from(fontColor),
+        fontFamily: normalizeFreeTextAnnotationFontFamily(
+          defaultAppearanceData.fontName
+        ),
+        bold,
         fontSize,
+        italic,
+        textAlign: ["left", "center", "right"][textAlignment] || "left",
+        underline,
         value: textContent.join("\n"),
         position: textPosition,
         pageIndex: pageNumber - 1,
@@ -825,6 +1013,11 @@ class FreeTextEditor extends AnnotationEditor {
     }
     const editor = await super.deserialize(data, parent, uiManager);
     editor.#fontSize = data.fontSize;
+    editor.#fontFamily = normalizeFreeTextAnnotationFontFamily(data.fontFamily);
+    editor.#bold = !!data.bold;
+    editor.#italic = !!data.italic;
+    editor.#underline = !!data.underline;
+    editor.#textAlign = data.textAlign || "left";
     editor.color = Util.makeHexColor(...data.color);
     editor.#content = FreeTextEditor.#deserializeContent(data.value);
     editor._initialData = initialData;
@@ -849,8 +1042,13 @@ class FreeTextEditor extends AnnotationEditor {
       this.isAttachedToDOM ? getComputedStyle(this.editorDiv).color : this.color
     );
     const serialized = Object.assign(super.serialize(isForCopying), {
+      bold: this.#bold,
       color,
+      fontFamily: this.#fontFamily,
       fontSize: this.#fontSize,
+      italic: this.#italic,
+      textAlign: this.#textAlign,
+      underline: this.#underline,
       value: this.#serializeContent(),
     });
     this.addComment(serialized);
@@ -872,13 +1070,28 @@ class FreeTextEditor extends AnnotationEditor {
   }
 
   #hasElementChanged(serialized) {
-    const { value, fontSize, color, pageIndex } = this._initialData;
+    const {
+      bold,
+      color,
+      fontFamily,
+      fontSize,
+      italic,
+      pageIndex,
+      textAlign,
+      underline,
+      value,
+    } = this._initialData;
 
     return (
       this.hasEditedComment ||
       this._hasBeenMoved ||
       serialized.value !== value ||
+      serialized.fontFamily !== fontFamily ||
       serialized.fontSize !== fontSize ||
+      serialized.bold !== !!bold ||
+      serialized.italic !== !!italic ||
+      serialized.underline !== !!underline ||
+      serialized.textAlign !== (textAlign || "left") ||
       serialized.color.some((c, i) => c !== color[i]) ||
       serialized.pageIndex !== pageIndex
     );
@@ -893,6 +1106,8 @@ class FreeTextEditor extends AnnotationEditor {
     const { style } = content;
     style.fontSize = `calc(${this.#fontSize}px * var(--total-scale-factor))`;
     style.color = this.color;
+    this.#applyFontFamily(content);
+    this.#applyTextFormat(content);
 
     content.replaceChildren();
     for (const line of this.#content.split("\n")) {
@@ -905,10 +1120,7 @@ class FreeTextEditor extends AnnotationEditor {
 
     annotation.updateEdited({
       rect: this.getPDFRect(),
-      popup:
-        this._uiManager.hasCommentManager() || this.hasEditedComment
-          ? this.comment
-          : { text: this.#content },
+      popup: this.hasEditedComment ? this.comment : null,
     });
 
     return content;

--- a/src/display/editor/redaction.js
+++ b/src/display/editor/redaction.js
@@ -1,0 +1,204 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AnnotationEditor } from "./editor.js";
+import { AnnotationEditorType } from "../../shared/util.js";
+import { MathClamp } from "../../shared/math_clamp.js";
+
+/**
+ * A visual redaction marker. It is intentionally not saved as a PDF annotation:
+ * the viewer rasterizes pages containing these editors and paints the black
+ * boxes into the replacement page image.
+ */
+class RedactionEditor extends AnnotationEditor {
+  #boxes = null;
+
+  static _type = "redaction";
+
+  static _editorType = AnnotationEditorType.REDACTION;
+
+  constructor(params) {
+    super({ ...params, name: "redactionEditor" });
+    if (params.boxes?.length > 0) {
+      this.#setBoxes(params.boxes);
+    } else {
+      this.width ||= 0.24;
+      this.height ||= 0.065;
+    }
+    this.canAddComment = false;
+    this.defaultL10nId = "pdfjs-editor-redaction-editor";
+  }
+
+  #boxToCurrentCoords({ x, y, width, height }) {
+    const [pageWidth, pageHeight] = this.pageDimensions;
+    const [pageX, pageY] = this.pageTranslation;
+    const left = x * pageWidth + pageX;
+    const top = (1 - y) * pageHeight + pageY;
+    const rect = [
+      left,
+      top - height * pageHeight,
+      left + width * pageWidth,
+      top,
+    ];
+    const [currentX, currentY, currentWidth, currentHeight] =
+      this.getRectInCurrentCoords(rect, pageHeight);
+
+    return {
+      x: currentX / pageWidth,
+      y: currentY / pageHeight,
+      width: currentWidth / pageWidth,
+      height: currentHeight / pageHeight,
+    };
+  }
+
+  #setBoxes(boxes) {
+    const currentBoxes = boxes.map(this.#boxToCurrentCoords, this);
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+
+    for (const { x, y, width, height } of currentBoxes) {
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + width);
+      maxY = Math.max(maxY, y + height);
+    }
+
+    this.x = minX;
+    this.y = minY;
+    this.width = maxX - minX;
+    this.height = maxY - minY;
+
+    this.#boxes = currentBoxes.map(({ x, y, width, height }) => ({
+      x: (x - minX) / this.width,
+      y: (y - minY) / this.height,
+      width: width / this.width,
+      height: height / this.height,
+    }));
+  }
+
+  #getPDFRectForBox({ x, y, width, height }) {
+    const [pageWidth, pageHeight] = this.pageDimensions;
+    const [pageX, pageY] = this.pageTranslation;
+    const boxX = this.x + x * this.width;
+    const boxY = this.y + y * this.height;
+    const boxWidth = width * this.width;
+    const boxHeight = height * this.height;
+    const old = {
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+    };
+
+    this.x = boxX;
+    this.y = boxY;
+    this.width = boxWidth;
+    this.height = boxHeight;
+    const rect = this.getRect(0, 0);
+    this.x = old.x;
+    this.y = old.y;
+    this.width = old.width;
+    this.height = old.height;
+
+    return rect.map((value, i) => {
+      if (i % 2 === 0) {
+        return MathClamp(value, pageX, pageX + pageWidth);
+      }
+      return MathClamp(value, pageY, pageY + pageHeight);
+    });
+  }
+
+  #getRedactionRects() {
+    if (!this.#boxes) {
+      return [this.getPDFRect()];
+    }
+    return this.#boxes.map(box => this.#getPDFRectForBox(box));
+  }
+
+  #renderBoxes() {
+    if (!this.div) {
+      return;
+    }
+    const boxes = this.#boxes || [{ x: 0, y: 0, width: 1, height: 1 }];
+    for (const box of boxes) {
+      const element = document.createElement("div");
+      element.className = "redactionEditorBox";
+      element.style.left = `${(100 * box.x).toFixed(2)}%`;
+      element.style.top = `${(100 * box.y).toFixed(2)}%`;
+      element.style.width = `${(100 * box.width).toFixed(2)}%`;
+      element.style.height = `${(100 * box.height).toFixed(2)}%`;
+      this.div.append(element);
+    }
+  }
+
+  /** @inheritdoc */
+  static initialize(l10n, uiManager) {
+    AnnotationEditor.initialize(l10n, uiManager);
+  }
+
+  /** @inheritdoc */
+  get isResizable() {
+    return true;
+  }
+
+  /** @inheritdoc */
+  render() {
+    if (this.div) {
+      return this.div;
+    }
+
+    super.render();
+    this.#renderBoxes();
+    this.setDims();
+
+    return this.div;
+  }
+
+  /** @inheritdoc */
+  onceAdded(focus) {
+    if (!this.annotationElementId) {
+      this.parent.addUndoableEditor(this);
+      this._uiManager.a11yAlert(AnnotationEditor._l10nAlert[this.editorType]);
+    }
+    this._isDraggable = true;
+    if (this._initialOptions?.isCentered) {
+      this.center();
+    }
+    this._initialOptions = null;
+    if (focus) {
+      this.div.focus();
+    }
+  }
+
+  /** @inheritdoc */
+  serialize(isForCopying = false) {
+    if (this.deleted) {
+      return this.serializeDeleted();
+    }
+
+    const serialized = Object.assign(super.serialize(isForCopying), {
+      color: [0, 0, 0],
+      redactionRects: this.#getRedactionRects(),
+    });
+    if (isForCopying) {
+      serialized.isCopy = true;
+    }
+    return serialized;
+  }
+}
+
+export { RedactionEditor };

--- a/src/display/editor/stamp.js
+++ b/src/display/editor/stamp.js
@@ -13,7 +13,11 @@
  * limitations under the License.
  */
 
-import { AnnotationEditorType, AnnotationPrefix } from "../../shared/util.js";
+import {
+  AnnotationEditorParamsType,
+  AnnotationEditorType,
+  AnnotationPrefix,
+} from "../../shared/util.js";
 import {
   ColorScheme,
   OutputScale,
@@ -22,6 +26,8 @@ import {
 } from "../display_utils.js";
 import { AnnotationEditor } from "./editor.js";
 import { StampAnnotationElement } from "../annotation_layer.js";
+
+const REDLINE_DEBUG_IMAGE_SIZING_KEY = "redlinePdfjsDebugImageSizing";
 
 /**
  * Basic text editor in order to create a FreeTex annotation.
@@ -47,22 +53,74 @@ class StampEditor extends AnnotationEditor {
 
   #isSvg = false;
 
+  #initialWidth = null;
+
   #hasBeenAddedInUndoStack = false;
 
   static _type = "stamp";
 
   static _editorType = AnnotationEditorType.STAMP;
 
+  static _defaultCreationParams = null;
+
   constructor(params) {
     super({ ...params, name: "stampEditor" });
     this.#bitmapUrl = params.bitmapUrl;
     this.#bitmapFile = params.bitmapFile;
+    this.#initialWidth = params.initialWidth || null;
+    if (params.altText) {
+      this.altTextData = { altText: params.altText, decorative: false };
+    }
     this.defaultL10nId = "pdfjs-editor-stamp-editor";
   }
 
   /** @inheritdoc */
   static initialize(l10n, uiManager) {
     AnnotationEditor.initialize(l10n, uiManager);
+  }
+
+  /** @inheritdoc */
+  static updateDefaultParams(type, value) {
+    if (type === AnnotationEditorParamsType.STAMP_IMAGE) {
+      this._defaultCreationParams = value;
+    }
+  }
+
+  static getDefaultCreationParams() {
+    return this._defaultCreationParams;
+  }
+
+  get #hasCanonicalDimensions() {
+    return typeof this.width === "number" && typeof this.height === "number";
+  }
+
+  #debugImageSizing(action, details = null) {
+    let enabled = false;
+    try {
+      enabled = localStorage.getItem(REDLINE_DEBUG_IMAGE_SIZING_KEY) === "1";
+    } catch {}
+    if (!enabled) {
+      return;
+    }
+    const { width: naturalWidth, height: naturalHeight } = this.#bitmap || {};
+    const [pageWidth, pageHeight] = this.pageDimensions;
+    const base = {
+      action,
+      naturalWidth,
+      naturalHeight,
+      pageWidth,
+      pageHeight,
+      zoomScale: this.scale,
+    };
+    if (this.#hasCanonicalDimensions) {
+      base.storedCanonicalWidth = this.width;
+      base.storedCanonicalHeight = this.height;
+    }
+    // eslint-disable-next-line no-console
+    console.debug(
+      "PDF.js stamp sizing",
+      details ? { ...base, ...details } : base
+    );
   }
 
   /** @inheritdoc */
@@ -413,6 +471,11 @@ class StampEditor extends AnnotationEditor {
     if (this.#resizeTimeoutId !== null) {
       clearTimeout(this.#resizeTimeoutId);
     }
+    if (this.#hasCanonicalDimensions) {
+      this.#debugImageSizing(
+        "skippedInitialFitBecauseCanonicalDimensionsExist"
+      );
+    }
     // The user's zooming the page, there is no need to redraw the bitmap at
     // each step, hence we wait a bit before redrawing it.
     const TIME_TO_WAIT = 200;
@@ -424,24 +487,42 @@ class StampEditor extends AnnotationEditor {
 
   #createCanvas() {
     const { div } = this;
-    let { width, height } = this.#bitmap;
+    const { width: naturalWidth, height: naturalHeight } = this.#bitmap;
+    let width = naturalWidth;
+    let height = naturalHeight;
     const [pageWidth, pageHeight] = this.pageDimensions;
-    const MAX_RATIO = 0.75;
-    if (this.width) {
+    const MAX_RATIO = 0.8;
+    let fitScale = 1;
+    let fitOnceApplied = false;
+    let usedCanonicalDimensions = false;
+    if (this.#hasCanonicalDimensions) {
       width = this.width * pageWidth;
       height = this.height * pageHeight;
+      usedCanonicalDimensions = true;
+    } else if (this.#initialWidth) {
+      width = Math.min(this.#initialWidth, MAX_RATIO) * pageWidth;
+      height = (width * naturalHeight) / naturalWidth;
+      if (height > MAX_RATIO * pageHeight) {
+        const heightScale = (MAX_RATIO * pageHeight) / height;
+        width *= heightScale;
+        height *= heightScale;
+      }
+      fitScale = width / naturalWidth;
+      fitOnceApplied = true;
+      this.#initialWidth = null;
     } else if (
       width > MAX_RATIO * pageWidth ||
       height > MAX_RATIO * pageHeight
     ) {
       // If the image is too big compared to the page dimensions
       // (more than MAX_RATIO) then we scale it down.
-      const factor = Math.min(
+      fitScale = Math.min(
         (MAX_RATIO * pageWidth) / width,
         (MAX_RATIO * pageHeight) / height
       );
-      width *= factor;
-      height *= factor;
+      width *= fitScale;
+      height *= fitScale;
+      fitOnceApplied = true;
     }
 
     this._uiManager.enableWaiting(false);
@@ -452,6 +533,13 @@ class StampEditor extends AnnotationEditor {
     this.width = width / pageWidth;
     this.height = height / pageHeight;
     this.setDims();
+    this.#debugImageSizing("createCanvas", {
+      initialFitScale: fitScale,
+      placedWidth: width,
+      placedHeight: height,
+      fitOnceApplied,
+      rerenderSkippedInitialFit: usedCanonicalDimensions,
+    });
 
     if (this._initialOptions?.isCentered) {
       this.center();
@@ -661,6 +749,10 @@ class StampEditor extends AnnotationEditor {
       !canvas ||
       (canvas.width === scaledWidth && canvas.height === scaledHeight)
     ) {
+      this.#debugImageSizing("drawBitmapSkipped", {
+        serializedWidth: width,
+        serializedHeight: height,
+      });
       return;
     }
 
@@ -684,6 +776,12 @@ class StampEditor extends AnnotationEditor {
       scaledWidth,
       scaledHeight
     );
+    this.#debugImageSizing("drawBitmap", {
+      serializedWidth: width,
+      serializedHeight: height,
+      canvasWidth: canvas.width,
+      canvasHeight: canvas.height,
+    });
   }
 
   #serializeBitmap(toUrl) {
@@ -818,6 +916,10 @@ class StampEditor extends AnnotationEditor {
     const [parentWidth, parentHeight] = editor.pageDimensions;
     editor.width = (rect[2] - rect[0]) / parentWidth;
     editor.height = (rect[3] - rect[1]) / parentHeight;
+    editor.#debugImageSizing("deserialize", {
+      deserializedWidth: rect[2] - rect[0],
+      deserializedHeight: rect[3] - rect[1],
+    });
 
     if (accessibilityData) {
       editor.altTextData = accessibilityData;
@@ -846,6 +948,12 @@ class StampEditor extends AnnotationEditor {
     const serialized = Object.assign(super.serialize(isForCopying), {
       bitmapId: this.#bitmapId,
       isSvg: this.#isSvg,
+    });
+    this.#debugImageSizing("serialize", {
+      serializedDimensions: [
+        serialized.rect[2] - serialized.rect[0],
+        serialized.rect[3] - serialized.rect[1],
+      ],
     });
     this.addComment(serialized);
 

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -1469,7 +1469,36 @@ class AnnotationEditorUIManager {
   }
 
   commentSelection(methodOfCreation = "") {
-    this.highlightSelection(methodOfCreation, /* comment */ true);
+    void methodOfCreation;
+  }
+
+  redactSelection(methodOfCreation = "") {
+    const selection = document.getSelection();
+    if (!selection || selection.isCollapsed) {
+      return;
+    }
+    const anchorElement = this.#getAnchorElementForSelection(selection);
+    const textLayer = anchorElement.closest(".textLayer");
+    const boxes =
+      this.getSelectionBoxes(textLayer, { granularity: "character" }) ||
+      this.getSelectionBoxes(textLayer);
+    if (!boxes) {
+      return;
+    }
+    selection.empty();
+
+    const layer = this.#getLayerForTextLayer(textLayer);
+    const callback = () => {
+      layer?.createAndAddNewEditor({ x: 0, y: 0 }, false, {
+        methodOfCreation,
+        boxes,
+      });
+    };
+    if (this.#mode === AnnotationEditorType.NONE) {
+      this.switchToMode(AnnotationEditorType.REDACTION, callback);
+      return;
+    }
+    callback();
   }
 
   #beforeUnload(e) {
@@ -1577,6 +1606,7 @@ class AnnotationEditorUIManager {
 
     if (
       this.#mode !== AnnotationEditorType.HIGHLIGHT &&
+      this.#mode !== AnnotationEditorType.REDACTION &&
       this.#mode !== AnnotationEditorType.NONE
     ) {
       return;
@@ -1589,7 +1619,8 @@ class AnnotationEditorUIManager {
     this.#highlightWhenShiftUp = this.isShiftKeyDown;
     if (!this.isShiftKeyDown) {
       const activeLayer =
-        this.#mode === AnnotationEditorType.HIGHLIGHT
+        this.#mode === AnnotationEditorType.HIGHLIGHT ||
+        this.#mode === AnnotationEditorType.REDACTION
           ? this.#getLayerForTextLayer(textLayer)
           : null;
       activeLayer?.toggleDrawing();
@@ -1624,6 +1655,8 @@ class AnnotationEditorUIManager {
   #onSelectEnd(methodOfCreation = "") {
     if (this.#mode === AnnotationEditorType.HIGHLIGHT) {
       this.highlightSelection(methodOfCreation);
+    } else if (this.#mode === AnnotationEditorType.REDACTION) {
+      this.redactSelection(methodOfCreation);
     } else if (this.#enableHighlightFloatingButton) {
       this.#displayFloatingToolbar();
     }
@@ -2266,6 +2299,12 @@ class AnnotationEditorUIManager {
     switch (type) {
       case AnnotationEditorParamsType.CREATE:
         this.currentLayer.addNewEditor(value);
+        return;
+      case AnnotationEditorParamsType.STAMP_IMAGE:
+        for (const editorType of this.#editorTypes) {
+          editorType.updateDefaultParams(type, value);
+        }
+        this.unselectAll();
         return;
       case AnnotationEditorParamsType.HIGHLIGHT_SHOW_ALL:
         this._eventBus.dispatch("reporttelemetry", {
@@ -2951,7 +2990,75 @@ class AnnotationEditorUIManager {
     return shadow(this, "imageManager", new ImageManager());
   }
 
-  getSelectionBoxes(textLayer) {
+  #getSelectionCharacterBoxes(selection, textLayer, rotator) {
+    const { ownerDocument } = textLayer;
+    const boxes = [];
+    const charRange = ownerDocument.createRange();
+    const segmenter =
+      typeof Intl !== "undefined" && Intl.Segmenter
+        ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+        : null;
+
+    const collectSegments = text => {
+      if (segmenter) {
+        return Array.from(segmenter.segment(text), ({ index, segment }) => [
+          index,
+          index + segment.length,
+        ]);
+      }
+      const segments = [];
+      for (let i = 0, ii = text.length; i < ii; ) {
+        const length = text.codePointAt(i) > 0xffff ? 2 : 1;
+        segments.push([i, i + length]);
+        i += length;
+      }
+      return segments;
+    };
+
+    const walker = ownerDocument.createTreeWalker(
+      textLayer,
+      NodeFilter.SHOW_TEXT
+    );
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const text = node.nodeValue || "";
+      if (!text) {
+        continue;
+      }
+
+      for (let i = 0, ii = selection.rangeCount; i < ii; i++) {
+        const range = selection.getRangeAt(i);
+        if (!range.intersectsNode(node)) {
+          continue;
+        }
+
+        const start = range.startContainer === node ? range.startOffset : 0;
+        const end = range.endContainer === node ? range.endOffset : text.length;
+        if (start >= end) {
+          continue;
+        }
+
+        for (const [segmentStart, segmentEnd] of collectSegments(text)) {
+          const from = Math.max(segmentStart, start);
+          const to = Math.min(segmentEnd, end);
+          if (from >= to) {
+            continue;
+          }
+          charRange.setStart(node, from);
+          charRange.setEnd(node, to);
+          for (const { x, y, width, height } of charRange.getClientRects()) {
+            if (width === 0 || height === 0) {
+              continue;
+            }
+            boxes.push(rotator(x, y, width, height));
+          }
+        }
+      }
+    }
+    charRange.detach?.();
+    return boxes.length === 0 ? null : boxes;
+  }
+
+  getSelectionBoxes(textLayer, options = null) {
     if (!textLayer) {
       return null;
     }
@@ -3007,6 +3114,10 @@ class AnnotationEditorUIManager {
           height: h / parentHeight,
         });
         break;
+    }
+
+    if (options?.granularity === "character") {
+      return this.#getSelectionCharacterBoxes(selection, textLayer, rotator);
     }
 
     const boxes = [];

--- a/src/display/pages_mapper.js
+++ b/src/display/pages_mapper.js
@@ -38,6 +38,9 @@ class PagesMapper {
    */
   #prevPageNumbers = null;
 
+  /** Rotation added to each page position, in clockwise degrees. */
+  #rotationDeltas = null;
+
   /** @type {number} */
   #pagesNumber = 0;
 
@@ -61,6 +64,7 @@ class PagesMapper {
     this.#pagesNumber = n;
     this.#pageNumberToId = null;
     this.#prevPageNumbers = null;
+    this.#rotationDeltas = null;
   }
 
   /**
@@ -77,6 +81,7 @@ class PagesMapper {
       pageNumberToId[i] = i + 1;
     }
     this.#prevPageNumbers = new Int32Array(pageNumberToId);
+    this.#rotationDeltas = new Int16Array(n);
   }
 
   /**
@@ -114,11 +119,13 @@ class PagesMapper {
     const prevIdToPageNumber = this.#buildIdToPageNumber();
     const movedCount = pagesToMove.length;
     const mappedPagesToMove = new Uint32Array(movedCount);
+    const movedRotations = new Int16Array(movedCount);
     let removedBeforeTarget = 0;
 
     for (let i = 0; i < movedCount; i++) {
       const pageIndex = pagesToMove[i] - 1;
       mappedPagesToMove[i] = pageNumberToId[pageIndex];
+      movedRotations[i] = this.#rotationDeltas[pageIndex];
       if (pageIndex < index) {
         removedBeforeTarget++;
       }
@@ -135,7 +142,8 @@ class PagesMapper {
     // Compact: keep only non-moved pages.
     for (let i = 0, r = 0; i < pagesNumber; i++) {
       if (!selectedPages.has(i + 1)) {
-        pageNumberToId[r++] = pageNumberToId[i];
+        pageNumberToId[r] = pageNumberToId[i];
+        this.#rotationDeltas[r++] = this.#rotationDeltas[i];
       }
     }
 
@@ -146,10 +154,19 @@ class PagesMapper {
       remainingLen
     );
     pageNumberToId.set(mappedPagesToMove, adjustedTarget);
+    this.#rotationDeltas.copyWithin(
+      adjustedTarget + movedCount,
+      adjustedTarget,
+      remainingLen
+    );
+    this.#rotationDeltas.set(movedRotations, adjustedTarget);
 
     this.#updatePrevPageNumbers(prevIdToPageNumber);
 
-    if (pageNumberToId.every((id, i) => id === i + 1)) {
+    if (
+      pageNumberToId.every((id, i) => id === i + 1) &&
+      this.#rotationDeltas.every(rotation => rotation === 0)
+    ) {
       this.#pageNumberToId = null;
     }
   }
@@ -168,12 +185,14 @@ class PagesMapper {
       pageNumberToId: pageNumberToId.slice(),
       pagesNumber: this.#pagesNumber,
       prevPageNumbers: this.#prevPageNumbers.slice(),
+      rotationDeltas: this.#rotationDeltas.slice(),
     };
 
     const newN = this.#pagesNumber - pagesToDelete.length;
     this.#pagesNumber = newN;
     const newPageNumberToId = (this.#pageNumberToId = new Uint32Array(newN));
     this.#prevPageNumbers = new Int32Array(newN);
+    const newRotationDeltas = new Int16Array(newN);
 
     let sourceIndex = 0;
     let destIndex = 0;
@@ -185,12 +204,21 @@ class PagesMapper {
           destIndex
         );
         destIndex += pageIndex - sourceIndex;
+        newRotationDeltas.set(
+          this.#rotationDeltas.subarray(sourceIndex, pageIndex),
+          destIndex - (pageIndex - sourceIndex)
+        );
       }
       sourceIndex = pageIndex + 1;
     }
     if (sourceIndex < pageNumberToId.length) {
       newPageNumberToId.set(pageNumberToId.subarray(sourceIndex), destIndex);
+      newRotationDeltas.set(
+        this.#rotationDeltas.subarray(sourceIndex),
+        destIndex
+      );
     }
+    this.#rotationDeltas = newRotationDeltas;
 
     this.#updatePrevPageNumbers(prevIdToPageNumber, new Set(pagesToDelete));
   }
@@ -200,6 +228,7 @@ class PagesMapper {
       this.#pageNumberToId = this.#savedData.pageNumberToId;
       this.#pagesNumber = this.#savedData.pagesNumber;
       this.#prevPageNumbers = this.#savedData.prevPageNumbers;
+      this.#rotationDeltas = this.#savedData.rotationDeltas;
       this.#savedData = null;
     }
   }
@@ -217,6 +246,7 @@ class PagesMapper {
     this.#clipboard = {
       pageNumbers: pagesToCopy,
       pageIds: pagesToCopy.map(n => this.#pageNumberToId[n - 1]),
+      rotationDeltas: pagesToCopy.map(n => this.#rotationDeltas[n - 1]),
     };
   }
 
@@ -232,13 +262,17 @@ class PagesMapper {
     this.#ensureInit();
     const pageNumberToId = this.#pageNumberToId;
     const prevIdToPageNumber = this.#buildIdToPageNumber();
-    const { pageNumbers: copiedPageNumbers, pageIds: copiedPageIds } =
-      this.#clipboard;
+    const {
+      pageNumbers: copiedPageNumbers,
+      pageIds: copiedPageIds,
+      rotationDeltas: copiedRotationDeltas,
+    } = this.#clipboard;
 
     const newN = this.#pagesNumber + copiedPageNumbers.length;
     this.#pagesNumber = newN;
     const newPageNumberToId = (this.#pageNumberToId = new Uint32Array(newN));
     this.#prevPageNumbers = new Int32Array(newN);
+    const newRotationDeltas = new Int16Array(newN);
 
     newPageNumberToId.set(pageNumberToId.subarray(0, index), 0);
     newPageNumberToId.set(copiedPageIds, index);
@@ -246,6 +280,13 @@ class PagesMapper {
       pageNumberToId.subarray(index),
       index + copiedPageNumbers.length
     );
+    newRotationDeltas.set(this.#rotationDeltas.subarray(0, index), 0);
+    newRotationDeltas.set(copiedRotationDeltas, index);
+    newRotationDeltas.set(
+      this.#rotationDeltas.subarray(index),
+      index + copiedPageNumbers.length
+    );
+    this.#rotationDeltas = newRotationDeltas;
 
     this.#updatePrevPageNumbers(
       prevIdToPageNumber,
@@ -303,11 +344,32 @@ class PagesMapper {
   }
 
   /**
+   * Add a clockwise rotation to the given page positions.
+   * @param {Iterable<number>} pageNumbers
+   * @param {number} delta
+   */
+  rotatePages(pageNumbers, delta) {
+    this.#ensureInit();
+    for (const pageNumber of pageNumbers) {
+      const index = pageNumber - 1;
+      this.#rotationDeltas[index] =
+        (this.#rotationDeltas[index] + delta + 360) % 360;
+    }
+  }
+
+  getRotationDelta(pageNumber) {
+    return this.#rotationDeltas?.[pageNumber - 1] || 0;
+  }
+
+  /**
    * Checks if the page mappings have been altered from their initial state.
    * @returns {boolean}
    */
   hasBeenAltered() {
-    return this.#pageNumberToId !== null;
+    return (
+      this.#pageNumberToId !== null ||
+      !!this.#rotationDeltas?.some(rotation => rotation !== 0)
+    );
   }
 
   /**
@@ -347,19 +409,26 @@ class PagesMapper {
         document: null,
         pageIndices: [],
         includePages: [],
+        rotationDeltas: [],
       };
     }
 
     for (const [id, pageNumbers] of idToPageNumber) {
       for (let i = 0, ii = pageNumbers.length; i < ii; i++) {
-        extractParams[i].includePages.push([id - 1, pageNumbers[i] - 1]);
+        const pageIndex = pageNumbers[i] - 1;
+        extractParams[i].includePages.push([
+          id - 1,
+          pageIndex,
+          this.#rotationDeltas?.[pageIndex] || 0,
+        ]);
       }
     }
 
-    for (const { includePages, pageIndices } of extractParams) {
+    for (const { includePages, pageIndices, rotationDeltas } of extractParams) {
       includePages.sort((a, b) => a[0] - b[0]);
       for (let i = 0, ii = includePages.length; i < ii; i++) {
         pageIndices.push(includePages[i][1]);
+        rotationDeltas.push(includePages[i][2]);
         includePages[i] = includePages[i][0];
       }
     }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -84,6 +84,7 @@ const AnnotationEditorType = {
   POPUP: 16,
   SIGNATURE: 101,
   COMMENT: 102,
+  REDACTION: 103,
 };
 
 const AnnotationEditorParamsType = {
@@ -92,6 +93,11 @@ const AnnotationEditorParamsType = {
   FREETEXT_SIZE: 11,
   FREETEXT_COLOR: 12,
   FREETEXT_OPACITY: 13,
+  FREETEXT_FONT_FAMILY: 14,
+  FREETEXT_BOLD: 15,
+  FREETEXT_ITALIC: 16,
+  FREETEXT_UNDERLINE: 17,
+  FREETEXT_ALIGNMENT: 18,
   INK_COLOR: 21,
   INK_THICKNESS: 22,
   INK_OPACITY: 23,
@@ -101,7 +107,84 @@ const AnnotationEditorParamsType = {
   HIGHLIGHT_FREE: 33,
   HIGHLIGHT_SHOW_ALL: 34,
   DRAW_STEP: 41,
+  STAMP_IMAGE: 42,
 };
+
+const FreeTextAnnotationFontFamily = {
+  DEFAULT: "Helvetica",
+  HELVETICA: "Helvetica",
+  ARIAL: "Arial",
+  TIMES_NEW_ROMAN: "Times New Roman",
+  COURIER_NEW: "Courier New",
+  GEORGIA: "Georgia",
+  VERDANA: "Verdana",
+};
+
+const FreeTextAnnotationFontAliases = new Map([
+  ["Helv", FreeTextAnnotationFontFamily.HELVETICA],
+  ["Helvetica", FreeTextAnnotationFontFamily.HELVETICA],
+  ["HelvB", FreeTextAnnotationFontFamily.HELVETICA],
+  ["HelvI", FreeTextAnnotationFontFamily.HELVETICA],
+  ["HelvBI", FreeTextAnnotationFontFamily.HELVETICA],
+  ["Arial", FreeTextAnnotationFontFamily.ARIAL],
+  ["Times", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["Times-Roman", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["TimesNewRoman", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["Times New Roman", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["TimesB", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["TimesI", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["TimesBI", FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN],
+  ["Courier", FreeTextAnnotationFontFamily.COURIER_NEW],
+  ["CourierNew", FreeTextAnnotationFontFamily.COURIER_NEW],
+  ["Courier New", FreeTextAnnotationFontFamily.COURIER_NEW],
+  ["CourierB", FreeTextAnnotationFontFamily.COURIER_NEW],
+  ["CourierI", FreeTextAnnotationFontFamily.COURIER_NEW],
+  ["CourierBI", FreeTextAnnotationFontFamily.COURIER_NEW],
+  ["Georgia", FreeTextAnnotationFontFamily.GEORGIA],
+  ["Verdana", FreeTextAnnotationFontFamily.VERDANA],
+]);
+
+const FreeTextAnnotationPdfFontMap = new Map([
+  [
+    FreeTextAnnotationFontFamily.HELVETICA,
+    { resourceName: "Helv", pdfFontName: "Helvetica" },
+  ],
+  [
+    FreeTextAnnotationFontFamily.ARIAL,
+    { resourceName: "Helv", pdfFontName: "Helvetica" },
+  ],
+  [
+    FreeTextAnnotationFontFamily.TIMES_NEW_ROMAN,
+    { resourceName: "Times", pdfFontName: "Times-Roman" },
+  ],
+  [
+    FreeTextAnnotationFontFamily.COURIER_NEW,
+    { resourceName: "Courier", pdfFontName: "Courier" },
+  ],
+  [
+    FreeTextAnnotationFontFamily.GEORGIA,
+    { resourceName: "Times", pdfFontName: "Times-Roman" },
+  ],
+  [
+    FreeTextAnnotationFontFamily.VERDANA,
+    { resourceName: "Helv", pdfFontName: "Helvetica" },
+  ],
+]);
+
+function normalizeFreeTextAnnotationFontFamily(fontFamily) {
+  return (
+    FreeTextAnnotationFontAliases.get(fontFamily) ||
+    FreeTextAnnotationFontFamily.DEFAULT
+  );
+}
+
+function getFreeTextAnnotationFontStyle(fontName) {
+  const name = typeof fontName === "string" ? fontName : "";
+  return {
+    bold: /Bold|BI$|B$/i.test(name),
+    italic: /Italic|Oblique|BI$|I$/i.test(name),
+  };
+}
 
 // Permission flags from Table 22, Section 7.6.3.2 of the PDF specification.
 const PermissionFlag = {
@@ -1165,6 +1248,10 @@ export {
   FeatureTest,
   FONT_IDENTITY_MATRIX,
   FormatError,
+  FreeTextAnnotationFontAliases,
+  FreeTextAnnotationFontFamily,
+  FreeTextAnnotationPdfFontMap,
+  getFreeTextAnnotationFontStyle,
   getUuid,
   getVerbosityLevel,
   ImageKind,
@@ -1178,6 +1265,7 @@ export {
   makeMap,
   makeObj,
   MeshFigureType,
+  normalizeFreeTextAnnotationFontFamily,
   normalizeUnicode,
   objectSize,
   OPS,

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -4798,6 +4798,42 @@ describe("annotation", function () {
       ]);
     });
 
+    it("should save FreeText formatting in the PDF appearance", async () => {
+      const xref = (partialEvaluator.xref = new XRefMock());
+      const task = new WorkerTask("test styled FreeText creation");
+      const changes = new RefSetCache();
+      await AnnotationFactory.saveNewAnnotations(
+        partialEvaluator,
+        xref,
+        task,
+        [
+          {
+            annotationType: AnnotationEditorType.FREETEXT,
+            bold: true,
+            color: [0, 0, 0],
+            fontFamily: "Times New Roman",
+            fontSize: 10,
+            italic: true,
+            rect: [12, 34, 120, 78],
+            rotation: 0,
+            textAlign: "center",
+            underline: true,
+            value: "Styled",
+          },
+        ],
+        null,
+        changes
+      );
+      const data = await writeChanges(changes, xref);
+      const output = data.map(({ data: chunk }) => chunk).join("\n");
+
+      expect(output).toContain("/BaseFont /Times-BoldItalic");
+      expect(output).toContain("/DA (/TimesBI 10 Tf 0 g)");
+      expect(output).toContain("/Q 1");
+      expect(output).toContain("/RedlineUnderline true");
+      expect(output).toContain(" l S");
+    });
+
     it("should update an existing FreeText annotation", async function () {
       const freeTextDict = new Dict();
       freeTextDict.set("Type", Name.get("Annot"));

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -35,6 +35,7 @@
     "node_stream_spec.js",
     "obj_bin_transform_spec.js",
     "operator_list_dependencies_spec.js",
+    "pages_mapper_spec.js",
     "parser_spec.js",
     "pattern_spec.js",
     "pdf.image_decoders_spec.js",

--- a/test/unit/editor_spec.js
+++ b/test/unit/editor_spec.js
@@ -14,13 +14,58 @@
  */
 
 import {
+  AnnotationEditorParamsType,
+  AnnotationEditorType,
+  FeatureTest,
+  getFreeTextAnnotationFontStyle,
+} from "../../src/shared/util.js";
+import {
   CommandManager,
   KeyboardManager,
 } from "../../src/display/editor/tools.js";
-import { FeatureTest } from "../../src/shared/util.js";
+import { RedactionEditor } from "../../src/display/editor/redaction.js";
 import { SignatureExtractor } from "../../src/display/editor/drawers/signaturedraw.js";
+import { StampEditor } from "../../src/display/editor/stamp.js";
 
 describe("editor", function () {
+  it("should expose redaction and text formatting editor types", function () {
+    expect(RedactionEditor._editorType).toEqual(AnnotationEditorType.REDACTION);
+    expect(AnnotationEditorParamsType.FREETEXT_BOLD).toBeDefined();
+    expect(AnnotationEditorParamsType.FREETEXT_ITALIC).toBeDefined();
+    expect(AnnotationEditorParamsType.FREETEXT_UNDERLINE).toBeDefined();
+    expect(AnnotationEditorParamsType.FREETEXT_ALIGNMENT).toBeDefined();
+  });
+
+  it("should infer saved Base-14 font styles", function () {
+    expect(getFreeTextAnnotationFontStyle("HelvB")).toEqual({
+      bold: true,
+      italic: false,
+    });
+    expect(getFreeTextAnnotationFontStyle("TimesBI")).toEqual({
+      bold: true,
+      italic: true,
+    });
+  });
+
+  it("should store hardcoded stamp creation parameters", function () {
+    const params = {
+      bitmapUrl: "chrome-extension://test/stamp-check.svg",
+      initialWidth: 0.12,
+    };
+
+    StampEditor.updateDefaultParams(
+      AnnotationEditorParamsType.STAMP_IMAGE,
+      params
+    );
+    expect(StampEditor.getDefaultCreationParams()).toBe(params);
+
+    StampEditor.updateDefaultParams(
+      AnnotationEditorParamsType.STAMP_IMAGE,
+      null
+    );
+    expect(StampEditor.getDefaultCreationParams()).toBeNull();
+  });
+
   describe("Command Manager", function () {
     it("should check undo/redo", function () {
       const manager = new CommandManager(4);

--- a/test/unit/pages_mapper_spec.js
+++ b/test/unit/pages_mapper_spec.js
@@ -1,0 +1,41 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PagesMapper } from "../../src/display/pages_mapper.js";
+
+describe("PagesMapper", function () {
+  it("should preserve page rotations through duplication and deletion", function () {
+    const mapper = new PagesMapper();
+    mapper.pagesNumber = 3;
+
+    mapper.rotatePages([2], 90);
+    expect(mapper.getRotationDelta(2)).toEqual(90);
+
+    mapper.copyPages(Uint32Array.of(2));
+    mapper.pastePages(2);
+    expect(mapper.pagesNumber).toEqual(4);
+    expect(mapper.getRotationDelta(2)).toEqual(90);
+    expect(mapper.getRotationDelta(3)).toEqual(90);
+
+    mapper.deletePages(Uint32Array.of(2));
+    expect(mapper.pagesNumber).toEqual(3);
+    expect(mapper.getRotationDelta(2)).toEqual(90);
+
+    const params = mapper.getPageMappingForSaving();
+    expect(params.flatMap(({ rotationDeltas }) => rotationDeltas)).toContain(
+      90
+    );
+  });
+});

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -148,10 +148,11 @@
 .annotationEditorLayer.disabled {
   pointer-events: none;
 
-  &.highlightEditing
+  &:is(.highlightEditing, .redactionEditing)
     :is(
       .freeTextEditor,
       .inkEditor,
+      .redactionEditor,
       .stampEditor,
       .signatureEditor,
       .commentPopup
@@ -168,12 +169,26 @@
   cursor: var(--editorInk-editing-cursor);
 }
 
+.annotationEditorLayer.stampEditing {
+  cursor: crosshair;
+}
+
+.annotationEditorLayer.redactionEditing {
+  cursor: crosshair;
+}
+
 .annotationEditorLayer .draw {
   box-sizing: border-box;
 }
 
 .annotationEditorLayer
-  :is(.freeTextEditor, .inkEditor, .stampEditor, .signatureEditor) {
+  :is(
+    .freeTextEditor,
+    .inkEditor,
+    .redactionEditor,
+    .stampEditor,
+    .signatureEditor
+  ) {
   position: absolute;
   background: transparent;
   z-index: 1;
@@ -234,6 +249,7 @@
   :is(
     .freeTextEditor,
     .inkEditor,
+    .redactionEditor,
     .stampEditor,
     .highlightEditor,
     .signatureEditor
@@ -562,6 +578,12 @@
   height: 100%;
 }
 
+.annotationEditorLayer .redactionEditorBox {
+  position: absolute;
+  background: #000;
+  pointer-events: none;
+}
+
 .annotationEditorLayer .inkEditor.editing {
   cursor: inherit;
 }
@@ -627,7 +649,13 @@
 }
 
 .annotationEditorLayer {
-  :is(.freeTextEditor, .inkEditor, .stampEditor, .signatureEditor) {
+  :is(
+    .freeTextEditor,
+    .inkEditor,
+    .redactionEditor,
+    .stampEditor,
+    .signatureEditor
+  ) {
     & > .resizers {
       position: absolute;
       inset: 0;

--- a/web/annotation_editor_params.js
+++ b/web/annotation_editor_params.js
@@ -27,10 +27,16 @@ import { internalOpt } from "./internal_evt.js";
  * @typedef {Object} AnnotationEditorParamsOptions
  * @property {HTMLInputElement} editorFreeTextFontSize
  * @property {HTMLInputElement} editorFreeTextColor
+ * @property {HTMLSelectElement} editorFreeTextFontFamily
+ * @property {HTMLButtonElement} editorFreeTextBold
+ * @property {HTMLButtonElement} editorFreeTextItalic
+ * @property {HTMLButtonElement} editorFreeTextUnderline
+ * @property {NodeListOf<HTMLButtonElement>} editorFreeTextAlignments
  * @property {HTMLInputElement} editorInkColor
  * @property {HTMLInputElement} editorInkThickness
  * @property {HTMLInputElement} editorInkOpacity
  * @property {HTMLButtonElement} editorStampAddImage
+ * @property {NodeListOf<HTMLButtonElement>} editorStampChoices
  * @property {HTMLInputElement} editorFreeHighlightThickness
  * @property {HTMLButtonElement} editorHighlightShowAll
  * @property {HTMLButtonElement} editorSignatureAddSignature
@@ -52,10 +58,16 @@ class AnnotationEditorParams {
   #bindListeners({
     editorFreeTextFontSize,
     editorFreeTextColor,
+    editorFreeTextFontFamily,
+    editorFreeTextBold,
+    editorFreeTextItalic,
+    editorFreeTextUnderline,
+    editorFreeTextAlignments,
     editorInkColor,
     editorInkThickness,
     editorInkOpacity,
     editorStampAddImage,
+    editorStampChoices,
     editorFreeHighlightThickness,
     editorHighlightShowAll,
     editorSignatureAddSignature,
@@ -75,6 +87,27 @@ class AnnotationEditorParams {
     editorFreeTextColor.addEventListener("input", function () {
       dispatchEvent("FREETEXT_COLOR", this.value);
     });
+    editorFreeTextFontFamily.addEventListener("input", function () {
+      dispatchEvent("FREETEXT_FONT_FAMILY", this.value);
+    });
+    const bindTextToggle = (button, type) => {
+      button.addEventListener("click", function () {
+        const selected = this.getAttribute("aria-pressed") !== "true";
+        this.setAttribute("aria-pressed", selected);
+        dispatchEvent(type, selected);
+      });
+    };
+    bindTextToggle(editorFreeTextBold, "FREETEXT_BOLD");
+    bindTextToggle(editorFreeTextItalic, "FREETEXT_ITALIC");
+    bindTextToggle(editorFreeTextUnderline, "FREETEXT_UNDERLINE");
+    for (const button of editorFreeTextAlignments) {
+      button.addEventListener("click", function () {
+        for (const choice of editorFreeTextAlignments) {
+          choice.setAttribute("aria-pressed", choice === this);
+        }
+        dispatchEvent("FREETEXT_ALIGNMENT", this.dataset.alignment);
+      });
+    }
 
     // Handlers for INK_COLOR and INK_OPACITY sync-back, set up differently
     // depending on whether alpha is supported.
@@ -134,7 +167,24 @@ class AnnotationEditorParams {
     editorInkThickness.addEventListener("input", function () {
       dispatchEvent("INK_THICKNESS", this.valueAsNumber);
     });
+    const setStampChoiceSelected = (button, selected) => {
+      for (const choice of editorStampChoices) {
+        choice.setAttribute("aria-pressed", choice === button && selected);
+      }
+      dispatchEvent(
+        "STAMP_IMAGE",
+        selected
+          ? {
+              altText: button.dataset.stampAlt,
+              bitmapUrl: new URL(button.dataset.stampSrc, document.baseURI)
+                .href,
+              initialWidth: Number(button.dataset.stampWidth),
+            }
+          : null
+      );
+    };
     editorStampAddImage.addEventListener("click", () => {
+      setStampChoiceSelected(null, false);
       eventBus.dispatch("reporttelemetry", {
         source: this,
         details: {
@@ -144,6 +194,12 @@ class AnnotationEditorParams {
       });
       dispatchEvent("CREATE");
     });
+    for (const choice of editorStampChoices) {
+      choice.addEventListener("click", function () {
+        const selected = this.getAttribute("aria-pressed") !== "true";
+        setStampChoiceSelected(this, selected);
+      });
+    }
     editorFreeHighlightThickness.addEventListener("input", function () {
       dispatchEvent("HIGHLIGHT_THICKNESS", this.valueAsNumber);
     });
@@ -166,6 +222,26 @@ class AnnotationEditorParams {
               break;
             case AnnotationEditorParamsType.FREETEXT_COLOR:
               editorFreeTextColor.value = value;
+              break;
+            case AnnotationEditorParamsType.FREETEXT_FONT_FAMILY:
+              editorFreeTextFontFamily.value = value;
+              break;
+            case AnnotationEditorParamsType.FREETEXT_BOLD:
+              editorFreeTextBold.setAttribute("aria-pressed", value);
+              break;
+            case AnnotationEditorParamsType.FREETEXT_ITALIC:
+              editorFreeTextItalic.setAttribute("aria-pressed", value);
+              break;
+            case AnnotationEditorParamsType.FREETEXT_UNDERLINE:
+              editorFreeTextUnderline.setAttribute("aria-pressed", value);
+              break;
+            case AnnotationEditorParamsType.FREETEXT_ALIGNMENT:
+              for (const choice of editorFreeTextAlignments) {
+                choice.setAttribute(
+                  "aria-pressed",
+                  choice.dataset.alignment === value
+                );
+              }
               break;
             case AnnotationEditorParamsType.INK_COLOR:
               updateInkColor(value);

--- a/web/app.js
+++ b/web/app.js
@@ -40,6 +40,7 @@ import {
 } from "./ui_utils.js";
 import {
   AnnotationEditorType,
+  AnnotationMode,
   build,
   FeatureTest,
   getDocument,
@@ -1393,23 +1394,165 @@ const PDFViewerApplication = {
     // a message and change PdfjsChild.sys.mjs to take it into account.
     const { classList } = this.appConfig.appContainer;
     classList.add("wait");
-
-    if (this.pdfThumbnailViewer?.hasStructuralChanges()) {
-      this.externalServices.reportTelemetry({
-        type: "pageOrganization",
-        data: { action: "save" },
-      });
-      await this.onSavePages({
-        data: this.pdfThumbnailViewer.getStructuralChanges(),
-      });
-    } else {
-      await (this.pdfDocument?.annotationStorage.size > 0
-        ? this.save()
-        : this.download());
+    try {
+      const redactions = this._getRedactions();
+      if (redactions.length > 0) {
+        await this._saveWithRedactions(redactions);
+      } else if (this.pdfThumbnailViewer?.hasStructuralChanges()) {
+        this.externalServices.reportTelemetry({
+          type: "pageOrganization",
+          data: { action: "save" },
+        });
+        await this.onSavePages({
+          data: this.pdfThumbnailViewer.getStructuralChanges(),
+        });
+      } else {
+        await (this.pdfDocument?.annotationStorage.size > 0
+          ? this.save()
+          : this.download());
+      }
+      delete this._mergedDocumentNeedsSaving;
+      this.setTitle();
+    } finally {
+      classList.remove("wait");
     }
-    delete this._mergedDocumentNeedsSaving;
-    this.setTitle();
-    classList.remove("wait");
+  },
+
+  _getRedactions() {
+    const redactions = [];
+    for (const [key, value] of this.pdfDocument?.annotationStorage || []) {
+      if (value?.mode !== AnnotationEditorType.REDACTION) {
+        continue;
+      }
+      const serialized = value.serialize?.(false);
+      if (serialized && !serialized.deleted) {
+        redactions.push({ key, serialized, value });
+      }
+    }
+    return redactions;
+  },
+
+  async _renderRedactedPage(pageIndex, redactions) {
+    const page = await this.pdfDocument.getPage(pageIndex + 1);
+    const rotation =
+      (page.rotate +
+        this.pdfDocument.pagesMapper.getRotationDelta(pageIndex + 1)) %
+      360;
+    let scale = window.devicePixelRatio || 1;
+    if (scale < 2) {
+      scale = 2;
+    } else if (scale > 3) {
+      scale = 3;
+    }
+    const viewport = page.getViewport({ rotation, scale });
+    const canvas = new OffscreenCanvas(
+      Math.ceil(viewport.width),
+      Math.ceil(viewport.height)
+    );
+    const canvasContext = canvas.getContext("2d", { alpha: false });
+
+    await page.render({
+      annotationMode: AnnotationMode.ENABLE_STORAGE,
+      background: "#ffffff",
+      canvasContext,
+      viewport,
+    }).promise;
+
+    canvasContext.fillStyle = "#000000";
+    for (const redaction of redactions) {
+      for (const rect of redaction.redactionRects || [redaction.rect]) {
+        const [x1, y1] = viewport.convertToViewportPoint(rect[0], rect[1]);
+        const [x2, y2] = viewport.convertToViewportPoint(rect[2], rect[3]);
+        const x = Math.min(x1, x2);
+        const y = Math.min(y1, y2);
+        const width = Math.abs(x2 - x1);
+        const height = Math.abs(y2 - y1);
+        canvasContext.fillRect(x - 1, y - 1, width + 2, height + 2);
+      }
+    }
+
+    return {
+      fullPage: true,
+      image: canvas.transferToImageBitmap(),
+      pageIndices: [pageIndex],
+      pageSize: {
+        width: viewport.width / scale,
+        height: viewport.height / scale,
+      },
+    };
+  },
+
+  async _saveWithRedactions(redactions) {
+    if (this._saveInProgress) {
+      return;
+    }
+    this._saveInProgress = true;
+    await this.pdfScriptingManager.dispatchWillSave();
+
+    const { annotationStorage, pagesMapper } = this.pdfDocument;
+    const removed = new Map();
+    let saved = false;
+    try {
+      const grouped = new Map();
+      for (const { key, serialized, value } of redactions) {
+        removed.set(key, value);
+        annotationStorage.remove(key);
+        const list = grouped.get(serialized.pageIndex) || [];
+        list.push(serialized);
+        grouped.set(serialized.pageIndex, list);
+      }
+
+      const imagePages = await Promise.all(
+        [...grouped].map(([pageIndex, pageRedactions]) =>
+          this._renderRedactedPage(pageIndex, pageRedactions)
+        )
+      );
+      const redactedPageIndices = new Set(grouped.keys());
+
+      for (const [key, value] of annotationStorage) {
+        const pageIndex = value?.pageIndex ?? value?.page?._pageIndex;
+        if (!redactedPageIndices.has(pageIndex)) {
+          continue;
+        }
+        removed.set(key, value);
+        annotationStorage.remove(key);
+      }
+
+      const usedIds = new Map();
+      for (
+        let pageNumber = 1;
+        pageNumber <= pagesMapper.pagesNumber;
+        ++pageNumber
+      ) {
+        if (redactedPageIndices.has(pageNumber - 1)) {
+          continue;
+        }
+        const id = pagesMapper.getPageId(pageNumber);
+        const pageNumbers = usedIds.get(id) || [];
+        pageNumbers.push(pageNumber);
+        usedIds.set(id, pageNumbers);
+      }
+      const extractParams = usedIds.size
+        ? pagesMapper.getPageMappingForSaving(usedIds)
+        : [];
+      extractParams.push(...imagePages);
+
+      const data = await this.pdfDocument.extractPages(extractParams);
+      this.downloadManager.download(data, this._downloadUrl, this._docFilename);
+      saved = true;
+    } catch (reason) {
+      console.error("Error when permanently redacting the document:", reason);
+      throw reason;
+    } finally {
+      for (const [key, value] of removed) {
+        annotationStorage.setValue(key, value);
+      }
+      if (saved) {
+        annotationStorage.resetModified();
+      }
+      await this.pdfScriptingManager.dispatchDidSave();
+      this._saveInProgress = false;
+    }
   },
 
   /**
@@ -2286,6 +2429,18 @@ const PDFViewerApplication = {
       );
     }
     eventBus.on("pagesedited", this.onPagesEdited.bind(this), opts);
+    eventBus.on(
+      "individualpagerotationchanged",
+      ({ rotations }) => {
+        for (const { pageNumber, rotationDelta } of rotations) {
+          pdfViewer.getPageView(pageNumber - 1)?.update({
+            rotation: (pdfViewer.pagesRotation + rotationDelta) % 360,
+          });
+        }
+        pdfViewer.update();
+      },
+      opts
+    );
     eventBus.on("saveextractedpages", this.onSavePages.bind(this), opts);
     eventBus.on("saveandload", this.onSaveAndLoad.bind(this), opts);
   },

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -239,7 +239,8 @@ const defaultOptions = {
   },
   enableMerge: {
     /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+    value:
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING || CHROME"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableNewAltTextWhenAddingImage: {
@@ -279,7 +280,8 @@ const defaultOptions = {
   },
   enableSplitMerge: {
     /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+    value:
+      typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING || CHROME"),
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   enableUpdatedAddImage: {
@@ -297,7 +299,7 @@ const defaultOptions = {
   },
   externalLinkTarget: {
     /** @type {number} */
-    value: 0,
+    value: 2,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   highlightEditorColors: {

--- a/web/images/editor-align-center.svg
+++ b/web/images/editor-align-center.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M1 2h14v2H1zm2 5h10v2H3zm-2 5h14v2H1z"/></svg>

--- a/web/images/editor-align-left.svg
+++ b/web/images/editor-align-left.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M1 2h14v2H1zm0 5h10v2H1zm0 5h14v2H1z"/></svg>

--- a/web/images/editor-align-right.svg
+++ b/web/images/editor-align-right.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path d="M1 2h14v2H1zm4 5h10v2H5zm-4 5h14v2H1z"/></svg>

--- a/web/images/stamp-arrow.svg
+++ b/web/images/stamp-arrow.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 48"><path fill="none" stroke="#c8252c" stroke-linecap="round" stroke-linejoin="round" stroke-width="7" d="M6 24h76M62 7l20 17-20 17"/></svg>

--- a/web/images/stamp-check.svg
+++ b/web/images/stamp-check.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path fill="none" stroke="#c8252c" stroke-linecap="round" stroke-linejoin="round" stroke-width="9" d="m10 34 14 14 30-34"/></svg>

--- a/web/images/stamp-circle.svg
+++ b/web/images/stamp-circle.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="25" fill="none" stroke="#c8252c" stroke-width="6"/></svg>

--- a/web/images/stamp-rectangle.svg
+++ b/web/images/stamp-rectangle.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64"><rect x="6" y="7" width="84" height="50" rx="1" fill="none" stroke="#c8252c" stroke-width="6"/></svg>

--- a/web/images/stamp-triangle.svg
+++ b/web/images/stamp-triangle.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 64"><path fill="none" stroke="#c8252c" stroke-linejoin="round" stroke-width="6" d="M36 6 66 57H6z"/></svg>

--- a/web/images/stamp-x.svg
+++ b/web/images/stamp-x.svg
@@ -1,0 +1,15 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path fill="none" stroke="#c8252c" stroke-linecap="round" stroke-width="9" d="m13 13 38 38M51 13 13 51"/></svg>

--- a/web/images/toolbarButton-editorRedaction.svg
+++ b/web/images/toolbarButton-editorRedaction.svg
@@ -1,0 +1,17 @@
+<!-- Copyright 2026 Mozilla Foundation
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M2 4h12v8H2zM0 2h5v1H1v4H0zm11 0h5v5h-1V3h-4zM0 9h1v4h4v1H0zm15 0h1v5h-5v-1h4z"/>
+</svg>

--- a/web/pdf_thumbnail_viewer.js
+++ b/web/pdf_thumbnail_viewer.js
@@ -137,6 +137,12 @@ class PDFThumbnailViewer {
 
   #manageCutButton = null;
 
+  #manageRotateButton = null;
+
+  #manageAddBlankButton = null;
+
+  #manageDuplicateButton = null;
+
   #copiedThumbnails = null;
 
   #savedThumbnails = null;
@@ -223,6 +229,9 @@ class PDFThumbnailViewer {
       const {
         button: menuButton,
         menu,
+        rotate,
+        addBlank,
+        duplicate,
         copy,
         cut,
         delete: del,
@@ -241,11 +250,16 @@ class PDFThumbnailViewer {
         "pagesloaded",
         () => {
           menuButton.disabled = false;
+          rotate.disabled = addBlank.disabled = duplicate.disabled = false;
+          del.disabled = !this.#canDelete();
         },
         { once: true, ...internalOpt }
       );
 
       this._manageMenu = new Menu(menu, menuButton, [
+        rotate,
+        addBlank,
+        duplicate,
         copy,
         cut,
         del,
@@ -262,6 +276,12 @@ class PDFThumbnailViewer {
       copy.addEventListener("click", this.#copyPages.bind(this));
       this.#manageCutButton = cut;
       cut.addEventListener("click", this.#cutPages.bind(this));
+      this.#manageRotateButton = rotate;
+      rotate.addEventListener("click", this.#rotatePages.bind(this));
+      this.#manageAddBlankButton = addBlank;
+      addBlank.addEventListener("click", this.#addBlankPage.bind(this));
+      this.#manageDuplicateButton = duplicate;
+      duplicate.addEventListener("click", this.#duplicatePages.bind(this));
 
       this.#toggleMenuEntries(false);
       menuButton.disabled = true;
@@ -383,6 +403,10 @@ class PDFThumbnailViewer {
       this.#toggleBar("status");
       return;
     }
+    this.#insertPageEntries(entries, insertAfter);
+  }
+
+  #insertPageEntries(entries, insertAfter) {
     const pagesCount = this.#pagesMapper.pagesNumber;
     const data = this.hasStructuralChanges()
       ? this.getStructuralChanges()
@@ -417,6 +441,83 @@ class PDFThumbnailViewer {
     this.eventBus.dispatch("saveandload", {
       source: this,
       data,
+    });
+  }
+
+  #getActionPageNumbers() {
+    if (this.#selectedPages?.size) {
+      return Uint32Array.from(this.#selectedPages).sort((a, b) => a - b);
+    }
+    return Uint32Array.of(this._currentPageNumber);
+  }
+
+  #rotatePages() {
+    const pageNumbers = this.#getActionPageNumbers();
+    const pagesMapper = this.#pagesMapper;
+    pagesMapper.rotatePages(pageNumbers, 90);
+    const rotations = [];
+    for (const pageNumber of pageNumbers) {
+      const rotationDelta = pagesMapper.getRotationDelta(pageNumber);
+      this._thumbnails[pageNumber - 1].update({
+        rotation: (this._pagesRotation + rotationDelta) % 360,
+      });
+      rotations.push({ pageNumber, rotationDelta });
+    }
+    this.#reportTelemetry({ action: "rotate" });
+    this.eventBus.dispatch("individualpagerotationchanged", {
+      source: this,
+      rotations,
+    });
+    this.eventBus.dispatch("pagesedited", {
+      source: this,
+      pagesMapper,
+      type: "rotate",
+    });
+  }
+
+  #addBlankPage() {
+    const canvas = new OffscreenCanvas(612, 792);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "white";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    this.#reportTelemetry({ action: "addBlank" });
+    this.#toggleBar("waiting", "pdfjs-views-manager-waiting-for-file");
+    this.#insertPageEntries(
+      [
+        {
+          image: canvas.transferToImageBitmap(),
+          insertAfter: this._currentPageNumber - 1,
+        },
+      ],
+      this._currentPageNumber - 1
+    );
+  }
+
+  #duplicatePages() {
+    const pageNumbers = (this.#copiedPageNumbers =
+      this.#getActionPageNumbers());
+    const pagesMapper = this.#pagesMapper;
+    pagesMapper.copyPages(pageNumbers);
+    this.#copiedThumbnails = new Map();
+    for (const pageNumber of pageNumbers) {
+      this.#copiedThumbnails.set(pageNumber, this._thumbnails[pageNumber - 1]);
+    }
+    const insertIndex = pageNumbers.at(-1);
+    pagesMapper.pastePages(insertIndex);
+    this.#updateThumbnails(this._currentPageNumber);
+    this.#savedThumbnails = null;
+    this.#thumbnailsPositions = null;
+    this.#copiedThumbnails = null;
+    this.#copiedPageNumbers = null;
+    this.#selectedPages?.clear();
+    this.#updateMenuEntries();
+    this.#updateStatus("select");
+    this.#updateCurrentPage(insertIndex + 1, /* forceFocus = */ true);
+    this.#reportTelemetry({ action: "duplicate" });
+    this.eventBus.dispatch("pagesedited", {
+      source: this,
+      pagesMapper,
+      type: "paste",
     });
   }
 
@@ -494,9 +595,11 @@ class PDFThumbnailViewer {
     }
     this._pagesRotation = rotation;
 
-    const updateArgs = { rotation };
-    for (const thumbnail of this._thumbnails) {
-      thumbnail.update(updateArgs);
+    for (let i = 0, ii = this._thumbnails.length; i < ii; i++) {
+      const rotationDelta = this.#pagesMapper?.getRotationDelta(i + 1) || 0;
+      this._thumbnails[i].update({
+        rotation: (rotation + rotationDelta) % 360,
+      });
     }
   }
 
@@ -852,7 +955,7 @@ class PDFThumbnailViewer {
       draggedContainer.style.translate = "";
     }
 
-    const selectedPages = this.#selectedPages;
+    const selectedPages = (this.#selectedPages ??= new Set());
     if (
       !isNaN(lastDraggedOverIndex) &&
       isDropping &&
@@ -996,7 +1099,7 @@ class PDFThumbnailViewer {
   }
 
   #canDelete() {
-    const size = this.#selectedPages?.size || 0;
+    const size = this.#selectedPages?.size || (this._thumbnails.length ? 1 : 0);
     return size > 0 && size < this._thumbnails.length;
   }
 
@@ -1142,7 +1245,10 @@ class PDFThumbnailViewer {
       return;
     }
 
-    const selectedPages = this.#selectedPages;
+    const selectedPages = (this.#selectedPages ??= new Set());
+    if (selectedPages.size === 0) {
+      selectedPages.add(this._currentPageNumber);
+    }
     if (type === "delete") {
       this.#reportTelemetry({ action: "delete" });
       this.#updateStatus("delete");
@@ -1175,6 +1281,10 @@ class PDFThumbnailViewer {
     this.#manageExportButton.disabled = this.#manageCopyButton.disabled = !size;
     this.#manageDeleteButton.disabled = this.#manageCutButton.disabled =
       !this.#canDelete();
+    this.#manageRotateButton.disabled =
+      this.#manageAddBlankButton.disabled =
+      this.#manageDuplicateButton.disabled =
+        false;
   }
 
   #toggleMenuEntries(enable) {

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -105,6 +105,18 @@ class Toolbar {
         },
       },
       {
+        element: options.editorRedactionButton,
+        eventName: "switchannotationeditormode",
+        eventDetails: {
+          get mode() {
+            const { classList } = options.editorRedactionButton;
+            return classList.contains("toggled")
+              ? AnnotationEditorType.NONE
+              : AnnotationEditorType.REDACTION;
+          },
+        },
+      },
+      {
         element: options.editorInkButton,
         eventName: "switchannotationeditormode",
         eventDetails: {
@@ -324,6 +336,7 @@ class Toolbar {
       editorFreeTextParamsToolbar,
       editorHighlightButton,
       editorHighlightParamsToolbar,
+      editorRedactionButton,
       editorInkButton,
       editorInkParamsToolbar,
       editorStampButton,
@@ -348,6 +361,10 @@ class Toolbar {
       editorHighlightParamsToolbar
     );
     toggleExpandedBtn(
+      editorRedactionButton,
+      mode === AnnotationEditorType.REDACTION
+    );
+    toggleExpandedBtn(
       editorInkButton,
       mode === AnnotationEditorType.INK,
       editorInkParamsToolbar
@@ -366,6 +383,7 @@ class Toolbar {
     editorCommentButton.disabled =
       editorFreeTextButton.disabled =
       editorHighlightButton.disabled =
+      editorRedactionButton.disabled =
       editorInkButton.disabled =
       editorStampButton.disabled =
       editorSignatureButton.disabled =

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -80,6 +80,7 @@
   --toolbarButton-editorComment-icon: url(images/comment-editButton.svg);
   --toolbarButton-editorFreeText-icon: url(images/toolbarButton-editorFreeText.svg);
   --toolbarButton-editorHighlight-icon: url(images/toolbarButton-editorHighlight.svg);
+  --toolbarButton-editorRedaction-icon: url(images/toolbarButton-editorRedaction.svg);
   --toolbarButton-editorInk-icon: url(images/toolbarButton-editorInk.svg);
   --toolbarButton-editorStamp-icon: url(images/toolbarButton-editorStamp.svg);
   --toolbarButton-editorSignature-icon: url(images/toolbarButton-editorSignature.svg);
@@ -123,6 +124,9 @@
   );
   --secondaryToolbarButton-documentProperties-icon: url(images/secondaryToolbarButton-documentProperties.svg);
   --editorParams-stampAddImage-icon: url(images/toolbarButton-zoomIn.svg);
+  --editorParams-alignLeft-icon: url(images/editor-align-left.svg);
+  --editorParams-alignCenter-icon: url(images/editor-align-center.svg);
+  --editorParams-alignRight-icon: url(images/editor-align-right.svg);
   --comment-edit-button-icon: url(images/comment-editButton.svg);
 }
 
@@ -467,6 +471,10 @@ body {
 
 #editorHighlightButton::before {
   mask-image: var(--toolbarButton-editorHighlight-icon);
+}
+
+#editorRedactionButton::before {
+  mask-image: var(--toolbarButton-editorRedaction-icon);
 }
 
 #editorInkButton::before {
@@ -898,6 +906,110 @@ dialog :link {
       mask-image: var(--editorParams-stampAddImage-icon);
     }
 
+    .editorStampChoice {
+      min-height: 58px;
+      gap: 8px;
+
+      &::before {
+        display: none;
+      }
+
+      &[aria-pressed="true"] {
+        background-color: var(--toggled-btn-bg-color);
+        color: var(--toggled-btn-color);
+      }
+
+      > img {
+        width: 116px;
+        height: 34px;
+        object-fit: contain;
+        background-color: white;
+      }
+    }
+
+    .stampChoiceGrid {
+      display: grid;
+      grid-template-columns: repeat(3, 36px);
+      gap: 6px;
+      padding: 6px 12px 10px;
+
+      .editorStampChoice {
+        display: grid;
+        place-items: center;
+        width: 36px;
+        height: 36px;
+        padding: 5px;
+        border: 1px solid var(--doorhanger-separator-color);
+        border-radius: 4px;
+        background: var(--doorhanger-bg-color);
+
+        &:hover {
+          border-color: var(--toolbar-icon-bg-color);
+        }
+
+        &[aria-pressed="true"] {
+          border: 2px solid var(--toggled-btn-bg-color);
+          background: var(--button-hover-color);
+        }
+
+        img {
+          width: 100%;
+          height: 100%;
+          object-fit: contain;
+        }
+      }
+    }
+
+    .editorTextButtonGroup {
+      display: grid;
+      grid-template-columns: repeat(3, 32px);
+      gap: 4px;
+    }
+
+    .editorTextFormatButton {
+      display: grid;
+      place-items: center;
+      width: 32px;
+      height: 28px;
+      padding: 0;
+      border: 1px solid var(--doorhanger-separator-color);
+      border-radius: 3px;
+      color: var(--main-color);
+      background: var(--field-bg-color);
+      font-size: 14px;
+
+      &:hover {
+        background: var(--button-hover-color);
+      }
+
+      &[aria-pressed="true"] {
+        border-color: var(--toggled-btn-bg-color);
+        background: var(--toggled-btn-bg-color);
+        color: var(--toggled-btn-color);
+      }
+
+      &.editorFreeTextAlignment::before {
+        content: "";
+        width: 16px;
+        height: 16px;
+        background: currentColor;
+        mask-position: center;
+        mask-repeat: no-repeat;
+      }
+
+      &.alignLeft::before {
+        mask-image: var(--editorParams-alignLeft-icon);
+      }
+
+      &.alignCenter::before {
+        mask-image: var(--editorParams-alignCenter-icon);
+      }
+
+      &.alignRight::before {
+        mask-image: var(--editorParams-alignRight-icon);
+      }
+    }
+
     .editorParamsLabel {
       flex: none;
       font: menu;
@@ -935,6 +1047,12 @@ dialog :link {
         height: 32px;
         flex: none;
         padding: 0;
+      }
+
+      .editorParamsSelect {
+        min-width: 145px;
+        height: 32px;
+        flex: none;
       }
 
       .editorParamsSlider {

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -229,6 +229,15 @@ See https://github.com/adobe-type-tools/cmap-resources
                             <span data-l10n-id="pdfjs-views-manager-pages-status-action-button-label"></span>
                           </button>
                           <menu id="viewsManagerStatusActionOptions" class="popupMenu">
+                            <button id="viewsManagerStatusActionRotate" class="noIcon" role="menuitem" type="button" tabindex="-1" disabled>
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-rotate-button-label"></span>
+                            </button>
+                            <button id="viewsManagerStatusActionAddBlank" class="noIcon" role="menuitem" type="button" tabindex="-1" disabled>
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-add-blank-button-label"></span>
+                            </button>
+                            <button id="viewsManagerStatusActionDuplicate" class="noIcon" role="menuitem" type="button" tabindex="-1" disabled>
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-duplicate-button-label"></span>
+                            </button>
                             <button id="viewsManagerStatusActionCopy" class="noIcon" role="menuitem" type="button" tabindex="-1" disabled>
                               <span data-l10n-id="pdfjs-views-manager-pages-status-copy-button-label"></span>
                             </button>
@@ -236,7 +245,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                               <span data-l10n-id="pdfjs-views-manager-pages-status-cut-button-label"></span>
                             </button>
                             <button id="viewsManagerStatusActionDelete" class="noIcon" role="menuitem" type="button" tabindex="-1" disabled>
-                              <span data-l10n-id="pdfjs-views-manager-pages-status-delete-button-label"></span>
+                              <span data-l10n-id="pdfjs-views-manager-pages-status-remove-button-label"></span>
                             </button>
                             <button id="viewsManagerStatusActionExport" class="noIcon" role="menuitem" type="button" tabindex="-1" disabled>
                               <span data-l10n-id="pdfjs-views-manager-pages-status-export-selected-button-label"></span>
@@ -539,6 +548,19 @@ See https://github.com/adobe-type-tools/cmap-resources
                       </div>
                     </div>
                   </div>
+                  <div id="editorRedaction" class="toolbarButtonWithContainer">
+                    <button
+                      id="editorRedactionButton"
+                      class="toolbarButton"
+                      type="button"
+                      disabled="disabled"
+                      aria-expanded="false"
+                      tabindex="0"
+                      data-l10n-id="pdfjs-editor-redaction-button"
+                    >
+                      <span data-l10n-id="pdfjs-editor-redaction-button-label"></span>
+                    </button>
+                  </div>
                   <div id="editorFreeText" class="toolbarButtonWithContainer">
                     <button
                       id="editorFreeTextButton"
@@ -562,6 +584,81 @@ See https://github.com/adobe-type-tools/cmap-resources
                         <div class="editorParamsSetter">
                           <label for="editorFreeTextFontSize" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-size-input"></label>
                           <input type="range" id="editorFreeTextFontSize" class="editorParamsSlider" value="10" min="5" max="100" step="1" tabindex="0" />
+                        </div>
+                        <div class="editorParamsSetter">
+                          <label for="editorFreeTextFontFamily" class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-font-family-input"></label>
+                          <select id="editorFreeTextFontFamily" class="editorParamsSelect" tabindex="0">
+                            <option value="Helvetica">Default / Helvetica</option>
+                            <option value="Arial">Arial</option>
+                            <option value="Times New Roman">Times New Roman</option>
+                            <option value="Courier New">Courier New</option>
+                            <option value="Georgia">Georgia</option>
+                            <option value="Verdana">Verdana</option>
+                          </select>
+                        </div>
+                        <div class="editorParamsSetter">
+                          <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-format-input"></span>
+                          <div class="editorTextButtonGroup">
+                            <button
+                              id="editorFreeTextBold"
+                              class="editorTextFormatButton"
+                              type="button"
+                              aria-pressed="false"
+                              tabindex="0"
+                              data-l10n-id="pdfjs-editor-free-text-bold-button"
+                            >
+                              <strong>B</strong>
+                            </button>
+                            <button
+                              id="editorFreeTextItalic"
+                              class="editorTextFormatButton"
+                              type="button"
+                              aria-pressed="false"
+                              tabindex="0"
+                              data-l10n-id="pdfjs-editor-free-text-italic-button"
+                            >
+                              <em>I</em>
+                            </button>
+                            <button
+                              id="editorFreeTextUnderline"
+                              class="editorTextFormatButton"
+                              type="button"
+                              aria-pressed="false"
+                              tabindex="0"
+                              data-l10n-id="pdfjs-editor-free-text-underline-button"
+                            >
+                              <u>U</u>
+                            </button>
+                          </div>
+                        </div>
+                        <div class="editorParamsSetter">
+                          <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-free-text-alignment-input"></span>
+                          <div class="editorTextButtonGroup">
+                            <button
+                              class="editorTextFormatButton editorFreeTextAlignment alignLeft"
+                              type="button"
+                              data-alignment="left"
+                              aria-pressed="true"
+                              tabindex="0"
+                              data-l10n-id="pdfjs-editor-free-text-align-left-button"
+                            ></button>
+                            <button
+                              class="editorTextFormatButton editorFreeTextAlignment alignCenter"
+                              type="button"
+                              data-alignment="center"
+                              aria-pressed="false"
+                              tabindex="0"
+                              data-l10n-id="pdfjs-editor-free-text-align-center-button"
+                            ></button>
+                            <button
+                              class="editorTextFormatButton editorFreeTextAlignment alignRight"
+                              type="button"
+                              data-alignment="right"
+                              aria-pressed="false"
+                              tabindex="0"
+                              data-l10n-id="pdfjs-editor-free-text-align-right-button"
+                            ></button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -588,7 +685,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                         </div>
                         <div class="editorParamsSetter">
                           <label for="editorInkThickness" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-thickness-input"></label>
-                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="1" max="20" step="1" tabindex="0" />
+                          <input type="range" id="editorInkThickness" class="editorParamsSlider" value="1" min="0.1" max="20" step="0.1" tabindex="0" />
                         </div>
                         <div class="editorParamsSetter">
                           <label for="editorInkOpacity" class="editorParamsLabel" data-l10n-id="pdfjs-editor-ink-opacity-input"></label>
@@ -622,6 +719,80 @@ See https://github.com/adobe-type-tools/cmap-resources
                         >
                           <span class="editorParamsLabel" data-l10n-id="pdfjs-editor-stamp-add-image-button-label"></span>
                         </button>
+                        <div class="stampChoiceGrid">
+                          <button
+                            class="editorStampChoice"
+                            type="button"
+                            tabindex="0"
+                            aria-pressed="false"
+                            data-stamp-src="images/stamp-check.svg"
+                            data-stamp-width="0.12"
+                            data-stamp-alt="Check mark"
+                            data-l10n-id="pdfjs-editor-stamp-check-button"
+                          >
+                            <img src="images/stamp-check.svg" alt="" />
+                          </button>
+                          <button
+                            class="editorStampChoice"
+                            type="button"
+                            tabindex="0"
+                            aria-pressed="false"
+                            data-stamp-src="images/stamp-x.svg"
+                            data-stamp-width="0.12"
+                            data-stamp-alt="X mark"
+                            data-l10n-id="pdfjs-editor-stamp-x-button"
+                          >
+                            <img src="images/stamp-x.svg" alt="" />
+                          </button>
+                          <button
+                            class="editorStampChoice"
+                            type="button"
+                            tabindex="0"
+                            aria-pressed="false"
+                            data-stamp-src="images/stamp-arrow.svg"
+                            data-stamp-width="0.2"
+                            data-stamp-alt="Arrow"
+                            data-l10n-id="pdfjs-editor-stamp-arrow-button"
+                          >
+                            <img src="images/stamp-arrow.svg" alt="" />
+                          </button>
+                          <button
+                            class="editorStampChoice"
+                            type="button"
+                            tabindex="0"
+                            aria-pressed="false"
+                            data-stamp-src="images/stamp-circle.svg"
+                            data-stamp-width="0.16"
+                            data-stamp-alt="Circle"
+                            data-l10n-id="pdfjs-editor-stamp-circle-button"
+                          >
+                            <img src="images/stamp-circle.svg" alt="" />
+                          </button>
+                          <button
+                            class="editorStampChoice"
+                            type="button"
+                            tabindex="0"
+                            aria-pressed="false"
+                            data-stamp-src="images/stamp-rectangle.svg"
+                            data-stamp-width="0.2"
+                            data-stamp-alt="Rectangle"
+                            data-l10n-id="pdfjs-editor-stamp-rectangle-button"
+                          >
+                            <img src="images/stamp-rectangle.svg" alt="" />
+                          </button>
+                          <button
+                            class="editorStampChoice"
+                            type="button"
+                            tabindex="0"
+                            aria-pressed="false"
+                            data-stamp-src="images/stamp-triangle.svg"
+                            data-stamp-width="0.16"
+                            data-stamp-alt="Triangle"
+                            data-l10n-id="pdfjs-editor-stamp-triangle-button"
+                          >
+                            <img src="images/stamp-triangle.svg" alt="" />
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -61,6 +61,7 @@ function getViewerConfiguration() {
       editorHighlightColorPicker: document.getElementById(
         "editorHighlightColorPicker"
       ),
+      editorRedactionButton: document.getElementById("editorRedactionButton"),
       editorInkButton: document.getElementById("editorInkButton"),
       editorInkParamsToolbar: document.getElementById("editorInkParamsToolbar"),
       editorStampButton: document.getElementById("editorStampButton"),
@@ -170,6 +171,9 @@ function getViewerConfiguration() {
       manageMenu: {
         button: document.getElementById("viewsManagerStatusActionButton"),
         menu: document.getElementById("viewsManagerStatusActionOptions"),
+        rotate: document.getElementById("viewsManagerStatusActionRotate"),
+        addBlank: document.getElementById("viewsManagerStatusActionAddBlank"),
+        duplicate: document.getElementById("viewsManagerStatusActionDuplicate"),
         copy: document.getElementById("viewsManagerStatusActionCopy"),
         cut: document.getElementById("viewsManagerStatusActionCut"),
         delete: document.getElementById("viewsManagerStatusActionDelete"),
@@ -315,10 +319,22 @@ function getViewerConfiguration() {
       ),
       editorFreeTextFontSize: document.getElementById("editorFreeTextFontSize"),
       editorFreeTextColor: document.getElementById("editorFreeTextColor"),
+      editorFreeTextFontFamily: document.getElementById(
+        "editorFreeTextFontFamily"
+      ),
+      editorFreeTextBold: document.getElementById("editorFreeTextBold"),
+      editorFreeTextItalic: document.getElementById("editorFreeTextItalic"),
+      editorFreeTextUnderline: document.getElementById(
+        "editorFreeTextUnderline"
+      ),
+      editorFreeTextAlignments: document.querySelectorAll(
+        ".editorFreeTextAlignment"
+      ),
       editorInkColor: document.getElementById("editorInkColor"),
       editorInkThickness: document.getElementById("editorInkThickness"),
       editorInkOpacity: document.getElementById("editorInkOpacity"),
       editorStampAddImage: document.getElementById("editorStampAddImage"),
+      editorStampChoices: document.querySelectorAll(".editorStampChoice"),
       editorSignatureAddSignature: document.getElementById(
         "editorSignatureAddSignature"
       ),


### PR DESCRIPTION
## Summary

Adds a custom PDF editor workflow to the Chromium PDF.js extension, including real redaction, page organization tools, native symbol stamps, expanded text formatting, smaller ink brush sizes, and safer PDF link opening in a new tab.

## Highlights

- Add real redaction support that burns selected redactions into saved PDFs.
- Support character-level redaction boxes when redacting selected text.
- Add page rotate, blank page, duplicate page, and remove page workflows.
- Add native symbol/shape stamp choices: check, X, arrow, circle, rectangle, and triangle.
- Add text formatting controls for font family, bold, italic, underline, and alignment.
- Reduce minimum ink brush size to 0.1.
- Disable editor comment/note creation for the custom viewer tools.
- Open PDF links in a new tab without refreshing the original page.

## Validation

- npx gulp lint
- node --enable-source-maps node_modules/jasmine/bin/jasmine.js --config=test/unit/clitests.json --filter='FreeText|redaction|hardcoded stamp|PagesMapper'
- npx gulp chromium lib-legacy
