### PR TITLE
Stop event propagation, for the `Enter` key, in the passwordPrompt input

### DIFF
--- a/web/password_prompt.js
+++ b/web/password_prompt.js
@@ -57,6 +57,7 @@ class PasswordPrompt {
     this.input.addEventListener("keydown", e => {
       if (e.keyCode === /* Enter = */ 13) {
         this.#verify();
+        e.preventDefault();
       }
     });
 


### PR DESCRIPTION
**Steps to reproduce:**
 1. Open the viewer.
 2. Show the sidebar, and switch to the "Pages" view if necessary.
 3. Click on the "Add file" button.
 4. Choose a password-protected PDF, e.g. the `issue6010_1.pdf` file, via the "File Upload" dialog opened by the browser.
 5. Enter the password, i.e. `abc`, and press the <kbd>Enter</kbd> key.

**Expected result:**
That the new PDF document is merged into the existing one, without UI side-effects.

**Actual result:**
Merging works, *however* the "File Upload" dialog is re-opened.

---

It seems that when the passwordPrompt dialog closes, the <kbd>Enter</kbd> key press (from the input) is forwarded to the previously focused element which naturally is the "Add file" button.

*Note:* This doesn't seem (easily) possible to test, since the integration-tests directly populate the `viewsManagerAddFilePicker` and doesn't actually "click" on the `viewsManagerAddFileButton` first.