### PR TITLE
Move SVG text selection styles to pdf_viewer.css (bug 2049302)

### DIFF
--- a/web/draw_layer_builder.css
+++ b/web/draw_layer_builder.css
@@ -14,16 +14,6 @@
  */
 
 .canvasWrapper {
-  .selection {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    background: rgb(0 90 255 / 0.22);
-  }
-
   svg {
     transform: none;
 

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -120,6 +120,19 @@
         image-rendering: pixelated;
       }
     }
+
+    /* Used by the DrawLayer, but we keep these styles here and not in
+     * draw_layer_builder.css because we need them to be loaded in GECKOVIEW for
+     * text selection. */
+    .selection {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      background: rgb(0 90 255 / 0.22);
+    }
   }
 }
 


### PR DESCRIPTION
> draw_layer_builder.css, which originally included these styles, is not loaded in GECKOVIEW. This is because it also includes all the styles related to highlights and drawing, which are only supported in the main viewer.
>
> The new SVG-based highlights are also used in GECKOVIEW, so even though the JS logic for them lives in the DrawLayer builder, we need to move the CSS somewhere where we know it's going to be loaded.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2049302

I tested this by building Firefox for Android with the updated mozcentral build from this PR.