### PR TITLE
Tweak some `String.prototype.substring()` usage

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -3108,7 +3108,7 @@ class TextWidgetAnnotation extends WidgetAnnotation {
     }
 
     if (startChunk < line.length) {
-      chunks.push(line.substring(startChunk, line.length));
+      chunks.push(line.substring(startChunk));
     }
 
     return chunks;

--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -386,7 +386,7 @@ function escapePDFName(str) {
   }
 
   if (start < str.length) {
-    buffer.push(str.substring(start, str.length));
+    buffer.push(str.substring(start));
   }
 
   return buffer.join("");
@@ -545,7 +545,7 @@ function encodeToXmlString(str) {
     return str;
   }
   if (start < str.length) {
-    buffer.push(str.substring(start, str.length));
+    buffer.push(str.substring(start));
   }
   return buffer.join("");
 }

--- a/src/core/xml_parser.js
+++ b/src/core/xml_parser.js
@@ -17,6 +17,7 @@
 // https://github.com/mozilla/shumway/blob/16451d8836fa85f4b16eeda8b4bda2fa9e2b22b0/src/avm2/natives/xml.ts
 
 import { encodeToXmlString } from "./core_utils.js";
+import { shadow } from "../shared/util.js";
 
 const XMLParserErrorCode = {
   NoError: 0,
@@ -47,12 +48,17 @@ function isWhitespaceString(s) {
 }
 
 class XMLParserBase {
+  static get _entityRegex() {
+    return shadow(this, "_entityRegex", /&(?:#x([^;]+)|#([^;]+)|([^;]+));/g);
+  }
+
   _resolveEntities(s) {
-    return s.replaceAll(/&([^;]+);/g, (all, entity) => {
-      if (entity.substring(0, 2) === "#x") {
-        return String.fromCodePoint(parseInt(entity.substring(2), 16));
-      } else if (entity.at(0) === "#") {
-        return String.fromCodePoint(parseInt(entity.substring(1), 10));
+    return s.replaceAll(XMLParserBase._entityRegex, (_, hex, dec, entity) => {
+      if (hex) {
+        return String.fromCodePoint(parseInt(hex, 16));
+      }
+      if (dec) {
+        return String.fromCodePoint(parseInt(dec, 10));
       }
       switch (entity) {
         case "lt":


### PR DESCRIPTION
In a few spots the `indexEnd` parameter is explicitly set to the string-length, which is unnecessary since that's the default value if the parameter is omitted; note https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#description

In the `XMLParserBase.prototype._resolveEntities` method the `substring` usage can be replaced with an updated (and cached) regular expression that directly finds numbers.