### PR TITLE
Fix the version comment in the font tests GitHub Actions workflow

### DIFF
--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -60,7 +60,7 @@ jobs:
         run: npm ci
 
       - name: Use Python 3.14
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.2
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.14'
           cache: 'pip'


### PR DESCRIPTION
It looks like Dependabot somehow didn't match, and thus update, the version number correctly in the most recent bump.

Fixes 6b0777d5.