### PR TITLE
Replace a couple of `indexOf` calls with `startsWith`

### DIFF
--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -113,16 +113,9 @@ function preprocess(inFilename, outFilename, defines) {
     const realPath = fs.realpathSync(inFilename);
     const dir = path.dirname(realPath);
     try {
-      let fullpath;
-      if (file.indexOf("$ROOT/") === 0) {
-        fullpath = path.join(
-          __dirname,
-          "../..",
-          file.substring("$ROOT/".length)
-        );
-      } else {
-        fullpath = path.join(dir, file);
-      }
+      const fullpath = file.startsWith("$ROOT/")
+        ? path.join(__dirname, "../..", file.substring("$ROOT/".length))
+        : path.join(dir, file);
       preprocess(fullpath, writeLine, defines);
     } catch (e) {
       if (e.code === "ENOENT") {

--- a/external/cmapscompress/compress.mjs
+++ b/external/cmapscompress/compress.mjs
@@ -386,7 +386,7 @@ function writeNumber(n) {
     if (buffer > 0) {
       s = writeByte((buffer & 0x7f) | (s.length > 0 ? 0x80 : 0)) + s;
     }
-    while (s.indexOf("80") === 0) {
+    while (s.startsWith("80")) {
       s = s.substring(2);
     }
     return s;


### PR DESCRIPTION
These cases weren't detected/fixed by the following ESLint plugin rule; see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-starts-ends-with.md

Additionally, replace the `if` with a ternary statement in the `external/builder/builder.mjs` file since this patch touches that code anyway.