### PR TITLE
Add integration tests for the Home/End keys in the `Menu` class

### DIFF
--- a/test/integration/thumbnail_view_spec.mjs
+++ b/test/integration/thumbnail_view_spec.mjs
@@ -327,6 +327,80 @@ describe("PDF Thumbnail View", () => {
         })
       );
     });
+
+    it("must move to the previous item after pressing the End key", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await showViewsManager(page);
+          await waitForThumbnailVisible(page, 1);
+
+          await enableMenuItems(page);
+
+          await kbFocusNext(page, "#viewsManagerStatusActionButton");
+          await page.keyboard.press("Enter");
+          await waitForMenu(page, "#viewsManagerStatusActionButton");
+          await page.waitForSelector("#viewsManagerStatusActionCopy:focus", {
+            visible: true,
+          });
+
+          // Move to the second menu item.
+          await page.keyboard.press("ArrowDown");
+          await page.waitForSelector("#viewsManagerStatusActionCut:focus", {
+            visible: true,
+          });
+
+          // Jump to the last menu item.
+          await page.keyboard.press("End");
+          await page.waitForSelector("#viewsManagerStatusActionExport:focus", {
+            visible: true,
+          });
+
+          // The focus must move relative to the last menu item, and not
+          // relative to the item that was focused before pressing End.
+          await page.keyboard.press("ArrowUp");
+          await page.waitForSelector("#viewsManagerStatusActionDelete:focus", {
+            visible: true,
+          });
+        })
+      );
+    });
+
+    it("must move to the next item after pressing the Home key", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await showViewsManager(page);
+          await waitForThumbnailVisible(page, 1);
+
+          await enableMenuItems(page);
+
+          await kbFocusNext(page, "#viewsManagerStatusActionButton");
+          await page.keyboard.press("Enter");
+          await waitForMenu(page, "#viewsManagerStatusActionButton");
+          await page.waitForSelector("#viewsManagerStatusActionCopy:focus", {
+            visible: true,
+          });
+
+          // Wrap around to the last menu item.
+          await page.keyboard.press("ArrowUp");
+          await page.waitForSelector("#viewsManagerStatusActionExport:focus", {
+            visible: true,
+          });
+
+          // Jump to the first menu item.
+          await page.keyboard.press("Home");
+          await page.waitForSelector("#viewsManagerStatusActionCopy:focus", {
+            visible: true,
+          });
+
+          // The focus must move relative to the first menu item, and not
+          // relative to the item that was focused before pressing Home.
+          await page.keyboard.press("ArrowDown");
+          await page.waitForSelector("#viewsManagerStatusActionCut:focus", {
+            visible: true,
+          });
+        })
+      );
+    });
   });
 
   describe("Checkbox accessibility", () => {


### PR DESCRIPTION
Follow-up to PR #21690: these tests check that pressing Home/End correctly updates the last focused menu-item index, so that a following ArrowUp/ArrowDown press doesn't move focus to an unexpected menu-item.