### PR TITLE
Use the `toThrowError()` matcher consistently in the unit tests

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1252,11 +1252,9 @@ describe("api", function () {
 
         expect(function () {
           getDocument(tracemonkeyGetDocumentParams);
-        }).toThrow(
-          new Error(
-            "PDFWorker.create - the worker is being destroyed.\n" +
-              "Please remember to await `PDFDocumentLoadingTask.destroy()`-calls."
-          )
+        }).toThrowError(
+          "PDFWorker.create - the worker is being destroyed.\n" +
+            "Please remember to await `PDFDocumentLoadingTask.destroy()`-calls."
         );
 
         await destroyPromise;
@@ -3927,10 +3925,8 @@ describe("api", function () {
     it("gets viewport with invalid rotation", function () {
       expect(function () {
         page.getViewport({ scale: 1, rotation: 45 });
-      }).toThrow(
-        new Error(
-          "PageViewport: Invalid rotation, must be a multiple of 90 degrees."
-        )
+      }).toThrowError(
+        "PageViewport: Invalid rotation, must be a multiple of 90 degrees."
       );
     });
 

--- a/test/unit/canvas_factory_spec.js
+++ b/test/unit/canvas_factory_spec.js
@@ -32,12 +32,12 @@ describe("canvas_factory", function () {
       // Invalid width.
       expect(function () {
         return canvasFactory.create(-1, 1);
-      }).toThrow(new Error("Invalid canvas size"));
+      }).toThrowError("Invalid canvas size");
 
       // Invalid height.
       expect(function () {
         return canvasFactory.create(1, -1);
-      }).toThrow(new Error("Invalid canvas size"));
+      }).toThrowError("Invalid canvas size");
     });
 
     it("`create` should return a canvas if the dimensions are valid", function () {
@@ -57,7 +57,7 @@ describe("canvas_factory", function () {
 
       expect(function () {
         return canvasFactory.reset(canvasAndContext, 20, 40);
-      }).toThrow(new Error("Canvas is not specified"));
+      }).toThrowError("Canvas is not specified");
     });
 
     it("`reset` should throw an error if the dimensions are invalid", function () {
@@ -66,12 +66,12 @@ describe("canvas_factory", function () {
       // Invalid width.
       expect(function () {
         return canvasFactory.reset(canvasAndContext, -1, 1);
-      }).toThrow(new Error("Invalid canvas size"));
+      }).toThrowError("Invalid canvas size");
 
       // Invalid height.
       expect(function () {
         return canvasFactory.reset(canvasAndContext, 1, -1);
-      }).toThrow(new Error("Invalid canvas size"));
+      }).toThrowError("Invalid canvas size");
     });
 
     it("`reset` should alter the canvas/context if the dimensions are valid", function () {
@@ -92,7 +92,7 @@ describe("canvas_factory", function () {
     it("`destroy` should throw an error if no canvas is provided", function () {
       expect(function () {
         return canvasFactory.destroy({});
-      }).toThrow(new Error("Canvas is not specified"));
+      }).toThrowError("Canvas is not specified");
     });
 
     it("`destroy` should clear the canvas/context", function () {

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -184,7 +184,7 @@ describe("cmap", function () {
     expect(cmap.length).toEqual(0x10000);
     expect(function () {
       return cmap.isIdentityCMap;
-    }).toThrow(new Error("should not access .isIdentityCMap"));
+    }).toThrowError("should not access .isIdentityCMap");
   });
 
   it("attempts to load a non-existent built-in CMap", async function () {

--- a/test/unit/core_utils_spec.js
+++ b/test/unit/core_utils_spec.js
@@ -170,7 +170,7 @@ describe("core_utils", function () {
       for (const input of ["foo", -1, 0]) {
         expect(function () {
           toRomanNumerals(input);
-        }).toThrow(new Error("The number should be a positive integer."));
+        }).toThrowError("The number should be a positive integer.");
       }
     });
 
@@ -575,8 +575,8 @@ describe("core_utils", function () {
     });
 
     it("throws an exception for invalid rotation values", function () {
-      expect(() => getRotationMatrix(42, 10, 20)).toThrow(
-        new Error("Invalid rotation")
+      expect(() => getRotationMatrix(42, 10, 20)).toThrowError(
+        "Invalid rotation"
       );
     });
   });

--- a/test/unit/murmurhash3_spec.js
+++ b/test/unit/murmurhash3_spec.js
@@ -45,8 +45,8 @@ describe("MurmurHash3_64", function () {
   });
   it("throws an exception for unsupported input types", function () {
     const hash = new MurmurHash3_64();
-    expect(() => hash.update(42)).toThrow(
-      new Error("Invalid data format, must be a string or TypedArray.")
+    expect(() => hash.update(42)).toThrowError(
+      "Invalid data format, must be a string or TypedArray."
     );
   });
 

--- a/test/unit/name_number_tree_spec.js
+++ b/test/unit/name_number_tree_spec.js
@@ -15,6 +15,7 @@
 
 import { Dict, Ref } from "../../src/core/primitives.js";
 import { NameTree, NumberTree } from "../../src/core/name_number_tree.js";
+import { FormatError } from "../../src/shared/util.js";
 import { XRefMock } from "./test_utils.js";
 
 describe("NameOrNumberTree", function () {
@@ -86,8 +87,9 @@ describe("NameOrNumberTree", function () {
       const xref = new XRefMock([{ ref: leafRef, data: leaf }]);
       const tree = new NameTree(root, xref);
 
-      expect(() => tree.getAll()).toThrow(
-        new Error('Duplicate entry in "Names" tree.')
+      expect(() => tree.getAll()).toThrowError(
+        FormatError,
+        'Duplicate entry in "Names" tree.'
       );
     });
 
@@ -162,8 +164,9 @@ describe("NameOrNumberTree", function () {
       const xref = new XRefMock([{ ref: leafRef, data: leaf }]);
       const tree = new NumberTree(root, xref);
 
-      expect(() => tree.getAll()).toThrow(
-        new Error('Duplicate entry in "Nums" tree.')
+      expect(() => tree.getAll()).toThrowError(
+        FormatError,
+        'Duplicate entry in "Nums" tree.'
       );
     });
   });

--- a/test/unit/network_utils_spec.js
+++ b/test/unit/network_utils_spec.js
@@ -64,15 +64,11 @@ describe("network_utils", function () {
     it("rejects invalid rangeChunkSize", function () {
       expect(function () {
         validateRangeRequestCapabilities({ rangeChunkSize: "abc" });
-      }).toThrow(
-        new Error("rangeChunkSize must be an integer larger than zero.")
-      );
+      }).toThrowError("rangeChunkSize must be an integer larger than zero.");
 
       expect(function () {
         validateRangeRequestCapabilities({ rangeChunkSize: 0 });
-      }).toThrow(
-        new Error("rangeChunkSize must be an integer larger than zero.")
-      );
+      }).toThrowError("rangeChunkSize must be an integer larger than zero.");
     });
 
     it("rejects disabled or non-HTTP range requests", function () {

--- a/test/unit/parser_spec.js
+++ b/test/unit/parser_spec.js
@@ -332,11 +332,8 @@ describe("parser", function () {
       );
         expect(function () {
           return Linearization.create(stream1);
-        }).toThrow(
-          new Error(
-            'The "L" parameter in the linearization ' +
-              "dictionary does not equal the stream length."
-          )
+        }).toThrowError(
+          'The "L" parameter in the linearization dictionary does not equal the stream length.'
         );
 
         // The /E parameter should not be zero.
@@ -356,10 +353,8 @@ describe("parser", function () {
       );
         expect(function () {
           return Linearization.create(stream2);
-        }).toThrow(
-          new Error(
-            'The "E" parameter in the linearization dictionary is invalid.'
-          )
+        }).toThrowError(
+          'The "E" parameter in the linearization dictionary is invalid.'
         );
 
         // The /O parameter should be an integer.
@@ -379,10 +374,8 @@ describe("parser", function () {
       );
         expect(function () {
           return Linearization.create(stream3);
-        }).toThrow(
-          new Error(
-            'The "O" parameter in the linearization dictionary is invalid.'
-          )
+        }).toThrowError(
+          'The "O" parameter in the linearization dictionary is invalid.'
         );
       }
     );
@@ -405,9 +398,7 @@ describe("parser", function () {
       );
       expect(function () {
         return Linearization.create(stream1);
-      }).toThrow(
-        new Error("Hint array in the linearization dictionary is invalid.")
-      );
+      }).toThrowError("Hint array in the linearization dictionary is invalid.");
 
       // The hint array should contain two, or four, elements.
       // prettier-ignore
@@ -426,9 +417,7 @@ describe("parser", function () {
       );
       expect(function () {
         return Linearization.create(stream2);
-      }).toThrow(
-        new Error("Hint array in the linearization dictionary is invalid.")
-      );
+      }).toThrowError("Hint array in the linearization dictionary is invalid.");
 
       // The hint array should not contain zero.
       // prettier-ignore
