### PR TITLE
Add option to disable page title from PDF title metadata

### DIFF
--- a/examples/mobile-viewer/viewer.mjs
+++ b/examples/mobile-viewer/viewer.mjs
@@ -77,7 +77,7 @@ const PDFViewerApplication = {
         });
 
         this.loadingBar.hide();
-        this.setTitleUsingMetadata(pdfDocument);
+        this.setTitleUsingMetadata(pdfDocument); // TODO: check for option to disable this. I'd add if (!AppOptions.get("ignorePdfTitle")) but IDK if it's available in this context 
       },
       reason => {
         let key = "pdfjs-loading-error";

--- a/examples/mobile-viewer/viewer.mjs
+++ b/examples/mobile-viewer/viewer.mjs
@@ -77,7 +77,7 @@ const PDFViewerApplication = {
         });
 
         this.loadingBar.hide();
-        this.setTitleUsingMetadata(pdfDocument); // TODO: check for option to disable this. I'd add if (!AppOptions.get("ignorePdfTitle")) but IDK if it's available in this context 
+        this.setTitleUsingMetadata(pdfDocument);
       },
       reason => {
         let key = "pdfjs-loading-error";

--- a/web/app.js
+++ b/web/app.js
@@ -1848,7 +1848,7 @@ const PDFViewerApplication = {
     );
     const pdfTitle = this._docTitle;
 
-    if (pdfTitle) {
+    if (pdfTitle && !AppOptions.get("ignorePdfTitle")) {
       this.setTitle(
         `${pdfTitle} - ${this._contentDispositionFilename || this._title}`
       );

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -423,6 +423,11 @@ const defaultOptions = {
     value: 0,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  ignorePdfTitle: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+  },
 
   cMapPacked: {
     /** @type {boolean} */


### PR DESCRIPTION
Many people never set the document title metadata when exporting as PDF, and therefore it often starts with "Microsoft Word..." or similar long irrelevant text (in my language, it might be as long as 33 characters with "Prezentace aplikace PowerPoint - "), making the filename more useful in the short space reserved for `document.title` in the tab header. Therefore, I propose the addition of a new option, available as `pdfjs.ignorePdfTitle` in `about:config`, false by default to preserve original functionality, but easy to change for people who often have several lazily MS Office-exported PDFs from coworkers opened and need to switch between them. 

Tests won't run on my machine, I don't have enough space to install puppeteerable browser. It's unlikely the little change, which preserves original functionality by default, has a chance to break existing tests but maybe it's a good idea to add a test whether implementations like the mobile viewer respect the new preference.