### PR TITLE
Remove the ambiguity from the PostScript number regex

### DIFF
--- a/src/core/postscript/lexer.js
+++ b/src/core/postscript/lexer.js
@@ -132,7 +132,7 @@ class Lexer {
     this.pos = 0;
     this.len = data.length;
     // Sticky regexes: set lastIndex before exec() to match at an exact offset.
-    this._numberPattern = /[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?/iy;
+    this._numberPattern = /[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?/iy;
     this._identifierPattern = /[a-z]+/y;
   }
 


### PR DESCRIPTION
`\d+\.?\d*` can split a run of digits in as many ways as it is long, so it would backtrack polynomially if anything following it could reject. The optional exponent can't, hence no bug today, but `\d+(?:\.\d*)?` accepts the same numbers unambiguously.