### PR TITLE
Update the file format entries in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,23 +1,24 @@
 # Force Unix line endings for most file formats (except binary files)
-*.js         text eol=lf
-*.jsm        text eol=lf
-*.css        text eol=lf
-*.html       text eol=lf
-*.md         text eol=lf
-*.ftl        text eol=lf
-*.yml        text eol=lf
-*.json       text eol=lf
 *.config     text eol=lf
-*.inc        text eol=lf
-*.manifest   text eol=lf
-*.rdf        text eol=lf
-*.jade       text eol=lf
-*.coffee     text eol=lf
+*.css        text eol=lf
+*.example    text eol=lf
+*.ftl        text eol=lf
+*.html       text eol=lf
+*.js         text eol=lf
+*.json       text eol=lf
+*.link       text eol=lf
+*.md         text eol=lf
+*.mjs        text eol=lf
+*.mts        text eol=lf
+*.njk        text eol=lf
+*.py         text eol=lf
+*.svg        text eol=lf
+*.ts         text eol=lf
+*.txt        text eol=lf
+*.yml        text eol=lf
 
 # PDF files shall not modify CRLF line endings
 *.pdf -crlf
 
 # Linguist language overrides
 *.js linguist-language=JavaScript
-*.jsm linguist-language=JavaScript
-*.inc linguist-language=XML


### PR DESCRIPTION
Several extensions (`.coffee`, `.jade`, `.inc` and others) became obsolete in e.g. the conversion to Wintersmith/Fluent/other tools, while other new extensions (`.mjs`, `.njk`, `.py` and others) were missing.

This commit removes all obsolete file format entries, adds all missing ones and orders the list alphatically (so it can more easily be matched against tooling that lists all in-use file extensions in the repository).

_I have compiled a list of the currently used file extensions in the repository with the following quick command: `find . -type f -not -path "./node_modules/*" -not -path "./build/*" -not -path "./.git/*" | awk -F. '!a[$NF]++{print $NF}' | grep -Ev "LICENSE|CODEOWNERS|EXPORT|AUTHORS|rc|ignore|attributes|mailmap" | sort`