### PR TITLE
Fix the z-order of ink drawings relative to the other editors

### DIFF
--- a/src/display/draw_layer.js
+++ b/src/display/draw_layer.js
@@ -814,6 +814,22 @@ class DrawLayer {
     }
   }
 
+  /**
+   * The SVGs live in the canvas wrapper whereas the editor divs live in the
+   * annotation editor layer: both are siblings, hence the SVGs must carry the
+   * same z-index as their editor in order to be stacked with them.
+   *
+   * @param {number} id
+   * @param {number} zIndex
+   * @returns {undefined}
+   */
+  updateZIndex(id, zIndex) {
+    const root = this.#mapping.get(id);
+    if (root) {
+      root.style.zIndex = zIndex;
+    }
+  }
+
   updateParent(id, layer) {
     if (layer === this) {
       return;

--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -124,6 +124,7 @@ class DrawingEditor extends AnnotationEditor {
         drawId,
         drawOutlines.defaultProperties
       );
+      this.parent.drawLayer.updateZIndex(drawId, this.zIndex);
     } else {
       // We create a new drawing.
       this._drawId = this.#createDrawing(drawOutlines, this.parent);
@@ -141,7 +142,27 @@ class DrawingEditor extends AnnotationEditor {
       /* isPathUpdatable = */ false,
       /* hasClip = */ false
     );
+    // The SVG lives in the canvas wrapper, which is a sibling of the annotation
+    // editor layer containing the editor divs, so it must share their z-index
+    // in order to be stacked with the other editors.
+    parent.drawLayer.updateZIndex(id, this.zIndex);
     return id;
+  }
+
+  /** @inheritdoc */
+  setInBackground() {
+    super.setInBackground();
+    if (this._drawId !== null) {
+      this.parent?.drawLayer.updateZIndex(this._drawId, 0);
+    }
+  }
+
+  /** @inheritdoc */
+  setInForeground() {
+    super.setInForeground();
+    if (this._drawId !== null) {
+      this.parent?.drawLayer.updateZIndex(this._drawId, this.zIndex);
+    }
   }
 
   static _mergeSVGProperties(p1, p2) {
@@ -346,6 +367,28 @@ class DrawingEditor extends AnnotationEditor {
         }
       )
     );
+  }
+
+  /** @inheritdoc */
+  select() {
+    super.select();
+    // The `.selectedEditor` rule raises the editor div, but the drawing itself
+    // lives in a separate SVG, which must be raised along with it.
+    this.parent?.drawLayer.updateProperties(this._drawId, {
+      rootClass: {
+        selected: true,
+      },
+    });
+  }
+
+  /** @inheritdoc */
+  unselect() {
+    super.unselect();
+    this.parent?.drawLayer.updateProperties(this._drawId, {
+      rootClass: {
+        selected: false,
+      },
+    });
   }
 
   _onStartDragging() {
@@ -831,6 +874,12 @@ class DrawingEditor extends AnnotationEditor {
       /* isPathUpdatable = */ true,
       /* hasClip = */ false
     ));
+    // The editor isn't created until the drawing session ends, so use the
+    // z-index it will be given in order to draw on top of the existing editors.
+    parent.drawLayer.updateZIndex(
+      this._currentDrawId,
+      AnnotationEditor._zIndex
+    );
   }
 
   static _drawMove(event) {

--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -139,6 +139,7 @@ class DrawingEditor extends AnnotationEditor {
         drawOutlines.defaultProperties
       );
       this.#createFocusOutline(this.parent);
+      this.parent.drawLayer.updateZIndex(drawId, this.zIndex);
     } else {
       // We create a new drawing.
       this._drawId = this.#createDrawing(drawOutlines, this.parent);
@@ -160,6 +161,11 @@ class DrawingEditor extends AnnotationEditor {
       this._clipPathId = clipPathId;
     }
     this.#createFocusOutline(parent);
+
+    // The SVG lives in the canvas wrapper, which is a sibling of the annotation
+    // editor layer containing the editor divs, so it must share their z-index
+    // in order to be stacked with the other editors.
+    parent.drawLayer.updateZIndex(id, this.zIndex);
 
     return id;
   }
