### PR TITLE
Deduplicate the signature-properties warn/error toolbar icon

### DIFF
--- a/web/digital_signature_properties.css
+++ b/web/digital_signature_properties.css
@@ -121,7 +121,7 @@
     background-color: var(--sig-icon-verified);
   }
   &.state-warn::before {
-    mask-image: var(--toolbarButton-signaturePropertiesWarn-icon);
+    mask-image: var(--toolbarButton-signaturePropertiesError-icon);
     background-color: var(--sig-icon-warn);
   }
   &.state-error::before {
@@ -297,7 +297,7 @@
     }
     &.cert--untrusted::before,
     &.cert--expired::before {
-      mask-image: var(--toolbarButton-signaturePropertiesWarn-icon);
+      mask-image: var(--toolbarButton-signaturePropertiesError-icon);
       background-color: var(--sig-icon-warn);
     }
     &.cert--revoked::before,

--- a/web/images/toolbarButton-signaturePropertiesWarn.svg
+++ b/web/images/toolbarButton-signaturePropertiesWarn.svg
@@ -1,7 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <mask id="m">
-    <rect width="16" height="16" fill="white"/>
-    <path d="M5.2 5.2l5.6 5.6M10.8 5.2l-5.6 5.6" stroke="black" stroke-width="1.8" fill="none" stroke-linecap="round"/>
-  </mask>
-  <circle cx="8" cy="8" r="7" fill="black" mask="url(#m)"/>
-</svg>

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -85,7 +85,6 @@
   --toolbarButton-editorStamp-icon: url(images/toolbarButton-editorStamp.svg);
   --toolbarButton-editorSignature-icon: url(images/toolbarButton-editorSignature.svg);
   --toolbarButton-signaturePropertiesVerified-icon: url(images/toolbarButton-signaturePropertiesVerified.svg);
-  --toolbarButton-signaturePropertiesWarn-icon: url(images/toolbarButton-signaturePropertiesWarn.svg);
   --toolbarButton-signaturePropertiesError-icon: url(images/toolbarButton-signaturePropertiesError.svg);
   --signatureProperties-rowCheck-icon: url(images/signature-properties-row-check.svg);
   --toolbarButton-menuArrow-icon: url(images/toolbarButton-menuArrow.svg);


### PR DESCRIPTION
The warn and error state badges shipped as byte-identical files (an X-in-circle glyph). Drop the redundant
toolbarButton-signaturePropertiesWarn.svg and point the warn state at the error icon instead; the amber-vs-red distinction is preserved via background-color (--sig-icon-warn vs --sig-icon-error), not the glyph.