### PR TITLE
Don't swallow `MissingDataException`s in the `Annotation.prototype.#setOptionalContent` method (PR 21313 follow-up)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -48,6 +48,7 @@ import {
   lookupMatrix,
   lookupNormalRect,
   lookupRect,
+  MissingDataException,
   numberToString,
   RESOURCES_KEYS_OPERATOR_LIST,
   RESOURCES_KEYS_TEXT_CONTENT,
@@ -1208,6 +1209,9 @@ class Annotation {
           /* resources = */ null
         );
       } catch (ex) {
+        if (ex instanceof MissingDataException) {
+          throw ex;
+        }
         warn(`#setOptionalContent: ${ex}`);
       }
     }


### PR DESCRIPTION
Unless the entire document has been loaded, the dictionary lookups in `parseMarkedContentProps` may throw `MissingDataException`s and in that case we need to re-parse the current Annotation rather than ignoring the optionalContent.