@@ -201,6 +207,22 @@ class DrawingEditor extends AnnotationEditor {
     parent.drawLayer.updateProperties(_drawId, { rootClass });
     if (_focusDrawId !== null) {
       parent.drawLayer.updateProperties(_focusDrawId, { rootClass });
+    }
+  }
+
+  /** @inheritdoc */
+  setInBackground() {
+    super.setInBackground();
+    if (this._drawId !== null) {
+      this.parent?.drawLayer.updateZIndex(this._drawId, 0);
+    }
+  }
+
+  /** @inheritdoc */
+  setInForeground() {
+    super.setInForeground();
+    if (this._drawId !== null) {
+      this.parent?.drawLayer.updateZIndex(this._drawId, this.zIndex);
     }
   }
 
@@ -429,6 +451,30 @@ class DrawingEditor extends AnnotationEditor {
         }
       )
     );
+  }
+
+  /** @inheritdoc */
+  select() {
+    super.select();
+    // The `.selectedEditor` rule raises the editor div, but the drawing itself
+    // lives in a separate SVG, which must be raised along with it.
+    this.parent?.drawLayer.updateProperties(this._drawId, {
+      rootClass: {
+        selected: true,
+      },
+    });
+    this.#toggleFocusOutlineClass({ hovered: false, selected: true });
+  }
+
+  /** @inheritdoc */
+  unselect() {
+    super.unselect();
+    this.parent?.drawLayer.updateProperties(this._drawId, {
+      rootClass: {
+        selected: false,
+      },
+    });
+    this.#toggleFocusOutlineClass({ selected: false });
   }
 
   _onStartDragging() {
@@ -764,18 +810,6 @@ class DrawingEditor extends AnnotationEditor {
     this.#updateVisibility();
   }
 
-  /** @inheritdoc */
-  select() {
-    super.select();
-    this.#toggleFocusOutlineClass({ hovered: false, selected: true });
-  }
-
-  /** @inheritdoc */
-  unselect() {
-    super.unselect();
-    this.#toggleFocusOutlineClass({ selected: false });
-  }
-
   pointerover() {
     if (!this.isSelected) {
       this.#toggleFocusOutlineClass({ hovered: true });
@@ -1033,6 +1067,12 @@ class DrawingEditor extends AnnotationEditor {
     );
     this._currentDrawId = id;
     DrawingEditor.#currentClipPathId = this._hasClipPath ? clipPathId : null;
+    // The editor isn't created until the drawing session ends, so use the
+    // z-index it will be given in order to draw on top of the existing editors.
+    parent.drawLayer.updateZIndex(
+      this._currentDrawId,
+      AnnotationEditor._zIndex
+    );
   }
 
   static _drawMove(event) {

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -372,6 +372,13 @@ class AnnotationEditor {
   }
 
   /**
+   * @returns {number} the z-index used to stack this editor with the others.
+   */
+  get zIndex() {
+    return this.#zIndex;
+  }
+
+  /**
    * This editor will be behind the others.
    */
   setInBackground() {

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -17,6 +17,7 @@ import {
   awaitPromise,
   clearEditors,
   closePages,
+  copyToClipboard,
   countStorageEntries,
   createPromise,
   dragAndDrop,
@@ -26,11 +27,13 @@ import {
   getRect,
   getSerialized,
   isCanvasMonochrome,
+  kbBigMoveDown,
   kbRedo,
   kbSave,
   kbUndo,
   loadAndWait,
   moveEditor,
+  pasteFromClipboard,
   pinch,
   scrollIntoView,
   selectEditor,
@@ -46,6 +49,10 @@ import {
   waitForTimeout,
 } from "./test_utils.mjs";
 import { AnnotationEditorType } from "../../src/shared/util.js";
+import fs from "fs";
+import path from "path";
+
+const __dirname = import.meta.dirname;
 
 const selectAll = selectEditors.bind(null, "ink");
 
@@ -57,6 +64,29 @@ const commit = async page => {
 };
 
 const switchToInk = switchToEditor.bind(null, "Ink");
+
+const switchToStamp = switchToEditor.bind(null, "Stamp");
+
+const copyImage = async (page, imagePath, selector) => {
+  const data = fs
+    .readFileSync(path.join(__dirname, imagePath))
+    .toString("base64");
+
+  await copyToClipboard(page, { "image/png": `data:image/png;base64,${data}` });
+  await pasteFromClipboard(page);
+
+  await page.waitForSelector(`${selector} canvas`);
+  await page.waitForSelector(`${selector} .altText`);
+};
+
+// The drawings are in SVGs living in the canvas wrapper, whereas the other
+// editors are divs living in the annotation editor layer. Both layers are
+// siblings, so the z-index is what decides which one is on top.
+const getZIndex = (page, selector) =>
+  page.evaluate(sel => {
+    const { zIndex } = getComputedStyle(document.querySelector(sel));
+    return zIndex === "auto" ? 0 : parseInt(zIndex, 10);
+  }, selector);
 
 const drawLine = async (page, x0, y0, x1, y1) => {
   const clickHandle = await waitForPointerUp(page);
@@ -1572,5 +1602,65 @@ describe("Tap after a two-finger gesture", () => {
         await waitForSelectedEditor(page, editorSelector);
       })
     );
+  });
+});
+
+describe("Ink stacking with a stamp", () => {
+  let pages;
+
+  beforeEach(async () => {
+    pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+  });
+
+  afterEach(async () => {
+    await closePages(pages);
+  });
+  it("must draw on top of a stamp added before", async () => {
+    // Run sequentially to avoid clipboard issues.
+    for (const [browserName, page] of pages) {
+      await switchToStamp(page);
+      const stampSelector = getEditorSelector(0);
+      await copyImage(page, "../images/firefox_logo.png", stampSelector);
+      // A pasted stamp is centered, so move it away in order to draw on an
+      // empty area: the stamp would otherwise intercept the pointer events.
+      await moveEditor(page, stampSelector, 10, () => kbBigMoveDown(page));
+      await unselectEditor(page, stampSelector);
+
+      await switchToInk(page);
+      const rect = await getRect(page, ".annotationEditorLayer");
+      const x = rect.x + 100;
+      const y = rect.y + 100;
+      await drawLine(page, x, y, x + 50, y + 50);
+      await commit(page);
+      // Unselect: a selected editor is always brought to the front, which
+      // would hide the stacking we want to check here.
+      await unselectEditor(page, getEditorSelector(1));
+
+      expect(await getZIndex(page, ".canvasWrapper .draw"))
+        .withContext(`In ${browserName}`)
+        .toBeGreaterThan(await getZIndex(page, stampSelector));
+    }
+  });
+
+  it("must be under a stamp added after", async () => {
+    // Run sequentially to avoid clipboard issues.
+    for (const [browserName, page] of pages) {
+      await switchToInk(page);
+      const rect = await getRect(page, ".annotationEditorLayer");
+      const x = rect.x + 100;
+      const y = rect.y + 100;
+      await drawLine(page, x, y, x + 50, y + 50);
+      await commit(page);
+      await unselectEditor(page, getEditorSelector(0));
+
+      await switchToStamp(page);
+      const stampSelector = getEditorSelector(1);
+      await copyImage(page, "../images/firefox_logo.png", stampSelector);
+      await unselectEditor(page, stampSelector);
+
+      expect(await getZIndex(page, ".canvasWrapper .draw"))
+        .withContext(`In ${browserName}`)
+        .toBeLessThan(await getZIndex(page, stampSelector));
+    }
   });
 });

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -17,6 +17,7 @@ import {
   awaitPromise,
   clearEditors,
   closePages,
+  copyToClipboard,
   countStorageEntries,
   createPromise,
   dragAndDrop,
@@ -26,11 +27,13 @@ import {
   getRect,
   getSerialized,
   isCanvasMonochrome,
+  kbBigMoveDown,
   kbRedo,
   kbSave,
   kbUndo,
   loadAndWait,
   moveEditor,
+  pasteFromClipboard,
   pinch,
   scrollIntoView,
   selectEditor,
@@ -47,6 +50,10 @@ import {
   waitForTimeout,
 } from "./test_utils.mjs";
 import { AnnotationEditorType } from "../../src/shared/util.js";
+import fs from "fs";
+import path from "path";
+
+const __dirname = import.meta.dirname;
 
 const selectAll = selectEditors.bind(null, "ink");
 
@@ -58,6 +65,29 @@ const commit = async page => {
 };
 
 const switchToInk = switchToEditor.bind(null, "Ink");
+
+const switchToStamp = switchToEditor.bind(null, "Stamp");
+
+const copyImage = async (page, imagePath, selector) => {
+  const data = fs
+    .readFileSync(path.join(__dirname, imagePath))
+    .toString("base64");
+
+  await copyToClipboard(page, { "image/png": `data:image/png;base64,${data}` });
+  await pasteFromClipboard(page);
+
+  await page.waitForSelector(`${selector} canvas`);
+  await page.waitForSelector(`${selector} .altText`);
+};
+
+// The drawings are in SVGs living in the canvas wrapper, whereas the other
+// editors are divs living in the annotation editor layer. Both layers are
+// siblings, so the z-index is what decides which one is on top.
+const getZIndex = (page, selector) =>
+  page.evaluate(sel => {
+    const { zIndex } = getComputedStyle(document.querySelector(sel));
+    return zIndex === "auto" ? 0 : parseInt(zIndex, 10);
+  }, selector);
 
 const drawLine = async (page, x0, y0, x1, y1) => {
   const clickHandle = await waitForPointerUp(page);
@@ -1240,24 +1270,28 @@ describe("The drawn line must reach the pointer", () => {
           });
         }, deltas);
         await page.mouse.move(lastX, lastY);
-        const { coalescedEventsCalls, path } = await page.evaluate(() => {
-          const d = document
-            .querySelector(`.canvasWrapper svg.draw path[d]:not([d=""])`)
-            .getAttribute("d");
-          const calls = globalThis.__coalescedEventsCalls;
-          globalThis.__restoreGetCoalescedEvents();
-          delete globalThis.__coalescedEventsCalls;
-          delete globalThis.__restoreGetCoalescedEvents;
-          return {
-            coalescedEventsCalls: calls,
-            path: d.slice(d.lastIndexOf("M")).trim(),
-          };
-        });
+        const { coalescedEventsCalls, path: drawnPath } = await page.evaluate(
+          () => {
+            const d = document
+              .querySelector(`.canvasWrapper svg.draw path[d]:not([d=""])`)
+              .getAttribute("d");
+            const calls = globalThis.__coalescedEventsCalls;
+            globalThis.__restoreGetCoalescedEvents();
+            delete globalThis.__coalescedEventsCalls;
+            delete globalThis.__restoreGetCoalescedEvents;
+            return {
+              coalescedEventsCalls: calls,
+              path: d.slice(d.lastIndexOf("M")).trim(),
+            };
+          }
+        );
         await page.mouse.up();
         await awaitPromise(pointerUpHandle);
 
         expect(coalescedEventsCalls).withContext(`In ${browserName}`).toBe(1);
-        expect(path).withContext(`In ${browserName}`).toEqual(sequentialPath);
+        expect(drawnPath)
+          .withContext(`In ${browserName}`)
+          .toEqual(sequentialPath);
       })
     );
   });