@@ -447,9 +436,7 @@ describe("parser", function () {
       );
       expect(function () {
         return Linearization.create(stream3);
-      }).toThrow(
-        new Error("Hint (2) in the linearization dictionary is invalid.")
-      );
+      }).toThrowError("Hint (2) in the linearization dictionary is invalid.");
     });
   });
 });

--- a/test/unit/postscript_spec.js
+++ b/test/unit/postscript_spec.js
@@ -36,6 +36,7 @@ import {
   PsUnaryNode,
 } from "../../src/core/postscript/ast.js";
 import { buildPostScriptJsFunction } from "../../src/core/postscript/js_evaluator.js";
+import { FormatError } from "../../src/shared/util.js";
 
 // Precision argument for toBeCloseTo() in trigonometric tests.
 const TRIGONOMETRY_EPS = 1e-10;
@@ -171,7 +172,10 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
 
     it("throws on standalone if without preceding block", function () {
       const parser = new Parser(new Lexer("{ 1 if }"));
-      expect(() => parser.parse()).toThrow();
+      expect(() => parser.parse()).toThrowError(
+        FormatError,
+        "PostScript function: unexpected 'if' operator."
+      );
     });
 
     it("ignores content after closing brace (warns, does not throw)", function () {
@@ -180,11 +184,17 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
     });
 
     it("throws when first token is not a left brace", function () {
-      expect(() => parsePostScriptFunction("add }")).toThrow();
+      expect(() => parsePostScriptFunction("add }")).toThrowError(
+        FormatError,
+        "PostScript function: expected token id 1, got 5."
+      );
     });
 
     it("throws when a procedure block is not followed by if or ifelse", function () {
-      expect(() => parsePostScriptFunction("{ { 1 } add }")).toThrow();
+      expect(() => parsePostScriptFunction("{ { 1 } add }")).toThrowError(
+        FormatError,
+        "PostScript function: a procedure block must be followed by 'if' or '{…} ifelse'."
+      );
     });
   });
 

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -59,7 +59,7 @@ describe("primitives", function () {
     it("should not accept to create a non-string name", function () {
       expect(function () {
         Name.get(123);
-      }).toThrow(new Error('Name: The "name" must be a string.'));
+      }).toThrowError('Name: The "name" must be a string.');
     });
   });
 
