### PR TITLE
Update `PDFViewerApplication._initializeAutoPrint` to handle `getJSActions` returning a Map (PR 21664 follow-up)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1855,7 +1855,7 @@ const PDFViewerApplication = {
       console.warn("Warning: JavaScript support is not enabled");
 
       // Hack to support auto printing.
-      for (const name in jsActions) {
+      for (const [name, actions] of jsActions) {
         if (triggerAutoPrint) {
           break;
         }
@@ -1867,7 +1867,7 @@ const PDFViewerApplication = {
           case "DidPrint":
             continue;
         }
-        triggerAutoPrint = jsActions[name].some(js => AutoPrintRegExp.test(js));
+        triggerAutoPrint = actions.some(js => AutoPrintRegExp.test(js));
       }
     }
 


### PR DESCRIPTION
This was overlooked in PR #21664, since the code-path in question isn't invoked when scripting is enabled (which is the default value).