@@ -1872,5 +1906,66 @@ describe("Removal during a pinch-resize", () => {
         }
       })
     );
+  });
+});
+
+describe("Ink stacking with a stamp", () => {
+  let pages;
+
+  beforeEach(async () => {
+    pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+  });
+
+  afterEach(async () => {
+    await closePages(pages);
+  });
+
+  it("must draw on top of a stamp added before", async () => {
+    // Run sequentially to avoid clipboard issues.
+    for (const [browserName, page] of pages) {
+      await switchToStamp(page);
+      const stampSelector = getEditorSelector(0);
+      await copyImage(page, "../images/firefox_logo.png", stampSelector);
+      // A pasted stamp is centered, so move it away in order to draw on an
+      // empty area: the stamp would otherwise intercept the pointer events.
+      await moveEditor(page, stampSelector, 10, () => kbBigMoveDown(page));
+      await unselectEditor(page, stampSelector);
+
+      await switchToInk(page);
+      const rect = await getRect(page, ".annotationEditorLayer");
+      const x = rect.x + 100;
+      const y = rect.y + 100;
+      await drawLine(page, x, y, x + 50, y + 50);
+      await commit(page);
+      // Unselect: a selected editor is always brought to the front, which
+      // would hide the stacking we want to check here.
+      await unselectEditor(page, getEditorSelector(1));
+
+      expect(await getZIndex(page, ".canvasWrapper .draw"))
+        .withContext(`In ${browserName}`)
+        .toBeGreaterThan(await getZIndex(page, stampSelector));
+    }
+  });
+
+  it("must be under a stamp added after", async () => {
+    // Run sequentially to avoid clipboard issues.
+    for (const [browserName, page] of pages) {
+      await switchToInk(page);
+      const rect = await getRect(page, ".annotationEditorLayer");
+      const x = rect.x + 100;
+      const y = rect.y + 100;
+      await drawLine(page, x, y, x + 50, y + 50);
+      await commit(page);
+      await unselectEditor(page, getEditorSelector(0));
+
+      await switchToStamp(page);
+      const stampSelector = getEditorSelector(1);
+      await copyImage(page, "../images/firefox_logo.png", stampSelector);
+      await unselectEditor(page, stampSelector);
+
+      expect(await getZIndex(page, ".canvasWrapper .draw"))
+        .withContext(`In ${browserName}`)
+        .toBeLessThan(await getZIndex(page, stampSelector));
+    }
   });
 });

