### PR TITLE
Avoid text selection workaround in modern Chromium

### DIFF
--- a/test/integration/text_layer_spec.mjs
+++ b/test/integration/text_layer_spec.mjs
@@ -757,7 +757,7 @@ describe("Text layer", () => {
                 .withContext(`In ${browserName}`)
                 .toHaveRoughlySelected(
                   "rs as the railway projects under\n" +
-                    "development enter the construction phase (estimated at"
+                    "development enter the construction phase (estimated a"
                 );
             })
           );
@@ -801,7 +801,7 @@ describe("Text layer", () => {
                 .withContext(`In ${browserName}`)
                 .toHaveRoughlySelected(
                   "quarters as the railway projects under\n" +
-                    "development enter the construction phase (estimated at around"
+                    "development enter the construction phase (estimated at"
                 );
             })
           );

--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -264,7 +264,7 @@ class TextLayerBuilder {
 
     if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
       // eslint-disable-next-line no-var
-      var isFirefox, prevRange;
+      var isFirefoxOrModernChromium, prevRange;
     }
 
     document.addEventListener(
@@ -304,22 +304,38 @@ class TextLayerBuilder {
         if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
           return;
         }
-        if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME")) {
-          isFirefox ??=
-            getComputedStyle(
-              this.#textLayers.values().next().value
-            ).getPropertyValue("-moz-user-select") === "none";
+        if (isFirefoxOrModernChromium === undefined) {
+          if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME")) {
+            isFirefoxOrModernChromium =
+              getComputedStyle(
+                this.#textLayers.values().next().value
+              ).getPropertyValue("-moz-user-select") === "none";
+          }
+          if (
+            (typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")) ||
+            !isFirefoxOrModernChromium
+          ) {
+            // navigator.userAgentData is only available in secure contexts
+            const chromiumVersion = navigator.userAgentData
+              ? navigator.userAgentData.brands.find(
+                  ({ brand }) => brand === "Chromium"
+                )?.version
+              : /\bChrome\/(\d+)\b/.exec(navigator.userAgent)?.[1];
 
-          if (isFirefox) {
-            return;
+            isFirefoxOrModernChromium =
+              !!chromiumVersion && parseInt(chromiumVersion, 10) >= 148;
           }
         }
-        // In non-Firefox browsers, when hovering over an empty space (thus,
-        // on .endOfContent), the selection will expand to cover all the
-        // text between the current selection and .endOfContent. By moving
-        // .endOfContent to right after (or before, depending on which side
-        // of the selection the user is moving), we limit the selection jump
-        // to at most cover the enteirety of the <span> where the selection
+        if (isFirefoxOrModernChromium) {
+          return;
+        }
+
+        // In browsers other than Firefox or Chromium 148+, when hovering over
+        // an empty space (thus, on .endOfContent), the selection will expand to
+        // cover all the text between the current selection and .endOfContent.
+        // By moving .endOfContent to right after (or before, depending on which
+        // side of the selection the user is moving), we limit the selection
+        // jump to at most cover the entirety of the <span> where the selection
         // is being modified.
         const range = selection.getRangeAt(0);
         const modifyStart =


### PR DESCRIPTION
> **Avoid text selection workaround in modern Chromium**
>
> Chromium 148+ improved their selection behavior when it comes to absolutely positioned elements, thus making text selectino in PDF.js much better.
>
> Unfortunately this does not only mean that the workaround we currently have for Chromium is unnecessary, but it actually become harmful. It conflicts with Chromium's new behavior, making text selection *worse* on mobile.
>
> As the change has been released in Chrome only a month ago, this patch keeps the workaround for older Chromium versions. There is no easy way to feture-detect is, so unfortunately we need to do user agent version detection.

Also, somehow the "right click on images" layer undoes the negative effects of the workaround, so even in modern mobile Chromium if there are images text selection already works well.

This is the behavior on various Chromium versions. By "scroll jump" I meant that the page scroll position moves to the wrong place (usually top right of the page) while selection; by "selection explodes" I mean that suddenly all the page is selected while trying to select something.


| Chromium version | Input | Before this PR | After this PR |
|---|---|---|---|
| ≥ 148 | Touch | :x: Scroll jump | :heavy_check_mark: |
| ≥ 148 | Mouse | :heavy_check_mark: | :heavy_check_mark:  (but running less code!) |
| < 148 | Touch | :x: Scroll jump | :x: Scroll jump |
| < 148 | Mouse | :heavy_check_mark: | :heavy_check_mark: |

The changed code is not included in the mozcentral build. In the Chromium build it now looks like this:
```js
      if (isFirefoxOrModernChromium === undefined) {
        const chromiumVersion = navigator.userAgentData ? navigator.userAgentData.brands.find(({
          brand
        }) => brand === "Chromium")?.version : /\bChrome\/(\d+)\b/.exec(navigator.userAgent)?.[1];
        isFirefoxOrModernChromium = !!chromiumVersion && parseInt(chromiumVersion, 10) >= 148;
      }
      if (isFirefoxOrModernChromium) {
        return;
      }
```
while in the generic build it looks like this:
```js
      if (isFirefoxOrModernChromium === undefined) {
        isFirefoxOrModernChromium = getComputedStyle(this.#textLayers.values().next().value).getPropertyValue("-moz-user-select") === "none";
        if (!isFirefoxOrModernChromium) {
          const chromiumVersion = navigator.userAgentData ? navigator.userAgentData.brands.find(({
            brand
          }) => brand === "Chromium")?.version : /\bChrome\/(\d+)\b/.exec(navigator.userAgent)?.[1];
          isFirefoxOrModernChromium = !!chromiumVersion && parseInt(chromiumVersion, 10) >= 148;
        }
      }
      if (isFirefoxOrModernChromium) {
        return;
      }
```