### PR TITLE
Move `SCALE_MATRIX` into `CanvasGraphics` and initialize its `DOMMatrix` lazily (issue 21720)

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -66,10 +66,6 @@ const EXECUTION_STEPS = 10;
 
 const FULL_CHUNK_HEIGHT = 16;
 
-// Only used in rescaleAndStroke. The goal is to avoid
-// creating a new DOMMatrix object each time we need it.
-const SCALE_MATRIX = new DOMMatrix();
-
 // Used to get some coordinates.
 const XY = new Float32Array(2);
 
@@ -496,6 +492,10 @@ const NORMAL_CLIP = {};
 const EO_CLIP = {};
 
 class CanvasGraphics {
+  // Only used in rescaleAndStroke. The goal is to avoid
+  // creating a new DOMMatrix object each time we need it.
+  static #SCALE_MATRIX = null;
+
   // Knockout group support fields.
   #knockoutGroupLevel = 0;
 
@@ -4320,6 +4320,7 @@ class CanvasGraphics {
       ctx.stroke(path);
       return;
     }
+    const SCALE_MATRIX = (CanvasGraphics.#SCALE_MATRIX ??= new DOMMatrix());
 
     const dashes = ctx.getLineDash();
     if (saveRestore) {


### PR DESCRIPTION
While this shouldn't affect performance negatively, it does however (ever so slightly) increase the bundle size of the Firefox PDF Viewer.
If that's not desirable, since it's only needed in order to improve Node.js compatibility, we could also just WONTFIX the issue.