### PR TITLE
Shorten the `ViewHistory` class a little bit

### DIFF
--- a/web/view_history.js
+++ b/web/view_history.js
@@ -26,29 +26,22 @@ const DEFAULT_VIEW_HISTORY_CACHE_SIZE = 20;
  */
 class ViewHistory {
   constructor(fingerprint, cacheSize = DEFAULT_VIEW_HISTORY_CACHE_SIZE) {
-    this.fingerprint = fingerprint;
-    this.cacheSize = cacheSize;
-
     this._initializedPromise = this._readFromStorage().then(databaseStr => {
       const database = JSON.parse(databaseStr || "{}");
       let index = -1;
       if (!Array.isArray(database.files)) {
         database.files = [];
       } else {
-        while (database.files.length >= this.cacheSize) {
+        while (database.files.length >= cacheSize) {
           database.files.shift();
         }
 
-        for (let i = 0, ii = database.files.length; i < ii; i++) {
-          const branch = database.files[i];
-          if (branch.fingerprint === this.fingerprint) {
-            index = i;
-            break;
-          }
-        }
+        index = database.files.findIndex(
+          branch => branch.fingerprint === fingerprint
+        );
       }
       if (index === -1) {
-        index = database.files.push({ fingerprint: this.fingerprint }) - 1;
+        index = database.files.push({ fingerprint }) - 1;
       }
       this.file = database.files[index];
       this.database = database;


### PR DESCRIPTION
 - Replace the manual loop, used to find an existing entry, with the native [`findIndex` method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex).

 - Remove the `fingerprint`/`cacheSize` class fields, since they are completely unused.