### PR TITLE
Fix escapePDFName producing malformed name escapes for control characters

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -376,7 +376,7 @@ function escapePDFName(str) {
       if (start < i) {
         buffer.push(str.substring(start, i));
       }
-      buffer.push(`#${char.toString(16)}`);
+      buffer.push(`#${char.toString(16).padStart(2, "0")}`);
       start = i + 1;
     }
   }

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -290,6 +290,11 @@ describe("core_utils", function () {
         "#23#28#29#3c#3e#5b#5d#7b#7d#2f#25"
       );
     });
+
+    it("should escape control characters using two hexadecimal digits", function () {
+      expect(escapePDFName("\x00\x09\x0a\x1f")).toEqual("#00#09#0a#1f");
+      expect(escapePDFName("a\tb")).toEqual("a#09b");
+    });
   });
 
   describe("escapeString", function () {


### PR DESCRIPTION
## Description

`escapePDFName` emits a single hex digit for character codes below `0x10`, producing malformed PDF name escapes.

PDF 32000-1 section 7.3.5 requires exactly two hexadecimal digits after `#` in a name. The current code does `` `#${char.toString(16)}` ``, so:

- TAB (`0x09`) becomes `#9` instead of `#09`
- LF (`0x0A`) becomes `#a` instead of `#0a`
- `0x01` becomes `#1` instead of `#01`

When pdf.js re-serializes a document (annotations and form fields via `writer.js`, font names via `default_appearance.js`), a `Name` containing such a byte is written malformed. On reload the lexer mis-parses it and silently drops or corrupts bytes. For example a name `a\tb` round-trips through `Lexer.getName` as `a` (the TAB and everything after are lost), and `a\x01b` comes back with the wrong byte.

## Fix

```diff
-      buffer.push(`#${char.toString(16)}`);
+      buffer.push(`#${char.toString(16).padStart(2, "0")}`);
```

This is a no-op for codes `0x10` to `0xFF` (already two digits), so existing output is unchanged; it only fixes the `0x00` to `0x0F` range.

## Test

Added a case to `test/unit/core_utils_spec.js` covering control characters. It fails before the change (`#0#9#a#1f` style single-digit output) and passes after.
