### PR TITLE
Add scripts correctly in `Field.prototype.setAction` (PR 12569 follow-up)

### DIFF
--- a/src/scripting_api/field.js
+++ b/src/scripting_api/field.js
@@ -14,9 +14,9 @@
  */
 
 import { createActionsMap, FieldType, getFieldType } from "./common.js";
+import { makeArr, serializeError } from "./app_utils.js";
 import { Color } from "./color.js";
 import { PDFObject } from "./pdf_object.js";
-import { serializeError } from "./app_utils.js";
 
 class Field extends PDFObject {
   constructor(data) {
@@ -496,10 +496,7 @@ class Field extends PDFObject {
     if (typeof cTrigger !== "string" || typeof cScript !== "string") {
       return;
     }
-    if (!(cTrigger in this._actions)) {
-      this._actions[cTrigger] = [];
-    }
-    this._actions[cTrigger].push(cScript);
+    this._actions.getOrInsertComputed(cTrigger, makeArr).push(cScript);
   }
 
   setFocus() {

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -363,6 +363,80 @@ describe("Scripting", function () {
       });
     });
 
+    it("should trigger an event added with setAction", async () => {
+      const refId = getId();
+      const data = {
+        objects: {
+          field: [
+            {
+              id: refId,
+              value: "",
+              actions: {},
+              type: "text",
+            },
+          ],
+        },
+        appInfo: { language: "en-US", platform: "Linux x86_64" },
+        calculationOrder: [],
+      };
+      sandbox.createSandbox(data);
+
+      await myeval(
+        `(this.getField("field").setAction("test", 'event.source.value = "abc";'), 0)`
+      );
+
+      await sandbox.dispatchEventInSandbox({
+        id: refId,
+        value: "",
+        name: "test",
+        willCommit: true,
+      });
+
+      expect(send_queue.has(refId)).toBeTrue();
+      expect(send_queue.get(refId)).toEqual({
+        id: refId,
+        value: "abc",
+      });
+    });
+
+    it("should trigger an event appended with setAction", async () => {
+      const refId = getId();
+      const data = {
+        objects: {
+          field: [
+            {
+              id: refId,
+              value: "",
+              actions: {
+                test: [`event.source.value = "a";`],
+              },
+              type: "text",
+            },
+          ],
+        },
+        appInfo: { language: "en-US", platform: "Linux x86_64" },
+        calculationOrder: [],
+      };
+      sandbox.createSandbox(data);
+
+      await myeval(
+        `(this.getField("field").setAction("test", 'event.source.value += "b";'), 0)`
+      );
+
+      await sandbox.dispatchEventInSandbox({
+        id: refId,
+        value: "",
+        name: "test",
+        willCommit: true,
+      });
+
+      expect(send_queue.has(refId)).toBeTrue();
+      expect(send_queue.get(refId)).toEqual({
+        id: refId,
+        value: "ab",
+      });
+    });
+
     it("should trigger a Keystroke event and invalidate it", async () => {
       const refId = getId();
       const data = {


### PR DESCRIPTION
In PR #12569 the `_actions` class-field was changed from an Object into a Map, with *most* of the code updated to reflect that.
However, in the `setAction` method it's still treated as an Object which means that any added script will simply be ignored. Most likely that part of the scripting-implementation isn't being used, since this code has been "wrong" for close to six years now.

*Note:* This was found by code inspection, and I unfortunately don't have a test-case that fails without it.