@@ -84,7 +84,7 @@ describe("primitives", function () {
     it("should not accept to create a non-string cmd", function () {
       expect(function () {
         Cmd.get(123);
-      }).toThrow(new Error('Cmd: The "cmd" must be a string.'));
+      }).toThrowError('Cmd: The "cmd" must be a string.');
     });
   });
 
@@ -165,7 +165,7 @@ describe("primitives", function () {
       const dict = new Dict();
       expect(function () {
         dict.set(123, "val");
-      }).toThrow(new Error('Dict.set: The "key" must be a string.'));
+      }).toThrowError('Dict.set: The "key" must be a string.');
 
       expect(dict.has(123)).toBeFalsy();
 
@@ -176,7 +176,7 @@ describe("primitives", function () {
       const dict = new Dict();
       expect(function () {
         dict.set("Size");
-      }).toThrow(new Error('Dict.set: The "value" cannot be undefined.'));
+      }).toThrowError('Dict.set: The "value" cannot be undefined.');
 
       expect(dict.has("Size")).toBeFalsy();
 

--- a/test/unit/svg_factory_spec.js
+++ b/test/unit/svg_factory_spec.js
@@ -32,12 +32,12 @@ describe("svg_factory", function () {
       // Invalid width.
       expect(function () {
         return svgFactory.create(-1, 0);
-      }).toThrow(new Error("Invalid SVG dimensions"));
+      }).toThrowError("Invalid SVG dimensions");
 
       // Invalid height.
       expect(function () {
         return svgFactory.create(0, -1);
-      }).toThrow(new Error("Invalid SVG dimensions"));
+      }).toThrowError("Invalid SVG dimensions");
     });
 
     it("`create` should return an SVG element if the dimensions are valid", function () {
@@ -57,7 +57,7 @@ describe("svg_factory", function () {
     it("`createElement` should throw an error if the type is not a string", function () {
       expect(function () {
         return svgFactory.createElement(true);
-      }).toThrow(new Error("Invalid SVG element type"));
+      }).toThrowError("Invalid SVG element type");
     });
 
     it("`createElement` should return an SVG element if the type is valid", function () {

--- a/test/unit/util_spec.js
+++ b/test/unit/util_spec.js
@@ -44,7 +44,7 @@ describe("util", function () {
     it("handles non-array arguments", function () {
       expect(function () {
         bytesToString(null);
-      }).toThrow(new Error("Invalid argument for bytesToString"));
+      }).toThrowError("Invalid argument for bytesToString");
     });
 
     it("handles array arguments with a length not exceeding the maximum", function () {
@@ -72,7 +72,7 @@ describe("util", function () {
     it("handles non-string arguments", function () {
       expect(function () {
         stringToBytes(null);
-      }).toThrow(new Error("Invalid argument for stringToBytes"));
+      }).toThrowError("Invalid argument for stringToBytes");
     });
 
     it("handles string arguments", function () {

--- a/test/unit/xfa_formcalc_spec.js
+++ b/test/unit/xfa_formcalc_spec.js
@@ -301,13 +301,13 @@ describe("FormCalc expression parser", function () {
 
     it("should parse var declaration with error", function () {
       let parser = new Parser("var 123 = a");
-      expect(() => parser.parse()).toThrow(new Error(Errors.var));
+      expect(() => parser.parse()).toThrowError(Errors.var);
 
       parser = new Parser(`var "123" = a`);
-      expect(() => parser.parse()).toThrow(new Error(Errors.var));
+      expect(() => parser.parse()).toThrowError(Errors.var);
 
       parser = new Parser(`var for var a`);
-      expect(() => parser.parse()).toThrow(new Error(Errors.var));
+      expect(() => parser.parse()).toThrowError(Errors.var);
     });
 
     it("should parse for declaration with a step", function () {
@@ -382,27 +382,27 @@ endfor`);
 
     it("should parse for declaration with error", function () {
       let parser = new Parser("for 123 = i upto 1 do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.assignment));
+      expect(() => parser.parse()).toThrowError(Errors.assignment);
 
       parser = new Parser("for var 123 = i upto 1 do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.assignment));
+      expect(() => parser.parse()).toThrowError(Errors.assignment);
 
       parser = new Parser("for var i = 123 upt 1 do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.for));
+      expect(() => parser.parse()).toThrowError(Errors.for);
 
       parser = new Parser("for var i = 123 var 1 do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.for));
+      expect(() => parser.parse()).toThrowError(Errors.for);
 
       parser = new Parser(
         "for var i = 123 upto 1 step for var j = 1 do endfor do a = 1 endfor"
       );
-      expect(() => parser.parse()).toThrow(new Error(Errors.for));
+      expect(() => parser.parse()).toThrowError(Errors.for);
 
       parser = new Parser("for var i = 123 downto 1 do a = 1 endfunc");
-      expect(() => parser.parse()).toThrow(new Error(Errors.for));
+      expect(() => parser.parse()).toThrowError(Errors.for);
 
       parser = new Parser("for var i = 123 downto 1 do a = 1");
-      expect(() => parser.parse()).toThrow(new Error(Errors.for));
+      expect(() => parser.parse()).toThrowError(Errors.for);
     });
 
     it("should parse foreach declaration", function () {
@@ -433,25 +433,25 @@ endfor`);
 
     it("should parse foreach declaration with error", function () {
       let parser = new Parser("foreach 123 in (1, 2, 3) do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.foreach));
+      expect(() => parser.parse()).toThrowError(Errors.foreach);
 
       parser = new Parser("foreach foo in 1, 2, 3) do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.foreach));
+      expect(() => parser.parse()).toThrowError(Errors.foreach);
 
       parser = new Parser("foreach foo in (1, 2, 3 do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.params));
+      expect(() => parser.parse()).toThrowError(Errors.params);
 
       parser = new Parser("foreach foo in (1, 2 3) do a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.params));
+      expect(() => parser.parse()).toThrowError(Errors.params);
 
       parser = new Parser("foreach foo in (1, 2, 3) od a = 1 endfor");
-      expect(() => parser.parse()).toThrow(new Error(Errors.foreach));
+      expect(() => parser.parse()).toThrowError(Errors.foreach);
 
       parser = new Parser("foreach foo in (1, 2, 3) do a = 1 endforeach");
-      expect(() => parser.parse()).toThrow(new Error(Errors.foreach));
+      expect(() => parser.parse()).toThrowError(Errors.foreach);
 
       parser = new Parser("foreach foo in (1, 2, 3) do a = 1  123");
-      expect(() => parser.parse()).toThrow(new Error(Errors.foreach));
+      expect(() => parser.parse()).toThrowError(Errors.foreach);
     });
 
     it("should parse while declaration", function () {
@@ -483,16 +483,16 @@ endwhile
 
     it("should parse while declaration with error", function () {
       let parser = new Parser("while a == 1 do a = 2 endwhile");
-      expect(() => parser.parse()).toThrow(new Error(Errors.while));
+      expect(() => parser.parse()).toThrowError(Errors.while);
 
       parser = new Parser("while (a == 1 do a = 2 endwhile");
-      expect(() => parser.parse()).toThrow(new Error(Errors.while));
+      expect(() => parser.parse()).toThrowError(Errors.while);
 
       parser = new Parser("while (a == 1) var a = 2 endwhile");
-      expect(() => parser.parse()).toThrow(new Error(Errors.while));
+      expect(() => parser.parse()).toThrowError(Errors.while);
 
       parser = new Parser("while (a == 1) do var a = 2 end");
-      expect(() => parser.parse()).toThrow(new Error(Errors.while));
+      expect(() => parser.parse()).toThrowError(Errors.while);
     });
 
     it("should parse do declaration", function () {
@@ -527,7 +527,7 @@ do
   y = 2
 endfunc
       `);
-      expect(() => parser.parse()).toThrow(new Error(Errors.block));
+      expect(() => parser.parse()).toThrowError(Errors.block);
     });
 
     it("should parse func declaration", function () {
@@ -553,19 +553,19 @@ endfunc
 
     it("should parse func declaration with error", function () {
       let parser = new Parser("func 123(a, b) do a = 1 endfunc");
-      expect(() => parser.parse()).toThrow(new Error(Errors.func));
+      expect(() => parser.parse()).toThrowError(Errors.func);
 
       parser = new Parser("func foo(a, b) for a = 1 endfunc");
-      expect(() => parser.parse()).toThrow(new Error(Errors.func));
+      expect(() => parser.parse()).toThrowError(Errors.func);
 
       parser = new Parser("func foo(a, b) do a = 1 endfun");
-      expect(() => parser.parse()).toThrow(new Error(Errors.func));
+      expect(() => parser.parse()).toThrowError(Errors.func);
 
       parser = new Parser("func foo(a, b, c do a = 1 endfunc");
-      expect(() => parser.parse()).toThrow(new Error(Errors.func));
+      expect(() => parser.parse()).toThrowError(Errors.func);
 
       parser = new Parser("func foo(a, b, 123) do a = 1 endfunc");
-      expect(() => parser.parse()).toThrow(new Error(Errors.func));
+      expect(() => parser.parse()).toThrowError(Errors.func);
     });
 
     it("should parse if declaration", function () {
@@ -714,20 +714,20 @@ endfunc
 
     it("should parse if declaration with error", function () {
       let parser = new Parser("if foo == 1 then a = 1 endif");
-      expect(() => parser.parse()).toThrow(new Error(Errors.if));
+      expect(() => parser.parse()).toThrowError(Errors.if);
 
       parser = new Parser("if (foo == 1 then a = 1 endif");
-      expect(() => parser.parse()).toThrow(new Error(Errors.if));
+      expect(() => parser.parse()).toThrowError(Errors.if);
 
       parser = new Parser(
         "if (foo == 1) then a = 1 elseiff (foo == 2) then a = 2 endif"
       );
-      expect(() => parser.parse()).toThrow(new Error(Errors.if));
+      expect(() => parser.parse()).toThrowError(Errors.if);
 
       parser = new Parser(
         "if (foo == 1) then a = 1 elseif (foo == 2) then a = 2 end"
       );
-      expect(() => parser.parse()).toThrow(new Error(Errors.if));
+      expect(() => parser.parse()).toThrowError(Errors.if);
     });
 
     it("should parse som predicate", () => {


### PR DESCRIPTION
Currently we mostly use `toThrow()`, which seems intended for things that throw non-Errors (something that we "forbid" with ESLint).
Hence `toThrowError()` seems more appropriate, and it also simplifies things slightly; see https://jasmine.github.io/api/edge/matchers.html#toThrowError