### PR TITLE
Ignore Annotations with `fieldValue = null` when saving (issue 21582)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -4104,6 +4104,8 @@ class ChoiceWidgetAnnotation extends WidgetAnnotation {
 }
 
 class SignatureWidgetAnnotation extends WidgetAnnotation {
+  _hasValueFromXFA = false;
+
   constructor(params) {
     super(params);
 

--- a/src/core/writer.js
+++ b/src/core/writer.js
@@ -224,7 +224,7 @@ function writeXFADataForAcroform(str, changes) {
       continue;
     }
     const { path, value } = xfa;
-    if (!path) {
+    if (!path || value === null) {
       continue;
     }
     const nodePath = parseXFAPath(path);

--- a/test/pdfs/issue21582.pdf.link
+++ b/test/pdfs/issue21582.pdf.link
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/files/30091865/VBA-21-0966-ARE.pdf

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -40,6 +40,14 @@
     "type": "other"
   },
   {
+    "id": "issue21582",
+    "file": "pdfs/issue21582.pdf",
+    "md5": "bcc5a2ae3a588f360edbf94c3dd476a8",
+    "rounds": 1,
+    "link": true,
+    "type": "other"
+  },
+  {
     "id": "filled-background-range",
     "file": "pdfs/filled-background.pdf",
     "md5": "2e3120255d9c3e79b96d2543b12d2589",

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2805,6 +2805,16 @@ describe("api", function () {
       await Promise.all([loadingTask1.destroy(), loadingTask2.destroy()]);
     });
 
+    it("saving should ignore Annotations with null `fieldValue` (issue 21582)", async function () {
+      const loadingTask = getDocument(buildGetDocumentParams("issue21582.pdf"));
+      const pdfDoc = await loadingTask.promise;
+
+      const data = await pdfDoc.saveDocument();
+      expect(data).toBeInstanceOf(Uint8Array);
+
+      await loadingTask.destroy();
+    });
+
     it("write a value in an annotation, save the pdf and load it", async function () {
       let loadingTask = getDocument(buildGetDocumentParams("evaljs.pdf"));
       let pdfDoc = await loadingTask.promise;


### PR DESCRIPTION
Some Annotations, e.g. `SignatureWidgetAnnotation`, set `fieldValue = null` which may causing saving to fail during `writeXFADataForAcroform`, hence we simply ignore any such Annotation-data during saving.

*Please note:* This is probably more of a work-around, rather than a "proper" solution, so I fully understand if this patch is rejected.