### PR TITLE
Docs: document Buffer-backed Uint8Array transfer behavior

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -118,7 +118,11 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
  *
  *   NOTE: If TypedArrays are used they will generally be transferred to the
  *   worker-thread. This will help reduce main-thread memory usage, however
- *   it will take ownership of the TypedArrays.
+ *   it will take ownership of the TypedArrays. In Node.js, avoid passing a
+ *   `Uint8Array` view over a `Buffer`'s underlying `ArrayBuffer`, such as
+ *   `new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)`,
+ *   when the original `Buffer` must be reused. Use `new Uint8Array(buffer)`
+ *   to copy the data in that case.
  * @property {Object} [httpHeaders] - Basic authentication headers.
  * @property {boolean} [withCredentials] - Indicates whether or not
  *   cross-site Access-Control requests should be made using credentials such

--- a/src/display/api_utils.js
+++ b/src/display/api_utils.js
@@ -63,7 +63,9 @@ function getDataProp(val) {
     val instanceof Buffer // eslint-disable-line no-undef
   ) {
     throw new Error(
-      "Please provide binary data as `Uint8Array`, rather than `Buffer`."
+      "Please provide binary data as `Uint8Array`, rather than `Buffer`. " +
+        "If the original `Buffer` must be reused, pass `new Uint8Array(buffer)` " +
+        "rather than a view over `buffer.buffer`."
     );
   }
   if (val instanceof Uint8Array && val.byteLength === val.buffer.byteLength) {


### PR DESCRIPTION
This clarifies the `DocumentInitParameters.data` ownership note for Node.js users.

When a `Uint8Array` is created as a view over a Node `Buffer`'s underlying`ArrayBuffer`, for example:
```js
new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
```

the original Buffer may share the same backing store that PDF.js transfers to the worker. 
If the caller needs to reuse the original Buffer after loading the document, new Uint8Array(buffer) should be used to copy the data instead.

PDF.js already documents that TypedArray data may be transferred to the worker and that ownership is taken. 
This adds the Node-specific case where users may try to satisfy the "use Uint8Array rather than Buffer" requirement by creating a view over buffer.buffer, which can still affect the original Buffer.