### PR TITLE
[api-minor] Convert `getViewerPreferences` to return data in a Map

### DIFF
--- a/pdfjs.config
+++ b/pdfjs.config
@@ -1,5 +1,5 @@
 {
   "stableVersion": "6.1.200",
-  "baseVersion": "b168293c173b0b9befe462c0b254136cf038c3ef",
-  "versionPrefix": "6.1."
+  "baseVersion": "eddd70a2ca1054ad2e0792972c3f2774b89f0cd2",
+  "versionPrefix": "6.2."
 }

--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -1076,17 +1076,18 @@ class Catalog {
           break;
         case "PrintPageRange":
           // The number of elements must be even.
-          if (Array.isArray(value) && value.length % 2 === 0) {
-            const isValid = value.every(
+          if (
+            Array.isArray(value) &&
+            value.length % 2 === 0 &&
+            value.every(
               (page, i, arr) =>
                 Number.isInteger(page) &&
                 page > 0 &&
                 (i === 0 || page >= arr[i - 1]) &&
                 page <= this.numPages
-            );
-            if (isValid) {
-              prefValue = value;
-            }
+            )
+          ) {
+            prefValue = value;
           }
           break;
         case "NumCopies":
@@ -1103,8 +1104,7 @@ class Catalog {
         warn(`Bad value, for key "${key}", in ViewerPreferences: ${value}.`);
         continue;
       }
-      prefs ??= Object.create(null);
-      prefs[key] = prefValue;
+      (prefs ??= new Map()).set(key, prefValue);
     }
     return shadow(this, "viewerPreferences", prefs);
   }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -820,9 +820,9 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @returns {Promise<Object | null>} A promise that is resolved with an
-   *   {Object} containing the viewer preferences, or `null` when no viewer
-   *   preferences are present in the PDF file.
+   * @returns {Promise<Map | null>} A promise that is resolved with a {Map}
+   *   containing the viewer preferences, or `null` when no viewer preferences
+   *   are present in the PDF file.
    */
   getViewerPreferences() {
     return this._transport.getViewerPreferences();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1760,7 +1760,7 @@ describe("api", function () {
 
     it("gets non-default viewer preferences", async function () {
       const prefs = await pdfDocument.getViewerPreferences();
-      expect(prefs).toEqual({ Direction: "L2R" });
+      expect(prefs).toEqual(new Map([["Direction", "L2R"]]));
     });
 
     it("gets default open action", async function () {


### PR DESCRIPTION
Compared to regular Objects there's a number of advantages to using Maps:
 - They support proper iteration.
 - They have a simple way to check for the existence of data.
 - They have a simple/efficient way to check the number of elements.

If this functionality was added today, I cannot imagine that we'd choose an Object for this data.