### PR TITLE
Fix protocol-relative viewer file URLs

### DIFF
--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -55,9 +55,10 @@ function loadAndWait(filename, selector, zoom, setups, options, viewport) {
         }
       }
 
-      const fileParam = filename.startsWith("http")
-        ? filename
-        : `/test/pdfs/${filename}`;
+      const fileParam =
+        filename.startsWith("http") || filename.startsWith("//")
+          ? filename
+          : `/test/pdfs/${filename}`;
       const url = `${global.integrationBaseUrl}?file=${fileParam}#zoom=${zoom ?? "page-fit"}${app_options}`;
 
       if (setups) {

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -1325,6 +1325,32 @@ describe("PDF viewer", () => {
     });
   });
 
+  describe("File param with a protocol-relative URL (issue 20218)", () => {
+    let pages;
+
+    beforeEach(async () => {
+      const baseURL = new URL(global.integrationBaseUrl);
+      const url = `//${baseURL.host}/build/generic/web/compressed.tracemonkey-pldi-09.pdf`;
+      pages = await loadAndWait(url, ".textLayer .endOfContent");
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must load and extract the filename correctly", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const filename = await page.evaluate(() => document.title);
+
+          expect(filename)
+            .withContext(`In ${browserName}`)
+            .toBe("compressed.tracemonkey-pldi-09.pdf");
+        })
+      );
+    });
+  });
+
   describe("File param with encoded characters (issue 20420)", () => {
     let pages;
 

--- a/web/app.js
+++ b/web/app.js
@@ -889,7 +889,10 @@ const PDFViewerApplication = {
       const params = parseQueryString(queryString);
       file = params.get("file") ?? AppOptions.get("defaultUrl");
       try {
-        file = new URL(file).href;
+        file = new URL(
+          file,
+          file.startsWith("//") ? window.location : undefined
+        ).href;
       } catch {
         file = encodeURIComponent(file).replaceAll("%2F", "/");
       }


### PR DESCRIPTION
## Summary

Resolve protocol-relative `file` parameters against the viewer location.

## Problem

A value such as `//host:port/document.pdf` falls through to the fallback encoder, which percent-encodes the colon in the authority and prevents the PDF from loading.

## Solution

Supply the viewer location as the URL base only for protocol-relative values. Absolute and ordinary relative URL handling remains unchanged.

## Testing

- Added integration coverage for a protocol-relative PDF URL
- Confirmed the focused test fails before the fix
- Confirmed the focused test passes after the fix
- `npx gulp lint`
- `npx gulp typestest`
- `npx gulp generic`
- Relevant unit/integration results recorded above

Fixes #20218