### PR TITLE
Same-Origin fix for strict CSP

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2079,9 +2079,18 @@ class PDFWorker {
           : "./pdf.worker.mjs";
       }
 
-      // Check if URLs have the same origin. For non-HTTP based URLs, returns
-      // false.
-      this._isSameOrigin = (baseUrl, otherUrl) => {
+      // Check if URL has the same origin as the document of the window given.
+      // For about:blank, window parent or opener is used to determine the origin.
+      // For non-HTTP based URLs, returns false.
+      this._isSameOrigin = (wnd, otherUrl) => {
+        const baseUrl = wnd.location.href;
+        if (baseUrl === "about:blank") {
+          if (window.parent) {
+            return this._isSameOrigin(window.parent, otherUrl);
+          } else if (window.opener) {
+            return this._isSameOrigin(window.opener, otherUrl);
+          }
+        }
         const base = URL.parse(baseUrl);
         if (!base?.origin || base.origin === "null") {
           return false; // non-HTTP url
@@ -2202,7 +2211,7 @@ class PDFWorker {
       if (
         typeof PDFJSDev !== "undefined" &&
         PDFJSDev.test("GENERIC") &&
-        !PDFWorker._isSameOrigin(window.location, workerSrc)
+        !PDFWorker._isSameOrigin(window, workerSrc)
       ) {
         workerSrc = PDFWorker._createCDNWrapper(
           new URL(workerSrc, window.location).href


### PR DESCRIPTION
Based on https://www.w3.org/TR/2011/WD-html5-20110525/browsers.html#creator-document, this commit introduces support for inherited browser context.

When self-hosted pdf.min.js is loaded in an about:blank iframe dynamically, Pdf.Js doesn't follow the W3C rules about same-origin and tries to load self-hosted pdf.worker.js using the CDN wrapper - a blob:**** URL.
The same-origin rules, however, set the about:blank origin as that of the parent/opener. Pdf.js shouldn't try to load pdf.worker.js using blob:, since it's the same origin as iframe opener.

In our environment, using blob:*** as a worker source is disallowed by Content-Security-Policy.

The behaviour can be observer on https://greunlis.github.io/pdf.js/self-hosted/ (the worker fails to load) and https://greunlis.github.io/pdf.js/self-hosted-new/