### PR TITLE
Use the `toBeFalse()` matcher consistently in the unit/integration tests

### DIFF
--- a/test/integration/annotation_spec.mjs
+++ b/test/integration/annotation_spec.mjs
@@ -73,7 +73,7 @@ describe("Annotation highlight", () => {
             getAnnotationSelector("21R"),
             el => el.hidden
           );
-          expect(hidden).withContext(`In ${browserName}`).toEqual(false);
+          expect(hidden).withContext(`In ${browserName}`).toBeFalse();
         })
       );
     });
@@ -346,10 +346,10 @@ describe("Annotation and storage", () => {
             expect(checked).toEqual(true);
 
             checked = await page.$eval(getSelector(radio1Id), el => el.checked);
-            expect(checked).toEqual(false);
+            expect(checked).toBeFalse();
 
             checked = await page.$eval(getSelector(radio2Id), el => el.checked);
-            expect(checked).toEqual(false);
+            expect(checked).toBeFalse();
           }
 
           // Change data on page 5 and check that other pages changed.
@@ -384,13 +384,13 @@ describe("Annotation and storage", () => {
               getSelector(checkId),
               el => el.checked
             );
-            expect(checked).toEqual(false);
+            expect(checked).toBeFalse();
 
             checked = await page.$eval(getSelector(radio1Id), el => el.checked);
-            expect(checked).toEqual(false);
+            expect(checked).toBeFalse();
 
             checked = await page.$eval(getSelector(radio2Id), el => el.checked);
-            expect(checked).toEqual(false);
+            expect(checked).toBeFalse();
           }
         })
       );
@@ -442,7 +442,7 @@ describe("ResetForm action", () => {
               getSelector(`${id}R`),
               el => el.checked
             );
-            expect(checked).withContext(`In ${browserName}`).toEqual(false);
+            expect(checked).withContext(`In ${browserName}`).toBeFalse();
           }
 
           let selected = await page.$eval(
@@ -495,7 +495,7 @@ describe("ResetForm action", () => {
             );
             expect(checked)
               .withContext(`In ${browserName + id}`)
-              .toEqual(false);
+              .toBeFalse();
           }
 
           ids = [71, 75];
@@ -644,7 +644,7 @@ describe("ResetForm action", () => {
               `document.querySelector('${selector}').hidden !== true`
             );
             hidden = await page.$eval(selector, el => el.hidden);
-            expect(hidden).withContext(`In ${browserName}`).toEqual(false);
+            expect(hidden).withContext(`In ${browserName}`).toBeFalse();
 
             await page.keyboard.press("Enter");
             await page.waitForFunction(
@@ -658,7 +658,7 @@ describe("ResetForm action", () => {
               `document.querySelector('${selector}').hidden !== true`
             );
             hidden = await page.$eval(selector, el => el.hidden);
-            expect(hidden).withContext(`In ${browserName}`).toEqual(false);
+            expect(hidden).withContext(`In ${browserName}`).toBeFalse();
 
             await page.keyboard.press("Escape");
             await page.waitForFunction(

--- a/test/integration/comment_spec.mjs
+++ b/test/integration/comment_spec.mjs
@@ -912,7 +912,7 @@ describe("Comment", () => {
               ),
             editorSelector
           );
-          expect(hasCommentButton).withContext(`In ${browserName}`).toBe(false);
+          expect(hasCommentButton).withContext(`In ${browserName}`).toBeFalse();
         })
       );
     });

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -290,7 +290,7 @@ describe("FreeText Editor", () => {
               sel => !!document.querySelector(sel),
               getEditorSelector(n)
             );
-            expect(hasEditor).withContext(`In ${browserName}`).toEqual(false);
+            expect(hasEditor).withContext(`In ${browserName}`).toBeFalse();
           }
         })
       );

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -886,7 +886,7 @@ describe("Highlight Editor", () => {
           });
           expect(editingEvent.isEditing)
             .withContext(`In ${browserName}`)
-            .toBe(false);
+            .toBeFalse();
           expect(editingEvent.hasSelectedText)
             .withContext(`In ${browserName}`)
             .toBe(true);
@@ -901,7 +901,7 @@ describe("Highlight Editor", () => {
           });
           expect(editingEvent.hasSelectedText)
             .withContext(`In ${browserName}`)
-            .toBe(false);
+            .toBeFalse();
 
           await page.mouse.click(x, y, { count: 2, delay: 100 });
           await page.waitForFunction(() => window.editingEvents.length > 0);

