### PR TITLE
Change `defaultOptions`, in the `web/app_options.js` file, to a Map

### DIFF
--- a/web/app_options.js
+++ b/web/app_options.js
@@ -58,579 +58,882 @@ const Type = {
  *       see `OptionKind.PREFERENCE`, hence the values below must use only
  *       primitive types and cannot rely on any imported types.
  */
-const defaultOptions = {
-  allowedGlobalEvents: {
-    /** @type {Object} */
-    value: null,
-    kind: OptionKind.BROWSER,
-  },
-  canvasMaxAreaInBytes: {
-    /** @type {number} */
-    value: -1,
-    kind: OptionKind.BROWSER + OptionKind.API,
-  },
-  isInAutomation: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.BROWSER,
-  },
-  localeProperties: {
-    /** @type {Object} */
-    value:
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
-        ? { lang: navigator.language || "en-US" }
-        : null,
-    kind: OptionKind.BROWSER,
-  },
-  maxCanvasDim: {
-    /** @type {number} */
-    value: 32767,
-    kind: OptionKind.BROWSER + OptionKind.VIEWER,
-  },
-  nimbusDataStr: {
-    /** @type {string} */
-    value: "",
-    kind: OptionKind.BROWSER,
-  },
-  supportsCaretBrowsingMode: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.BROWSER,
-  },
-  supportsDocumentFonts: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.BROWSER,
-  },
-  supportsDownloading: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.BROWSER,
-  },
-  supportsIntegratedFind: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.BROWSER,
-  },
-  supportsMouseWheelZoomCtrlKey: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.BROWSER,
-  },
-  supportsMouseWheelZoomMetaKey: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.BROWSER,
-  },
-  supportsPinchToZoom: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.BROWSER,
-  },
-  supportsPrinting: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.BROWSER,
-  },
-  toolbarDensity: {
-    /** @type {number} */
-    value: 0, // 0 = "normal", 1 = "compact", 2 = "touch"
-    kind: OptionKind.BROWSER + OptionKind.EVENT_DISPATCH,
-  },
+const defaultOptions = new Map([
+  // Begin OptionKind.BROWSER
+  [
+    "allowedGlobalEvents",
+    {
+      /** @type {Object} */
+      value: null,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "canvasMaxAreaInBytes",
+    {
+      /** @type {number} */
+      value: -1,
+      kind: OptionKind.BROWSER + OptionKind.API,
+    },
+  ],
+  [
+    "isInAutomation",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "localeProperties",
+    {
+      /** @type {Object} */
+      value:
+        typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
+          ? { lang: navigator.language || "en-US" }
+          : null,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "maxCanvasDim",
+    {
+      /** @type {number} */
+      value: 32767,
+      kind: OptionKind.BROWSER + OptionKind.VIEWER,
+    },
+  ],
+  [
+    "nimbusDataStr",
+    {
+      /** @type {string} */
+      value: "",
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsCaretBrowsingMode",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsDocumentFonts",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsDownloading",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsIntegratedFind",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsMouseWheelZoomCtrlKey",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsMouseWheelZoomMetaKey",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsPinchToZoom",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "supportsPrinting",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.BROWSER,
+    },
+  ],
+  [
+    "toolbarDensity",
+    {
+      /** @type {number} */
+      value: 0, // 0 = "normal", 1 = "compact", 2 = "touch"
+      kind: OptionKind.BROWSER + OptionKind.EVENT_DISPATCH,
+    },
+  ],
+  // End OptionKind.BROWSER
 
-  altTextLearnMoreUrl: {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
-        ? "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/pdf-alt-text"
-        : "",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  annotationEditorMode: {
-    /** @type {number} */
-    value: 0,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  annotationMode: {
-    /** @type {number} */
-    value: 2,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  capCanvasAreaFactor: {
-    /** @type {number} */
-    value: 200,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  commentLearnMoreUrl: {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("MOZCENTRAL")
-        ? "https://support.mozilla.org/%LOCALE%/kb/view-pdf-files-firefox-or-choose-another-viewer#w_add-a-comment-to-a-pdf"
-        : "",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  cursorToolOnLoad: {
-    /** @type {number} */
-    value: 0,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  debuggerSrc: {
-    /** @type {string} */
-    value: "./debugger.mjs",
-    kind: OptionKind.VIEWER,
-  },
-  defaultZoomDelay: {
-    /** @type {number} */
-    value: 400,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  defaultZoomValue: {
-    /** @type {string} */
-    value: "",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  disableHistory: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER,
-  },
-  disablePageLabels: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableAltText: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableAltTextModelDownload: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE + OptionKind.EVENT_DISPATCH,
-  },
-  enableAutoLinking: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableComment: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableDetailCanvas: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER,
-  },
-  enableGuessAltText: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE + OptionKind.EVENT_DISPATCH,
-  },
-  enableHighlightFloatingButton: {
-    // We'll probably want to make some experiments before enabling this
-    // in Firefox release, but it has to be temporary.
-    // TODO: remove it when unnecessary.
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableMerge: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableNewAltTextWhenAddingImage: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableNewBadge: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("MOZCENTRAL"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableOptimizedPartialRendering: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enablePermissions: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enablePrintAutoRotate: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableScripting: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableSignatureEditor: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableSignatureVerification: {
-    // On in MOZCENTRAL (NSS provides the verification path) and in
-    // local dev builds; off in shipping GENERIC builds, where no
-    // verifier is wired up by default.
-    /** @type {boolean} */
-    value:
-      typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING || MOZCENTRAL"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableSplitMerge: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  enableUpdatedAddImage: {
-    // We'll probably want to make some experiments before enabling this
-    // in Firefox release, but it has to be temporary.
-    // TODO: remove it when unnecessary.
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  externalLinkRel: {
-    /** @type {string} */
-    value: "noopener noreferrer nofollow",
-    kind: OptionKind.VIEWER,
-  },
-  externalLinkTarget: {
-    /** @type {number} */
-    value: 0,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
+  // Begin OptionKind.VIEWER
+  [
+    "altTextLearnMoreUrl",
+    {
+      /** @type {string} */
+      value:
+        typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+          ? "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/pdf-alt-text"
+          : "",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "annotationEditorMode",
+    {
+      /** @type {number} */
+      value: 0,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "annotationMode",
+    {
+      /** @type {number} */
+      value: 2,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "capCanvasAreaFactor",
+    {
+      /** @type {number} */
+      value: 200,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "commentLearnMoreUrl",
+    {
+      /** @type {string} */
+      value:
+        typeof PDFJSDev === "undefined" || PDFJSDev.test("MOZCENTRAL")
+          ? "https://support.mozilla.org/%LOCALE%/kb/view-pdf-files-firefox-or-choose-another-viewer#w_add-a-comment-to-a-pdf"
+          : "",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "cursorToolOnLoad",
+    {
+      /** @type {number} */
+      value: 0,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "debuggerSrc",
+    {
+      /** @type {string} */
+      value: "./debugger.mjs",
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  ...(typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")
+    ? [
+        [
+          "defaultUrl",
+          {
+            /** @type {string} */
+            value:
+              typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")
+                ? ""
+                : "compressed.tracemonkey-pldi-09.pdf",
+            kind: OptionKind.VIEWER,
+          },
+        ],
+      ]
+    : []),
+  [
+    "defaultZoomDelay",
+    {
+      /** @type {number} */
+      value: 400,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "defaultZoomValue",
+    {
+      /** @type {string} */
+      value: "",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "disableHistory",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  [
+    "disablePageLabels",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  ...(typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")
+    ? [
+        [
+          "disablePreferences",
+          {
+            /** @type {boolean} */
+            value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
+            kind: OptionKind.VIEWER,
+          },
+        ],
+      ]
+    : []),
+  ...(typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")
+    ? [
+        [
+          "disableTelemetry",
+          {
+            /** @type {boolean} */
+            value: false,
+            kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+          },
+        ],
+      ]
+    : []),
+  [
+    "enableAltText",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableAltTextModelDownload",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind:
+        OptionKind.VIEWER + OptionKind.PREFERENCE + OptionKind.EVENT_DISPATCH,
+    },
+  ],
+  [
+    "enableAutoLinking",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableComment",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableDetailCanvas",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  ...(typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")
+    ? [
+        [
+          "enableFakeMLManager",
+          {
+            /** @type {boolean} */
+            value: true,
+            kind: OptionKind.VIEWER,
+          },
+        ],
+      ]
+    : []),
+  [
+    "enableGuessAltText",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind:
+        OptionKind.VIEWER + OptionKind.PREFERENCE + OptionKind.EVENT_DISPATCH,
+    },
+  ],
+  [
+    "enableHighlightFloatingButton",
+    {
+      // We'll probably want to make some experiments before enabling this
+      // in Firefox release, but it has to be temporary.
+      // TODO: remove it when unnecessary.
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableMerge",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableNewAltTextWhenAddingImage",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableNewBadge",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || PDFJSDev.test("MOZCENTRAL"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableOptimizedPartialRendering",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enablePermissions",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enablePrintAutoRotate",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableScripting",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || !PDFJSDev.test("CHROME"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableSelectionRendering",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableSignatureEditor",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableSignatureVerification",
+    {
+      // On in MOZCENTRAL (NSS provides the verification path) and in
+      // local dev builds; off in shipping GENERIC builds, where no
+      // verifier is wired up by default.
+      /** @type {boolean} */
+      value:
+        typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("TESTING || MOZCENTRAL"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableSplitMerge",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableUpdatedAddImage",
+    {
+      // We'll probably want to make some experiments before enabling this
+      // in Firefox release, but it has to be temporary.
+      // TODO: remove it when unnecessary.
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "externalLinkRel",
+    {
+      /** @type {string} */
+      value: "noopener noreferrer nofollow",
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  [
+    "externalLinkTarget",
+    {
+      /** @type {number} */
+      value: 0,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
   ...(typeof PDFJSDev === "undefined" ||
   PDFJSDev.test("MOZCENTRAL && !GECKOVIEW")
-    ? {
-        featuresNotificationDismissed: {
-          /** @type {boolean} */
-          value: false,
-          kind:
-            OptionKind.VIEWER +
-            OptionKind.PREFERENCE +
-            OptionKind.EVENT_DISPATCH,
-        },
-      }
-    : {}),
-  highlightEditorColors: {
-    /** @type {string} */
-    value:
-      "yellow=#FFFF98,green=#53FFBC,blue=#80EBFF,pink=#FFCBE6,red=#FF4F5F," +
-      "yellow_HCM=#FFFFCC,green_HCM=#53FFBC,blue_HCM=#80EBFF,pink_HCM=#F6B8FF,red_HCM=#C50043",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  historyUpdateUrl: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  ignoreDestinationZoom: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  imageResourcesPath: {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
-        ? "resource://pdf.js/web/images/"
-        : "./images/",
-    kind: OptionKind.VIEWER,
-  },
-  enableSelectionRendering: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  imagesRightClickMinSize: {
-    /** @type {number} */
-    value:
-      typeof PDFJSDev === "undefined" ||
-      // Firefox mobile does not support right-clicking on images,
-      // see https://bugzilla.mozilla.org/show_bug.cgi?id=2014081.
-      // This option is disabled by default outside of MOZCENTRAL
-      // because it degrades the text selection experience in Chrome
-      // and Safari.
-      PDFJSDev.test("MOZCENTRAL && !GECKOVIEW")
-        ? 16
-        : -1,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  maxCanvasPixels: {
-    /** @type {number} */
-    value: 2 ** 25,
-    kind: OptionKind.VIEWER,
-  },
-  minDurationToUpdateCanvas: {
-    /** @type {number} */
-    value: 500, // ms
-    kind: OptionKind.VIEWER,
-  },
-  forcePageColors: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  pageColorsBackground: {
-    /** @type {string} */
-    value: "Canvas",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  pageColorsForeground: {
-    /** @type {string} */
-    value: "CanvasText",
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  pdfBugEnabled: {
-    /** @type {boolean} */
-    value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  postMessageAfterPrintCallback: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  printResolution: {
-    /** @type {number} */
-    value: 150,
-    kind: OptionKind.VIEWER,
-  },
-  sidebarViewOnLoad: {
-    /** @type {number} */
-    value: -1,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  scrollModeOnLoad: {
-    /** @type {number} */
-    value: -1,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  spreadModeOnLoad: {
-    /** @type {number} */
-    value: -1,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  textLayerMode: {
-    /** @type {number} */
-    value: 1,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  viewerCssTheme: {
-    /** @type {number} */
-    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME") ? 2 : 0,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
-  viewOnLoad: {
-    /** @type {boolean} */
-    value: 0,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  },
+    ? [
+        [
+          "featuresNotificationDismissed",
+          {
+            /** @type {boolean} */
+            value: false,
+            kind:
+              OptionKind.VIEWER +
+              OptionKind.PREFERENCE +
+              OptionKind.EVENT_DISPATCH,
+          },
+        ],
+      ]
+    : []),
+  [
+    "highlightEditorColors",
+    {
+      /** @type {string} */
+      value:
+        "yellow=#FFFF98,green=#53FFBC,blue=#80EBFF,pink=#FFCBE6,red=#FF4F5F," +
+        "yellow_HCM=#FFFFCC,green_HCM=#53FFBC,blue_HCM=#80EBFF,pink_HCM=#F6B8FF,red_HCM=#C50043",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "historyUpdateUrl",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "ignoreDestinationZoom",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "imageResourcesPath",
+    {
+      /** @type {string} */
+      value:
+        typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+          ? "resource://pdf.js/web/images/"
+          : "./images/",
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  [
+    "imagesRightClickMinSize",
+    {
+      /** @type {number} */
+      value:
+        typeof PDFJSDev === "undefined" ||
+        // Firefox mobile does not support right-clicking on images,
+        // see https://bugzilla.mozilla.org/show_bug.cgi?id=2014081.
+        // This option is disabled by default outside of MOZCENTRAL
+        // because it degrades the text selection experience in Chrome
+        // and Safari.
+        PDFJSDev.test("MOZCENTRAL && !GECKOVIEW")
+          ? 16
+          : -1,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "maxCanvasPixels",
+    {
+      /** @type {number} */
+      value: 2 ** 25,
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  [
+    "minDurationToUpdateCanvas",
+    {
+      /** @type {number} */
+      value: 500, // ms
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  [
+    "forcePageColors",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "pageColorsBackground",
+    {
+      /** @type {string} */
+      value: "Canvas",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "pageColorsForeground",
+    {
+      /** @type {string} */
+      value: "CanvasText",
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "pdfBugEnabled",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING"),
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "postMessageAfterPrintCallback",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "printResolution",
+    {
+      /** @type {number} */
+      value: 150,
+      kind: OptionKind.VIEWER,
+    },
+  ],
+  ...(typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")
+    ? [
+        [
+          "sandboxBundleSrc",
+          {
+            /** @type {string} */
+            value:
+              typeof PDFJSDev === "undefined"
+                ? "../build/dev-sandbox/pdf.sandbox.mjs"
+                : "../build/pdf.sandbox.mjs",
+            kind: OptionKind.VIEWER,
+          },
+        ],
+      ]
+    : []),
+  [
+    "sidebarViewOnLoad",
+    {
+      /** @type {number} */
+      value: -1,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "scrollModeOnLoad",
+    {
+      /** @type {number} */
+      value: -1,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "spreadModeOnLoad",
+    {
+      /** @type {number} */
+      value: -1,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "textLayerMode",
+    {
+      /** @type {number} */
+      value: 1,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "viewerCssTheme",
+    {
+      /** @type {number} */
+      value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME") ? 2 : 0,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "viewOnLoad",
+    {
+      /** @type {boolean} */
+      value: 0,
+      kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
+    },
+  ],
+  // End OptionKind.VIEWER
 
-  cMapPacked: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.API,
-  },
-  cMapUrl: {
-    /** @type {string} */
-    value:
-      // eslint-disable-next-line no-nested-ternary
-      typeof PDFJSDev === "undefined"
-        ? "../external/bcmaps/"
-        : PDFJSDev.test("MOZCENTRAL")
-          ? "resource://pdf.js/web/cmaps/"
-          : "../web/cmaps/",
-    kind: OptionKind.API,
-  },
-  disableAutoFetch: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  disableFontFace: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  disableRange: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  disableStream: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  docBaseUrl: {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev === "undefined"
-        ? // NOTE: We cannot use the `updateUrlHash` function here, because of
-          // the default preferences generation (see `gulpfile.mjs`).
-          // However, the following line is *only* used in development mode.
-          document.URL.split("#", 1)[0]
-        : "",
-    kind: OptionKind.API,
-  },
-  enableHWA: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  enableWebGPU: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  enableXfa: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.API + OptionKind.PREFERENCE,
-  },
-  fontExtraProperties: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.API,
-  },
-  iccUrl: {
-    /** @type {string} */
-    value:
-      // eslint-disable-next-line no-nested-ternary
-      typeof PDFJSDev === "undefined"
-        ? "../external/iccs/"
-        : PDFJSDev.test("MOZCENTRAL")
-          ? "resource://pdf.js/web/iccs/"
-          : "../web/iccs/",
-    kind: OptionKind.API,
-  },
-  isOffscreenCanvasSupported: {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.API,
-  },
-  maxImageSize: {
-    /** @type {number} */
-    value: -1,
-    kind: OptionKind.API,
-  },
-  pdfBug: {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.API,
-  },
-  standardFontDataUrl: {
-    /** @type {string} */
-    value:
-      // eslint-disable-next-line no-nested-ternary
-      typeof PDFJSDev === "undefined"
-        ? "../external/standard_fonts/"
-        : PDFJSDev.test("MOZCENTRAL")
-          ? "resource://pdf.js/web/standard_fonts/"
-          : "../web/standard_fonts/",
-    kind: OptionKind.API,
-  },
-  useSystemFonts: {
-    // On Android, there is almost no chance to have the font we want so we
-    // don't use the system fonts in this case (bug 1882613).
-    /** @type {boolean|undefined} */
-    value: (
-      typeof PDFJSDev === "undefined"
-        ? window.isGECKOVIEW
-        : PDFJSDev.test("GECKOVIEW")
-    )
-      ? false
-      : undefined,
-    kind: OptionKind.API,
-    type: Type.BOOLEAN + Type.UNDEFINED,
-  },
-  verbosity: {
-    /** @type {number} */
-    value: 1,
-    kind: OptionKind.API,
-  },
-  wasmUrl: {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
-        ? "resource://pdf.js/web/wasm/"
-        : "../web/wasm/",
-    kind: OptionKind.API,
-  },
+  // Begin OptionKind.API
+  [
+    "cMapPacked",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "cMapUrl",
+    {
+      /** @type {string} */
+      value:
+        // eslint-disable-next-line no-nested-ternary
+        typeof PDFJSDev === "undefined"
+          ? "../external/bcmaps/"
+          : PDFJSDev.test("MOZCENTRAL")
+            ? "resource://pdf.js/web/cmaps/"
+            : "../web/cmaps/",
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "disableAutoFetch",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "disableFontFace",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "disableRange",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "disableStream",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "docBaseUrl",
+    {
+      /** @type {string} */
+      value:
+        typeof PDFJSDev === "undefined"
+          ? // NOTE: We cannot use the `updateUrlHash` function here, because of
+            // the default preferences generation (see `gulpfile.mjs`).
+            // However, the following line is *only* used in development mode.
+            document.URL.split("#", 1)[0]
+          : "",
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "enableHWA",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableWebGPU",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "enableXfa",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
+    "fontExtraProperties",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "iccUrl",
+    {
+      /** @type {string} */
+      value:
+        // eslint-disable-next-line no-nested-ternary
+        typeof PDFJSDev === "undefined"
+          ? "../external/iccs/"
+          : PDFJSDev.test("MOZCENTRAL")
+            ? "resource://pdf.js/web/iccs/"
+            : "../web/iccs/",
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "isOffscreenCanvasSupported",
+    {
+      /** @type {boolean} */
+      value: true,
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "maxImageSize",
+    {
+      /** @type {number} */
+      value: -1,
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "pdfBug",
+    {
+      /** @type {boolean} */
+      value: false,
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "standardFontDataUrl",
+    {
+      /** @type {string} */
+      value:
+        // eslint-disable-next-line no-nested-ternary
+        typeof PDFJSDev === "undefined"
+          ? "../external/standard_fonts/"
+          : PDFJSDev.test("MOZCENTRAL")
+            ? "resource://pdf.js/web/standard_fonts/"
+            : "../web/standard_fonts/",
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "useSystemFonts",
+    {
+      // On Android, there is almost no chance to have the font we want so we
+      // don't use the system fonts in this case (bug 1882613).
+      /** @type {boolean|undefined} */
+      value: (
+        typeof PDFJSDev === "undefined"
+          ? window.isGECKOVIEW
+          : PDFJSDev.test("GECKOVIEW")
+      )
+        ? false
+        : undefined,
+      kind: OptionKind.API,
+      type: Type.BOOLEAN + Type.UNDEFINED,
+    },
+  ],
+  [
+    "verbosity",
+    {
+      /** @type {number} */
+      value: 1,
+      kind: OptionKind.API,
+    },
+  ],
+  [
+    "wasmUrl",
+    {
+      /** @type {string} */
+      value:
+        typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+          ? "resource://pdf.js/web/wasm/"
+          : "../web/wasm/",
+      kind: OptionKind.API,
+    },
+  ],
+  // End OptionKind.API
 
-  workerPort: {
-    /** @type {Object} */
-    value:
-      typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
-        ? globalThis.pdfjsPreloadedWorker || null
-        : null,
-    kind: OptionKind.WORKER,
-  },
-  workerSrc: {
-    /** @type {string} */
-    value:
-      // eslint-disable-next-line no-nested-ternary
-      typeof PDFJSDev === "undefined"
-        ? "../src/pdf.worker.js"
-        : PDFJSDev.test("MOZCENTRAL")
-          ? "resource://pdf.js/build/pdf.worker.mjs"
-          : "../build/pdf.worker.mjs",
-    kind: OptionKind.WORKER,
-  },
-};
-if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
-  defaultOptions.defaultUrl = {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev !== "undefined" && PDFJSDev.test("CHROME")
-        ? ""
-        : "compressed.tracemonkey-pldi-09.pdf",
-    kind: OptionKind.VIEWER,
-  };
-  defaultOptions.sandboxBundleSrc = {
-    /** @type {string} */
-    value:
-      typeof PDFJSDev === "undefined"
-        ? "../build/dev-sandbox/pdf.sandbox.mjs"
-        : "../build/pdf.sandbox.mjs",
-    kind: OptionKind.VIEWER,
-  };
-  defaultOptions.enableFakeMLManager = {
-    /** @type {boolean} */
-    value: true,
-    kind: OptionKind.VIEWER,
-  };
-}
-if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  defaultOptions.disablePreferences = {
-    /** @type {boolean} */
-    value: typeof PDFJSDev !== "undefined" && PDFJSDev.test("TESTING"),
-    kind: OptionKind.VIEWER,
-  };
-} else if (PDFJSDev.test("CHROME")) {
-  defaultOptions.disableTelemetry = {
-    /** @type {boolean} */
-    value: false,
-    kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
-  };
-}
+  // Begin OptionKind.WORKER
+  [
+    "workerPort",
+    {
+      /** @type {Object} */
+      value:
+        typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")
+          ? globalThis.pdfjsPreloadedWorker || null
+          : null,
+      kind: OptionKind.WORKER,
+    },
+  ],
+  [
+    "workerSrc",
+    {
+      /** @type {string} */
+      value:
+        // eslint-disable-next-line no-nested-ternary
+        typeof PDFJSDev === "undefined"
+          ? "../src/pdf.worker.js"
+          : PDFJSDev.test("MOZCENTRAL")
+            ? "resource://pdf.js/build/pdf.worker.mjs"
+            : "../build/pdf.worker.mjs",
+      kind: OptionKind.WORKER,
+    },
+  ],
+  // End OptionKind.WORKER
+]);
 
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
   // Ensure that the `defaultOptions` are correctly specified.
-  for (const name in defaultOptions) {
-    const { value, kind, type } = defaultOptions[name];
-
+  for (const [name, { value, kind, type }] of defaultOptions) {
     if (kind & OptionKind.PREFERENCE) {
       if (kind === OptionKind.PREFERENCE) {
         throw new Error(`Cannot use only "PREFERENCE" kind: ${name}`);
@@ -681,8 +984,8 @@ class AppOptions {
 
   static {
     // Initialize all the user-options.
-    for (const name in defaultOptions) {
-      this.#opts.set(name, defaultOptions[name].value);
+    for (const [name, defaultOpt] of defaultOptions) {
+      this.#opts.set(name, defaultOpt.value);
     }
 
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
@@ -721,9 +1024,7 @@ class AppOptions {
 
   static getAll(kind = null, defaultOnly = false) {
     const options = Object.create(null);
-    for (const name in defaultOptions) {
-      const defaultOpt = defaultOptions[name];
-
+    for (const [name, defaultOpt] of defaultOptions) {
       if (kind && !(kind & defaultOpt.kind)) {
         continue;
       }
@@ -743,7 +1044,7 @@ class AppOptions {
     let events;
 
     for (const name in options) {
-      const defaultOpt = defaultOptions[name],
+      const defaultOpt = defaultOptions.get(name),
         userOpt = options[name];
 
       if (


### PR DESCRIPTION
Compared to regular Objects there's a number of advantages to using Maps, e.g. they support proper iteration.

Additionally the conditionally defined options are moved into the main list, to maintain alphabetical order for each individual `OptionKind`.
Finally, the `enableSelectionRendering` option is moved to its "correct" position and the `enableFakeMLManager` option is limited to TESTING builds (since that's consistent with its usage in `web/app.js`).

*Note:* Despite making the source-code larger, the size of the `gulp mozcentral` bundle is *reduced* by `686` bytes.