### PR TITLE
Enable a few more `eslint-plugin-regexp` rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,7 +62,13 @@ export default [
     rules: {
       ...regexpPlugin.configs["flat/recommended"].rules,
       "regexp/no-legacy-features": "off",
+      "regexp/no-octal": "error",
+      "regexp/no-potentially-useless-backreference": "error",
+      "regexp/no-standalone-backslash": "error",
       "regexp/no-super-linear-move": "error",
+      "regexp/optimal-lookaround-quantifier": "error",
+      "regexp/prefer-escape-replacement-dollar-char": "error",
+      "regexp/prefer-regexp-exec": "error",
     },
   },
   {


### PR DESCRIPTION
The remaining rules from the plugin's "Best Practices" category that the recommended config leaves off, plus the two it only warns about, all of which the code already complies with.

`regexp/prefer-regexp-test` is left off, since `unicorn/prefer-regexp-test` already covers it.