### PR TITLE
Use the `#getPageL10nArgs` helper in the `PDFThumbnailView.prototype.addPasteButton` method

### DIFF
--- a/web/pdf_thumbnail_view.js
+++ b/web/pdf_thumbnail_view.js
@@ -171,12 +171,7 @@ class PDFThumbnailView extends RenderableView {
       "data-l10n-id",
       "pdfjs-views-manager-paste-button-after"
     );
-    pasteButton.setAttribute(
-      "data-l10n-args",
-      JSON.stringify({
-        page: this.pageLabel ?? this.id,
-      })
-    );
+    pasteButton.setAttribute("data-l10n-args", this.#getPageL10nArgs());
     const span = document.createElement("span");
     span.setAttribute("data-l10n-id", "pdfjs-views-manager-paste-button-label");
     pasteButton.append(span);


### PR DESCRIPTION
Rather than effectively duplicating code, we can re-use the existing helper here as well.