### PR TITLE
Use the `toBeNull()` matcher consistently in the unit/integration tests

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -652,7 +652,7 @@ describe("FreeText Editor", () => {
           const oldAriaOwns = await page.$eval(`span[pdfjs="true"]`, el =>
             el.getAttribute("aria-owns")
           );
-          expect(oldAriaOwns).withContext(`In ${browserName}`).toEqual(null);
+          expect(oldAriaOwns).withContext(`In ${browserName}`).toBeNull();
 
           const rect = await getRect(page, `span[pdfjs="true"]`);
           await createFreeTextEditor({

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -251,17 +251,17 @@ describe("annotation", function () {
     });
 
     it("should ignore missing quadpoints", function () {
-      expect(getQuadPoints(dict, rect)).toEqual(null);
+      expect(getQuadPoints(dict, rect)).toBeNull();
     });
 
     it("should ignore non-array values", function () {
       dict.set("QuadPoints", "foo");
-      expect(getQuadPoints(dict, rect)).toEqual(null);
+      expect(getQuadPoints(dict, rect)).toBeNull();
     });
 
     it("should ignore arrays where the length is not a multiple of eight", function () {
       dict.set("QuadPoints", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      expect(getQuadPoints(dict, rect)).toEqual(null);
+      expect(getQuadPoints(dict, rect)).toBeNull();
     });
 
     it("should ignore quadpoints if one coordinate lies outside the rectangle", function () {
@@ -274,7 +274,7 @@ describe("annotation", function () {
       ];
       for (const input of inputs) {
         dict.set("QuadPoints", input);
-        expect(getQuadPoints(dict, rect)).toEqual(null);
+        expect(getQuadPoints(dict, rect)).toBeNull();
       }
     });
 
@@ -366,7 +366,7 @@ describe("annotation", function () {
       });
       annotation.setModificationDate(undefined);
 
-      expect(annotation.modificationDate).toEqual(null);
+      expect(annotation.modificationDate).toBeNull();
     });
 
     it("should set and get flags", function () {
@@ -442,7 +442,7 @@ describe("annotation", function () {
       });
       annotation.setColor([]);
 
-      expect(annotation.color).toEqual(null);
+      expect(annotation.color).toBeNull();
     });
 
     it("should set and get a grayscale color", function () {
@@ -621,7 +621,7 @@ describe("annotation", function () {
       });
       markupAnnotation.setCreationDate(undefined);
 
-      expect(markupAnnotation.creationDate).toEqual(null);
+      expect(markupAnnotation.creationDate).toBeNull();
     });
 
     it("should not parse IRT/RT when not defined", async function () {
@@ -775,7 +775,7 @@ describe("annotation", function () {
       expect(data.creationDate).toEqual("D:20180523");
       expect(data.modificationDate).toEqual("D:20190523");
       expect(data.color).toEqual(new Uint8ClampedArray([102, 102, 102]));
-      expect(data.popupRef).toEqual(null);
+      expect(data.popupRef).toBeNull();
     });
   });
 
@@ -1601,7 +1601,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.textAlignment).toEqual(null);
+      expect(data.textAlignment).toBeNull();
       expect(data.maxLen).toEqual(0);
       expect(data.readOnly).toEqual(false);
       expect(data.hidden).toEqual(false);
@@ -1625,7 +1625,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.textAlignment).toEqual(null);
+      expect(data.textAlignment).toBeNull();
       expect(data.maxLen).toEqual(0);
       expect(data.readOnly).toEqual(false);
       expect(data.hidden).toEqual(false);
@@ -1951,7 +1951,7 @@ describe("annotation", function () {
         RenderingIntentFlag.PRINT,
         annotationStorage
       );
-      expect(appearance).toEqual(null);
+      expect(appearance).toBeNull();
     });
 
     it("should render multiline text for printing", async function () {
@@ -3306,7 +3306,7 @@ describe("annotation", function () {
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.checkBox).toEqual(false);
       expect(data.radioButton).toEqual(true);
-      expect(data.fieldValue).toEqual(null);
+      expect(data.fieldValue).toBeNull();
       expect(data.buttonValue).toEqual("2");
     });
 
@@ -4613,7 +4613,7 @@ describe("annotation", function () {
         "Annotation attachment"
       );
       // An unknown id resolves to no content.
-      expect(catalog.attachmentContent("nonexistent")).toEqual(null);
+      expect(catalog.attachmentContent("nonexistent")).toBeNull();
     });
   });
 
