### PR TITLE
Implement unit tests for the `getRotationMatrix` core utility function

### DIFF
--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -21,6 +21,7 @@ import {
   escapeString,
   getInheritableProperty,
   getModificationDate,
+  getRotationMatrix,
   getSizeInBytes,
   isWhiteSpace,
   numberToString,
@@ -563,6 +564,20 @@ describe("core_utils", function () {
       const date = new Date(Date.UTC(3141, 5, 9, 2, 6, 53));
       expect(getModificationDate(date)).toEqual("31410609020653");
       expect(getModificationDate(date.toString())).toEqual("31410609020653");
+    });
+  });
+
+  describe("getRotationMatrix", function () {
+    it("should get a rotation matrix for valid rotation values", function () {
+      expect(getRotationMatrix(90, 10, 20)).toEqual([0, 1, -1, 0, 10, 0]);
+      expect(getRotationMatrix(180, 10, 20)).toEqual([-1, 0, 0, -1, 10, 20]);
+      expect(getRotationMatrix(270, 10, 20)).toEqual([0, -1, 1, 0, 0, 20]);
+    });
+
+    it("throws an exception for invalid rotation values", function () {
+      expect(() => getRotationMatrix(42, 10, 20)).toThrow(
+        new Error("Invalid rotation")
+      );
     });
   });
 


### PR DESCRIPTION
This function is mostly covered indirectly by higher-level tests, but unlike the other core utility functions it lacked dedicated unit tests. This commit implements unit tests for it that also cover the previously uncovered exception case, which brings coverage of the function to 100% and ever so slighly increases coverage of the overarching file.