--- a/test/integration/scripting_spec.mjs
+++ b/test/integration/scripting_spec.mjs
@@ -276,7 +276,7 @@ describe("Interaction", () => {
           expect(text).toEqual("");
 
           checked = await page.$eval(getSelector("449R"), el => el.checked);
-          expect(checked).toEqual(false);
+          expect(checked).toBeFalse();
 
           const visibility = await page.$eval(
             getSelector("427R"),
@@ -2023,7 +2023,7 @@ describe("Interaction", () => {
           );
 
           readonly = await page.$eval(getSelector("353R"), el => el.disabled);
-          expect(readonly).withContext(`In ${browserName}`).toEqual(false);
+          expect(readonly).withContext(`In ${browserName}`).toBeFalse();
 
           await page.click(getSelector("353R"));
           await page.waitForFunction(
@@ -2043,7 +2043,7 @@ describe("Interaction", () => {
           readonly = await page.$eval(getSelector("353R"), el => el.disabled);
           expect(readonly).withContext(`In ${browserName}`).toEqual(true);
           checked = await page.$eval(getSelector("353R"), el => el.checked);
-          expect(checked).withContext(`In ${browserName}`).toEqual(false);
+          expect(checked).withContext(`In ${browserName}`).toBeFalse();
         })
       );
     });

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -835,7 +835,7 @@ describe("PDF viewer", () => {
               );
 
               expect(isSame).withContext(`In ${browserName}`).toBe(true);
-              expect(rendered).withContext(`In ${browserName}`).toBe(false);
+              expect(rendered).withContext(`In ${browserName}`).toBeFalse();
             });
           });
         });

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -381,8 +381,8 @@ describe("annotation", function () {
       expect(annotation.hasFlag(AnnotationFlag.INVISIBLE)).toEqual(true);
       expect(annotation.hasFlag(AnnotationFlag.NOZOOM)).toEqual(true);
       expect(annotation.hasFlag(AnnotationFlag.PRINT)).toEqual(true);
-      expect(annotation.hasFlag(AnnotationFlag.READONLY)).toEqual(false);
-      expect(annotation.hasFlag(AnnotationFlag.HIDDEN)).toEqual(false);
+      expect(annotation.hasFlag(AnnotationFlag.READONLY)).toBeFalse();
+      expect(annotation.hasFlag(AnnotationFlag.HIDDEN)).toBeFalse();
     });
 
     it("should be viewable and not printable by default", function () {
@@ -394,7 +394,7 @@ describe("annotation", function () {
       });
 
       expect(annotation.viewable).toEqual(true);
-      expect(annotation.printable).toEqual(false);
+      expect(annotation.printable).toBeFalse();
     });
 
     it("should set and get a valid rectangle", function () {
@@ -1603,10 +1603,10 @@ describe("annotation", function () {
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.textAlignment).toBeNull();
       expect(data.maxLen).toEqual(0);
-      expect(data.readOnly).toEqual(false);
-      expect(data.hidden).toEqual(false);
-      expect(data.multiLine).toEqual(false);
-      expect(data.comb).toEqual(false);
+      expect(data.readOnly).toBeFalse();
+      expect(data.hidden).toBeFalse();
+      expect(data.multiLine).toBeFalse();
+      expect(data.comb).toBeFalse();
       expect(data.defaultFieldValue).toEqual("foo");
     });
 
@@ -1627,10 +1627,10 @@ describe("annotation", function () {
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.textAlignment).toBeNull();
       expect(data.maxLen).toEqual(0);
-      expect(data.readOnly).toEqual(false);
-      expect(data.hidden).toEqual(false);
-      expect(data.multiLine).toEqual(false);
-      expect(data.comb).toEqual(false);
+      expect(data.readOnly).toBeFalse();
+      expect(data.hidden).toBeFalse();
+      expect(data.multiLine).toBeFalse();
+      expect(data.comb).toBeFalse();
     });
 
     it("should set valid text alignment, maximum length and flags", async function () {
@@ -1654,7 +1654,7 @@ describe("annotation", function () {
       expect(data.textAlignment).toEqual(1);
       expect(data.maxLen).toEqual(20);
       expect(data.readOnly).toEqual(true);
-      expect(data.hidden).toEqual(false);
+      expect(data.hidden).toBeFalse();
       expect(data.multiLine).toEqual(true);
     });
 
@@ -1671,7 +1671,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.comb).toEqual(false);
+      expect(data.comb).toBeFalse();
     });
 
     it("should accept comb fields with a maximum length", async function () {
@@ -2563,7 +2563,7 @@ describe("annotation", function () {
       expect(data.checkBox).toEqual(true);
       expect(data.fieldValue).toEqual("Checked");
       expect(data.defaultFieldValue).toEqual("Off");
-      expect(data.radioButton).toEqual(false);
+      expect(data.radioButton).toBeFalse();
       expect(data.exportValue).toEqual("Checked");
     });
 
@@ -2595,7 +2595,7 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.checkBox).toEqual(true);
-      expect(data.radioButton).toEqual(false);
+      expect(data.radioButton).toBeFalse();
       expect(data.exportValue).toEqual("I Agree to terms");
       expect(data.fieldValue).toEqual("I Agree to terms");
       expect(data.defaultFieldValue).toEqual("I Agree to terms");
@@ -2635,7 +2635,7 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.checkBox).toEqual(true);
-      expect(data.radioButton).toEqual(false);
+      expect(data.radioButton).toBeFalse();
       expect(data.exportValue).toEqual("I Agree to terms");
       expect(data.fieldValue).toEqual("I Agree to terms");
       expect(data.defaultFieldValue).toEqual("I Agree to terms");
@@ -2660,7 +2660,7 @@ describe("annotation", function () {
       expect(data.checkBox).toEqual(true);
       expect(data.fieldValue).toEqual("Checked");
       expect(data.defaultFieldValue).toEqual("Off");
-      expect(data.radioButton).toEqual(false);
+      expect(data.radioButton).toBeFalse();
     });
 
     it("should handle checkboxes without /Off appearance", async function () {
@@ -2689,7 +2689,7 @@ describe("annotation", function () {
       expect(data.checkBox).toEqual(true);
       expect(data.fieldValue).toEqual("Checked");
       expect(data.defaultFieldValue).toEqual("Off");
-      expect(data.radioButton).toEqual(false);
+      expect(data.radioButton).toBeFalse();
       expect(data.exportValue).toEqual("Checked");
     });
 
@@ -3123,7 +3123,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.checkBox).toEqual(false);
+      expect(data.checkBox).toBeFalse();
       expect(data.radioButton).toEqual(true);
       expect(data.fieldValue).toEqual("1");
       expect(data.buttonValue).toEqual("2");
@@ -3276,7 +3276,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.checkBox).toEqual(false);
+      expect(data.checkBox).toBeFalse();
       expect(data.radioButton).toEqual(true);
       expect(data.fieldValue).toEqual(name);
       expect(data.buttonValue).toEqual(name);
@@ -3304,7 +3304,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.checkBox).toEqual(false);
+      expect(data.checkBox).toBeFalse();
       expect(data.radioButton).toEqual(true);
       expect(data.fieldValue).toBeNull();
       expect(data.buttonValue).toEqual("2");
