### PR TITLE
Re-factor the `bCache`, used with /Mesh Shadings

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -667,25 +667,25 @@ class MeshStreamReader {
   }
 }
 
-let bCache = Object.create(null);
+let bCache = null;
 
-function buildB(count) {
-  const lut = [];
-  for (let i = 0; i <= count; i++) {
-    const t = i / count,
-      t_ = 1 - t;
-    lut.push(
-      new Float32Array([t_ ** 3, 3 * t * t_ ** 2, 3 * t ** 2 * t_, t ** 3])
-    );
-  }
-  return lut;
-}
 function getB(count) {
-  return (bCache[count] ||= buildB(count));
+  return (bCache ??= new Map()).getOrInsertComputed(count, () =>
+    Array.from({ length: count + 1 }, (_, i) => {
+      const t = i / count,
+        t_ = 1 - t;
+      return new Float32Array([
+        t_ ** 3,
+        3 * t * t_ ** 2,
+        3 * t ** 2 * t_,
+        t ** 3,
+      ]);
+    })
+  );
 }
 
 function clearPatternCaches() {
-  bCache = Object.create(null);
+  bCache?.clear();
 }
 
 class MeshShading extends BaseShading {

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -36,6 +36,8 @@ function applyBoundingBox(ctx, bbox) {
 }
 
 class BaseShadingPattern {
+  matrix = null;
+
   constructor() {
     if (
       (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) &&
@@ -64,7 +66,6 @@ class RadialAxialShadingPattern extends BaseShadingPattern {
     this._p1 = IR[5];
     this._r0 = IR[6];
     this._r1 = IR[7];
-    this.matrix = null;
   }
 
   isOriginBased() {
@@ -381,7 +382,6 @@ class MeshShadingPattern extends BaseShadingPattern {
     this._bounds = IR[5];
     this._bbox = IR[6];
     this._background = IR[7];
-    this.matrix = null;
     // Pre-compile the mesh pipeline now that we know GPU-renderable content
     // is present; no-op if the GPU is not available or already compiled.
     loadMeshShader();


### PR DESCRIPTION
 - Initialize the `bCache` lazily, since many/most PDF documents don't need it.
 - Change the `bCache` to a `Map`, rather than an Object, which thanks to `getOrInsertComputed` allows the `buildB` function to be inlined.

Also, while unrelated here, move the `this.matrix = null;` definition to the `BaseShadingPattern` class to reduce (a tiny bit of) unnecessary duplication.