### PR TITLE
Use Iterator methods to avoid some unnecessary Array creation

### DIFF
--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -447,7 +447,10 @@ class XFAObject {
   [_getUnsetAttributes](protoAttributes) {
     const allAttr = this[_attributeNames];
     const setAttr = this[_setAttributes];
-    return [...protoAttributes].filter(x => allAttr.has(x) && !setAttr.has(x));
+    return protoAttributes
+      .keys()
+      .filter(x => allAttr.has(x) && !setAttr.has(x))
+      .toArray();
   }
 
   /**

--- a/src/display/draw_layer.js
+++ b/src/display/draw_layer.js
@@ -366,8 +366,10 @@ class DrawLayer {
    *   Connected text layers sorted in document order.
    */
   static #getOrderedTextLayers() {
-    return [...this.#textLayerSet]
+    return this.#textLayerSet
+      .keys()
       .filter(textLayer => textLayer.isConnected)
+      .toArray()
       .sort(compareTextLayers);
   }
 

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -113,7 +113,7 @@ class MathMLSanitizer {
       "sanitizer",
       FeatureTest.isSanitizerSupported
         ? new Sanitizer({
-            elements: [...MathMLElements].map(name => ({
+            elements: Array.from(MathMLElements.keys(), name => ({
               name,
               namespace: MathMLNamespace,
             })),


### PR DESCRIPTION
Currently there are some spots in the code-base where intermediate Arrays are unnecessarily created from Iterators, before `filter` and `map` is used to create a final Array.
Thanks to newer Iterators methods, see e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter, that can be now be avoided.