### PR TITLE
Do not drop the character after U+FFFE or U+FFFF in Font.prototype.encodeString

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3710,7 +3710,7 @@ class Font {
 
     for (let i = 0, ii = str.length; i < ii; i++) {
       const unicode = str.codePointAt(i);
-      if (unicode > 0xd7ff && (unicode < 0xe000 || unicode > 0xfffd)) {
+      if (unicode > 0xffff) {
         // unicode is represented by two uint16
         i++;
       }

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -26,6 +26,7 @@
     "event_utils_spec.js",
     "fetch_stream_spec.js",
     "font_substitutions_spec.js",
+    "fonts_spec.js",
     "image_utils_spec.js",
     "message_handler_spec.js",
     "metadata_spec.js",

--- a/test/unit/fonts_spec.js
+++ b/test/unit/fonts_spec.js
@@ -1,0 +1,44 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Font } from "../../src/core/fonts.js";
+import { IdentityToUnicodeMap } from "../../src/core/to_unicode_map.js";
+
+describe("Font", () => {
+  describe("encodeString", () => {
+    // `encodeString` only reads `this.toUnicode` and `this.cMap`, so a
+    // full `Font` (which needs a complete properties/font-file setup) isn't
+    // necessary to exercise it in isolation.
+    function encodeString(str, { cMap = null } = {}) {
+      const fakeFont = {
+        toUnicode: new IdentityToUnicodeMap(0, 0x10ffff),
+        cMap,
+      };
+      return Font.prototype.encodeString.call(fakeFont, str);
+    }
+
+    it("should keep the character after U+FFFE or U+FFFF", () => {
+      expect(encodeString("￿A")).toEqual(["\xffA"]);
+      expect(encodeString("￾B")).toEqual(["\xfeB"]);
+    });
+
+    it("should still treat a real surrogate pair as one code point", () => {
+      // U+1F602 ("😂") is genuinely represented by a surrogate pair; the
+      // character after it must still be kept, and the pair itself must
+      // not be split into its two unpaired halves.
+      expect(encodeString("😂C")).toEqual(["\x02C"]);
+    });
+  });
+});

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -72,6 +72,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/event_utils_spec.js",
       "pdfjs-test/unit/fetch_stream_spec.js",
       "pdfjs-test/unit/font_substitutions_spec.js",
+      "pdfjs-test/unit/fonts_spec.js",
       "pdfjs-test/unit/image_utils_spec.js",
       "pdfjs-test/unit/message_handler_spec.js",
       "pdfjs-test/unit/metadata_spec.js",


### PR DESCRIPTION
`Font.prototype.encodeString` has the same surrogate-pair guard that `encodeToXmlString` had before #21526: `unicode > 0xd7ff && (unicode < 0xe000 || unicode > 0xfffd)`. That predicate is also true for U+FFFE and U+FFFF, which are single UTF-16 code units, not surrogate pairs. The extra `i++` then steps over the character that follows them, so it gets silently dropped from the font-encoded output used when saving or printing a PDF.

Same fix as #21526: the correct test for a real surrogate pair is `unicode > 0xffff`, since `codePointAt` only returns a value at or above `0x10000` for an actual pair. This keeps the existing behavior for real surrogate pairs (emoji, supplementary-plane CJK, etc.) and the U+FFFD boundary, and only stops the character after U+FFFE/U+FFFF from being dropped.

`Font.prototype.encodeString` didn't have a direct unit test, so I added `test/unit/fonts_spec.js`. It calls the method on a minimal fake `this` (only `toUnicode`/`cMap` are read by this method), since building a full `Font` needs a complete properties/font-file setup that this bug doesn't depend on.

Verified locally: reverting only the `fonts.js` fix (keeping the new tests) turns the new test red (the encoded output is missing the trailing character), confirming the test catches the bug; with the fix it's green. A full `test/unit` run (skipping `api_spec`/`pdf_spec`/the two specs that need downloaded reference PDFs, unavailable in my sandbox) is unaffected: same 8 pre-existing environment-only failures and 15 pending specs as an unmodified checkout, before and after this change. `eslint`/`prettier --check` are clean on the touched files.
