### PR TITLE
Shorten the `Menu` constructor a tiny bit

### DIFF
--- a/web/menu.js
+++ b/web/menu.js
@@ -39,14 +39,9 @@ class Menu {
   constructor(menuContainer, triggeringButton, menuItems) {
     this.#menu = menuContainer;
     this.#triggeringButton = triggeringButton;
-    if (Array.isArray(menuItems)) {
-      this.#menuItems = menuItems;
-    } else {
-      this.#menuItems = [];
-      for (const button of this.#menu.querySelectorAll("button")) {
-        this.#menuItems.push(button);
-      }
-    }
+    this.#menuItems = Array.isArray(menuItems)
+      ? menuItems
+      : [...this.#menu.querySelectorAll("button")];
     this.#setUpMenu();
   }
 


### PR DESCRIPTION
The fallback path used when the `menuItems` aren't provided/correct can be simplified, since the manual loop isn't necessary.