### PR TITLE
Use direct `return await` a bit more in the `src/core/` folder

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -319,10 +319,7 @@ class AnnotationFactory {
       const pageRef = annotDict.getRaw("P");
       if (pageRef instanceof Ref) {
         try {
-          const pageIndex = await pdfManager.ensureCatalog("getPageIndex", [
-            pageRef,
-          ]);
-          return pageIndex;
+          return await pdfManager.ensureCatalog("getPageIndex", [pageRef]);
         } catch (ex) {
           info(`_getPageIndex -- not a valid page reference: "${ex}".`);
         }

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -664,14 +664,14 @@ class WorkerMessageHandler {
           const pdfEditor = new PDFEditor();
           task = new WorkerTask(`ExtractPages: ${pageInfos.length} page(s)`);
           startWorkerTask(task);
-          const buffer = await pdfEditor.extractPages(
+
+          return await pdfEditor.extractPages(
             pageInfos,
             annotationStorage,
             pdfManager.pdfDocument,
             handler,
             task
           );
-          return buffer;
         } catch (reason) {
           warn(`extractPages: "${reason}".`);
           return null;


### PR DESCRIPTION
In these cases there's no need for a temporary variable, since the result of the asynchronous operation is returned as-is without any additional parsing.