### PR TITLE
Document the preserve and dependencyLists params for recordOperation

### DIFF
--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -303,6 +303,10 @@ class CanvasBBoxTracker {
 
   /**
    * @param {number} idx
+   * @param {boolean} [preserve=false] - When false, the pending bounding box is
+   *   cleared once recorded; pass true to keep it for subsequent operations.
+   * @param {Iterable<Iterable<number>>} [dependencyLists] - Groups of operation
+   *   indices whose bounding boxes are also expanded to cover this operation.
    */
   recordOperation(idx, preserve = false, dependencyLists) {
     if (this._pendingBBoxIdx !== idx) {
@@ -735,6 +739,8 @@ class CanvasDependencyTracker {
 
   /**
    * @param {number} idx
+   * @param {boolean} [preserve=false] - When false, the pending dependencies
+   *   are cleared once recorded; pass true to keep them for later operations.
    */
   recordOperation(idx, preserve = false) {
     this.recordDependencies(idx, [FORCED_DEPENDENCY_LABEL]);


### PR DESCRIPTION
The two `recordOperation` methods in `canvas_dependency_tracker.js` have a JSDoc block that only documents `idx`, even though they also take a `preserve` flag (and `dependencyLists` in the `CanvasBBoxTracker` version).

I filled in the missing `@param` entries based on how the arguments are used in each method. Docs only, no behavior change.