### PR TITLE
Document how to use the viewer to open files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ latest JavaScript features; please also see [this wiki page](https://github.com/
 
 + Older browsers: https://mozilla.github.io/pdf.js/legacy/web/viewer.html
 
+> [!NOTE]
+> Open new files via the menu (the ">>" icon) or by dragging and dropping.
+
 ### Browser Extensions
 
 #### Firefox


### PR DESCRIPTION
This is not an option that appears in the Firefox integration, so it is not obvious how to find it.

Also, rearrange the surrounding text to account for the changes in other browsers.  The legacy viewer might be useful in narrow cases, but modern JS support is now pretty widely available.