@@ -5421,8 +5421,8 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.POPUP);
-      expect(data.modificationDate).toEqual(null);
-      expect(data.color).toEqual(null);
+      expect(data.modificationDate).toBeNull();
+      expect(data.color).toBeNull();
     });
 
     it(
@@ -6037,7 +6037,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-      expect(data.quadPoints).toEqual(null);
+      expect(data.quadPoints).toBeNull();
     });
 
     it("should set quadpoints if defined", async function () {
@@ -6079,7 +6079,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.HIGHLIGHT);
-      expect(data.quadPoints).toEqual(null);
+      expect(data.quadPoints).toBeNull();
     });
 
     it("should create a new Highlight annotation", async function () {
@@ -6426,7 +6426,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.UNDERLINE);
-      expect(data.quadPoints).toEqual(null);
+      expect(data.quadPoints).toBeNull();
     });
 
     it("should set quadpoints if defined", async function () {
@@ -6468,7 +6468,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.SQUIGGLY);
-      expect(data.quadPoints).toEqual(null);
+      expect(data.quadPoints).toBeNull();
     });
 
     it("should set quadpoints if defined", async function () {
@@ -6510,7 +6510,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.STRIKEOUT);
-      expect(data.quadPoints).toEqual(null);
+      expect(data.quadPoints).toBeNull();
     });
 
     it("should set quadpoints if defined", async function () {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -706,7 +706,7 @@ describe("api", function () {
       expect(opList.fnArray.length).toEqual(0);
       expect(opList.argsArray.length).toEqual(0);
       expect(opList.lastChunk).toEqual(true);
-      expect(opList.separateAnnots).toEqual(null);
+      expect(opList.separateAnnots).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -727,7 +727,7 @@ describe("api", function () {
       expect(opList.fnArray.length).toEqual(0);
       expect(opList.argsArray.length).toEqual(0);
       expect(opList.lastChunk).toEqual(true);
-      expect(opList.separateAnnots).toEqual(null);
+      expect(opList.separateAnnots).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -801,7 +801,7 @@ describe("api", function () {
       expect(opListA.fnArray.length).toBeGreaterThan(5);
       expect(opListA.argsArray.length).toBeGreaterThan(5);
       expect(opListA.lastChunk).toEqual(true);
-      expect(opListA.separateAnnots).toEqual(null);
+      expect(opListA.separateAnnots).toBeNull();
 
       const pageB = await pdfDocument2.getPage(1);
       expect(pageB).toBeInstanceOf(PDFPageProxy);
@@ -810,7 +810,7 @@ describe("api", function () {
       expect(opListB.fnArray.length).toBe(0);
       expect(opListB.argsArray.length).toBe(0);
       expect(opListB.lastChunk).toEqual(true);
-      expect(opListB.separateAnnots).toEqual(null);
+      expect(opListB.separateAnnots).toBeNull();
 
       try {
         await pdfDocument3.getPage(1);
@@ -851,7 +851,7 @@ describe("api", function () {
       expect(opListA.fnArray.length).toEqual(19);
       expect(opListA.argsArray.length).toEqual(19);
       expect(opListA.lastChunk).toEqual(true);
-      expect(opListA.separateAnnots).toEqual(null);
+      expect(opListA.separateAnnots).toBeNull();
 
       const pageB = await pdfDocument2.getPage(1);
       expect(pageB).toBeInstanceOf(PDFPageProxy);
@@ -860,7 +860,7 @@ describe("api", function () {
       expect(opListB.fnArray.length).toEqual(1);
       expect(opListB.argsArray.length).toEqual(1);
       expect(opListB.lastChunk).toEqual(true);
-      expect(opListB.separateAnnots).toEqual(null);
+      expect(opListB.separateAnnots).toBeNull();
 
       await Promise.all([loadingTask1.destroy(), loadingTask2.destroy()]);
     });
@@ -894,7 +894,7 @@ describe("api", function () {
         expect(opList.fnArray.length).toBeGreaterThan(5);
         expect(opList.argsArray.length).toBeGreaterThan(5);
         expect(opList.lastChunk).toEqual(true);
-        expect(opList.separateAnnots).toEqual(null);
+        expect(opList.separateAnnots).toBeNull();
       }
 
       await Promise.all([loadingTask1.destroy(), loadingTask2.destroy()]);
@@ -1488,7 +1488,7 @@ describe("api", function () {
       const destination = await pdfDocument.getDestination(
         "non-existent-named-destination"
       );
-      expect(destination).toEqual(null);
+      expect(destination).toBeNull();
     });
 
     it("gets destinations, from /Names (NameTree) dictionary", async function () {
@@ -1541,7 +1541,7 @@ describe("api", function () {
       const destination = await pdfDoc.getDestination(
         "non-existent-named-destination"
       );
-      expect(destination).toEqual(null);
+      expect(destination).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -1671,7 +1671,7 @@ describe("api", function () {
 
     it("gets non-existent page labels", async function () {
       const pageLabels = await pdfDocument.getPageLabels();
-      expect(pageLabels).toEqual(null);
+      expect(pageLabels).toBeNull();
     });
 
     it("gets page labels", async function () {
@@ -1752,7 +1752,7 @@ describe("api", function () {
       const loadingTask = getDocument(tracemonkeyGetDocumentParams);
       const pdfDoc = await loadingTask.promise;
       const prefs = await pdfDoc.getViewerPreferences();
-      expect(prefs).toEqual(null);
+      expect(prefs).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -1766,7 +1766,7 @@ describe("api", function () {
       const loadingTask = getDocument(tracemonkeyGetDocumentParams);
       const pdfDoc = await loadingTask.promise;
       const openAction = await pdfDoc.getOpenAction();
-      expect(openAction).toEqual(null);
+      expect(openAction).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -1810,7 +1810,7 @@ describe("api", function () {
 
     it("gets non-existent attachments", async function () {
       const attachments = await pdfDocument.getAttachments();
-      expect(attachments).toEqual(null);
+      expect(attachments).toBeNull();
     });
 
     it("gets attachments", async function () {
@@ -1975,7 +1975,7 @@ describe("api", function () {
 
     it("gets non-existent JSActions", async function () {
       const jsActions = await pdfDocument.getJSActions();
-      expect(jsActions).toEqual(null);
+      expect(jsActions).toBeNull();
     });
 
     it("gets JSActions", async function () {
@@ -2011,7 +2011,7 @@ describe("api", function () {
 
     it("gets non-existent fieldObjects", async function () {
       const fieldObjects = await pdfDocument.getFieldObjects();
-      expect(fieldObjects).toEqual(null);
+      expect(fieldObjects).toBeNull();
     });
 
     it("gets fieldObjects", async function () {
@@ -2108,7 +2108,7 @@ describe("api", function () {
       const pdfDoc = await loadingTask.promise;
       const fieldObjects = await pdfDoc.getFieldObjects();
 
-      expect(fieldObjects).toEqual(null);
+      expect(fieldObjects).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -2276,7 +2276,7 @@ describe("api", function () {
 
     it("gets non-existent calculationOrder", async function () {
       const calculationOrder = await pdfDocument.getCalculationOrderIds();
-      expect(calculationOrder).toEqual(null);
+      expect(calculationOrder).toBeNull();
     });
 
     it("gets calculationOrder", async function () {
@@ -2311,7 +2311,7 @@ describe("api", function () {
       const loadingTask = getDocument(tracemonkeyGetDocumentParams);
       const pdfDoc = await loadingTask.promise;
       const outline = await pdfDoc.getOutline();
-      expect(outline).toEqual(null);
+      expect(outline).toBeNull();
 
       await loadingTask.destroy();
     });
@@ -2327,7 +2327,7 @@ describe("api", function () {
       const outlineItem = outline[1];
       expect(outlineItem.title).toEqual("Chapter 1");
       expect(Array.isArray(outlineItem.dest)).toEqual(true);
-      expect(outlineItem.url).toEqual(null);
+      expect(outlineItem.url).toBeNull();
       expect(outlineItem.unsafeUrl).toBeUndefined();
       expect(outlineItem.newWindow).toBeUndefined();
 
@@ -2348,7 +2348,7 @@ describe("api", function () {
 
       const outlineItemTwo = outline[2];
       expect(typeof outlineItemTwo.title).toEqual("string");
-      expect(outlineItemTwo.dest).toEqual(null);
+      expect(outlineItemTwo.dest).toBeNull();
       expect(outlineItemTwo.url).toEqual("http://google.com/");
       expect(outlineItemTwo.unsafeUrl).toEqual("http://google.com");
       expect(outlineItemTwo.newWindow).toBeUndefined();
@@ -2640,7 +2640,7 @@ describe("api", function () {
 
     it("gets non-existent permissions", async function () {
       const permissions = await pdfDocument.getPermissions();
-      expect(permissions).toEqual(null);
+      expect(permissions).toBeNull();
     });
 
     it("gets permissions", async function () {
@@ -2702,7 +2702,7 @@ describe("api", function () {
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.7");
       expect(info.Language).toEqual("en");
-      expect(info.EncryptFilterName).toEqual(null);
+      expect(info.EncryptFilterName).toBeNull();
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(false);
       expect(info.IsXFAPresent).toEqual(false);
@@ -2712,7 +2712,7 @@ describe("api", function () {
       expect(metadata).toBeInstanceOf(Metadata);
       expect(metadata.get("dc:title")).toEqual("Basic API Test");
 
-      expect(contentDispositionFilename).toEqual(null);
+      expect(contentDispositionFilename).toBeNull();
       expect(contentLength).toEqual(basicApiFileLength);
     });
 
@@ -2735,16 +2735,16 @@ describe("api", function () {
       );
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.4");
-      expect(info.Language).toEqual(null);
-      expect(info.EncryptFilterName).toEqual(null);
+      expect(info.Language).toBeNull();
+      expect(info.EncryptFilterName).toBeNull();
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(false);
       expect(info.IsXFAPresent).toEqual(false);
       expect(info.IsCollectionPresent).toEqual(false);
       expect(info.IsSignaturesPresent).toEqual(false);
 
-      expect(metadata).toEqual(null);
-      expect(contentDispositionFilename).toEqual(null);
+      expect(metadata).toBeNull();
+      expect(contentDispositionFilename).toBeNull();
       expect(contentLength).toEqual(1016315);
 
       await loadingTask.destroy();
@@ -2759,17 +2759,17 @@ describe("api", function () {
       // Custom, non-standard, information dictionary entries.
       expect(info.Custom).toEqual(undefined);
       // The following are PDF.js specific, non-standard, properties.
-      expect(info.PDFFormatVersion).toEqual(null);
-      expect(info.Language).toEqual(null);
-      expect(info.EncryptFilterName).toEqual(null);
+      expect(info.PDFFormatVersion).toBeNull();
+      expect(info.Language).toBeNull();
+      expect(info.EncryptFilterName).toBeNull();
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(false);
       expect(info.IsXFAPresent).toEqual(false);
       expect(info.IsCollectionPresent).toEqual(false);
       expect(info.IsSignaturesPresent).toEqual(false);
 
-      expect(metadata).toEqual(null);
-      expect(contentDispositionFilename).toEqual(null);
+      expect(metadata).toBeNull();
+      expect(contentDispositionFilename).toBeNull();
       expect(contentLength).toEqual(624);
 
       await loadingTask.destroy();
@@ -2787,16 +2787,16 @@ describe("api", function () {
       expect(info.Custom).toEqual(undefined);
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.6");
-      expect(info.Language).toEqual(null);
-      expect(info.EncryptFilterName).toEqual(null);
+      expect(info.Language).toBeNull();
+      expect(info.EncryptFilterName).toBeNull();
       expect(info.IsLinearized).toEqual(false);
       expect(info.IsAcroFormPresent).toEqual(true);
       expect(info.IsXFAPresent).toEqual(false);
       expect(info.IsCollectionPresent).toEqual(false);
       expect(info.IsSignaturesPresent).toEqual(false);
 
-      expect(metadata).toEqual(null);
-      expect(contentDispositionFilename).toEqual(null);
+      expect(metadata).toBeNull();
+      expect(contentDispositionFilename).toBeNull();
       expect(contentLength).toEqual(244351);
 
       await loadingTask.destroy();
@@ -4165,7 +4165,7 @@ page 1 / 3`);
       // Font name will be a random object id.
       const fontName = items[0].fontName;
       expect(Object.keys(styles)).toEqual([fontName]);
-      expect(lang).toEqual(null);
+      expect(lang).toBeNull();
 
       expect(items[0]).toEqual({
         dir: "ltr",
@@ -4631,7 +4631,7 @@ have written that much by now. So, here’s to squashing bugs.`);
     it("gets empty structure tree", async function () {
       const tree = await page.getStructTree();
 
-      expect(tree).toEqual(null);
+      expect(tree).toBeNull();
     });
 
     it("gets simple structure tree", async function () {
@@ -4926,7 +4926,7 @@ have written that much by now. So, here’s to squashing bugs.`);
           expect(opList.fnArray.length).toBeGreaterThan(100);
           expect(opList.argsArray.length).toBeGreaterThan(100);
           expect(opList.lastChunk).toEqual(true);
-          expect(opList.separateAnnots).toEqual(null);
+          expect(opList.separateAnnots).toBeNull();
 
           await loadingTask1.destroy();
         });
@@ -4938,7 +4938,7 @@ have written that much by now. So, here’s to squashing bugs.`);
           expect(opList.fnArray.length).toEqual(0);
           expect(opList.argsArray.length).toEqual(0);
           expect(opList.lastChunk).toEqual(true);
-          expect(opList.separateAnnots).toEqual(null);
+          expect(opList.separateAnnots).toBeNull();
 
           await loadingTask2.destroy();
         });
@@ -4998,7 +4998,7 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(opListAnnotDisable.fnArray.length).toEqual(0);
       expect(opListAnnotDisable.argsArray.length).toEqual(0);
       expect(opListAnnotDisable.lastChunk).toEqual(true);
-      expect(opListAnnotDisable.separateAnnots).toEqual(null);
+      expect(opListAnnotDisable.separateAnnots).toBeNull();
 
       const opListAnnotEnable = await pdfPage.getOperatorList({
         annotationMode: AnnotationMode.ENABLE,
@@ -5108,7 +5108,7 @@ have written that much by now. So, here’s to squashing bugs.`);
 
     it("gets page stats after parsing page, without `pdfBug` set", async function () {
       await page.getOperatorList();
-      expect(page.stats).toEqual(null);
+      expect(page.stats).toBeNull();
     });
 
     it("gets page stats after parsing page, with `pdfBug` set", async function () {
@@ -5549,7 +5549,7 @@ have written that much by now. So, here’s to squashing bugs.`);
         const objsPool = i >= NUM_PAGES_THRESHOLD ? commonObjs : objs;
         const imgData = objsPool.get(objId);
 
-        expect(imgData).toBe(null);
+        expect(imgData).toBeNull();
 
         if (i === NUM_PAGES_THRESHOLD) {
           checkedGlobalDecodeFailed = true;
@@ -5954,7 +5954,7 @@ have written that much by now. So, here’s to squashing bugs.`);
 
       const { contentDispositionFilename, contentLength } =
         await pdfDocument.getMetadata();
-      expect(contentDispositionFilename).toEqual(null);
+      expect(contentDispositionFilename).toBeNull();
       expect(contentLength).toEqual(dataLength);
 
       expect(fetches).toEqual(3);
@@ -6008,7 +6008,7 @@ have written that much by now. So, here’s to squashing bugs.`);
 
       const { contentDispositionFilename, contentLength } =
         await pdfDocument.getMetadata();
-      expect(contentDispositionFilename).toEqual(null);
+      expect(contentDispositionFilename).toBeNull();
       expect(contentLength).toEqual(dataLength);
 
       expect(fetches).toEqual(0);
@@ -8072,18 +8072,18 @@ small scripts as well as for`);
 
         // Item [2]: URI action
         expect(outline[2].title).toEqual("External URL");
-        expect(outline[2].dest).toEqual(null);
+        expect(outline[2].dest).toBeNull();
         expect(outline[2].url).toEqual("https://mozilla.org/");
 
         // Item [3]: built-in named action
         expect(outline[3].title).toEqual("Next Page action");
-        expect(outline[3].dest).toEqual(null);
+        expect(outline[3].dest).toBeNull();
         expect(outline[3].action).toEqual("NextPage");
 
         // Item [4]: GoToR (remote PDF) – relative path, so url is null but
         // unsafeUrl holds the raw file path (with dest hash appended).
         expect(outline[4].title).toEqual("Remote PDF link");
-        expect(outline[4].dest).toEqual(null);
+        expect(outline[4].dest).toBeNull();
         expect(outline[4].unsafeUrl).toContain("other.pdf");
 
         // Item [5]: "Chapter" – parent with named dest and 3 children
@@ -8115,7 +8115,7 @@ small scripts as well as for`);
         // Item [6]: "No dest parent" – no dest, but has a child
         const noDestParent = outline[6];
         expect(noDestParent.title).toEqual("No dest parent");
-        expect(noDestParent.dest).toEqual(null);
+        expect(noDestParent.dest).toBeNull();
         expect(noDestParent.items.length).toEqual(1);
         expect(noDestParent.count).toEqual(originalOutline[6].count);
         expect(noDestParent.items[0].title).toEqual("Child with dest");
@@ -8189,7 +8189,7 @@ small scripts as well as for`);
         // surviving children, so it must be kept.
         const chapter = outline.find(i => i.title === "Chapter");
         expect(chapter).not.toBeUndefined();
-        expect(chapter.dest).toEqual(null);
+        expect(chapter.dest).toBeNull();
         expect(chapter.items.length).toEqual(2);
 
         const childTitles = chapter.items.map(i => i.title);
@@ -8304,7 +8304,7 @@ small scripts as well as for`);
         const newPdfDoc = await newLoadingTask.promise;
         const outline = await newPdfDoc.getOutline();
 
-        expect(outline).toEqual(null);
+        expect(outline).toBeNull();
 
         await newLoadingTask.destroy();
       });
@@ -8388,7 +8388,7 @@ small scripts as well as for`);
         // "Parent" is kept as a plain container (dest cleared, no action).
         const parent = outline[0];
         expect(parent.title).toEqual("Parent");
-        expect(parent.dest).toEqual(null);
+        expect(parent.dest).toBeNull();
         expect(parent.items.length).toEqual(1);
 
         // "Child" keeps its explicit dest pointing to the (only) kept page.

--- a/test/unit/canvas_factory_spec.js
+++ b/test/unit/canvas_factory_spec.js
@@ -104,8 +104,8 @@ describe("canvas_factory", function () {
       canvasFactory.destroy(canvasAndContext);
 
       const { canvas, context } = canvasAndContext;
-      expect(canvas).toBe(null);
-      expect(context).toBe(null);
+      expect(canvas).toBeNull();
+      expect(context).toBeNull();
     });
   });
 });

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -303,7 +303,7 @@ describe("document", function () {
         expect(sig.subFilter).toEqual("adbe.pkcs7.detached");
         expect(sig.signatureType).toEqual(0);
         expect(sig.byteRange).toEqual([0, 100, 200, 300]);
-        expect(sig.parentId).toEqual(null);
+        expect(sig.parentId).toBeNull();
         expect(sig.revisionIndex).toEqual(0);
         // The bytes (pkcs7 + signed-data spans) are no longer attached
         // to the metadata array — they're fetched on demand via
@@ -485,7 +485,7 @@ describe("document", function () {
         expect(signatures.length).toEqual(2);
         // Sorted descending by c+d, so outer comes first.
         expect(signatures[0].signerName).toEqual("Outer");
-        expect(signatures[0].parentId).toEqual(null);
+        expect(signatures[0].parentId).toBeNull();
         expect(signatures[0].revisionIndex).toEqual(0);
         expect(signatures[1].signerName).toEqual("Inner");
         expect(signatures[1].parentId).toEqual(signatures[0].id);
@@ -518,7 +518,7 @@ describe("document", function () {
 
         expect(await signatureType("adbe.pkcs7.detached")).toEqual(0);
         expect(await signatureType("adbe.pkcs7.sha1")).toEqual(1);
-        expect(await signatureType("ETSI.CAdES.detached")).toEqual(null);
+        expect(await signatureType("ETSI.CAdES.detached")).toBeNull();
       });
     });
 
@@ -526,7 +526,7 @@ describe("document", function () {
       const acroForm = new Dict();
 
       let pdfDocument = getDocument(acroForm);
-      expect(pdfDocument.calculationOrderIds).toEqual(null);
+      expect(pdfDocument.calculationOrderIds).toBeNull();
 
       acroForm.set("CO", [Ref.get(1, 0), Ref.get(2, 0), Ref.get(3, 0)]);
       pdfDocument = getDocument(acroForm);
@@ -534,11 +534,11 @@ describe("document", function () {
 
       acroForm.set("CO", []);
       pdfDocument = getDocument(acroForm);
-      expect(pdfDocument.calculationOrderIds).toEqual(null);
+      expect(pdfDocument.calculationOrderIds).toBeNull();
 
       acroForm.set("CO", ["1", "2"]);
       pdfDocument = getDocument(acroForm);
-      expect(pdfDocument.calculationOrderIds).toEqual(null);
+      expect(pdfDocument.calculationOrderIds).toBeNull();
 
       acroForm.set("CO", ["1", Ref.get(1, 0), "2"]);
       pdfDocument = getDocument(acroForm);
@@ -550,12 +550,12 @@ describe("document", function () {
 
       let pdfDocument = getDocument(acroForm);
       let fields = await pdfDocument.fieldObjects;
-      expect(fields).toEqual(null);
+      expect(fields).toBeNull();
 
       acroForm.set("Fields", []);
       pdfDocument = getDocument(acroForm);
       fields = await pdfDocument.fieldObjects;
-      expect(fields).toEqual(null);
+      expect(fields).toBeNull();
 
       const kid1Ref = Ref.get(314, 0);
       const kid11Ref = Ref.get(159, 0);

--- a/test/unit/encodings_spec.js
+++ b/test/unit/encodings_spec.js
@@ -40,7 +40,7 @@ describe("encodings", function () {
     });
 
     it("fetches `null` for unknown encoding names", function () {
-      expect(getEncoding("FooBarEncoding")).toEqual(null);
+      expect(getEncoding("FooBarEncoding")).toBeNull();
     });
   });
 });

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -120,7 +120,7 @@ describe("evaluator", function () {
       expect(result.argsArray.length).toEqual(3);
       expect(result.argsArray[0]).toEqual(["img_p0_1"]);
       expect(result.argsArray[1]).toEqual(["img_p0_1", 1, 1]);
-      expect(result.argsArray[2]).toEqual(null);
+      expect(result.argsArray[2]).toBeNull();
     });
 
     it("should handle three glued operations", async function () {

--- a/test/unit/metadata_spec.js
+++ b/test/unit/metadata_spec.js
@@ -32,7 +32,7 @@ describe("metadata", function () {
     const metadata = createMetadata(data);
 
     expect(metadata.get("dc:title")).toEqual("Foo bar baz");
-    expect(metadata.get("dc:qux")).toEqual(null);
+    expect(metadata.get("dc:qux")).toBeNull();
 
     expect([...metadata]).toEqual([["dc:title", "Foo bar baz"]]);
   });
@@ -47,7 +47,7 @@ describe("metadata", function () {
     const metadata = createMetadata(data);
 
     expect(metadata.get("dc:title")).toEqual("PDF&");
-    expect(metadata.get("dc:qux")).toEqual(null);
+    expect(metadata.get("dc:qux")).toBeNull();
 
     expect([...metadata]).toEqual([["dc:title", "PDF&"]]);
   });
@@ -89,7 +89,7 @@ describe("metadata", function () {
     expect(metadata.get("dc:title")).toEqual(
       "L'Odissee thématique logo Odisséé - décembre 2008.pub"
     );
-    expect(metadata.get("dc:qux")).toEqual(null);
+    expect(metadata.get("dc:qux")).toBeNull();
 
     expect([...metadata].sort()).toEqual([
       ["dc:creator", ["ODIS"]],
@@ -158,7 +158,7 @@ describe("metadata", function () {
     const metadata = createMetadata(data);
 
     expect(metadata.get("dc:title")).toEqual("");
-    expect(metadata.get("dc:qux")).toEqual(null);
+    expect(metadata.get("dc:qux")).toBeNull();
 
     expect([...metadata].sort()).toEqual([
       ["dc:creator", [""]],
@@ -187,7 +187,7 @@ describe("metadata", function () {
     const metadata = createMetadata(data);
 
     expect(metadata.get("dc:title")).toEqual("'Foo bar baz'");
-    expect(metadata.get("dc:qux")).toEqual(null);
+    expect(metadata.get("dc:qux")).toBeNull();
 
     expect([...metadata]).toEqual([["dc:title", "'Foo bar baz'"]]);
   });
@@ -242,7 +242,7 @@ describe("metadata", function () {
     const metadata = createMetadata(data);
 
     expect(metadata.get("dc:title")).toEqual("a&lol9;b");
-    expect(metadata.get("dc:qux")).toEqual(null);
+    expect(metadata.get("dc:qux")).toBeNull();
 
     expect([...metadata]).toEqual([["dc:title", "a&lol9;b"]]);
   });

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -270,7 +270,7 @@ describe("parser", function () {
         ">>\n" +
         "endobj"
       );
-      expect(Linearization.create(stream1)).toEqual(null);
+      expect(Linearization.create(stream1)).toBeNull();
 
       // Linearization dictionary with invalid version number.
       // prettier-ignore
@@ -281,7 +281,7 @@ describe("parser", function () {
         ">>\n" +
         "endobj"
       );
-      expect(Linearization.create(stream2)).toEqual(null);
+      expect(Linearization.create(stream2)).toBeNull();
     });
 
     it("should accept a valid linearization dictionary", function () {

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -125,7 +125,7 @@ describe("primitives", function () {
 
     it("should allow assigning an XRef table after creation", function () {
       const dict = new Dict(null);
-      expect(dict.xref).toEqual(null);
+      expect(dict.xref).toBeNull();
 
       const xref = new XRefMock([]);
       dict.assignXref(xref);

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -737,7 +737,7 @@ describe("Scripting", function () {
         expect(value).toEqual(-123.456);
 
         value = await myeval(`AFMakeNumber("not a number")`);
-        expect(value).toEqual(null);
+        expect(value).toBeNull();
       });
     });
 

--- a/test/unit/type1_parser_spec.js
+++ b/test/unit/type1_parser_spec.js
@@ -76,7 +76,7 @@ describe("Type1Parser", function () {
     expect(parser.getToken()).toEqual("]");
     expect(parser.getToken()).toEqual("noaccess");
     expect(parser.getToken()).toEqual("def");
-    expect(parser.getToken()).toEqual(null);
+    expect(parser.getToken()).toBeNull();
   });
 
   it("handles glued tokens", function () {
@@ -220,7 +220,7 @@ describe("Type1Parser", function () {
     });
     const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
 
-    expect(parser.extractCidKeyedFontProgram({})).toEqual(null);
+    expect(parser.extractCidKeyedFontProgram({})).toBeNull();
   });
 
   it("uses subrs when parsing a CID-keyed Type 1 font", function () {
@@ -307,7 +307,7 @@ describe("Type1Parser", function () {
     const stream = createCidKeyedFontStream({ binary, cidCount: 3 });
     const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
 
-    expect(parser.extractCidKeyedFontProgram({})).toEqual(null);
+    expect(parser.extractCidKeyedFontProgram({})).toBeNull();
   });
 
   it("rejects malformed StartData token sequences", function () {
@@ -330,7 +330,7 @@ describe("Type1Parser", function () {
           tail
       );
       const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
-      expect(parser.extractCidKeyedFontProgram({})).toEqual(null);
+      expect(parser.extractCidKeyedFontProgram({})).toBeNull();
     }
   });
 
@@ -345,7 +345,7 @@ describe("Type1Parser", function () {
     );
     const parser = new Type1Parser(stream, false, SEAC_ANALYSIS_ENABLED);
 
-    expect(parser.extractCidKeyedFontProgram({})).toEqual(null);
+    expect(parser.extractCidKeyedFontProgram({})).toBeNull();
   });
 
   it("parses font header font matrix", function () {

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -83,13 +83,13 @@ describe("util", function () {
 
   describe("createValidAbsoluteUrl", function () {
     it("handles invalid URLs", function () {
-      expect(createValidAbsoluteUrl(undefined, undefined)).toEqual(null);
-      expect(createValidAbsoluteUrl(null, null)).toEqual(null);
-      expect(createValidAbsoluteUrl("/foo", "/bar")).toEqual(null);
+      expect(createValidAbsoluteUrl(undefined, undefined)).toBeNull();
+      expect(createValidAbsoluteUrl(null, null)).toBeNull();
+      expect(createValidAbsoluteUrl("/foo", "/bar")).toBeNull();
     });
 
     it("handles URLs that do not use an allowed protocol", function () {
-      expect(createValidAbsoluteUrl("magnet:?foo", null)).toEqual(null);
+      expect(createValidAbsoluteUrl("magnet:?foo", null)).toBeNull();
     });
 
     it("correctly creates a valid URL for allowed protocols", function () {
@@ -129,7 +129,7 @@ describe("util", function () {
       expect(createValidAbsoluteUrl("tel:+0123456789", null)).toEqual(
         new URL("tel:+0123456789")
       );
-      expect(createValidAbsoluteUrl("/foo", "tel:0123456789")).toEqual(null);
+      expect(createValidAbsoluteUrl("/foo", "tel:0123456789")).toBeNull();
     });
   });
 

--- a/test/unit/xfa_parser_spec.js
+++ b/test/unit/xfa_parser_spec.js
@@ -716,7 +716,7 @@ describe("XFAParser", function () {
       expect(found[$text]()).toBe("60.00");
 
       found = searchNode(root, units, "Total_Pric");
-      expect(found).toEqual(null);
+      expect(found).toBeNull();
     });
 
     it("should search some nodes in a datasets object using SOM", function () {

--- a/test/unit/xfa_tohtml_spec.js
+++ b/test/unit/xfa_tohtml_spec.js
@@ -463,10 +463,10 @@ describe("XFAFactory", function () {
 
       const pages = await factory.getPages();
       const field1 = searchHtmlNode(pages, "name", "input");
-      expect(field1).not.toEqual(null);
+      expect(field1).not.toBeNull();
 
       const field2 = searchHtmlNode(pages, "name", "textarea");
-      expect(field2).not.toEqual(null);
+      expect(field2).not.toBeNull();
     });
   });
 
@@ -517,7 +517,7 @@ describe("XFAFactory", function () {
 
     const pages = await factory.getPages();
     const field1 = searchHtmlNode(pages, "name", "input");
-    expect(field1).not.toEqual(null);
+    expect(field1).not.toBeNull();
     expect(field1.attributes.value).toEqual("123");
   });
 


### PR DESCRIPTION
This replaces all `toEqual(null)` and `toBe(null)` occurrences.