### PR TITLE
Validate PredictorStream Colors/BitsPerComponent/Columns parameters

### DIFF
--- a/src/core/predictor_stream.js
+++ b/src/core/predictor_stream.js
@@ -42,8 +42,30 @@ class PredictorStream extends DecodeStream {
     const bits = (this.bits = params.get("BPC", "BitsPerComponent") || 8);
     const columns = (this.columns = params.get("Columns") || 1);
 
-    this.pixBytes = (colors * bits + 7) >> 3;
-    this.rowBytes = (columns * colors * bits + 7) >> 3;
+    // The existing `|| fallback` above only guards against zero/falsy values;
+    // negative or non-integer values (e.g. `/Colors -1`) pass through, and a
+    // very large `Columns` overflows the `>> 3` arithmetic below (which coerces
+    // to a signed int32), yielding a negative or zero row length. Both produce
+    // silently corrupted output instead of an error, so reject them up front.
+    if (
+      !Number.isInteger(colors) ||
+      colors < 1 ||
+      !Number.isInteger(bits) ||
+      bits < 1 ||
+      bits > 16 ||
+      !Number.isInteger(columns) ||
+      columns < 1
+    ) {
+      throw new FormatError(
+        `Invalid predictor parameters: Colors=${colors}, ` +
+          `BitsPerComponent=${bits}, Columns=${columns}`
+      );
+    }
+
+    // Use `Math.ceil(.../ 8)` rather than `(... + 7) >> 3` so the byte counts
+    // are not truncated to a signed int32 for large `columns` values.
+    this.pixBytes = Math.ceil((colors * bits) / 8);
+    this.rowBytes = Math.ceil((columns * colors * bits) / 8);
 
     return this;
   }

--- a/test/unit/stream_spec.js
+++ b/test/unit/stream_spec.js
@@ -74,5 +74,28 @@ describe("stream", function () {
       }
       expect(decoded).toEqual(expected);
     });
+
+    it("should reject invalid predictor parameters", function () {
+      const makeStream = (key, value) => {
+        const dict = new Dict();
+        dict.set("Predictor", 12);
+        dict.set("Colors", 1);
+        dict.set("BitsPerComponent", 8);
+        dict.set("Columns", 2);
+        dict.set(key, value);
+
+        const input = new Stream(new Uint8Array([0, 0, 0]), 0, 3, dict);
+        return () => new PredictorStream(input, /* length = */ 3, dict);
+      };
+
+      // Negative values slip past the `|| fallback` because they are truthy.
+      expect(makeStream("Colors", -1)).toThrowError(/Invalid predictor/);
+      expect(makeStream("BitsPerComponent", -8)).toThrowError(
+        /Invalid predictor/
+      );
+      // A large `Columns` used to overflow `(... + 7) >> 3` to a negative
+      // row length; it must now be handled without truncation.
+      expect(makeStream("Columns", 2147483647)).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
### What
`PredictorStream` reads `Colors`, `BitsPerComponent` and `Columns` from
`/DecodeParms` guarding only against falsy values (`|| fallback`), with no
sign or range check:

    this.pixBytes = (colors * bits + 7) >> 3;
    this.rowBytes = (columns * colors * bits + 7) >> 3;

### Problem
- Negative / non-integer values slip through because they're truthy — e.g.
  `/Colors -1` flips `pixBytes` negative, turning "look back one pixel" into
  "look forward".
- `>> 3` coerces to a signed int32, so a large `Columns` wraps `rowBytes` to
  zero/negative (`268435456 → -268435456`, `2147483647 → -1`).

In both cases decoding runs against a wrongly-sized buffer and silently
produces corrupted/empty output instead of raising a `FormatError`.

### Fix
- Reject non-integer / out-of-range `Colors`, `BitsPerComponent`, `Columns`
  with a `FormatError` before computing the geometry.
- Compute the byte counts with `Math.ceil(.../ 8)` so they aren't truncated
  to a signed int32.

### Tests
Adds a unit test in `stream_spec.js` covering negative `Colors` /
`BitsPerComponent` (now rejected) and a large `Columns` (now handled without
int32 wrap). `npx gulp lint` and `npx gulp unittest` pass locally (the one
unrelated pre-existing `should parse a date with a format` failure is present
on `master` too).

### Scope
Targets the correctness/validation bug. It does not add an upper bound on
`rowBytes`, so it doesn't change per-image allocation for a still-valid large
`Columns` — happy to add a ceiling here or in a follow-up if preferred.