### PR TITLE
Don't needlessly wrap the marked content `id`-attribute in a string

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -303,7 +303,7 @@ class TextLayer {
           this.#container = document.createElement("span");
           this.#container.classList.add("markedContent");
           if (item.id) {
-            this.#container.setAttribute("id", `${item.id}`);
+            this.#container.setAttribute("id", item.id);
           }
           if (item.tag === "Artifact") {
             this.#container.ariaHidden = true;


### PR DESCRIPTION
When the marked content `id` is defined it'll always be a string, hence wrapping it in a string when setting the attribute is pointless; note https://github.com/mozilla/pdf.js/blob/e148b154cdff4344db1bc263fe3b546b03eff5ae/src/core/evaluator.js#L3529-L3531