### PR TITLE
[GeckoView] Add `web-digital_signature_properties_manager` import map (PR 21247 follow-up)

### DIFF
--- a/web/digital_signature_properties_manager.js
+++ b/web/digital_signature_properties_manager.js
@@ -263,9 +263,6 @@ class SignaturePropertiesManager {
     if (!pdfDocument) {
       return;
     }
-    this.#signatures = [];
-    this.#results.clear();
-    this.#pendingVerify.clear();
     this.#isLoading = true;
     this.#render();
 
@@ -274,7 +271,6 @@ class SignaturePropertiesManager {
       signatures = await pdfDocument.getSignatures();
     } catch (ex) {
       console.warn("getSignatures failed:", ex);
-      signatures = [];
     }
     if (pdfDocument !== this.#pdfDocument) {
       return;

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -88,6 +88,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "web-print_service": "./pdf_print_service.js",
           "web-secondary_toolbar": "./stubs-geckoview.js",
           "web-signature_manager": "./stubs-geckoview.js",
+          "web-digital_signature_properties_manager": "./digital_signature_properties_manager.js",
           "web-toolbar": "./toolbar-geckoview.js",
           "web-views_manager": "./stubs-geckoview.js"
         }


### PR DESCRIPTION
 - **[GeckoView] Add `web-digital_signature_properties_manager` import map (PR 21247 follow-up)**

   Currently the GeckoView development viewer, i.e. http://localhost:8888/web/viewer-geckoview.html, is completely broken with the following error:
   ```
   Uncaught TypeError: The specifier “web-digital_signature_properties_manager” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”. app.js:97:44
   ```

 - **Remove unnecessary class-field resetting in `SignaturePropertiesManager.prototype.setDocument` (PR 21247 follow-up)**

   This corresponds to the initial values of these fields, and they were *already* reset when a (previous) PDF document was closed.