### PR TITLE
fix(input): fix input pageNumber behavior on android devices

### DIFF
--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -378,11 +378,13 @@ class Toolbar {
 
     if (resetNumPages) {
       if (this.hasPageLabels) {
-        opts.pageNumber.type = "text";
+        opts.pageNumber.pattern = undefined;
+        opts.pageNumber.inputMode = undefined;
 
         opts.numPages.setAttribute("data-l10n-id", "pdfjs-page-of-pages");
       } else {
-        opts.pageNumber.type = "number";
+        opts.pageNumber.pattern = "\\d+";
+        opts.pageNumber.inputMode = "numeric";
 
         opts.numPages.setAttribute("data-l10n-id", "pdfjs-of-pages");
         opts.numPages.setAttribute(

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -374,11 +374,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div class="toolbarHorizontalGroup">
                   <span class="loadingInput start toolbarHorizontalGroup">
                     <input
-                      type="number"
                       id="pageNumber"
                       class="toolbarField"
+                      type="text"
+                      enterkeyhint="go"
                       value="1"
-                      min="1"
                       tabindex="0"
                       data-l10n-id="pdfjs-page-input"
                       autocomplete="off"


### PR DESCRIPTION
For example:

```html
<form>
.... some fields
<iframe>
pdf viewer
</iframe>

...some fields
</form>
```

When using pageNumber field on android default button is next field instead of submit, that make uncomfortable to use viewer because after it page scrolled to next field instead of just scrolling viewer to show entered page