### PR TITLE
Compute the next ParentTree key correctly

### DIFF
--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -2858,7 +2858,11 @@ class PDFEditor {
       const parentTree = this.xref[parentTreeRef.num];
       parentTree.setIfName("Type", "ParentTree");
       structTree.set("ParentTree", parentTreeRef);
-      structTree.set("ParentTreeNextKey", this.parentTree.size);
+      let nextKey = 0;
+      for (const key of this.parentTree.keys()) {
+        nextKey = Math.max(nextKey, key + 1);
+      }
+      structTree.set("ParentTreeNextKey", nextKey);
     }
     if (this.idTree.size > 0) {
       const idTreeRef = this.#makeNameNumTree(

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -7016,6 +7016,38 @@ small scripts as well as for`);
         await loadingTask.destroy();
       });
 
+      it("uses the next available ParentTree key", async function () {
+        const objects = [
+          "1 0 obj\n<< /Type /Catalog /Pages 2 0 R " +
+            "/StructTreeRoot 4 0 R >>\nendobj\n",
+          "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+          "3 0 obj\n<< /Type /Page /Parent 2 0 R /StructParents 0 " +
+            "/MediaBox [0 0 100 100] /Annots [8 0 R] >>\nendobj\n",
+          "4 0 obj\n<< /Type /StructTreeRoot /K [5 0 R] " +
+            "/ParentTree 7 0 R /ParentTreeNextKey 9 >>\nendobj\n",
+          "5 0 obj\n<< /Type /StructElem /S /Document /P 4 0 R " +
+            "/K 6 0 R >>\nendobj\n",
+          "6 0 obj\n<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R " +
+            "/K 0 >>\nendobj\n",
+          "7 0 obj\n<< /Nums [0 9 0 R 1 6 0 R] >>\nendobj\n",
+          "8 0 obj\n<< /Type /Annot /Subtype /Link /Rect [0 0 10 10] " +
+            "/StructParent 1 >>\nendobj\n",
+          "9 0 obj\n<< /Type /StructElem /S /Span /Pg 3 0 R " +
+            "/K 0 >>\nendobj\n",
+        ];
+
+        let loadingTask = getDocument({ data: assemblePdf(objects) });
+        let pdfDoc = await loadingTask.promise;
+        const data = await pdfDoc.extractPages([{ document: null }]);
+        expect(countMarker(data, "/ParentTreeNextKey 2")).toEqual(1);
+        await loadingTask.destroy();
+
+        loadingTask = getDocument({ data });
+        pdfDoc = await loadingTask.promise;
+        expect(pdfDoc.numPages).toEqual(1);
+        await loadingTask.destroy();
+      });
+
       it("extract pages and merge struct trees", async function () {
         let loadingTask = getDocument(
           buildGetDocumentParams("two_paragraphs.pdf")


### PR DESCRIPTION
`/ParentTreeNextKey` was set to `parentTree.size`, but the map is sparse: `extractPages` deletes the entries of the struct elements that were never cloned, so `size` is no longer a free key. PDF 32000-1 Table 322 requires "an integer greater than any key in the parent tree", hence `max(key) + 1`.