### PR TITLE
Use more optional chaining in the `src/` and `web/` folders

### DIFF
--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -2688,7 +2688,7 @@ class PDFEditor {
    */
   #makePageLabelsTree() {
     const { pageLabels } = this;
-    if (!pageLabels || pageLabels.length === 0) {
+    if (!pageLabels?.length) {
       return;
     }
     const { rootDict } = this;
@@ -2776,7 +2776,7 @@ class PDFEditor {
 
   #makeStructTree() {
     const { structTreeKids } = this;
-    if (!structTreeKids || structTreeKids.length === 0) {
+    if (!structTreeKids?.length) {
       return;
     }
     const { rootDict } = this;

--- a/src/display/editor/drawers/inkdraw.js
+++ b/src/display/editor/drawers/inkdraw.js
@@ -72,7 +72,7 @@ class InkDrawOutliner {
   }
 
   isEmpty() {
-    return !this.#lines || this.#lines.length === 0;
+    return !this.#lines?.length;
   }
 
   isCancellable() {

--- a/src/display/editor/freetext.js
+++ b/src/display/editor/freetext.js
@@ -800,7 +800,7 @@ class FreeTextEditor extends AnnotationEditor {
       } = data;
       // textContent is supposed to be an array of strings containing each line
       // of text. However, it can be null or empty.
-      if (!textContent || textContent.length === 0) {
+      if (!textContent?.length) {
         // Empty annotation.
         return null;
       }

--- a/web/app.js
+++ b/web/app.js
@@ -846,7 +846,7 @@ const PDFViewerApplication = {
 
       fileInput.addEventListener("change", function (evt) {
         const { files } = evt.target;
-        if (!files || files.length === 0) {
+        if (!files?.length) {
           return;
         }
         eventBus.dispatch("fileinputchange", {

--- a/web/internal/draw_ops_view.js
+++ b/web/internal/draw_ops_view.js
@@ -237,7 +237,7 @@ class DrawOpDetailView {
     header.textContent = name;
     argsContainer.append(header);
 
-    if (!args || args.length === 0) {
+    if (!args?.length) {
       const none = document.createElement("div");
       none.className = "detail-empty";
       none.textContent = "(no arguments)";

--- a/web/text_accessibility.js
+++ b/web/text_accessibility.js
@@ -138,7 +138,7 @@ class TextAccessibilityManager {
     }
 
     const children = this.#textChildren;
-    if (!children || children.length === 0) {
+    if (!children?.length) {
       return;
     }
 
@@ -198,7 +198,7 @@ class TextAccessibilityManager {
     }
 
     const children = this.#textChildren;
-    if (!children || children.length === 0) {
+    if (!children?.length) {
       return null;
     }
 


### PR DESCRIPTION
There's a few spots where we check if something is either undefined or if its length is zero, which can be simplified by instead using optional chaining.