### PR TITLE
Avoid Unicode sets in the Autolinker regular expression

### DIFF
--- a/test/unit/autolinker_spec.js
+++ b/test/unit/autolinker_spec.js
@@ -24,6 +24,12 @@ function testLinks(links) {
 }
 
 describe("autolinker", function () {
+  it("should not require RegExp Unicode sets", function () {
+    expect(Autolinker.findLinks.toString()).not.toMatch(
+      /\)\/[dgimsuy]*v[dgimsuy]*;/
+    );
+  });
+
   it("should correctly find URLs", function () {
     const [matched] = Autolinker.findLinks("http://www.example.com");
     expect(matched.url).toEqual("http://www.example.com/");

--- a/web/autolinker.js
+++ b/web/autolinker.js
@@ -139,7 +139,7 @@ class Autolinker {
     // Regex can be tested and verified at https://regex101.com/r/rXoLiT/2.
     this.#regex ??=
       // eslint-disable-next-line regexp/no-super-linear-backtracking
-      /\b(?:https?:\/\/|mailto:|www\.)(?:[\S--[\p{P}<>]]|\/|[\S--[\[\]]]+[\S--[\p{P}<>]])+|(?=\p{L})[\S--[@\p{Ps}\p{Pe}<>]]+@([\S--[[\p{P}--\-]<>]]+(?:\.[\S--[[\p{P}--\-]<>]]+)+)/gv;
+      /\b(?:https?:\/\/|mailto:|www\.)(?:[^\s\p{P}<>]|\/|[^\s[\]]+[^\s\p{P}<>])+|(?=\p{L})[^\s@\p{Ps}\p{Pe}<>]+@((?:-|[^\s\p{P}<>])+(?:\.(?:-|[^\s\p{P}<>])+)+)/gu;
 
     const [normalizedText, diffs] = normalize(text, { ignoreDashEOL: true });
     const matches = normalizedText.matchAll(this.#regex);

--- a/web/autolinker.js
+++ b/web/autolinker.js
@@ -139,7 +139,7 @@ class Autolinker {
     // Regex can be tested and verified at https://regex101.com/r/rXoLiT/2.
     this.#regex ??=
       // eslint-disable-next-line regexp/no-super-linear-backtracking
-      /\b(?:https?:\/\/|mailto:|www\.)(?:[^\s\p{P}<>]|\/|[^\s[\]]+[^\s\p{P}<>])+|(?=\p{L})[^\s@\p{Ps}\p{Pe}<>]+@((?:-|[^\s\p{P}<>])+(?:\.(?:-|[^\s\p{P}<>])+)+)/gu;
+      /\b(?:https?:\/\/|mailto:|www\.)(?:[^\s\p{P}<>]|\/|[^\s[\]]+[^\s\p{P}<>])+|(?=\p{L})[^\s@\p{Ps}\p{Pe}<>]+@((?:(?=-|[^\s\p{P}<>])[\s\S])+(?:\.(?:(?=-|[^\s\p{P}<>])[\s\S])+)+)/gu;
 
     const [normalizedText, diffs] = normalize(text, { ignoreDashEOL: true });
     const matches = normalizedText.matchAll(this.#regex);


### PR DESCRIPTION
Fixes #21656.

## Summary

- express the Autolinker set subtractions with equivalent negated Unicode classes
- use the `u` flag instead of requiring RegExp Unicode sets via `v`
- add a regression assertion that prevents the Autolinker expression from requiring `v` again
- leave the documented browser support floor unchanged

The four translated character classes were exhaustively compared over every Unicode scalar value; all four comparisons produced 0 mismatches.

## Verification

- `npx gulp unittestcli` — 1483 specs, 0 failures, 41 pending
- `npx gulp lint`
- reproduced the original parse failure on an iPad Pro 9.7-inch (`iPad6,4`) running iPadOS 16.7.8 (`20H343`), where `new RegExp("", "v")` throws `SyntaxError: Invalid regular expression: invalid flags`