### PR TITLE
Fix parsing of ambiguous date formats like `Hm`

### DIFF
--- a/src/scripting_api/util.js
+++ b/src/scripting_api/util.js
@@ -602,7 +602,11 @@ class Util extends PDFObject {
         function (match, patternElement) {
           const { pattern, action } = handlers[patternElement];
           actions.push(action);
-          return pattern;
+          // If the format is "Hm", then /\d{1,2}\d{1,2}/ is ambiguous so we use
+          // a lookahead to ensure that we match the longest possible sequence.
+          return pattern.includes(",")
+            ? `(?=${pattern})\\${actions.length}`
+            : pattern;
         }
       );
 

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -251,6 +251,15 @@ describe("Scripting", function () {
         value = await myeval(`util.scand("mmddyyyy", "07a15b2007").toString()`);
         expect(new Date(value)).toEqual(new Date("07/15/2007 12:00:00"));
       });
+
+      it("should handle a format with repeated specifiers", async () => {
+        const cFormat = "Hm".repeat(40);
+        const cDate = `${"1".repeat(84)}x`;
+        const value = await myeval(
+          `util.scand("${cFormat}", "${cDate}")?.toString() ?? "null"`
+        );
+        expect(value).toEqual("null");
+      });
     });
 
     describe("printf", function () {


### PR DESCRIPTION
We support having hours/minutes numbers with one or two digits for strings like "1:30:31" but if the format is for example Hm, then "12" is really ambiguous. So the idea is to match the longest string as possible.