### PR TITLE
Remove the `objectSize` helper function

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -18,7 +18,6 @@ import {
   assert,
   BaseException,
   makeArr,
-  objectSize,
   Util,
   warn,
 } from "../shared/util.js";
@@ -491,7 +490,7 @@ function collectActions(xref, dict, eventType) {
       actions.Action = list;
     }
   }
-  return objectSize(actions) > 0 ? actions : null;
+  return Object.keys(actions).length ? actions : null;
 }
 
 const XMLEntities = {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -21,7 +21,6 @@ import {
   InvalidPDFException,
   isArrayEqual,
   makeArr,
-  objectSize,
   PageActionEventType,
   RenderingIntentFlag,
   shadow,
@@ -1986,7 +1985,7 @@ class PDFDocument {
         await Promise.all(allPromises);
 
         return {
-          allFields: objectSize(allFields) > 0 ? allFields : null,
+          allFields: Object.keys(allFields).length ? allFields : null,
           orphanFields,
         };
       });

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -615,10 +615,6 @@ function stringToBytes(str) {
   return bytes;
 }
 
-function objectSize(obj) {
-  return Object.keys(obj).length;
-}
-
 class FeatureTest {
   static get isLittleEndian() {
     const buffer8 = new Uint8Array(4);
@@ -1209,7 +1205,6 @@ export {
   makeSet,
   MeshFigureType,
   normalizeUnicode,
-  objectSize,
   OPS,
   PageActionEventType,
   PasswordException,

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -22,7 +22,6 @@ import {
   ImageKind,
   InvalidPDFException,
   isNodeJS,
-  objectSize,
   OPS,
   PasswordException,
   PasswordResponses,
@@ -4143,7 +4142,7 @@ describe("api", function () {
       const { items, styles, lang } = await page.getTextContent();
 
       expect(items.length).toEqual(15);
-      expect(objectSize(styles)).toEqual(5);
+      expect(Object.keys(styles).length).toEqual(5);
       expect(lang).toEqual("en");
 
       const text = mergeText(items);

--- a/test/unit/app_options_spec.js
+++ b/test/unit/app_options_spec.js
@@ -15,7 +15,6 @@
 
 import { AppOptions, OptionKind } from "../../web/app_options.js";
 import { BasePreferences } from "../../web/preferences.js";
-import { objectSize } from "../../src/shared/util.js";
 
 describe("AppOptions", function () {
   it("checks that getAll returns data, for every OptionKind", function () {
@@ -32,7 +31,7 @@ describe("AppOptions", function () {
       expect(typeof kind).toEqual("number");
 
       const options = AppOptions.getAll(kind);
-      expect(objectSize(options)).toBeGreaterThan(0);
+      expect(Object.keys(options).length).toBeGreaterThan(0);
     }
   });
 
@@ -43,7 +42,9 @@ describe("AppOptions", function () {
     const MAX_NUMBER_OF_PREFS = 50;
 
     const options = AppOptions.getAll(OptionKind.PREFERENCE);
-    expect(objectSize(options)).toBeLessThanOrEqual(MAX_NUMBER_OF_PREFS);
+    expect(Object.keys(options).length).toBeLessThanOrEqual(
+      MAX_NUMBER_OF_PREFS
+    );
   });
 });
 


### PR DESCRIPTION
Given that Maps are used a lot more these days, this helper function is now used very sparingly and inlining the necessary code seems reasonable.

*Note:* Once [this proposal](https://github.com/tc39/proposal-object-keys-length) makes it into Firefox, we should be able to simplify all `Object.keys(...).length` call-sites.