### PR TITLE
Use a reader for text content streams

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1766,10 +1766,19 @@ class PDFPageProxy {
       lang: null,
     };
 
-    for await (const value of readableStream) {
-      textContent.lang ??= value.lang;
-      Object.assign(textContent.styles, value.styles);
-      textContent.items.push(...value.items);
+    const reader = readableStream.getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        textContent.lang ??= value.lang;
+        Object.assign(textContent.styles, value.styles);
+        textContent.items.push(...value.items);
+      }
+    } finally {
+      reader.releaseLock();
     }
     return textContent;
   }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4061,6 +4061,63 @@ Paragraph 1.1 ...................................................... 3
 page 1 / 3`);
     });
 
+    it("gets text content from all stream chunks", async function () {
+      const reader = {
+        read: jasmine.createSpy().and.returnValues(
+          Promise.resolve({
+            value: {
+              items: [{ str: "first" }],
+              styles: { font1: { fontFamily: "serif" } },
+              lang: null,
+            },
+            done: false,
+          }),
+          Promise.resolve({
+            value: {
+              items: [{ str: "second" }],
+              styles: { font2: { fontFamily: "sans-serif" } },
+              lang: "en",
+            },
+            done: false,
+          }),
+          Promise.resolve({ value: undefined, done: true })
+        ),
+        releaseLock: jasmine.createSpy(),
+      };
+      spyOn(page, "streamTextContent").and.returnValue({
+        getReader() {
+          return reader;
+        },
+      });
+
+      const { items, styles, lang } = await page.getTextContent();
+
+      expect(items).toEqual([{ str: "first" }, { str: "second" }]);
+      expect(styles).toEqual({
+        font1: { fontFamily: "serif" },
+        font2: { fontFamily: "sans-serif" },
+      });
+      expect(lang).toEqual("en");
+      expect(reader.read).toHaveBeenCalledTimes(3);
+      expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+    });
+
+    it("releases the text content stream reader after an error", async function () {
+      const reason = new Error("text content stream failed");
+      const reader = {
+        read: jasmine.createSpy().and.rejectWith(reason),
+        releaseLock: jasmine.createSpy(),
+      };
+      spyOn(page, "streamTextContent").and.returnValue({
+        getReader() {
+          return reader;
+        },
+      });
+
+      await expectAsync(page.getTextContent()).toBeRejectedWith(reason);
+      expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+    });
+
     it("gets text content, with correct properties (issue 8276)", async function () {
       const loadingTask = getDocument(
         buildGetDocumentParams("issue8276_reduced.pdf")


### PR DESCRIPTION
Fixes #21557.

This changes `PDFPageProxy.getTextContent` to consume the text-content `ReadableStream` through `getReader()` instead of relying on async iteration.

Safari runtimes can support the `for await...of` language syntax while lacking `ReadableStream.prototype[Symbol.asyncIterator]`. As a result, the legacy bundle preserves syntactically valid code that fails when it attempts to iterate the stream. The reader API is supported by the affected runtime and provides the same chunked data.

The aggregation behavior for `items`, `styles`, and `lang` remains unchanged. The reader lock is released in a `finally` block after both successful completion and read failures.

Validation:

- `npx gulp lint`
- Focused `api_spec.js`: 2 specs, 0 failures
- `npx gulp generic`
- `npx gulp generic-legacy`
- `npx gulp lib-legacy`
