### PR TITLE
Enable the `regexp/no-super-linear-move` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,7 @@ export default [
     rules: {
       ...regexpPlugin.configs["flat/recommended"].rules,
       "regexp/no-legacy-features": "off",
+      "regexp/no-super-linear-move": "error",
     },
   },
   {

--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -53,7 +53,7 @@ function preprocess(inFilename, outFilename, defines) {
     }
 
     return content.replaceAll(
-      /^\s*@import\s+url\(([^)]+)\);\s*$/gm,
+      /^[ \t]*@import\s+url\(([^)]+)\);[ \t]*$/gm,
       function (all, url) {
         const file = path.join(path.dirname(baseUrl), url);
         const imported = fs.readFileSync(file, "utf8").toString();

--- a/external/cmapscompress/parse.mjs
+++ b/external/cmapscompress/parse.mjs
@@ -37,7 +37,7 @@ function parseAdobeCMap(content) {
     result.usecmap = m[1];
   }
   const re =
-    /(\d+)\s+(begincodespacerange|beginnotdefrange|begincidchar|begincidrange|beginbfchar|beginbfrange)\n([\s\S]*?)\n(?:endcodespacerange|endnotdefrange|endcidchar|endcidrange|endbfchar|endbfrange)/g;
+    /\b(\d+)\s+(begincodespacerange|beginnotdefrange|begincidchar|begincidrange|beginbfchar|beginbfrange)\n([\s\S]*?)\n(?:endcodespacerange|endnotdefrange|endcidchar|endcidrange|endbfchar|endbfrange)/g;
   while ((m = re.exec(body))) {
     const lines = m[3].toLowerCase().split("\n");
 

--- a/test/unit/scripting_spec.js
+++ b/test/unit/scripting_spec.js
@@ -753,10 +753,10 @@ describe("Scripting", function () {
       it("should parse a date with a format", async () => {
         const check = async (date, format, expected) => {
           const value = await myeval(
-            `AFParseDateEx("${date}", "${format}").toISOString().replace(/T.*$/, "")`
+            `AFParseDateEx("${date}", "${format}").toISOString().replace(/T.*/, "")`
           );
           expect(value).toEqual(
-            new Date(expected).toISOString().replace(/T.*$/, "")
+            new Date(expected).toISOString().replace(/T.*/, "")
           );
         };
 


### PR DESCRIPTION
It flags the regexes whose search is quadratic in the input length, like the autolinker and XFA-path ones fixed recently.

The three existing offenders: `\s*` matched the CSS indentation but also the line terminators that make `^` match with the `m` flag (the preprocessed CSS is unchanged), `(\d+)` made every digit of a number a candidate start position, and `/T.*$/` could fail on the `$` and backtrack since `.` doesn't match a line terminator.