### PR TITLE
Remove unneeded `this.#signatureData = null;` lines in `src/core/document.js`

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -2133,12 +2133,10 @@ class PDFDocument {
       .ensureDoc("formInfo")
       .then(async formInfo => {
         if (!formInfo.hasSignatures || !formInfo.hasFields) {
-          this.#signatureData = null;
           return null;
         }
         const annotationGlobals = await this.annotationGlobals;
         if (!annotationGlobals) {
-          this.#signatureData = null;
           return null;
         }
         const fields = annotationGlobals.acroForm.get("Fields");


### PR DESCRIPTION
Given that this is the *initial value* of the field, setting it again when no signatures exist is pointless.