### PR TITLE
[api-minor] Convert `getOpenAction` to return data in a Map

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -19,7 +19,6 @@ import {
   DocumentActionEventType,
   FormatError,
   info,
-  objectSize,
   PermissionFlag,
   shadow,
   stringToUTF8String,
@@ -1111,7 +1110,7 @@ class Catalog {
 
   get openAction() {
     const obj = this.#catDict.get("OpenAction");
-    const openAction = Object.create(null);
+    const openAction = new Map();
 
     if (obj instanceof Dict) {
       // Convert the OpenAction dictionary into a format that works with
@@ -1123,18 +1122,14 @@ class Catalog {
       Catalog.parseDestDictionary({ destDict, resultObj });
 
       if (Array.isArray(resultObj.dest)) {
-        openAction.dest = resultObj.dest;
+        openAction.set("dest", resultObj.dest);
       } else if (resultObj.action) {
-        openAction.action = resultObj.action;
+        openAction.set("action", resultObj.action);
       }
     } else if (isValidExplicitDest(obj)) {
-      openAction.dest = obj;
+      openAction.set("dest", obj);
     }
-    return shadow(
-      this,
-      "openAction",
-      objectSize(openAction) > 0 ? openAction : null
-    );
+    return shadow(this, "openAction", openAction.size ? openAction : null);
   }
 
   /**

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -829,9 +829,9 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @returns {Promise<any | null>} A promise that is resolved with an {Array}
-   *   containing the destination, or `null` when no open action is present
-   *   in the PDF.
+   * @returns {Promise<Map | null>} A promise that is resolved with a {Map}
+   *   containing a destination or action, or `null` when no open action is
+   *   present in the PDF.
    */
   getOpenAction() {
     return this._transport.getOpenAction();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1774,11 +1774,9 @@ describe("api", function () {
 
     it("gets non-default open action (with destination)", async function () {
       const openAction = await pdfDocument.getOpenAction();
-      expect(openAction.dest).toEqual([
-        { num: 15, gen: 0 },
-        { name: "FitH" },
-        null,
-      ]);
+      expect(openAction).toEqual(
+        new Map([["dest", [{ num: 15, gen: 0 }, { name: "FitH" }, null]]])
+      );
       expect(openAction.action).toBeUndefined();
     });
 
@@ -1796,16 +1794,14 @@ describe("api", function () {
       const promise1 = loadingTask1.promise
         .then(pdfDoc => pdfDoc.getOpenAction())
         .then(function (openAction) {
-          expect(openAction.dest).toBeUndefined();
-          expect(openAction.action).toEqual("Print");
+          expect(openAction).toEqual(new Map([["action", "Print"]]));
 
           return loadingTask1.destroy();
         });
       const promise2 = loadingTask2.promise
         .then(pdfDoc => pdfDoc.getOpenAction())
         .then(function (openAction) {
-          expect(openAction.dest).toBeUndefined();
-          expect(openAction.action).toEqual("Print");
+          expect(openAction).toEqual(new Map([["action", "Print"]]));
 
           return loadingTask2.destroy();
         });

--- a/web/app.js
+++ b/web/app.js
@@ -1589,7 +1589,7 @@ const PDFViewerApplication = {
           this._initializePdfHistory({
             fingerprint: pdfDocument.fingerprints[0],
             viewOnLoad,
-            initialDest: openAction?.dest,
+            initialDest: openAction?.get("dest"),
           });
           const initialBookmark = this.initialBookmark;
 
@@ -1788,7 +1788,7 @@ const PDFViewerApplication = {
     if (pdfDocument !== this.pdfDocument) {
       return; // The document was closed while the auto print data resolved.
     }
-    let triggerAutoPrint = openAction?.action === "Print";
+    let triggerAutoPrint = openAction?.get("action") === "Print";
 
     if (jsActions) {
       console.warn("Warning: JavaScript support is not enabled");


### PR DESCRIPTION
Compared to regular Objects there's a number of advantages to using Maps:
 - They support proper iteration.
 - They have a simple way to check for the existence of data.
 - They have a simple/efficient way to check the number of elements.

If this functionality was added today, I cannot imagine that we'd choose an Object for this data.