### PR TITLE
A couple of small tweaks of the `StructElementNode.prototype.mathML` getter

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -718,8 +718,7 @@ class Page {
         "_parseStructTree",
         [structTreeRoot]
       );
-      const data = await this.pdfManager.ensure(structTree, "serializable");
-      return data;
+      return await this.pdfManager.ensure(structTree, "serializable");
     } catch (ex) {
       warn(`getStructTree: "${ex}".`);
       return null;

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -20,9 +20,10 @@ import {
   warn,
 } from "../shared/util.js";
 import { Dict, isDict, isName, Name, Ref, RefSetCache } from "./primitives.js";
+import { lookupNormalRect, MissingDataException } from "./core_utils.js";
 import { stringToAsciiOrUTF16BE, stringToPDFString } from "./string_utils.js";
 import { BaseStream } from "./base_stream.js";
-import { lookupNormalRect } from "./core_utils.js";
+import { FileSpec } from "./file_spec.js";
 import { NumberTree } from "./name_number_tree.js";
 
 const MAX_DEPTH = 40;
@@ -594,24 +595,18 @@ class StructElementNode {
     }
     for (let af of AFs) {
       af = this.xref.fetchIfRef(af);
-      if (!isDict(af, "Filespec")) {
+      if (
+        !isDict(af, "Filespec") ||
+        !isName(af.get("AFRelationship"), "Supplement")
+      ) {
         continue;
       }
-      if (!isName(af.get("AFRelationship"), "Supplement")) {
-        continue;
-      }
-      const ef = af.get("EF");
-      if (!(ef instanceof Dict)) {
-        continue;
-      }
-      const fileStream = ef.get("UF") || ef.get("F");
-      if (!(fileStream instanceof BaseStream)) {
-        continue;
-      }
-      if (!isName(fileStream.dict.get("Type"), "EmbeddedFile")) {
-        continue;
-      }
-      if (!isName(fileStream.dict.get("Subtype"), "application/mathml+xml")) {
+      const fileStream = FileSpec.pickPlatformItem(af.get("EF"));
+      if (
+        !(fileStream instanceof BaseStream) ||
+        !isDict(fileStream.dict, "EmbeddedFile") ||
+        !isName(fileStream.dict.get("Subtype"), "application/mathml+xml")
+      ) {
         continue;
       }
       // The default encoding for xml files is UTF-8.
@@ -909,9 +904,16 @@ class StructTreePage {
         obj.alt = stringToPDFString(alt);
       }
       if (obj.role === "Formula") {
-        const { mathML } = node;
-        if (mathML) {
-          obj.mathML = mathML;
+        try {
+          const { mathML } = node;
+          if (mathML) {
+            obj.mathML = mathML;
+          }
+        } catch (ex) {
+          if (ex instanceof MissingDataException) {
+            throw ex;
+          }
+          warn(`Ignoring mathML: "${ex}".`);
         }
       }
 


### PR DESCRIPTION
 - Use `FileSpec.pickPlatformItem` when getting the fileStream, to ensure that /EF-entries are handled in a consistent way across the code-base.

 - Combine a couple of the data-validation steps, to reduce a tiny bit of duplication. Also, use the `isDict` helper a little more.

 - Finally, avoid using a temporary variable when returning data in the `Page.prototype.getStructTree` method.