### PR TITLE
Change `issue17906` to test "forms" rendering

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -11308,9 +11308,9 @@
     "md5": "f81c617e5113e0c510a4cfe8b012798e",
     "rounds": 1,
     "link": true,
-    "firstPage": 1,
     "lastPage": 1,
-    "type": "eq"
+    "type": "eq",
+    "forms": true
   },
   {
     "id": "issue17929",


### PR DESCRIPTION
Looking at the coverage data the code-path added in PR #17908 isn't actually covered by tests; note https://app.codecov.io/gh/mozilla/pdf.js/commit/10844326c7e29b563645c454e10c315549523605/blob/src/core/annotation.js?dropdown=coverage#L1250