--- a/web/draw_layer_builder.css
+++ b/web/draw_layer_builder.css
@@ -49,6 +49,19 @@
       position: absolute;
       mix-blend-mode: normal;
 
+      /* The SVG is purely visual: the editor div, in the annotation editor
+       * layer, is what handles the interactions. Since the SVG is stacked with
+       * the editors, it would otherwise be hit-tested before the layer and
+       * swallow the pointer events used to draw. */
+      pointer-events: none;
+
+      /* Raised along with the `.selectedEditor` div it belongs to. Scoped to
+       * `.draw` because highlight outlines use `.selected` for their own
+       * styling. */
+      &.selected {
+        z-index: 100000 !important;
+      }
+
       &[data-draw-rotation="90"] {
         transform: rotate(90deg);
       }


### PR DESCRIPTION
When an ink drawing and an image/stamp overlap, the editor always painted the image on top, whatever order they were created in. Saving and reopening the PDF showed the correct order, so the preview didn't match the final rendering.

The drawings are SVGs living in the canvas wrapper, whereas the other editors are divs living in the annotation editor layer. Both layers are siblings in the page and neither creates a stacking context, so their children compete directly, and the SVGs had no z-index at all.

The SVGs now carry the z-index of the editor they belong to, both when they're created and when it changes. The in-progress drawing uses the z-index its editor will be given once the drawing session ends, so that the stroke doesn't jump when the pointer is released.

Since the SVGs are now stacked with the editors, they're also hit-tested before the annotation editor layer, so they must not swallow the pointer events used to draw: they're purely visual, the editor div being what handles the interactions.

Fixes #21401.