### PR TITLE
Preserve table cell spans in the structure tree

### DIFF
--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -928,6 +928,17 @@ class StructTreePage {
         // For example when rendering on the canvas the commands between the
         // beginning and the end of the marked-content sequence, we can
         // compute the overall bbox.
+
+        if (isName(a.get("O"), "Table")) {
+          const rowSpan = a.get("RowSpan");
+          if (Number.isInteger(rowSpan) && rowSpan > 1) {
+            obj.rowSpan = rowSpan;
+          }
+          const colSpan = a.get("ColSpan");
+          if (Number.isInteger(colSpan) && colSpan > 1) {
+            obj.colSpan = colSpan;
+          }
+        }
       }
 
       const lang = node.dict.get("Lang");

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1292,6 +1292,8 @@ class PDFDocumentProxy {
  *   {@link StructTreeNode} and {@link StructTreeContent} objects.
  * @property {string} role - element's role, already mapped if a role map exists
  * in the PDF.
+ * @property {number} [rowSpan] - The number of rows spanned by a table cell.
+ * @property {number} [colSpan] - The number of columns spanned by a table cell.
  */
 
 /**

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4703,6 +4703,38 @@ have written that much by now. So, here’s to squashing bugs.`);
       await loadingTask.destroy();
     });
 
+    it("preserves table cell row and column spans (issue 18090)", async function () {
+      const objects = [
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R " +
+          "/StructTreeRoot 4 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /StructParents 0 " +
+          "/MediaBox [0 0 100 100] >>\nendobj\n",
+        "4 0 obj\n<< /Type /StructTreeRoot /K 5 0 R " +
+          "/ParentTree 8 0 R >>\nendobj\n",
+        "5 0 obj\n<< /Type /StructElem /S /Table /P 4 0 R " +
+          "/K 6 0 R >>\nendobj\n",
+        "6 0 obj\n<< /Type /StructElem /S /TR /P 5 0 R " +
+          "/K 7 0 R >>\nendobj\n",
+        "7 0 obj\n<< /Type /StructElem /S /TD /P 6 0 R /Pg 3 0 R /K 0 " +
+          "/A << /O /Table /RowSpan 2 /ColSpan 3 >> >>\nendobj\n",
+        "8 0 obj\n<< /Nums [0 [7 0 R]] >>\nendobj\n",
+      ];
+      const loadingTask = getDocument({ data: assemblePdf(objects) });
+      const pdfDoc = await loadingTask.promise;
+      const tree = await (await pdfDoc.getPage(1)).getStructTree();
+      const cell = tree.children[0].children[0].children[0];
+
+      expect(cell).toEqual({
+        role: "TD",
+        children: [{ type: "content", id: "p3R_mc0" }],
+        rowSpan: 2,
+        colSpan: 3,
+      });
+
+      await loadingTask.destroy();
+    });
+
     it("gets corrupt structure tree with non-dictionary nodes (issue 18503)", async function () {
       const loadingTask = getDocument(buildGetDocumentParams("issue18503.pdf"));
       const pdfDoc = await loadingTask.promise;

--- a/test/unit/pdf_viewer_spec.js
+++ b/test/unit/pdf_viewer_spec.js
@@ -13,9 +13,47 @@
  * limitations under the License.
  */
 
+import { isNodeJS } from "../../src/shared/util.js";
 import { PDFPageViewBuffer } from "../../web/pdf_viewer.js";
+import { StructTreeLayerBuilder } from "../../web/struct_tree_layer_builder.js";
 
 describe("PDFViewer", function () {
+  describe("StructTreeLayerBuilder", function () {
+    it("sets table cell row and column spans (issue 18090)", async function () {
+      if (isNodeJS) {
+        pending("Document is not supported in Node.js.");
+      }
+      const pdfPage = {
+        getStructTree: async () => ({
+          role: "Root",
+          children: [
+            {
+              role: "Table",
+              children: [
+                {
+                  role: "TR",
+                  children: [
+                    {
+                      role: "TD",
+                      children: [],
+                      rowSpan: 2,
+                      colSpan: 3,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      };
+      const tree = await new StructTreeLayerBuilder(pdfPage).render();
+      const cell = tree.querySelector('[role="cell"]');
+
+      expect(cell.getAttribute("aria-rowspan")).toEqual("2");
+      expect(cell.getAttribute("aria-colspan")).toEqual("3");
+    });
+  });
+
   describe("PDFPageViewBuffer", function () {
     function createViewsMap(startId, endId) {
       const map = new Map();

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -242,7 +242,7 @@ class StructTreeLayerBuilder {
   }
 
   #setAttributes(structElement, htmlElement) {
-    const { alt, id, lang } = structElement;
+    const { alt, colSpan, id, lang, rowSpan } = structElement;
     if (alt !== undefined) {
       // Don't add the label in the struct tree layer but on the annotation
       // in the annotation layer.
@@ -268,6 +268,12 @@ class StructTreeLayerBuilder {
         "lang",
         removeNullCharacters(lang, /* replaceInvisible = */ true)
       );
+    }
+    if (rowSpan !== undefined) {
+      htmlElement.setAttribute("aria-rowspan", rowSpan);
+    }
+    if (colSpan !== undefined) {
+      htmlElement.setAttribute("aria-colspan", colSpan);
     }
   }
 


### PR DESCRIPTION
## Summary
Preserve table-cell row and column spans in the PDF structure tree and expose them through the corresponding ARIA attributes.

## Problem
Tagged PDFs can define `/RowSpan` and `/ColSpan` in table structure attributes. PDF.js retained the table roles but dropped these values while serializing the structure tree, causing merged cells to be exposed as ordinary single cells to assistive technology.

## Solution
- Preserve valid table `RowSpan` and `ColSpan` values in `StructTreeNode`
- Map the values to `aria-rowspan` and `aria-colspan` in the viewer
- Add focused extraction and rendering regression tests

## Testing
- Confirmed both regression tests fail before the fix
- Confirmed the identical tests pass after the fix
- Confirmed the issue's `table.pdf` exposes three row spans and one column span
- `npx gulp lint`
- `npx gulp typestest`
- Generic build completed successfully during unit testing
- Full Chrome unit run completed with one unrelated timezone-sensitive date failure

Fixes #18090