### PR TITLE
Add a go to first/last menu-item helper method in the `Menu` class

### DIFF
--- a/web/menu.js
+++ b/web/menu.js
@@ -146,19 +146,11 @@ class Menu {
             stopEvent(e);
             break;
           case "Home":
-            this.#menuItems
-              .find(
-                item => !item.disabled && !item.classList.contains("hidden")
-              )
-              ?.focus();
+            this.#goToFirstLast(false);
             stopEvent(e);
             break;
           case "End":
-            this.#menuItems
-              .findLast(
-                item => !item.disabled && !item.classList.contains("hidden")
-              )
-              ?.focus();
+            this.#goToFirstLast(true);
             stopEvent(e);
             break;
           default:
@@ -194,11 +186,7 @@ class Menu {
             if (!this.#openMenuAC) {
               this.#openMenu();
             }
-            this.#menuItems
-              .find(
-                item => !item.disabled && !item.classList.contains("hidden")
-              )
-              ?.focus();
+            this.#goToFirstLast(false);
             break;
           case "ArrowUp":
           case "End":
@@ -206,11 +194,7 @@ class Menu {
             if (!this.#openMenuAC) {
               this.#openMenu();
             }
-            this.#menuItems
-              .findLast(
-                item => !item.disabled && !item.classList.contains("hidden")
-              )
-              ?.focus();
+            this.#goToFirstLast(true);
             break;
           case "Escape":
             this.#closeMenu();
@@ -249,6 +233,20 @@ class Menu {
         this.#lastIndex = i;
         break;
       }
+    }
+  }
+
+  /**
+   * Go to the first/last menu item.
+   * @param {boolean} [last]
+   */
+  #goToFirstLast(last = false) {
+    const i = this.#menuItems[last ? "findLastIndex" : "findIndex"](
+      item => !item.disabled && !item.classList.contains("hidden")
+    );
+    if (i >= 0) {
+      this.#menuItems[i].focus();
+      this.#lastIndex = i;
     }
   }
 


### PR DESCRIPTION
This fixes a bug when using the <kbd>Home</kbd> and <kbd>End</kbd> keyboard shortcuts to navigate through a `Menu` instance. These two buttons didn't update the `#lastIndex` field, which means that e.g. a following <kbd>ArrowDown</kbd> or <kbd>ArrowUp</kbd> press could make focus "jump" to an unexpected menu-item.

Also, the helper method reduces a little bit of code duplication in the event handlers.