### PR TITLE
Implement a unit test for passing unsupported data types to `MurmurHash3_64.update()`

### DIFF
--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -43,6 +43,12 @@ describe("MurmurHash3_64", function () {
     hash.update(new Uint32Array(new Uint8Array(sourceCharCodes).buffer));
     expect(hash.hexdigest()).toEqual(hexDigestExpected);
   });
+  it("throws an exception for unsupported input types", function () {
+    const hash = new MurmurHash3_64();
+    expect(() => hash.update(42)).toThrow(
+      new Error("Invalid data format, must be a string or TypedArray.")
+    );
+  });
 
   it("changes the hash after update without seed", function () {
     const hash = new MurmurHash3_64();


### PR DESCRIPTION
This commit brings the coverage of `src/shared/murmurhash3.js` to 100%.