### PR TITLE
Replace simple return `if` statements with ternary operators

### DIFF
--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -73,10 +73,7 @@ function preprocess(inFilename, outFilename, defines) {
   const out = [];
   let i = 0;
   function readLine() {
-    if (i < totalLines) {
-      return lines[i++];
-    }
-    return null;
+    return i < totalLines ? lines[i++] : null;
   }
   const writeLine =
     typeof outFilename === "function"
@@ -127,10 +124,7 @@ function preprocess(inFilename, outFilename, defines) {
   function expand(line) {
     line = line.replaceAll(/__\w+__/g, function (variable) {
       variable = variable.substring(2, variable.length - 2);
-      if (variable in defines) {
-        return defines[variable];
-      }
-      return "";
+      return variable in defines ? defines[variable] : "";
     });
     writeLine(line);
   }

--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -1428,10 +1428,9 @@ class CFFFDSelect {
   }
 
   getFDIndex(glyphIndex) {
-    if (glyphIndex < 0 || glyphIndex >= this.fdSelect.length) {
-      return -1;
-    }
-    return this.fdSelect[glyphIndex];
+    return glyphIndex < 0 || glyphIndex >= this.fdSelect.length
+      ? -1
+      : this.fdSelect[glyphIndex];
   }
 }
 

--- a/src/core/chunked_stream.js
+++ b/src/core/chunked_stream.js
@@ -239,10 +239,10 @@ class ChunkedStream extends Stream {
     };
     Object.defineProperty(ChunkedStreamSubstream.prototype, "isDataLoaded", {
       get() {
-        if (this.numChunksLoaded === this.numChunks) {
-          return true;
-        }
-        return this.getMissingChunks().length === 0;
+        return (
+          this.numChunksLoaded === this.numChunks ||
+          this.getMissingChunks().length === 0
+        );
       },
       configurable: true,
     });

--- a/src/core/decode_stream.js
+++ b/src/core/decode_stream.js
@@ -111,10 +111,9 @@ class DecodeStream extends BaseStream {
 
   async getImageData(length, decoderOptions) {
     if (!this.canAsyncDecodeImageFromBuffer) {
-      if (this.isAsyncDecoder) {
-        return this.decodeImage(null, length, decoderOptions);
-      }
-      return this.getBytes(length, decoderOptions);
+      return this.isAsyncDecoder
+        ? this.decodeImage(null, length, decoderOptions)
+        : this.getBytes(length, decoderOptions);
     }
     const data = await this.stream.asyncGetBytes();
     return this.decodeImage(data, length, decoderOptions);

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -186,10 +186,7 @@ class Parser {
     }
 
     if (typeof buf1 === "string") {
-      if (cipherTransform) {
-        return cipherTransform.decryptString(buf1);
-      }
-      return buf1;
+      return cipherTransform ? cipherTransform.decryptString(buf1) : buf1;
     }
 
     // simple object

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -39,10 +39,7 @@ class Stream extends BaseStream {
   }
 
   getByte() {
-    if (this.pos >= this.end) {
-      return -1;
-    }
-    return this.bytes[this.pos++];
+    return this.pos >= this.end ? -1 : this.bytes[this.pos++];
   }
 
   getBytes(length) {

--- a/src/core/string_utils.js
+++ b/src/core/string_utils.js
@@ -16,19 +16,15 @@
 import { stringToBytes, Util, warn } from "../shared/util.js";
 
 function isAscii(str) {
-  return (
-    typeof str === "string" &&
-    // eslint-disable-next-line no-control-regex
-    (!str || /^[\x00-\x7F]*$/.test(str))
-  );
+  // eslint-disable-next-line no-control-regex
+  return typeof str === "string" && (!str || /^[\x00-\x7F]*$/.test(str));
 }
 
 // If the string is null or undefined then it is returned as is.
 function stringToAsciiOrUTF16BE(str) {
-  if (str === null || str === undefined) {
-    return str;
-  }
-  return isAscii(str) ? str : stringToUTF16String(str, /* bigEndian = */ true);
+  return str === null || str === undefined || isAscii(str)
+    ? str
+    : stringToUTF16String(str, /* bigEndian = */ true);
 }
 
 function stringToUTF16HexString(str) {

--- a/src/core/to_unicode_map.js
+++ b/src/core/to_unicode_map.js
@@ -83,10 +83,9 @@ class IdentityToUnicodeMap {
   }
 
   get(i) {
-    if (this.firstChar <= i && i <= this.lastChar) {
-      return String.fromCharCode(i);
-    }
-    return undefined;
+    return this.firstChar <= i && i <= this.lastChar
+      ? String.fromCharCode(i)
+      : undefined;
   }
 
   charCodeOf(v) {

--- a/src/core/xfa/fonts.js
+++ b/src/core/xfa/fonts.js
@@ -154,10 +154,7 @@ class FontFinder {
 
 function selectFont(xfaFont, typeface) {
   if (xfaFont.posture === "italic") {
-    if (xfaFont.weight === "bold") {
-      return typeface.bolditalic;
-    }
-    return typeface.italic;
+    return xfaFont.weight === "bold" ? typeface.bolditalic : typeface.italic;
   } else if (xfaFont.weight === "bold") {
     return typeface.bold;
   }

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -6073,10 +6073,9 @@ class Value extends XFAObject {
 
   [$text]() {
     if (this.exData) {
-      if (typeof this.exData[$content] === "string") {
-        return this.exData[$content].trim();
-      }
-      return this.exData[$content][$text]().trim();
+      return typeof this.exData[$content] === "string"
+        ? this.exData[$content].trim()
+        : this.exData[$content][$text]().trim();
     }
     for (const name of Object.getOwnPropertyNames(this)) {
       if (name === "image") {

--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -284,10 +284,9 @@ class XFAObject {
   }
 
   [$text]() {
-    if (this[_children].length === 0) {
-      return this[$content];
-    }
-    return this[_children].map(c => c[$text]()).join("");
+    return this[_children].length === 0
+      ? this[$content]
+      : this[_children].map(c => c[$text]()).join("");
   }
 
   get [_attributeNames]() {
@@ -329,11 +328,7 @@ class XFAObject {
   }
 
   [$getChildren](name = null) {
-    if (!name) {
-      return this[_children];
-    }
-
-    return this[name];
+    return !name ? this[_children] : this[name];
   }
 
   [$dump]() {
@@ -680,11 +675,9 @@ class XFAObject {
   }
 
   [$getChildren](name = null) {
-    if (!name) {
-      return this[_children];
-    }
-
-    return this[_children].filter(c => c[$nodeName] === name);
+    return !name
+      ? this[_children]
+      : this[_children].filter(c => c[$nodeName] === name);
   }
 
   [$getChildrenByClass](name) {
@@ -909,11 +902,9 @@ class XmlObject extends XFAObject {
   }
 
   [$getChildren](name = null) {
-    if (!name) {
-      return this[_children];
-    }
-
-    return this[_children].filter(c => c[$nodeName] === name);
+    return !name
+      ? this[_children]
+      : this[_children].filter(c => c[$nodeName] === name);
   }
 
   [$getAttributes]() {

--- a/src/core/xml_parser.js
+++ b/src/core/xml_parser.js
@@ -324,10 +324,9 @@ class SimpleDOMNode {
   }
 
   get textContent() {
-    if (!this.childNodes) {
-      return this.nodeValue || "";
-    }
-    return this.childNodes.map(child => child.textContent).join("");
+    return !this.childNodes
+      ? this.nodeValue || ""
+      : this.childNodes.map(child => child.textContent).join("");
   }
 
   get children() {

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -3122,10 +3122,7 @@ class PopupElement {
   }
 
   get isVisible() {
-    if (this.#commentManager) {
-      return false;
-    }
-    return this.#container.hidden === false;
+    return !this.#commentManager && this.#container.hidden === false;
   }
 }
 

--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -188,10 +188,7 @@ class CanvasBBoxTracker {
   }
 
   getOpenMarker() {
-    if (this._savesStack.length === 0) {
-      return null;
-    }
-    return this._savesStack.at(-1);
+    return this._savesStack.length === 0 ? null : this._savesStack.at(-1);
   }
 
   recordCloseMarker(opIdx, onSavePopped) {

--- a/src/display/editor/alt_text.js
+++ b/src/display/editor/alt_text.js
@@ -131,17 +131,15 @@ class AltText {
   }
 
   isEmpty() {
-    if (this.#useNewAltTextFlow) {
-      return this.#altText === null;
-    }
-    return !this.#altText && !this.#altTextDecorative;
+    return this.#useNewAltTextFlow
+      ? this.#altText === null
+      : !this.#altText && !this.#altTextDecorative;
   }
 
   hasData() {
-    if (this.#useNewAltTextFlow) {
-      return this.#altText !== null || !!this.#guessedText;
-    }
-    return this.isEmpty();
+    return this.#useNewAltTextFlow
+      ? this.#altText !== null || !!this.#guessedText
+      : this.isEmpty();
   }
 
   get guessedText() {

--- a/src/display/editor/drawers/inkdraw.js
+++ b/src/display/editor/drawers/inkdraw.js
@@ -622,10 +622,7 @@ class InkDrawOutline extends Outline {
   }
 
   updateProperty(name, value) {
-    if (name === "stroke-width") {
-      return this.#updateThickness(value);
-    }
-    return null;
+    return name === "stroke-width" ? this.#updateThickness(value) : null;
   }
 
   #updateThickness(thickness) {

--- a/src/display/editor/signature.js
+++ b/src/display/editor/signature.js
@@ -254,10 +254,9 @@ class SignatureEditor extends DrawingEditor {
 
   /** @inheritdoc */
   get toolbarButtons() {
-    if (this._uiManager.signatureManager) {
-      return [["editSignature", this._uiManager.signatureManager]];
-    }
-    return super.toolbarButtons;
+    return this._uiManager.signatureManager
+      ? [["editSignature", this._uiManager.signatureManager]]
+      : super.toolbarButtons;
   }
 
   addSignature(data, heightInPage, description, uuid) {

--- a/src/pdf.sandbox.external.js
+++ b/src/pdf.sandbox.external.js
@@ -130,18 +130,12 @@ export class SandboxSupportBase {
         }
         this.win.alert(cMsg);
       },
-      confirm: cMsg => {
-        if (typeof cMsg !== "string") {
-          return false;
-        }
-        return this.win.confirm(cMsg);
-      },
-      prompt: (cQuestion, cDefault) => {
-        if (typeof cQuestion !== "string" || typeof cDefault !== "string") {
-          return null;
-        }
-        return this.win.prompt(cQuestion, cDefault);
-      },
+      confirm: cMsg =>
+        typeof cMsg !== "string" ? false : this.win.confirm(cMsg),
+      prompt: (cQuestion, cDefault) =>
+        typeof cQuestion !== "string" || typeof cDefault !== "string"
+          ? null
+          : this.win.prompt(cQuestion, cDefault),
       parseURL: cUrl => {
         const url = new this.win.URL(cUrl);
         const props = [

--- a/src/scripting_api/aform.js
+++ b/src/scripting_api/aform.js
@@ -52,11 +52,9 @@ class AForm {
   }
 
   AFMergeChange(event = globalThis.event) {
-    if (event.willCommit) {
-      return event.value.toString();
-    }
-
-    return this._app._eventDispatcher.mergeChange(event);
+    return event.willCommit
+      ? event.value.toString()
+      : this._app._eventDispatcher.mergeChange(event);
   }
 
   AFParseDateEx(cString, cOrder) {
@@ -102,10 +100,7 @@ class AForm {
   }
 
   AFMakeArrayFromList(string) {
-    if (typeof string === "string") {
-      return string.split(/, ?/g);
-    }
-    return string;
+    return typeof string === "string" ? string.split(/, ?/g) : string;
   }
 
   AFNumber_Format(
@@ -616,11 +611,9 @@ class AForm {
   }
 
   AFExactMatch(rePatterns, str) {
-    if (rePatterns instanceof RegExp) {
-      return str.match(rePatterns)?.[0] === str || 0;
-    }
-
-    return rePatterns.findIndex(re => str.match(re)?.[0] === str) + 1;
+    return rePatterns instanceof RegExp
+      ? str.match(rePatterns)?.[0] === str || 0
+      : rePatterns.findIndex(re => str.match(re)?.[0] === str) + 1;
   }
 }
 

--- a/src/scripting_api/field.js
+++ b/src/scripting_api/field.js
@@ -98,10 +98,7 @@ class Field extends PDFObject {
   }
 
   get currentValueIndices() {
-    if (!this._isChoice) {
-      return 0;
-    }
-    return this._currentValueIndices;
+    return !this._isChoice ? 0 : this._currentValueIndices;
   }
 
   set currentValueIndices(indices) {
@@ -683,17 +680,13 @@ class CheckboxField extends RadioButtonField {
   }
 
   isBoxChecked(nWidget) {
-    if (this._value === "Off") {
-      return false;
-    }
-    return super.isBoxChecked(nWidget);
+    return this._value === "Off" ? false : super.isBoxChecked(nWidget);
   }
 
   isDefaultChecked(nWidget) {
-    if (this.defaultValue === "Off") {
-      return this._value === "Off";
-    }
-    return super.isDefaultChecked(nWidget);
+    return this.defaultValue === "Off"
+      ? this._value === "Off"
+      : super.isDefaultChecked(nWidget);
   }
 
   checkThisBox(nWidget, bCheckIt = true) {

--- a/src/scripting_api/util.js
+++ b/src/scripting_api/util.js
@@ -252,10 +252,9 @@ class Util extends PDFObject {
     const patterns =
       /(mmmm|mmm|mm|m|dddd|ddd|dd|d|yyyy|yy|HH|H|hh|h|MM|M|ss|s|tt|t|\\.)/g;
     return cFormat.replaceAll(patterns, function (match, pattern) {
-      if (pattern in handlers) {
-        return handlers[pattern](data);
-      }
-      return pattern.charCodeAt(1);
+      return pattern in handlers
+        ? handlers[pattern](data)
+        : pattern.charCodeAt(1);
     });
   }
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -1007,10 +1007,9 @@ class Driver {
   }
 
   _getLastPageNumber(task) {
-    if (!task.pdfDoc) {
-      return task.firstPage || 1;
-    }
-    return task.lastPage || task.pdfDoc.numPages;
+    return !task.pdfDoc
+      ? task.firstPage || 1
+      : task.lastPage || task.pdfDoc.numPages;
   }
 
   _nextPage(task, loadError) {

--- a/test/unit/test_utils.js
+++ b/test/unit/test_utils.js
@@ -38,10 +38,9 @@ const WASM_URL = isNodeJS
 
 class DefaultFileReaderFactory {
   static async fetch(params) {
-    if (isNodeJS) {
-      return fetchDataNode(params.path);
-    }
-    return fetchDataDOM(params.path, /* type = */ "bytes");
+    return isNodeJS
+      ? fetchDataNode(params.path)
+      : fetchDataDOM(params.path, /* type = */ "bytes");
   }
 }
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -1600,13 +1600,10 @@ class PDFViewer {
   }
 
   get #pageWidthScaleFactor() {
-    if (
-      this._spreadMode !== SpreadMode.NONE &&
+    return this._spreadMode !== SpreadMode.NONE &&
       this._scrollMode !== ScrollMode.HORIZONTAL
-    ) {
-      return 2;
-    }
-    return 1;
+      ? 2
+      : 1;
   }
 
   #setScale(value, options) {


### PR DESCRIPTION
In a couple of cases, where a boolean is returned, it's also possible to use an OR operator rather a ternary.

*Note:* This patch reduces the size of the `gulp mozcentral` bundle by `960` bytes.