### PR TITLE
Use the `toBeUndefined()` matcher consistently in the unit tests

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2698,7 +2698,7 @@ describe("api", function () {
 
       expect(info.Title).toEqual("Basic API Test");
       // Custom, non-standard, information dictionary entries.
-      expect(info.Custom).toEqual(undefined);
+      expect(info.Custom).toBeUndefined();
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.7");
       expect(info.Language).toEqual("en");
@@ -2757,7 +2757,7 @@ describe("api", function () {
         await pdfDoc.getMetadata();
 
       // Custom, non-standard, information dictionary entries.
-      expect(info.Custom).toEqual(undefined);
+      expect(info.Custom).toBeUndefined();
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual(null);
       expect(info.Language).toEqual(null);
@@ -2784,7 +2784,7 @@ describe("api", function () {
         await pdfDoc.getMetadata();
 
       // Custom, non-standard, information dictionary entries.
-      expect(info.Custom).toEqual(undefined);
+      expect(info.Custom).toBeUndefined();
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.6");
       expect(info.Language).toEqual(null);

--- a/test/unit/event_utils_spec.js
+++ b/test/unit/event_utils_spec.js
@@ -26,7 +26,7 @@ describe("event_utils", function () {
       const eventBus = new EventBus();
       let count = 0;
       eventBus.on("test", function (evt) {
-        expect(evt).toEqual(undefined);
+        expect(evt).toBeUndefined();
         count++;
       });
       eventBus.dispatch("test");
@@ -204,7 +204,7 @@ describe("event_utils", function () {
       const eventBus = new EventBus();
       let count = 0;
       eventBus.on("test", function (evt) {
-        expect(evt).toEqual(undefined);
+        expect(evt).toBeUndefined();
         count++;
       });
       function domEventListener() {

--- a/test/unit/message_handler_spec.js
+++ b/test/unit/message_handler_spec.js
@@ -80,7 +80,7 @@ describe("message_handler", function () {
 
       await sleep(10);
       result = await reader.read();
-      expect(result.value).toEqual(undefined);
+      expect(result.value).toBeUndefined();
       expect(result.done).toEqual(true);
     });
 
@@ -260,7 +260,7 @@ describe("message_handler", function () {
       expect(log).toEqual("01p2p");
 
       result = await reader.read();
-      expect(result.value).toEqual(undefined);
+      expect(result.value).toBeUndefined();
       expect(result.done).toEqual(true);
     });
 
@@ -327,7 +327,7 @@ describe("message_handler", function () {
         expect(log).toEqual("012p");
 
         result = await reader.read();
-        expect(result.value).toEqual(undefined);
+        expect(result.value).toBeUndefined();
         expect(result.done).toEqual(true);
       }
     );
@@ -381,7 +381,7 @@ describe("message_handler", function () {
       expect(log).toEqual("01");
 
       result = await reader.read();
-      expect(result.value).toEqual(undefined);
+      expect(result.value).toBeUndefined();
       expect(result.done).toEqual(true);
     });
   });

--- a/test/unit/xfa_parser_spec.js
+++ b/test/unit/xfa_parser_spec.js
@@ -324,7 +324,7 @@ describe("XFAParser", function () {
       expect(font.weight).toEqual("bold");
       expect(font.posture).toEqual("italic");
       expect(font.fill.color.value).toEqual({ r: 1, g: 2, b: 3 });
-      expect(font.extras).toEqual(undefined);
+      expect(font.extras).toBeUndefined();
 
       font = root.template.subform.field[1].font;
       expect(font.typeface).toEqual("Foo");
@@ -374,7 +374,7 @@ describe("XFAParser", function () {
       expect(font.weight).toEqual("bold");
       expect(font.posture).toEqual("italic");
       expect(font.fill.color.value).toEqual({ r: 1, g: 2, b: 3 });
-      expect(font.extras).toEqual(undefined);
+      expect(font.extras).toBeUndefined();
 
       font = root.template.subform.field[1].font;
       expect(font.typeface).toEqual("Foo");
@@ -943,7 +943,7 @@ describe("XFAParser", function () {
       ).toBe("Spratt");
       expect(
         searchNode(form, form, "registration.apt..text")[0][$dump]().$content
-      ).toBe(undefined);
+      ).toBeUndefined();
       expect(
         searchNode(form, form, "registration.street..text")[0][$dump]().$content
       ).toBe("99 Candlestick Lane");
@@ -1003,7 +1003,7 @@ describe("XFAParser", function () {
       ).toBe("Spratt");
       expect(
         searchNode(form, form, "registration..apt..text")[0][$dump]().$content
-      ).toBe(undefined);
+      ).toBeUndefined();
       expect(
         searchNode(form, form, "registration..street..text")[0][$dump]()
           .$content


### PR DESCRIPTION
This replaces all `toEqual(undefined)` and `toBe(undefined)` occurrences.