### PR TITLE
Expose the table structure attributes in the struct tree

### DIFF
--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -16,10 +16,19 @@
 import {
   AnnotationPrefix,
   makeArr,
+  shadow,
   stringToUTF8String,
   warn,
 } from "../shared/util.js";
-import { Dict, isDict, isName, Name, Ref, RefSetCache } from "./primitives.js";
+import {
+  Dict,
+  isDict,
+  isName,
+  Name,
+  Ref,
+  RefSet,
+  RefSetCache,
+} from "./primitives.js";
 import { lookupNormalRect, MissingDataException } from "./core_utils.js";
 import { stringToAsciiOrUTF16BE, stringToPDFString } from "./string_utils.js";
 import { BaseStream } from "./base_stream.js";
@@ -27,6 +36,10 @@ import { FileSpec } from "./file_spec.js";
 import { NumberTree } from "./name_number_tree.js";
 
 const MAX_DEPTH = 40;
+const TABLE_SPAN_ATTRIBUTES = [
+  ["RowSpan", "rowSpan"],
+  ["ColSpan", "colSpan"],
+];
 
 const StructElementType = {
   PAGE_CONTENT: 1,
@@ -601,16 +614,146 @@ class StructElementNode {
       // The default encoding for xml files is UTF-8.
       return stringToUTF8String(fileStream.getString());
     }
-    const A = this.dict.get("A");
-    if (A instanceof Dict) {
+    for (const attributes of this.attributes) {
       // This stuff isn't in the spec, but MS Office seems to use it.
-      const O = A.get("O");
-      if (isName(O, "MSFT_Office")) {
-        const mathml = A.get("MSFT_MathML");
+      if (isName(attributes.get("O"), "MSFT_Office")) {
+        const mathml = attributes.get("MSFT_MathML");
         return mathml ? stringToPDFString(mathml) : null;
       }
     }
     return null;
+  }
+
+  #collectAttributes(value, attributes) {
+    const pending = [value];
+    const visited = new RefSet();
+
+    while (pending.length > 0) {
+      value = pending.pop();
+      if (value instanceof Ref) {
+        // Only indirect references can make a PDF attribute graph cyclic.
+        if (visited.has(value)) {
+          continue;
+        }
+        visited.put(value);
+        value = this.xref.fetch(value);
+      }
+      if (value instanceof BaseStream) {
+        value = value.dict;
+      }
+      if (value instanceof Dict) {
+        attributes.push(value);
+        continue;
+      }
+      if (!Array.isArray(value)) {
+        continue;
+      }
+
+      // Process entries in source order. Attribute arrays may interleave
+      // attribute objects and revision numbers.
+      for (let i = value.length - 1; i >= 0; i--) {
+        if (!Number.isInteger(value[i])) {
+          pending.push(value[i]);
+        }
+      }
+    }
+  }
+
+  get attributes() {
+    const attributes = [];
+
+    const classes = this.dict.getArray("C");
+    if (classes !== undefined) {
+      const classMap = this.tree.rootDict?.get("ClassMap");
+      if (classMap instanceof Dict) {
+        // Class names may be interleaved with revision numbers.
+        for (const className of Array.isArray(classes) ? classes : [classes]) {
+          if (className instanceof Name) {
+            this.#collectAttributes(
+              classMap.getRaw(className.name),
+              attributes
+            );
+          }
+        }
+      }
+    }
+
+    // Explicit attributes take precedence over attributes from a class.
+    this.#collectAttributes(this.dict.getRaw("A"), attributes);
+
+    return shadow(this, "attributes", attributes);
+  }
+
+  get tableAttributes() {
+    const { role } = this;
+    if (role !== "Table" && role !== "TH" && role !== "TD") {
+      return null;
+    }
+
+    const result = Object.create(null);
+    for (const attributes of this.attributes) {
+      if (!isName(attributes.get("O"), "Table")) {
+        continue;
+      }
+
+      if (role === "Table") {
+        if (attributes.has("Summary")) {
+          const summary = attributes.get("Summary");
+          if (typeof summary === "string" && summary) {
+            result.summary = stringToPDFString(summary);
+          } else {
+            delete result.summary;
+          }
+        }
+        continue;
+      }
+
+      for (const [key, name] of TABLE_SPAN_ATTRIBUTES) {
+        if (!attributes.has(key)) {
+          continue;
+        }
+        const value = attributes.get(key);
+        if (Number.isInteger(value) && value > 1) {
+          result[name] = value;
+        } else {
+          // Omit default and invalid values, clearing any earlier class value.
+          delete result[name];
+        }
+      }
+
+      if (attributes.has("Headers")) {
+        delete result.headers;
+        const headers = attributes.getArray("Headers");
+        if (Array.isArray(headers)) {
+          const ids = headers
+            .filter(header => typeof header === "string")
+            .map(header => stringToPDFString(header));
+          if (ids.length > 0) {
+            result.headers = ids;
+          }
+        }
+      }
+
+      if (role === "TH" && attributes.has("Scope")) {
+        delete result.scope;
+        const scope = attributes.get("Scope");
+        if (
+          scope instanceof Name &&
+          ["Row", "Column", "Both"].includes(scope.name)
+        ) {
+          result.scope = scope.name;
+        }
+      }
+
+      if (role === "TH" && attributes.has("Short")) {
+        delete result.short;
+        const short = attributes.get("Short");
+        if (typeof short === "string" && short) {
+          result.short = stringToPDFString(short);
+        }
+      }
+    }
+    return Object.keys(result).length > 0 ? result : null;
   }
 
   parseKids() {
@@ -892,6 +1035,18 @@ class StructTreePage {
       if (typeof alt === "string") {
         obj.alt = stringToPDFString(alt);
       }
+
+      // Note that this must not be called `id`, since that name is already
+      // used, with a different meaning, on the content/object/annotation
+      // children below.
+      const structId = node.dict.get("ID");
+      if (obj.role === "TH" && typeof structId === "string" && structId) {
+        obj.structId = stringToPDFString(structId);
+      }
+      const tableAttributes = node.tableAttributes;
+      if (tableAttributes) {
+        Object.assign(obj, tableAttributes);
+      }
       if (obj.role === "Formula") {
         try {
           const { mathML } = node;
@@ -906,29 +1061,30 @@ class StructTreePage {
         }
       }
 
-      const a = node.dict.get("A");
-      if (a instanceof Dict) {
-        const bbox = lookupNormalRect(a.getArray("BBox"), null);
-        if (bbox) {
-          obj.bbox = bbox;
-        } else {
-          const width = a.get("Width");
-          const height = a.get("Height");
-          if (
-            typeof width === "number" &&
-            width > 0 &&
-            typeof height === "number" &&
-            height > 0
-          ) {
-            obj.bbox = [0, 0, width, height];
-          }
+      let bbox = null,
+        size = null;
+      for (const a of node.attributes) {
+        bbox = lookupNormalRect(a.getArray("BBox"), bbox);
+        const width = a.get("Width");
+        const height = a.get("Height");
+        if (
+          typeof width === "number" &&
+          width > 0 &&
+          typeof height === "number" &&
+          height > 0
+        ) {
+          size = [0, 0, width, height];
         }
-        // TODO: If the bbox is not available, we should try to get it from
-        // the content stream.
-        // For example when rendering on the canvas the commands between the
-        // beginning and the end of the marked-content sequence, we can
-        // compute the overall bbox.
       }
+      // Prefer BBox because Width and Height cannot recover its position.
+      if (bbox || size) {
+        obj.bbox = bbox ?? size;
+      }
+      // TODO: If the bbox is not available, we should try to get it from
+      // the content stream.
+      // For example when rendering on the canvas the commands between the
+      // beginning and the end of the marked-content sequence, we can
+      // compute the overall bbox.
 
       const lang = node.dict.get("Lang");
       if (typeof lang === "string") {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1292,6 +1292,18 @@ class PDFDocumentProxy {
  *   {@link StructTreeNode} and {@link StructTreeContent} objects.
  * @property {string} role - element's role, already mapped if a role map exists
  * in the PDF.
+ * @property {string} [structId] - A table header's structure element
+ *   identifier, i.e. its `ID` entry. Note that this is unrelated to the `id`
+ *   property of a {@link StructTreeContent} object.
+ * @property {number} [rowSpan] - The number of rows spanned by a table cell.
+ * @property {number} [colSpan] - The number of columns spanned by a table cell.
+ * @property {Array<string>} [headers] - The `structId` values of the table
+ *   headers associated with a table cell.
+ * @property {"Row" | "Column" | "Both"} [scope] - The cells to which a table
+ *   header applies.
+ * @property {string} [short] - An abbreviated version of a table header's
+ *   content.
+ * @property {string} [summary] - A summary of a table's purpose and structure.
  */
 
 /**

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4711,6 +4711,85 @@ have written that much by now. So, here’s to squashing bugs.`);
       await loadingTask.destroy();
     });
 
+    it("gets table structure attributes (issue 18090)", async function () {
+      const objects = [
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R " +
+          "/StructTreeRoot 4 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /StructParents 0 " +
+          "/MediaBox [0 0 100 100] >>\nendobj\n",
+        "4 0 obj\n<< /Type /StructTreeRoot /K 5 0 R " +
+          "/ParentTree 10 0 R /ClassMap 11 0 R >>\nendobj\n",
+        "5 0 obj\n<< /Type /StructElem /S /Table /P 4 0 R /K 6 0 R " +
+          "/A [<< /O /Table /Summary (Purpose and structure) >> 0] " +
+          ">>\nendobj\n",
+        "6 0 obj\n<< /Type /StructElem /S /TR /P 5 0 R " +
+          "/K [7 0 R 8 0 R 9 0 R] >>\nendobj\n",
+        "7 0 obj\n<< /Type /StructElem /S /TH /P 6 0 R /Pg 3 0 R " +
+          "/ID (column) /C /spanning /K 0 " +
+          "/A [<< /O /Table /Scope /Column >> 1] >>\nendobj\n",
+        "8 0 obj\n<< /Type /StructElem /S /TH /P 6 0 R /Pg 3 0 R " +
+          "/ID (row) /C /overridden /K 1 " +
+          "/A << /O /Table /Scope /Row /Short (Row) " +
+          "/RowSpan 1 /ColSpan 1 >> " +
+          ">>\nendobj\n",
+        "9 0 obj\n<< /Type /StructElem /S /TD /P 6 0 R /Pg 3 0 R /K 2 " +
+          "/A [<< /O /Table /Headers 12 0 R >> 0] >>\nendobj\n",
+        "10 0 obj\n<< /Nums [0 [7 0 R 8 0 R 9 0 R]] >>\nendobj\n",
+        "11 0 obj\n<< " +
+          "/spanning << /O /Table /RowSpan 2 /ColSpan 3 " +
+          "/Short (Column) >> " +
+          "/overridden << /O /Table /RowSpan 4 /ColSpan 5 /Scope /Both " +
+          "/Short (Long row header) >> " +
+          ">>\nendobj\n",
+        "12 0 obj\n[(column) 13 0 R]\nendobj\n",
+        "13 0 obj\n(row)\nendobj\n",
+      ];
+      const loadingTask = getDocument({ data: assemblePdf(objects) });
+      const pdfDoc = await loadingTask.promise;
+      const tree = await (await pdfDoc.getPage(1)).getStructTree();
+
+      expect(tree).toEqual({
+        role: "Root",
+        children: [
+          {
+            role: "Table",
+            summary: "Purpose and structure",
+            children: [
+              {
+                role: "TR",
+                children: [
+                  {
+                    role: "TH",
+                    structId: "column",
+                    rowSpan: 2,
+                    colSpan: 3,
+                    scope: "Column",
+                    short: "Column",
+                    children: [{ type: "content", id: "p3R_mc0" }],
+                  },
+                  {
+                    role: "TH",
+                    structId: "row",
+                    scope: "Row",
+                    short: "Row",
+                    children: [{ type: "content", id: "p3R_mc1" }],
+                  },
+                  {
+                    role: "TD",
+                    headers: ["column", "row"],
+                    children: [{ type: "content", id: "p3R_mc2" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      await loadingTask.destroy();
+    });
+
     it("gets corrupt structure tree with non-dictionary nodes (issue 18503)", async function () {
       const loadingTask = getDocument(buildGetDocumentParams("issue18503.pdf"));
       const pdfDoc = await loadingTask.promise;

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -55,6 +55,7 @@
     "sound_spec.js",
     "stream_spec.js",
     "string_utils_spec.js",
+    "struct_tree_layer_builder_spec.js",
     "struct_tree_spec.js",
     "svg_factory_spec.js",
     "text_layer_spec.js",

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -102,6 +102,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/sound_spec.js",
       "pdfjs-test/unit/stream_spec.js",
       "pdfjs-test/unit/string_utils_spec.js",
+      "pdfjs-test/unit/struct_tree_layer_builder_spec.js",
       "pdfjs-test/unit/struct_tree_spec.js",
       "pdfjs-test/unit/svg_factory_spec.js",
       "pdfjs-test/unit/text_layer_spec.js",

--- a/test/unit/struct_tree_layer_builder_spec.js
+++ b/test/unit/struct_tree_layer_builder_spec.js
@@ -1,0 +1,215 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isNodeJS } from "../../src/shared/util.js";
+import { StructTreeLayerBuilder } from "../../web/struct_tree_layer_builder.js";
+
+describe("StructTreeLayerBuilder", function () {
+  function render(structTree) {
+    return new StructTreeLayerBuilder({
+      getStructTree: async () => structTree,
+    }).render();
+  }
+
+  beforeEach(function () {
+    if (isNodeJS) {
+      pending("Document is not supported in Node.js.");
+    }
+  });
+
+  it("exposes table semantics", async function () {
+    const tree = await render({
+      role: "Root",
+      children: [
+        {
+          role: "Table",
+          summary: "A summary of the table",
+          children: [
+            { role: "Caption", children: [] },
+            {
+              role: "THead",
+              children: [
+                {
+                  role: "TR",
+                  children: [
+                    {
+                      role: "TH",
+                      structId: "parentHeader",
+                      scope: "Column",
+                      short: "Parent",
+                      children: [],
+                    },
+                    {
+                      role: "TH",
+                      structId: "rowHeader",
+                      scope: "Row",
+                      rowSpan: 2,
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              role: "TBody",
+              children: [
+                {
+                  role: "TR",
+                  children: [
+                    {
+                      role: "TH",
+                      structId: "columnHeader",
+                      scope: "Column",
+                      colSpan: 3,
+                      headers: ["parentHeader"],
+                      children: [],
+                    },
+                    {
+                      role: "TD",
+                      headers: ["columnHeader", "rowHeader"],
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            { role: "TFoot", children: [] },
+          ],
+        },
+      ],
+    });
+    const table = tree.querySelector('[role="table"]');
+
+    expect(table.getAttribute("aria-description")).toEqual(
+      "A summary of the table"
+    );
+    expect(
+      Array.from(table.children, element => element.getAttribute("role"))
+    ).toEqual(["caption", "rowgroup", "rowgroup", "rowgroup"]);
+
+    const [parentHeader, columnHeader] = tree.querySelectorAll(
+      '[role="columnheader"]'
+    );
+    const rowHeader = tree.querySelector('[role="rowheader"]');
+    const cell = tree.querySelector('[role="cell"]');
+
+    expect(rowHeader.getAttribute("aria-rowspan")).toEqual("2");
+    expect(columnHeader.getAttribute("aria-colspan")).toEqual("3");
+
+    // Use generated DOM identifiers rather than identifiers supplied by the
+    // PDF.
+    expect(parentHeader.id).not.toEqual("parentHeader");
+
+    // Keep `Short` out of the header's own accessible name; referring cells
+    // use it through the hidden `aria-describedby` target.
+    expect(parentHeader.getAttribute("aria-label")).toBeNull();
+    const abbreviation = parentHeader.firstElementChild;
+    expect(abbreviation.textContent).toEqual("Parent");
+    expect(abbreviation.getAttribute("aria-hidden")).toEqual("true");
+
+    expect(columnHeader.getAttribute("aria-describedby")).toEqual(
+      abbreviation.id
+    );
+    expect(cell.getAttribute("aria-describedby").split(" ")).toEqual([
+      columnHeader.id,
+      abbreviation.id,
+      rowHeader.id,
+    ]);
+  });
+
+  it("keeps the alt text of a header having a short form", async function () {
+    const tree = await render({
+      role: "Root",
+      children: [
+        {
+          role: "Table",
+          children: [
+            {
+              role: "TR",
+              children: [
+                {
+                  role: "TH",
+                  structId: "header",
+                  scope: "Column",
+                  alt: "Gross domestic product",
+                  short: "GDP",
+                  children: [{ type: "content", id: "p1R_mc0" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const header = tree.querySelector('[role="columnheader"]');
+
+    expect(header.getAttribute("aria-label")).toEqual("Gross domestic product");
+    expect(header.getAttribute("aria-owns")).toEqual("p1R_mc0");
+    expect(header.firstElementChild.textContent).toEqual("GDP");
+  });
+
+  it("doesn't collapse a table cell into its row (issue 18090)", async function () {
+    // Keep a single structural cell distinct from its row; otherwise the
+    // cell's role and attributes would be applied to the row.
+    const tree = await render({
+      role: "Root",
+      children: [
+        {
+          role: "Table",
+          children: [
+            {
+              role: "TR",
+              children: [
+                {
+                  role: "TH",
+                  structId: "header",
+                  colSpan: 3,
+                  scope: "Column",
+                  children: [{ type: "content", id: "p1R_mc0" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const row = tree.querySelector('[role="row"]');
+    const header = row.firstElementChild;
+
+    expect(header.getAttribute("role")).toEqual("columnheader");
+    expect(header.getAttribute("aria-colspan")).toEqual("3");
+    expect(header.getAttribute("aria-owns")).toEqual("p1R_mc0");
+
+    expect(row.getAttribute("aria-colspan")).toBeNull();
+    expect(row.getAttribute("aria-owns")).toBeNull();
+    expect(row.id).toEqual("");
+  });
+
+  it("only uses the caption role inside a table or a figure", async function () {
+    const tree = await render({
+      role: "Root",
+      children: [
+        { role: "Table", children: [{ role: "Caption", children: [] }] },
+        { role: "Figure", children: [{ role: "Caption", children: [] }] },
+        { role: "Div", children: [{ role: "Caption", children: [] }] },
+      ],
+    });
+    const [table, figure, div] = tree.children;
+
+    expect(table.firstElementChild.getAttribute("role")).toEqual("caption");
+    expect(figure.firstElementChild.getAttribute("role")).toEqual("caption");
+    expect(div.firstElementChild.getAttribute("role")).toBeNull();
+  });
+});

--- a/test/unit/struct_tree_spec.js
+++ b/test/unit/struct_tree_spec.js
@@ -109,6 +109,43 @@ describe("struct tree", function () {
     });
   });
 
+  it("parses table cell spans from attribute arrays (issue 18090)", async function () {
+    // In this fixture, table and layout attribute dictionaries are separate
+    // indirect objects referenced from the cells' `A` arrays.
+    const filename = "issue13132.pdf";
+    const params = buildGetDocumentParams(filename);
+    const loadingTask = getDocument(params);
+    const doc = await loadingTask.promise;
+    const spans = [];
+
+    function collect(node, pageNumber) {
+      if (node.rowSpan || node.colSpan) {
+        spans.push(
+          `${pageNumber}:${node.role}:${node.rowSpan ?? 1}x${node.colSpan ?? 1}`
+        );
+      }
+      for (const kid of node.children || []) {
+        collect(kid, pageNumber);
+      }
+    }
+
+    for (const pageNumber of [1, 4]) {
+      const page = await doc.getPage(pageNumber);
+      collect(await page.getStructTree(), pageNumber);
+    }
+    expect(spans).toEqual([
+      "1:TD:1x5",
+      "1:TD:1x5",
+      "1:TH:1x3",
+      "1:TH:1x4",
+      "4:TD:1x2",
+      "4:TH:3x1",
+      "4:TD:2x1",
+    ]);
+
+    await loadingTask.destroy();
+  });
+
   it("parses structure with a figure and its bounding box", async function () {
     const filename = "bug1708040.pdf";
     const params = buildGetDocumentParams(filename);

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -15,7 +15,7 @@
 
 /** @typedef {import("../src/display/api").PDFPageProxy} PDFPageProxy */
 
-import { FeatureTest, makeMap, shadow } from "pdfjs-lib";
+import { FeatureTest, getUuid, makeMap, shadow } from "pdfjs-lib";
 import { removeNullCharacters } from "./ui_utils.js";
 
 const PDF_ROLE_TO_HTML_ROLE = {
@@ -63,9 +63,9 @@ const PDF_ROLE_TO_HTML_ROLE = {
   TD: "cell",
   THead: "rowgroup",
   TBody: "rowgroup",
-  TFoot: null,
+  TFoot: "rowgroup",
   // Standard structure type Caption
-  Caption: null,
+  Caption: "caption",
   // Standard structure type Figure
   Figure: "figure",
   // Standard structure type Formula
@@ -179,6 +179,12 @@ class StructTreeLayerBuilder {
 
   #elementAttributes = new Map();
 
+  #structElementIdPrefix = `pdfjs_internal_struct_${getUuid()}_`;
+
+  #structElementIds = new Map();
+
+  #structElements = new Map();
+
   #rawDims;
 
   #elementsToAddToTextLayer = null;
@@ -206,7 +212,9 @@ class StructTreeLayerBuilder {
     this.#treePromise = promise;
 
     try {
-      this.#treeDom = this.#walk(await this.#promise);
+      const tree = await this.#promise;
+      this.#collectStructElements(tree);
+      this.#treeDom = this.#walk(tree);
     } catch (ex) {
       reject(ex);
     }
@@ -241,8 +249,71 @@ class StructTreeLayerBuilder {
     }
   }
 
+  #collectStructElements(node) {
+    if (!node) {
+      return;
+    }
+    // Structure element IDs must be unique within the structure hierarchy;
+    // keep the first element when a malformed document reuses an ID.
+    if (node.structId) {
+      this.#structElements.getOrInsert(node.structId, node);
+    }
+    for (const child of node.children || []) {
+      this.#collectStructElements(child);
+    }
+  }
+
+  #getStructElementId(structId) {
+    return this.#structElementIds.getOrInsertComputed(
+      structId,
+      () => `${this.#structElementIdPrefix}${this.#structElementIds.size}`
+    );
+  }
+
+  #getHeaderIds(headers) {
+    const result = [],
+      visited = new Set(),
+      pending = headers.toReversed();
+
+    while (pending.length > 0) {
+      const structId = pending.pop();
+      if (visited.has(structId)) {
+        continue;
+      }
+      visited.add(structId);
+
+      // The core retains table structure elements from other pages but omits
+      // their marked content. `Alt` or `Short` can still provide accessible
+      // text.
+      const header = this.#structElements.get(structId);
+      if (header?.role !== "TH") {
+        continue;
+      }
+      result.push(this.#getStructElementId(structId));
+
+      // A header may itself refer to other headers. Include those
+      // recursively, as required by ISO 32000-1, Table 349.
+      if (header.headers) {
+        for (let i = header.headers.length - 1; i >= 0; i--) {
+          pending.push(header.headers[i]);
+        }
+      }
+    }
+    return result;
+  }
+
   #setAttributes(structElement, htmlElement) {
-    const { alt, id, lang } = structElement;
+    const {
+      alt,
+      colSpan,
+      headers,
+      id,
+      lang,
+      rowSpan,
+      short,
+      structId,
+      summary,
+    } = structElement;
     if (alt !== undefined) {
       // Don't add the label in the struct tree layer but on the annotation
       // in the annotation layer.
@@ -263,10 +334,49 @@ class StructTreeLayerBuilder {
     if (id !== undefined) {
       htmlElement.setAttribute("aria-owns", id);
     }
+    if (
+      structId !== undefined &&
+      this.#structElements.get(structId) === structElement
+    ) {
+      const elementId = this.#getStructElementId(structId);
+      if (short !== undefined) {
+        // `Short` is the PDF 2.0 abbreviated form of a TH element's content
+        // (see ISO 32000-2, Table 384). Keep the header's own accessible name
+        // and expose the abbreviation through a hidden target used by
+        // referring cells. `aria-describedby` includes directly referenced
+        // hidden content, while an unreferenced hidden child does not
+        // contribute to its parent's name.
+        const abbreviation = document.createElement("span");
+        abbreviation.setAttribute("id", elementId);
+        abbreviation.setAttribute("aria-hidden", "true");
+        abbreviation.textContent = removeNullCharacters(short);
+        htmlElement.append(abbreviation);
+      } else {
+        htmlElement.setAttribute("id", elementId);
+      }
+    }
     if (lang !== undefined) {
       htmlElement.setAttribute(
         "lang",
         removeNullCharacters(lang, /* replaceInvisible = */ true)
+      );
+    }
+    if (rowSpan !== undefined) {
+      htmlElement.setAttribute("aria-rowspan", rowSpan);
+    }
+    if (colSpan !== undefined) {
+      htmlElement.setAttribute("aria-colspan", colSpan);
+    }
+    if (headers?.length > 0) {
+      const headerIds = this.#getHeaderIds(headers);
+      if (headerIds.length > 0) {
+        htmlElement.setAttribute("aria-describedby", headerIds.join(" "));
+      }
+    }
+    if (summary !== undefined) {
+      htmlElement.setAttribute(
+        "aria-description",
+        removeNullCharacters(summary)
       );
     }
   }
@@ -387,14 +497,32 @@ class StructTreeLayerBuilder {
         element.setAttribute("role", "heading");
         element.setAttribute("aria-level", match[1]);
       } else if (PDF_ROLE_TO_HTML_ROLE[role]) {
-        element.setAttribute(
-          "role",
-          role === "TH" &&
+        let htmlRole = PDF_ROLE_TO_HTML_ROLE[role];
+        if (role === "TH") {
+          if (node.scope === "Row") {
+            htmlRole = "rowheader";
+          } else if (node.scope === "Column") {
+            htmlRole = "columnheader";
+          } else if (
             parentNodes.at(-1)?.role === "TR" &&
             parentNodes.at(-2)?.role === "TBody"
-            ? "rowheader" // TH inside TR itself in TBody is a rowheader.
-            : PDF_ROLE_TO_HTML_ROLE[role]
-        );
+          ) {
+            // ARIA has no role for a header applying to both axes. Use the
+            // existing positional fallback for Both and for an omitted Scope.
+            htmlRole = "rowheader";
+          }
+        } else if (role === "Caption") {
+          // ARIA's caption role requires a table, grid, treegrid, or figure
+          // context and SHOULD be a direct child. This builder only produces
+          // table and figure among those roles.
+          const parentRole = parentNodes.at(-1)?.role;
+          if (parentRole !== "Table" && parentRole !== "Figure") {
+            htmlRole = null;
+          }
+        }
+        if (htmlRole) {
+          element.setAttribute("role", htmlRole);
+        }
       }
       if (role === "Figure" && this.#addImageInTextLayer(node, element)) {
         return element;
@@ -430,9 +558,15 @@ class StructTreeLayerBuilder {
     this.#setAttributes(node, element);
 
     if (node.children) {
-      if (node.children.length === 1 && "id" in node.children[0]) {
+      if (
+        node.children.length === 1 &&
+        !("role" in node.children[0]) &&
+        "id" in node.children[0]
+      ) {
         // Often there is only one content node so just set the values on the
-        // parent node to avoid creating an extra span.
+        // parent node to avoid creating an extra span. Note that this must be
+        // limited to leaf children: a structure element has to be visited in
+        // order to get its own role and attributes.
         this.#setAttributes(node.children[0], element);
       } else if (visitChildren) {
         parentNodes.push(node);


### PR DESCRIPTION
Preserve `RowSpan`, `ColSpan`, `Headers`, `Scope`, `Short` and `Summary` when serializing the structure tree, and map them to the corresponding ARIA attributes in the viewer.

The attributes are now collected from both the `A` and the `C` entries, which may be arrays interleaving dictionaries and revision numbers: this also fixes the bounding box and the MS Office MathML lookups, which only handled a single direct dictionary.

Fixes #18090.