@@ -4008,10 +4008,10 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.readOnly).toEqual(false);
-      expect(data.hidden).toEqual(false);
-      expect(data.combo).toEqual(false);
-      expect(data.multiSelect).toEqual(false);
+      expect(data.readOnly).toBeFalse();
+      expect(data.hidden).toBeFalse();
+      expect(data.combo).toBeFalse();
+      expect(data.multiSelect).toBeFalse();
     });
 
     it("should not set invalid flags", async function () {
@@ -4029,10 +4029,10 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
-      expect(data.readOnly).toEqual(false);
-      expect(data.hidden).toEqual(false);
-      expect(data.combo).toEqual(false);
-      expect(data.multiSelect).toEqual(false);
+      expect(data.readOnly).toBeFalse();
+      expect(data.hidden).toBeFalse();
+      expect(data.combo).toBeFalse();
+      expect(data.multiSelect).toBeFalse();
     });
 
     it("should set valid flags", async function () {
@@ -4056,7 +4056,7 @@ describe("annotation", function () {
       );
       expect(data.annotationType).toEqual(AnnotationType.WIDGET);
       expect(data.readOnly).toEqual(true);
-      expect(data.hidden).toEqual(false);
+      expect(data.hidden).toBeFalse();
       expect(data.combo).toEqual(true);
       expect(data.multiSelect).toEqual(true);
     });
@@ -4658,7 +4658,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.RICHMEDIA);
-      expect(data.noHTML).toEqual(false);
+      expect(data.noHTML).toBeFalse();
       expect(data.richMedia).toEqual({
         fileId: "attachmentRef:100R",
         filename: "demo.mp4",
@@ -5017,7 +5017,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.SCREEN);
-      expect(data.noHTML).toEqual(false);
+      expect(data.noHTML).toBeFalse();
       expect(data.richMedia).toEqual({
         fileId: "attachmentRef:200R",
         filename: "demo.mp3",
@@ -5272,7 +5272,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       expect(data.annotationType).toEqual(AnnotationType.SOUND);
-      expect(data.noHTML).toEqual(false);
+      expect(data.noHTML).toBeFalse();
       expect(data.richMedia).toEqual({
         fileId: "attachmentRef:300R",
         filename: "sound.wav",

--- a/test/unit/annotation_storage_spec.js
+++ b/test/unit/annotation_storage_spec.js
@@ -81,7 +81,7 @@ describe("AnnotationStorage", function () {
       // not changing value
       called = false;
       annotationStorage.setValue("asdf", { value: "modified" });
-      expect(called).toBe(false);
+      expect(called).toBeFalse();
     });
   });
 
@@ -101,7 +101,7 @@ describe("AnnotationStorage", function () {
       // not changing value
       annotationStorage.setValue("asdf", { value: "original" });
       annotationStorage.resetModified();
-      expect(called).toBe(false);
+      expect(called).toBeFalse();
 
       // changing value
       annotationStorage.setValue("asdf", { value: "modified" });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1062,12 +1062,12 @@ describe("api", function () {
       await worker.promise;
       expect(worker.name).toEqual("test1");
       expect(!!worker.port).toEqual(true);
-      expect(worker.destroyed).toEqual(false);
+      expect(worker.destroyed).toBeFalse();
       expect(!!worker._webWorker).toEqual(true);
       expect(worker.port === worker._webWorker).toEqual(true);
 
       worker.destroy();
-      expect(!!worker.port).toEqual(false);
+      expect(!!worker.port).toBeFalse();
       expect(worker.destroyed).toEqual(true);
     });
 
@@ -1089,7 +1089,7 @@ describe("api", function () {
       await destroyPromise;
 
       const destroyedWorker = loadingTask._worker;
-      expect(!!destroyedWorker).toEqual(false);
+      expect(!!destroyedWorker).toBeFalse();
       expect(worker.destroyed).toEqual(true);
     });
 
@@ -1106,7 +1106,7 @@ describe("api", function () {
       );
       loadingTask.promise.then(function () {
         const docWorker = loadingTask._worker;
-        expect(!!docWorker).toEqual(false);
+        expect(!!docWorker).toBeFalse();
         // checking is the same port is used in the MessageHandler
         const messageHandlerPort = loadingTask._transport.messageHandler.comObj;
         expect(messageHandlerPort === worker.port).toEqual(true);
@@ -1117,7 +1117,7 @@ describe("api", function () {
       );
       await destroyPromise;
 
-      expect(worker.destroyed).toEqual(false);
+      expect(worker.destroyed).toBeFalse();
       worker.destroy();
     });
 
@@ -1154,10 +1154,10 @@ describe("api", function () {
     describe("isSameOrigin", function () {
       it("handles invalid base URLs", function () {
         // The base URL is not valid.
-        expect(PDFWorker._isSameOrigin("/foo", "/bar")).toEqual(false);
+        expect(PDFWorker._isSameOrigin("/foo", "/bar")).toBeFalse();
 
         // The base URL has no origin.
-        expect(PDFWorker._isSameOrigin("blob:foo", "/bar")).toEqual(false);
+        expect(PDFWorker._isSameOrigin("blob:foo", "/bar")).toBeFalse();
       });
 
       it("correctly checks if the origin of both URLs matches", function () {
@@ -1172,7 +1172,7 @@ describe("api", function () {
             "https://www.mozilla.org/foo",
             "https://www.example.com/bar"
           )
-        ).toEqual(false);
+        ).toBeFalse();
       });
     });
   });
@@ -1956,7 +1956,7 @@ describe("api", function () {
     it("gets hasJSActions, in document without javaScript", async function () {
       const hasJSActions = await pdfDocument.hasJSActions();
 
-      expect(hasJSActions).toEqual(false);
+      expect(hasJSActions).toBeFalse();
     });
 
     it("gets hasJSActions, in document with javaScript", async function () {
@@ -2265,7 +2265,7 @@ describe("api", function () {
       const signatures = await pdfDoc.getSignatures();
 
       expect(signatures.length).toEqual(1);
-      expect(signatures[0].coversWholeDocument).toEqual(false);
+      expect(signatures[0].coversWholeDocument).toBeFalse();
       expect(signatures[0].modificationsAfterSignature).toEqual(1);
       expect(fetches).toEqual(fetchesAfterLoading);
 
@@ -2330,7 +2330,7 @@ describe("api", function () {
       expect(outlineItem.newWindow).toBeUndefined();
 
       expect(outlineItem.bold).toEqual(true);
-      expect(outlineItem.italic).toEqual(false);
+      expect(outlineItem.italic).toBeFalse();
       expect(outlineItem.color).toEqual(new Uint8ClampedArray([0, 64, 128]));
 
       expect(outlineItem.items.length).toEqual(1);
@@ -2352,7 +2352,7 @@ describe("api", function () {
       expect(outlineItemTwo.newWindow).toBeUndefined();
 
       const outlineItemOne = outline[1];
-      expect(outlineItemOne.bold).toEqual(false);
+      expect(outlineItemOne.bold).toBeFalse();
       expect(outlineItemOne.italic).toEqual(true);
       expect(outlineItemOne.color).toEqual(new Uint8ClampedArray([0, 0, 0]));
 
@@ -2701,11 +2701,11 @@ describe("api", function () {
       expect(info.PDFFormatVersion).toEqual("1.7");
       expect(info.Language).toEqual("en");
       expect(info.EncryptFilterName).toBeNull();
-      expect(info.IsLinearized).toEqual(false);
-      expect(info.IsAcroFormPresent).toEqual(false);
-      expect(info.IsXFAPresent).toEqual(false);
-      expect(info.IsCollectionPresent).toEqual(false);
-      expect(info.IsSignaturesPresent).toEqual(false);
+      expect(info.IsLinearized).toBeFalse();
+      expect(info.IsAcroFormPresent).toBeFalse();
+      expect(info.IsXFAPresent).toBeFalse();
+      expect(info.IsCollectionPresent).toBeFalse();
+      expect(info.IsSignaturesPresent).toBeFalse();
 
       expect(metadata).toBeInstanceOf(Metadata);
       expect(metadata.get("dc:title")).toEqual("Basic API Test");
@@ -2735,11 +2735,11 @@ describe("api", function () {
       expect(info.PDFFormatVersion).toEqual("1.4");
       expect(info.Language).toBeNull();
       expect(info.EncryptFilterName).toBeNull();
-      expect(info.IsLinearized).toEqual(false);
-      expect(info.IsAcroFormPresent).toEqual(false);
-      expect(info.IsXFAPresent).toEqual(false);
-      expect(info.IsCollectionPresent).toEqual(false);
-      expect(info.IsSignaturesPresent).toEqual(false);
+      expect(info.IsLinearized).toBeFalse();
+      expect(info.IsAcroFormPresent).toBeFalse();
+      expect(info.IsXFAPresent).toBeFalse();
+      expect(info.IsCollectionPresent).toBeFalse();
+      expect(info.IsSignaturesPresent).toBeFalse();
 
       expect(metadata).toBeNull();
       expect(contentDispositionFilename).toBeNull();
@@ -2760,11 +2760,11 @@ describe("api", function () {
       expect(info.PDFFormatVersion).toBeNull();
       expect(info.Language).toBeNull();
       expect(info.EncryptFilterName).toBeNull();
-      expect(info.IsLinearized).toEqual(false);
-      expect(info.IsAcroFormPresent).toEqual(false);
-      expect(info.IsXFAPresent).toEqual(false);
-      expect(info.IsCollectionPresent).toEqual(false);
-      expect(info.IsSignaturesPresent).toEqual(false);
+      expect(info.IsLinearized).toBeFalse();
+      expect(info.IsAcroFormPresent).toBeFalse();
+      expect(info.IsXFAPresent).toBeFalse();
+      expect(info.IsCollectionPresent).toBeFalse();
+      expect(info.IsSignaturesPresent).toBeFalse();
 
       expect(metadata).toBeNull();
       expect(contentDispositionFilename).toBeNull();
@@ -2787,11 +2787,11 @@ describe("api", function () {
       expect(info.PDFFormatVersion).toEqual("1.6");
       expect(info.Language).toBeNull();
       expect(info.EncryptFilterName).toBeNull();
-      expect(info.IsLinearized).toEqual(false);
+      expect(info.IsLinearized).toBeFalse();
       expect(info.IsAcroFormPresent).toEqual(true);
-      expect(info.IsXFAPresent).toEqual(false);
-      expect(info.IsCollectionPresent).toEqual(false);
-      expect(info.IsSignaturesPresent).toEqual(false);
+      expect(info.IsXFAPresent).toBeFalse();
+      expect(info.IsCollectionPresent).toBeFalse();
+      expect(info.IsSignaturesPresent).toBeFalse();
 
       expect(metadata).toBeNull();
       expect(contentDispositionFilename).toBeNull();
@@ -2808,8 +2808,8 @@ describe("api", function () {
       const markInfo = await pdfDoc.getMarkInfo();
 
       expect(markInfo.Marked).toEqual(true);
-      expect(markInfo.UserProperties).toEqual(false);
-      expect(markInfo.Suspects).toEqual(false);
+      expect(markInfo.UserProperties).toBeFalse();
+      expect(markInfo.Suspects).toBeFalse();
 
       await loadingTask.destroy();
     });
@@ -3645,7 +3645,7 @@ describe("api", function () {
                 // For ease of debugging.
                 expect(error).toEqual("There should not be any error");
               }
-              expect(expectSuccess).toEqual(false);
+              expect(expectSuccess).toBeFalse();
             }
           );
       }
@@ -4437,7 +4437,7 @@ Caron Broadcasting, Inc., an Ohio corporation (“Lessee”).`)
       });
       const text = mergeText(items);
 
-      expect(/win aisle/.test(text)).toEqual(false);
+      expect(/win aisle/.test(text)).toBeFalse();
 
       await loadingTask.destroy();
     });
@@ -5011,7 +5011,7 @@ have written that much by now. So, here’s to squashing bugs.`);
         OPS.beginAnnotation
       );
       let isUsingOwnCanvas = opListAnnotEnable.argsArray[firstAnnotIndex][4];
-      expect(isUsingOwnCanvas).toEqual(false);
+      expect(isUsingOwnCanvas).toBeFalse();
 
       const opListAnnotEnableForms = await pdfPage.getOperatorList({
         annotationMode: AnnotationMode.ENABLE_FORMS,
@@ -5045,7 +5045,7 @@ have written that much by now. So, here’s to squashing bugs.`);
         OPS.beginAnnotation
       );
       isUsingOwnCanvas = opListAnnotEnableStorage.argsArray[firstAnnotIndex][4];
-      expect(isUsingOwnCanvas).toEqual(false);
+      expect(isUsingOwnCanvas).toBeFalse();
 
       // Sanity check to ensure that the `annotationMode` is correctly applied.
       expect(opListAnnotDisable.fnArray.length).toBeLessThan(
@@ -5147,7 +5147,7 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(renderTask).toBeInstanceOf(RenderTask);
 
       await renderTask.promise;
-      expect(renderTask.separateAnnots).toEqual(false);
+      expect(renderTask.separateAnnots).toBeFalse();
 
       const { stats } = pdfPage;
       expect(stats).toBeInstanceOf(StatTimer);
@@ -5231,7 +5231,7 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(reRenderTask).toBeInstanceOf(RenderTask);
 
       await reRenderTask.promise;
-      expect(reRenderTask.separateAnnots).toEqual(false);
+      expect(reRenderTask.separateAnnots).toBeFalse();
 
       canvasFactory.destroy(canvasAndCtx);
     });
@@ -5299,7 +5299,7 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(renderTask).toBeInstanceOf(RenderTask);
 
       await renderTask.promise;
-      expect(renderTask.separateAnnots).toEqual(false);
+      expect(renderTask.separateAnnots).toBeFalse();
 
       await pdfDoc.cleanup();
       expect(true).toEqual(true);
@@ -5345,7 +5345,7 @@ have written that much by now. So, here’s to squashing bugs.`);
         );
       }
       await renderTask.promise;
-      expect(renderTask.separateAnnots).toEqual(false);
+      expect(renderTask.separateAnnots).toBeFalse();
 
       // Use the red background-color to, more easily, tell that the page was
       // actually rendered successfully.
@@ -5398,13 +5398,13 @@ have written that much by now. So, here’s to squashing bugs.`);
           expect(objId).toEqual(`img_p${i - 1}_1`);
 
           expect(objs.has(objId)).toEqual(true);
-          expect(commonObjs.has(objId)).toEqual(false);
+          expect(commonObjs.has(objId)).toBeFalse();
         } else {
           expect(objId).toEqual(
             `g_${loadingTask.docId}_img_p${NUM_PAGES_THRESHOLD - 1}_1`
           );
 
-          expect(objs.has(objId)).toEqual(false);
+          expect(objs.has(objId)).toBeFalse();
           expect(commonObjs.has(objId)).toEqual(true);
         }
         expect(width).toEqual(EXPECTED_WIDTH);
@@ -5478,9 +5478,9 @@ have written that much by now. So, here’s to squashing bugs.`);
         if (i < NUM_PAGES_THRESHOLD) {
           // Image decoded in the worker-thread; stored as a page-level object.
           expect(objs.has(objId)).toEqual(true);
-          expect(commonObjs.has(objId)).toEqual(false);
+          expect(commonObjs.has(objId)).toBeFalse();
         } else if (i === NUM_PAGES_THRESHOLD) {
-          expect(objs.has(objId)).toEqual(false);
+          expect(objs.has(objId)).toBeFalse();
           expect(commonObjs.has(objId)).toEqual(true);
 
           // Ensure that the image was copied in the main-thread (into
@@ -5531,13 +5531,13 @@ have written that much by now. So, here’s to squashing bugs.`);
           expect(objId).toEqual(`img_p${i - 1}_1`);
 
           expect(objs.has(objId)).toEqual(true);
-          expect(commonObjs.has(objId)).toEqual(false);
+          expect(commonObjs.has(objId)).toBeFalse();
         } else {
           expect(objId).toEqual(
             `g_${loadingTask.docId}_img_p${NUM_PAGES_THRESHOLD - 1}_1`
           );
 
-          expect(objs.has(objId)).toEqual(false);
+          expect(objs.has(objId)).toBeFalse();
           expect(commonObjs.has(objId)).toEqual(true);
         }
 
@@ -5571,7 +5571,7 @@ have written that much by now. So, here’s to squashing bugs.`);
         });
 
         await renderTask.promise;
-        expect(renderTask.separateAnnots).toEqual(false);
+        expect(renderTask.separateAnnots).toBeFalse();
 
         const printData = canvasAndCtx.canvas.toDataURL();
         canvasFactory.destroy(canvasAndCtx);
@@ -5682,7 +5682,7 @@ have written that much by now. So, here’s to squashing bugs.`);
         viewport,
       });
       await renderTask.promise;
-      expect(renderTask.separateAnnots).toEqual(false);
+      expect(renderTask.separateAnnots).toBeFalse();
 
       const data = canvasAndCtx.canvas.toDataURL();
       canvasFactory.destroy(canvasAndCtx);

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -143,7 +143,7 @@ describe("cmap", function () {
     expect(cmap.useCMap).not.toBeNull();
     expect(cmap.builtInCMap).toBeFalsy();
     expect(cmap.length).toEqual(0x20a7);
-    expect(cmap.isIdentityCMap).toEqual(false);
+    expect(cmap.isIdentityCMap).toBeFalse();
   });
 
   it("parses cmapname", async function () {
@@ -170,7 +170,7 @@ describe("cmap", function () {
     expect(cmap.useCMap).toBeNull();
     expect(cmap.builtInCMap).toBeTruthy();
     expect(cmap.length).toEqual(0x20a7);
-    expect(cmap.isIdentityCMap).toEqual(false);
+    expect(cmap.isIdentityCMap).toBeFalse();
   });
 
   it("loads built in identity cmap", async function () {
@@ -180,7 +180,7 @@ describe("cmap", function () {
       useCMap: null,
     });
     expect(cmap).toBeInstanceOf(IdentityCMap);
-    expect(cmap.vertical).toEqual(false);
+    expect(cmap.vertical).toBeFalse();
     expect(cmap.length).toEqual(0x10000);
     expect(function () {
       return cmap.isIdentityCMap;

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -225,9 +225,9 @@ describe("core_utils", function () {
     });
 
     it("handles non-space characters", function () {
-      expect(isWhiteSpace(0x0b)).toEqual(false);
-      expect(isWhiteSpace(null)).toEqual(false);
-      expect(isWhiteSpace(undefined)).toEqual(false);
+      expect(isWhiteSpace(0x0b)).toBeFalse();
+      expect(isWhiteSpace(null)).toBeFalse();
+      expect(isWhiteSpace(undefined)).toBeFalse();
     });
   });
 
@@ -333,40 +333,40 @@ describe("core_utils", function () {
         italicAngle: 0,
       };
 
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = `"blah blah \\" blah blah"`;
       expect(validateCSSFont(cssFontInfo)).toEqual(true);
 
       cssFontInfo.fontFamily = `'blah blah ' blah blah'`;
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = `'blah blah \\' blah blah'`;
       expect(validateCSSFont(cssFontInfo)).toEqual(true);
 
       cssFontInfo.fontFamily = `"blah blah `;
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = `blah blah"`;
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = `'blah blah `;
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = `blah blah'`;
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = "blah blah blah";
       expect(validateCSSFont(cssFontInfo)).toEqual(true);
 
       cssFontInfo.fontFamily = "blah 0blah blah";
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = "blah blah -0blah";
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = "blah blah --blah";
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
 
       cssFontInfo.fontFamily = "blah blah -blah";
       expect(validateCSSFont(cssFontInfo)).toEqual(true);
@@ -375,7 +375,7 @@ describe("core_utils", function () {
       expect(validateCSSFont(cssFontInfo)).toEqual(true);
 
       cssFontInfo.fontFamily = "blah fdqAJqjH$JK23kl23__--Kj blah";
-      expect(validateCSSFont(cssFontInfo)).toEqual(false);
+      expect(validateCSSFont(cssFontInfo)).toBeFalse();
     });
 
     it("Check font weight", function () {

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -217,20 +217,20 @@ describe("display_utils", function () {
 
   describe("isValidFetchUrl", function () {
     it("handles invalid Fetch URLs", function () {
-      expect(isValidFetchUrl(null)).toEqual(false);
-      expect(isValidFetchUrl(100)).toEqual(false);
-      expect(isValidFetchUrl("foo")).toEqual(false);
-      expect(isValidFetchUrl("/foo", 100)).toEqual(false);
+      expect(isValidFetchUrl(null)).toBeFalse();
+      expect(isValidFetchUrl(100)).toBeFalse();
+      expect(isValidFetchUrl("foo")).toBeFalse();
+      expect(isValidFetchUrl("/foo", 100)).toBeFalse();
     });
 
     it("handles relative Fetch URLs", function () {
-      expect(isValidFetchUrl("/foo", "file://www.example.com")).toEqual(false);
+      expect(isValidFetchUrl("/foo", "file://www.example.com")).toBeFalse();
       expect(isValidFetchUrl("/foo", "http://www.example.com")).toEqual(true);
     });
 
     it("handles unsupported Fetch protocols", function () {
-      expect(isValidFetchUrl("file://www.example.com")).toEqual(false);
-      expect(isValidFetchUrl("ftp://www.example.com")).toEqual(false);
+      expect(isValidFetchUrl("file://www.example.com")).toBeFalse();
+      expect(isValidFetchUrl("ftp://www.example.com")).toBeFalse();
     });
 
     it("handles supported Fetch protocols", function () {

--- a/test/unit/document_spec.js
+++ b/test/unit/document_spec.js
@@ -603,12 +603,12 @@ describe("document", function () {
 
       let pdfDocument = getDocument(acroForm);
       let hasJSActions = await pdfDocument.hasJSActions;
-      expect(hasJSActions).toEqual(false);
+      expect(hasJSActions).toBeFalse();
 
       acroForm.set("Fields", []);
       pdfDocument = getDocument(acroForm);
       hasJSActions = await pdfDocument.hasJSActions;
-      expect(hasJSActions).toEqual(false);
+      expect(hasJSActions).toBeFalse();
 
       const kid1Ref = Ref.get(314, 0);
       const kid11Ref = Ref.get(159, 0);
@@ -638,7 +638,7 @@ describe("document", function () {
       acroForm.set("Fields", [parentRef]);
       pdfDocument = getDocument(acroForm, xref);
       hasJSActions = await pdfDocument.hasJSActions;
-      expect(hasJSActions).toEqual(false);
+      expect(hasJSActions).toBeFalse();
 
       const JS = Name.get("JavaScript");
       const additionalActionsDict = new Dict();

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -194,7 +194,7 @@ describe("evaluator", function () {
       expect(result.argsArray[0].length).toEqual(1);
       expect(result.argsArray[0][0]).toEqual(true);
       expect(result.argsArray[1].length).toEqual(1);
-      expect(result.argsArray[1][0]).toEqual(false);
+      expect(result.argsArray[1][0]).toBeFalse();
       expect(result.argsArray[2]).toEqual([OPS.endPath, [null], null]);
     });
   });

--- a/test/unit/fetch_stream_spec.js
+++ b/test/unit/fetch_stream_spec.js
@@ -64,7 +64,7 @@ describe("fetch_stream", function () {
 
     expect(len).toEqual(pdfLength);
     expect(isStreamingSupported).toEqual(true);
-    expect(isRangeSupported).toEqual(false);
+    expect(isRangeSupported).toBeFalse();
   });
 
   it("read ranges with streaming", async function () {

--- a/test/unit/message_handler_spec.js
+++ b/test/unit/message_handler_spec.js
@@ -76,7 +76,7 @@ describe("message_handler", function () {
       let result = await reader.read();
       expect(log).toEqual("p");
       expect(result.value).toEqual("hi");
-      expect(result.done).toEqual(false);
+      expect(result.done).toBeFalse();
 
       await sleep(10);
       result = await reader.read();
@@ -135,7 +135,7 @@ describe("message_handler", function () {
 
       const result = await reader.read();
       expect(result.value).toEqual([1, 2, 3, 4]);
-      expect(result.done).toEqual(false);
+      expect(result.done).toBeFalse();
 
       await sleep(10);
       expect(log).toEqual("01p2");
@@ -185,7 +185,7 @@ describe("message_handler", function () {
 
       const result = await reader.read();
       expect(result.value).toEqual([1, 2, 3, 4]);
-      expect(result.done).toEqual(false);
+      expect(result.done).toBeFalse();
 
       try {
         await reader.read();
@@ -247,14 +247,14 @@ describe("message_handler", function () {
 
       let result = await reader.read();
       expect(result.value).toEqual([1, 2, 3, 4]);
-      expect(result.done).toEqual(false);
+      expect(result.done).toBeFalse();
 
       await sleep(10);
       expect(log).toEqual("01p2");
 
       result = await reader.read();
       expect(result.value).toEqual([5, 6, 7, 8]);
-      expect(result.done).toEqual(false);
+      expect(result.done).toBeFalse();
 
       await sleep(10);
       expect(log).toEqual("01p2p");
@@ -314,14 +314,14 @@ describe("message_handler", function () {
 
         let result = await reader.read();
         expect(result.value).toEqual([1, 2, 3, 4]);
-        expect(result.done).toEqual(false);
+        expect(result.done).toBeFalse();
 
         await sleep(10);
         expect(log).toEqual("012p");
 
         result = await reader.read();
         expect(result.value).toEqual([5, 6, 7, 8]);
-        expect(result.done).toEqual(false);
+        expect(result.done).toBeFalse();
 
         await sleep(10);
         expect(log).toEqual("012p");
@@ -375,7 +375,7 @@ describe("message_handler", function () {
 
       let result = await reader.read();
       expect(result.value).toEqual([1, 2, 3, 4]);
-      expect(result.done).toEqual(false);
+      expect(result.done).toBeFalse();
 
       await sleep(10);
       expect(log).toEqual("01");

--- a/test/unit/network_spec.js
+++ b/test/unit/network_spec.js
@@ -55,8 +55,8 @@ describe("network", function () {
 
     expect(len).toEqual(pdf1Length);
     expect(count).toEqual(1);
-    expect(isStreamingSupported).toEqual(false);
-    expect(isRangeSupported).toEqual(false);
+    expect(isStreamingSupported).toBeFalse();
+    expect(isRangeSupported).toBeFalse();
   });
 
   it("read custom ranges", async function () {
@@ -113,7 +113,7 @@ describe("network", function () {
 
     expect(result1.value).toEqual(rangeSize);
     expect(result2.value).toEqual(tailSize);
-    expect(isStreamingSupported).toEqual(false);
+    expect(isStreamingSupported).toBeFalse();
     expect(isRangeSupported).toEqual(true);
     expect(fullReaderCancelled).toEqual(true);
   });
@@ -157,7 +157,7 @@ describe("network", function () {
       } catch (ex) {
         expect(ex).toBeInstanceOf(ResponseException);
         expect(ex.status).toEqual(0);
-        expect(ex.missing).toEqual(false);
+        expect(ex.missing).toBeFalse();
       }
     }
 

--- a/test/unit/node_stream_spec.js
+++ b/test/unit/node_stream_spec.js
@@ -58,8 +58,8 @@ describe("node_stream", function () {
 
     await Promise.all([read(), promise]);
 
-    expect(isStreamingSupported).toEqual(false);
-    expect(isRangeSupported).toEqual(false);
+    expect(isStreamingSupported).toBeFalse();
+    expect(isRangeSupported).toBeFalse();
     expect(len).toEqual(pdfLength);
   });
 
@@ -113,7 +113,7 @@ describe("node_stream", function () {
 
     expect(result1.value).toEqual(rangeSize);
     expect(result2.value).toEqual(tailSize);
-    expect(isStreamingSupported).toEqual(false);
+    expect(isStreamingSupported).toBeFalse();
     expect(isRangeSupported).toEqual(true);
     expect(fullReaderCancelled).toEqual(true);
   });
@@ -150,8 +150,8 @@ describe("node_stream", function () {
 
     await Promise.all([read(), promise]);
 
-    expect(isStreamingSupported).toEqual(false);
-    expect(isRangeSupported).toEqual(false);
+    expect(isStreamingSupported).toBeFalse();
+    expect(isRangeSupported).toBeFalse();
     expect(len).toEqual(smallLength);
   });
 });

--- a/test/unit/obj_bin_transform_spec.js
+++ b/test/unit/obj_bin_transform_spec.js
@@ -112,7 +112,7 @@ describe("obj_bin_transform", function () {
           const buffer = compileSystemFontInfo(systemFontInfo);
           expect(buffer.byteLength).toEqual(sizeEstimate);
           const deserialized = new SystemFontInfo(buffer);
-          expect(deserialized.guessFallback).toEqual(false);
+          expect(deserialized.guessFallback).toBeFalse();
           expect(deserialized.css).toEqual("some string");
           expect(deserialized.loadedName).toEqual("another string");
           expect(deserialized.baseFontName).toEqual("base name");

--- a/test/unit/pdf_find_utils_spec.js
+++ b/test/unit/pdf_find_utils_spec.js
@@ -52,7 +52,7 @@ describe("pdf_find_utils", function () {
       ]) {
         const content = `${open}word${close}`;
         expect(isEntireWord(content, 1, 4)).toEqual(true); // "word"
-        expect(isEntireWord(content, 1, 3)).toEqual(false); // "wor"
+        expect(isEntireWord(content, 1, 3)).toBeFalse(); // "wor"
       }
     });
 
@@ -74,8 +74,8 @@ describe("pdf_find_utils", function () {
     });
 
     it("keeps a word joined by a connecting character", function () {
-      expect(isEntireWord("foo_bar", 0, 3)).toEqual(false); // "foo" in "foo_bar"
-      expect(isEntireWord("foo_bar", 4, 3)).toEqual(false); // "bar" in "foo_bar"
+      expect(isEntireWord("foo_bar", 0, 3)).toBeFalse(); // "foo" in "foo_bar"
+      expect(isEntireWord("foo_bar", 4, 3)).toBeFalse(); // "bar" in "foo_bar"
     });
 
     it("handles combining marks (NFD) within a word", function () {
@@ -83,25 +83,25 @@ describe("pdf_find_utils", function () {
       // U+0301 COMBINING ACUTE ACCENT.
       const content = "café".normalize("NFD");
       expect(isEntireWord(content, 0, content.length)).toEqual(true); // whole
-      expect(isEntireWord(content, 0, 3)).toEqual(false); // "caf"
-      expect(isEntireWord(content, 0, 4)).toEqual(false); // "cafe", before U+0301
+      expect(isEntireWord(content, 0, 3)).toBeFalse(); // "caf"
+      expect(isEntireWord(content, 0, 4)).toBeFalse(); // "cafe", before U+0301
     });
 
     it("keeps a base character and its combining mark together", function () {
       // "áb" in NFD is "a" + U+0301 + "b"; it's a single word.
       const ab = "áb".normalize("NFD");
-      expect(isEntireWord(ab, 2, 1)).toEqual(false); // "b" inside "áb"
-      expect(isEntireWord(ab, 0, 2)).toEqual(false); // "á" inside "áb"
+      expect(isEntireWord(ab, 2, 1)).toBeFalse(); // "b" inside "áb"
+      expect(isEntireWord(ab, 0, 2)).toBeFalse(); // "á" inside "áb"
       // "café" is a whole word before a space, but not inside "caféteria".
       expect(isEntireWord("café bar".normalize("NFD"), 0, 5)).toEqual(true);
-      expect(isEntireWord("caféteria".normalize("NFD"), 0, 5)).toEqual(false);
+      expect(isEntireWord("caféteria".normalize("NFD"), 0, 5)).toBeFalse();
     });
 
     it("keeps non-BMP characters intact", function () {
       // "a𝐀b" is a single word (𝐀 = U+1D400, a surrogate pair).
       const withBoldA = "a\u{1D400}b";
-      expect(isEntireWord(withBoldA, 0, 1)).toEqual(false); // "a"
-      expect(isEntireWord(withBoldA, 3, 1)).toEqual(false); // "b"
+      expect(isEntireWord(withBoldA, 0, 1)).toBeFalse(); // "a"
+      expect(isEntireWord(withBoldA, 3, 1)).toBeFalse(); // "b"
       // Each CJK ideograph is its own word (𠀀 = U+20000, a surrogate pair).
       expect(isEntireWord("中\u{20000}国", 0, 1)).toEqual(true); // "中"
     });

--- a/test/unit/pdf_history_spec.js
+++ b/test/unit/pdf_history_spec.js
@@ -18,9 +18,9 @@ import { isDestArraysEqual, isDestHashesEqual } from "../../web/pdf_history.js";
 describe("pdf_history", function () {
   describe("isDestHashesEqual", function () {
     it("should reject non-equal destination hashes", function () {
-      expect(isDestHashesEqual(null, "page.157")).toEqual(false);
-      expect(isDestHashesEqual("title.0", "page.157")).toEqual(false);
-      expect(isDestHashesEqual("page=1&zoom=auto", "page.157")).toEqual(false);
+      expect(isDestHashesEqual(null, "page.157")).toBeFalse();
+      expect(isDestHashesEqual("title.0", "page.157")).toBeFalse();
+      expect(isDestHashesEqual("page=1&zoom=auto", "page.157")).toBeFalse();
 
       expect(isDestHashesEqual("nameddest-page.157", "page.157")).toEqual(
         false
@@ -36,8 +36,8 @@ describe("pdf_history", function () {
         748.972,
         null,
       ]);
-      expect(isDestHashesEqual(destArrayString, "page.157")).toEqual(false);
-      expect(isDestHashesEqual("page.157", destArrayString)).toEqual(false);
+      expect(isDestHashesEqual(destArrayString, "page.157")).toBeFalse();
+      expect(isDestHashesEqual("page.157", destArrayString)).toBeFalse();
     });
 
     it("should accept equal destination hashes", function () {
@@ -58,12 +58,12 @@ describe("pdf_history", function () {
     const fifthDest = [{ gen: 0, num: 1 }, { name: "XYZ" }, 0, 375, null];
 
     it("should reject non-equal destination arrays", function () {
-      expect(isDestArraysEqual(firstDest, undefined)).toEqual(false);
-      expect(isDestArraysEqual(firstDest, [1, 2, 3, 4, 5])).toEqual(false);
+      expect(isDestArraysEqual(firstDest, undefined)).toBeFalse();
+      expect(isDestArraysEqual(firstDest, [1, 2, 3, 4, 5])).toBeFalse();
 
-      expect(isDestArraysEqual(firstDest, secondDest)).toEqual(false);
-      expect(isDestArraysEqual(firstDest, thirdDest)).toEqual(false);
-      expect(isDestArraysEqual(firstDest, fourthDest)).toEqual(false);
+      expect(isDestArraysEqual(firstDest, secondDest)).toBeFalse();
+      expect(isDestArraysEqual(firstDest, thirdDest)).toBeFalse();
+      expect(isDestArraysEqual(firstDest, fourthDest)).toBeFalse();
     });
 
     it("should accept equal destination arrays", function () {

--- a/test/unit/pdf_viewer_spec.js
+++ b/test/unit/pdf_viewer_spec.js
@@ -156,7 +156,7 @@ describe("PDFViewer", function () {
         buffer.push(view);
       }
       expect(buffer.has(viewsMap.get(1))).toEqual(true);
-      expect(buffer.has(viewsMap.get(2))).toEqual(false);
+      expect(buffer.has(viewsMap.get(2))).toBeFalse();
     });
   });
 });

--- a/test/unit/postscript_spec.js
+++ b/test/unit/postscript_spec.js
@@ -1191,7 +1191,7 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
       expect(out[0]).toBeInstanceOf(PsConstNode);
       expect(out[0].value).toBe(true);
       expect(out[1]).toBeInstanceOf(PsConstNode);
-      expect(out[1].value).toBe(false);
+      expect(out[1].value).toBeFalse();
     });
 
     it("copy duplicates the top n nodes", function () {
@@ -1416,7 +1416,7 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
     it("x and false → false", function () {
       const out = toTree("{ false and }", 1);
       expect(out[0]).toBeInstanceOf(PsConstNode);
-      expect(out[0].value).toBe(false);
+      expect(out[0].value).toBeFalse();
     });
 
     it("x or false → x", function () {
@@ -1520,7 +1520,7 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
     it("x ne x → false (reflexive ne)", function () {
       const out = toTree("{ dup ne }", 1);
       expect(out[0]).toBeInstanceOf(PsConstNode);
-      expect(out[0].value).toBe(false);
+      expect(out[0].value).toBeFalse();
     });
 
     it("_nodesEqual handles structurally-equal unary nodes", function () {
@@ -1615,7 +1615,7 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
     it("false and x → false (second=false and)", function () {
       const out = toTree("{ false exch and }", 1);
       expect(out[0]).toBeInstanceOf(PsConstNode);
-      expect(out[0].value).toBe(false);
+      expect(out[0].value).toBeFalse();
     });
 
     it("false or x → x (second=false or)", function () {
@@ -1821,7 +1821,7 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
     });
 
     it("constant-folds boolean and, or, xor and bitshift", function () {
-      expect(toTree("{ true false and }", 0)[0].value).toBe(false);
+      expect(toTree("{ true false and }", 0)[0].value).toBeFalse();
       expect(toTree("{ false true or }", 0)[0].value).toBe(true);
       expect(toTree("{ true false xor }", 0)[0].value).toBe(true);
       expect(toTree("{ 4 2 bitshift }", 0)[0].value).toBe(16); // 4 << 2

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -581,7 +581,7 @@ describe("primitives", function () {
 
     it("handles non-names", function () {
       const nonName = {};
-      expect(isName(nonName)).toEqual(false);
+      expect(isName(nonName)).toBeFalse();
     });
 
     it("handles names", function () {
@@ -592,7 +592,7 @@ describe("primitives", function () {
     it("handles names with name check", function () {
       const name = Name.get("Font");
       expect(isName(name, "Font")).toEqual(true);
-      expect(isName(name, "Subtype")).toEqual(false);
+      expect(isName(name, "Subtype")).toBeFalse();
     });
 
     it("handles *empty* names, with name check", function () {
@@ -600,7 +600,7 @@ describe("primitives", function () {
 
       expect(isName(emptyName)).toEqual(true);
       expect(isName(emptyName, "")).toEqual(true);
-      expect(isName(emptyName, "string")).toEqual(false);
+      expect(isName(emptyName, "string")).toBeFalse();
     });
 
     /* eslint-enable no-restricted-syntax */
@@ -611,7 +611,7 @@ describe("primitives", function () {
 
     it("handles non-commands", function () {
       const nonCmd = {};
-      expect(isCmd(nonCmd)).toEqual(false);
+      expect(isCmd(nonCmd)).toBeFalse();
     });
 
     it("handles commands", function () {
@@ -622,7 +622,7 @@ describe("primitives", function () {
     it("handles commands with cmd check", function () {
       const cmd = Cmd.get("BT");
       expect(isCmd(cmd, "BT")).toEqual(true);
-      expect(isCmd(cmd, "ET")).toEqual(false);
+      expect(isCmd(cmd, "ET")).toBeFalse();
     });
 
     /* eslint-enable no-restricted-syntax */
@@ -633,20 +633,20 @@ describe("primitives", function () {
 
     it("handles non-dictionaries", function () {
       const nonDict = {};
-      expect(isDict(nonDict)).toEqual(false);
+      expect(isDict(nonDict)).toBeFalse();
     });
 
     it("handles empty dictionaries with type check", function () {
       const dict = Dict.empty;
       expect(isDict(dict)).toEqual(true);
-      expect(isDict(dict, "Page")).toEqual(false);
+      expect(isDict(dict, "Page")).toBeFalse();
     });
 
     it("handles dictionaries with type check", function () {
       const dict = new Dict();
       dict.set("Type", Name.get("Page"));
       expect(isDict(dict, "Page")).toEqual(true);
-      expect(isDict(dict, "Contents")).toEqual(false);
+      expect(isDict(dict, "Contents")).toBeFalse();
     });
 
     /* eslint-enable no-restricted-syntax */
@@ -662,7 +662,7 @@ describe("primitives", function () {
     it("should handle Refs pointing to different objects", function () {
       const ref1 = Ref.get(1, 0);
       const ref2 = Ref.get(2, 0);
-      expect(isRefsEqual(ref1, ref2)).toEqual(false);
+      expect(isRefsEqual(ref1, ref2)).toBeFalse();
     });
   });
 });

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -464,7 +464,7 @@ describe("Scripting", function () {
         name: "test",
         willCommit: true,
       });
-      expect(send_queue.has(refId)).toEqual(false);
+      expect(send_queue.has(refId)).toBeFalse();
     });
 
     it("should trigger a valid commit Keystroke event", async () => {
@@ -660,7 +660,7 @@ describe("Scripting", function () {
         name: "Keystroke",
         willCommit: true,
       });
-      expect(send_queue.has("alert")).toEqual(false);
+      expect(send_queue.has("alert")).toBeFalse();
       send_queue.delete(refId);
     });
   });
@@ -2006,13 +2006,13 @@ describe("Scripting", function () {
     describe("eMailValidate", function () {
       it("should validate an e-mail address", async () => {
         let value = await myeval(`eMailValidate(123)`);
-        expect(value).toEqual(false);
+        expect(value).toBeFalse();
 
         value = await myeval(`eMailValidate("foo@bar.com")`);
         expect(value).toEqual(true);
 
         value = await myeval(`eMailValidate("foo bar")`);
-        expect(value).toEqual(false);
+        expect(value).toBeFalse();
       });
     });
 

--- a/test/unit/string_utils_spec.js
+++ b/test/unit/string_utils_spec.js
@@ -24,14 +24,14 @@ describe("string_utils", function () {
   describe("isAscii", function () {
     it("handles ascii/non-ascii strings", function () {
       expect(isAscii("hello world")).toEqual(true);
-      expect(isAscii("こんにちは世界の")).toEqual(false);
+      expect(isAscii("こんにちは世界の")).toBeFalse();
       expect(isAscii("hello world in Japanese is こんにちは世界の")).toEqual(
         false
       );
       expect(isAscii("")).toEqual(true);
-      expect(isAscii(123)).toEqual(false);
-      expect(isAscii(null)).toEqual(false);
-      expect(isAscii(undefined)).toEqual(false);
+      expect(isAscii(123)).toBeFalse();
+      expect(isAscii(null)).toBeFalse();
+      expect(isAscii(undefined)).toBeFalse();
     });
   });
 

--- a/test/unit/ui_utils_spec.js
+++ b/test/unit/ui_utils_spec.js
@@ -61,17 +61,17 @@ describe("ui_utils", function () {
 
   describe("isValidRotation", function () {
     it("should reject non-integer angles", function () {
-      expect(isValidRotation()).toEqual(false);
-      expect(isValidRotation(null)).toEqual(false);
-      expect(isValidRotation(NaN)).toEqual(false);
-      expect(isValidRotation([90])).toEqual(false);
-      expect(isValidRotation("90")).toEqual(false);
-      expect(isValidRotation(90.5)).toEqual(false);
+      expect(isValidRotation()).toBeFalse();
+      expect(isValidRotation(null)).toBeFalse();
+      expect(isValidRotation(NaN)).toBeFalse();
+      expect(isValidRotation([90])).toBeFalse();
+      expect(isValidRotation("90")).toBeFalse();
+      expect(isValidRotation(90.5)).toBeFalse();
     });
 
     it("should reject non-multiple of 90 degree angles", function () {
-      expect(isValidRotation(45)).toEqual(false);
-      expect(isValidRotation(-123)).toEqual(false);
+      expect(isValidRotation(45)).toBeFalse();
+      expect(isValidRotation(-123)).toBeFalse();
     });
 
     it("should accept valid angles", function () {
@@ -105,7 +105,7 @@ describe("ui_utils", function () {
           width: 600,
           height: 300,
         })
-      ).toEqual(false);
+      ).toBeFalse();
     });
   });
 

--- a/test/unit/xfa_tohtml_spec.js
+++ b/test/unit/xfa_tohtml_spec.js
@@ -646,7 +646,7 @@ describe("XFAFactory", function () {
 
     a = searchHtmlNode(pages, "name", "a", false, [1]);
     expect(a.attributes.href).toEqual("https://github.com/allizom/pdf.js");
-    expect(a.attributes.newWindow).toEqual(false);
+    expect(a.attributes.newWindow).toBeFalse();
   });
 
   it("should take the absolute value of the font size", async () => {


### PR DESCRIPTION
This replaces all `toEqual(false)` and `toBe(false)` occurrences.