### PR TITLE
Track container touches in TouchManager

### DIFF
--- a/src/display/touch_manager.js
+++ b/src/display/touch_manager.js
@@ -38,6 +38,8 @@ class TouchManager {
 
   #signal;
 
+  #touchIds = new Set();
+
   #touchInfo = null;
 
   #touchManagerAC;
@@ -87,7 +89,13 @@ class TouchManager {
       return;
     }
 
-    if (evt.touches.length === 1) {
+    this.#pruneTouchIds(evt);
+    const touchIds = this.#touchIds;
+    for (const { identifier } of evt.changedTouches) {
+      touchIds.add(identifier);
+    }
+
+    if (touchIds.size === 1) {
       if (this.#pointerDownAC) {
         return;
       }
@@ -150,16 +158,55 @@ class TouchManager {
     }
 
     stopEvent(evt);
+    this.#setTouchInfo(evt);
+  }
 
-    if (evt.touches.length !== 2 || this.#isPinchingStopped?.()) {
+  /**
+   * Drop, from the tracked identifiers, the fingers which are no longer down.
+   *
+   * `evt.touches` lists every active touch in the document, whereas an element
+   * listener only receives events targeted at that element or bubbling from
+   * its descendants. Intersect with the document-wide list because an end
+   * event for a tracked touch can be stopped before reaching this manager.
+   * @param {TouchEvent} evt
+   */
+  #pruneTouchIds(evt) {
+    const previous = this.#touchIds;
+    if (previous.size === 0) {
+      return;
+    }
+    const touchIds = (this.#touchIds = new Set());
+    for (const { identifier } of evt.touches) {
+      if (previous.has(identifier)) {
+        touchIds.add(identifier);
+      }
+    }
+  }
+
+  /**
+   * @param {TouchEvent} evt
+   * @returns {Array<Touch>} The tracked fingers which are still down.
+   */
+  #getTrackedTouches(evt) {
+    const touchIds = this.#touchIds;
+    const touches = [];
+    for (const touch of evt.touches) {
+      if (touchIds.has(touch.identifier)) {
+        touches.push(touch);
+      }
+    }
+    return touches;
+  }
+
+  #setTouchInfo(evt) {
+    const touches = this.#getTrackedTouches(evt);
+    if (touches.length !== 2 || this.#isPinchingStopped?.()) {
       this.#touchInfo = null;
+      this.#isPinching = false;
       return;
     }
 
-    let [touch0, touch1] = evt.touches;
-    if (touch0.identifier > touch1.identifier) {
-      [touch0, touch1] = [touch1, touch0];
-    }
+    const [touch0, touch1] = touches;
     this.#touchInfo = {
       touch0X: touch0.screenX,
       touch0Y: touch0.screenY,
@@ -169,16 +216,17 @@ class TouchManager {
   }
 
   #onTouchMove(evt) {
-    if (!this.#touchInfo || evt.touches.length !== 2) {
+    if (!this.#touchInfo) {
+      return;
+    }
+    const touches = this.#getTrackedTouches(evt);
+    if (touches.length !== 2) {
       return;
     }
 
     stopEvent(evt);
 
-    let [touch0, touch1] = evt.touches;
-    if (touch0.identifier > touch1.identifier) {
-      [touch0, touch1] = [touch1, touch0];
-    }
+    const [touch0, touch1] = touches;
     const { screenX: screen0X, screenY: screen0Y } = touch0;
     const { screenX: screen1X, screenY: screen1Y } = touch1;
     const touchInfo = this.#touchInfo;
@@ -226,9 +274,15 @@ class TouchManager {
   }
 
   #onTouchEnd(evt) {
-    if (evt.touches.length >= 2) {
+    this.#pruneTouchIds(evt);
+    if (this.#touchIds.size >= 2) {
+      // Re-evaluate the remaining tracked touches; exactly two form a new
+      // baseline.
+      this.#setTouchInfo(evt);
       return;
     }
+    // Fewer than two tracked touches remain, so this manager's gesture is over;
+    // unrelated entries in the document-wide touch list must not keep it alive.
     // #touchMoveAC shouldn't be null but it seems that irl it can (see #19793).
     if (this.#touchMoveAC) {
       this.#touchMoveAC.abort();

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -1527,6 +1527,47 @@ describe("Resize with a touchscreen", () => {
       })
     );
   });
+
+  it("must end pinch-resize when one editor finger is lifted with another finger elsewhere", async () => {
+    await Promise.all(
+      pages.map(async ([browserName, page]) => {
+        const { layer, editor } = await drawAndSelectEditor(page);
+        // Keep both fingers inside the editor body.
+        const fingerY = editor.y + 0.8 * editor.height;
+        let finger0, finger1, finger2;
+
+        try {
+          // Two fingers start a pinch-resize session, which disables the layer.
+          finger0 = await page.touchscreen.touchStart(
+            editor.x + 0.2 * editor.width,
+            fingerY
+          );
+          finger1 = await page.touchscreen.touchStart(
+            editor.x + 0.55 * editor.width,
+            fingerY
+          );
+          await page.waitForSelector(".annotationEditorLayer.disabled");
+
+          // On the following editor `touchend`, this foreign finger is present
+          // in `evt.touches` but absent from `evt.changedTouches`.
+          finger2 = await page.touchscreen.touchStart(
+            layer.x + 0.2 * layer.width,
+            layer.y + 0.85 * layer.height
+          );
+
+          // Fewer than two editor fingers remain, so its pinch-resize session
+          // ends.
+          await finger0.end();
+          finger0 = null;
+          await page.waitForSelector(".annotationEditorLayer:not(.disabled)");
+        } finally {
+          await finger0?.end();
+          await finger1?.end();
+          await finger2?.end();
+        }
+      })
+    );
+  });
 });
 
 describe("Tap after a two-finger gesture", () => {

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -105,6 +105,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/struct_tree_spec.js",
       "pdfjs-test/unit/svg_factory_spec.js",
       "pdfjs-test/unit/text_layer_spec.js",
+      "pdfjs-test/unit/touch_manager_spec.js",
       "pdfjs-test/unit/type1_parser_spec.js",
       "pdfjs-test/unit/ui_utils_spec.js",
       "pdfjs-test/unit/unicode_spec.js",

--- a/test/unit/touch_manager_spec.js
+++ b/test/unit/touch_manager_spec.js
@@ -1,0 +1,126 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TouchManager } from "../../src/display/touch_manager.js";
+
+describe("TouchManager", function () {
+  function makeTouch(identifier, x, y = 0) {
+    return {
+      identifier,
+      screenX: x,
+      screenY: y,
+      clientX: x,
+      clientY: y,
+    };
+  }
+
+  class TouchManagerHelper {
+    #ac = new AbortController();
+
+    constructor() {
+      this.container = new EventTarget();
+      this.pinchings = [];
+      this.pinchStarts = 0;
+      this.pinchEnds = 0;
+
+      this.manager = new TouchManager({
+        container: this.container,
+        onPinchStart: () => {
+          this.pinchStarts += 1;
+        },
+        onPinching: (origin, prevDistance, distance) => {
+          this.pinchings.push({ origin, prevDistance, distance });
+        },
+        onPinchEnd: () => {
+          this.pinchEnds += 1;
+        },
+        signal: this.#ac.signal,
+      });
+    }
+
+    dispatch(type, touches, changedTouches) {
+      const event = Object.assign(new Event(type, { cancelable: true }), {
+        touches,
+        changedTouches,
+      });
+      this.container.dispatchEvent(event);
+      return event;
+    }
+
+    destroy() {
+      this.manager.destroy();
+      this.#ac.abort();
+    }
+  }
+
+  it("tracks only touches whose starts reach the container", function () {
+    const helper = new TouchManagerHelper();
+    const own0 = makeTouch(0, 100);
+    const own1 = makeTouch(1, 300);
+    const foreign = makeTouch(2, 500);
+
+    helper.dispatch("touchstart", [own0], [own0]);
+    helper.dispatch("touchstart", [own0, own1, foreign], [own1]);
+    expect(helper.pinchStarts).toEqual(1);
+
+    helper.dispatch("touchend", [own1, foreign], [own0]);
+    expect(helper.pinchEnds).toEqual(1);
+
+    // The end of own1 is not delivered. The next start must remove its stale
+    // identifier before adding the newly changed touch.
+    const own3 = makeTouch(3, 100);
+    const own4 = makeTouch(4, 300);
+    helper.dispatch("touchstart", [foreign, own3], [own3]);
+    expect(helper.pinchStarts).toEqual(1);
+    helper.dispatch("touchstart", [foreign, own3, own4], [own4]);
+    expect(helper.pinchStarts).toEqual(2);
+
+    helper.destroy();
+  });
+
+  it("re-baselines when exactly two tracked touches remain", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 0);
+    const touch1 = makeTouch(1, 200);
+    const touch2 = makeTouch(2, 400);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+    helper.dispatch("touchstart", [touch0, touch1, touch2], [touch2]);
+    helper.dispatch("touchend", [touch0, touch1], [touch2]);
+
+    const moved0 = makeTouch(0, -50);
+    const moved1 = makeTouch(1, 250);
+    helper.dispatch("touchmove", [moved0, moved1], [moved0, moved1]);
+    expect(helper.pinchings).toEqual([]);
+
+    const movedAgain0 = makeTouch(0, -100);
+    const movedAgain1 = makeTouch(1, 300);
+    helper.dispatch(
+      "touchmove",
+      [movedAgain0, movedAgain1],
+      [movedAgain0, movedAgain1]
+    );
+    expect(helper.pinchings).toEqual([
+      {
+        origin: [100, 0],
+        prevDistance: 300,
+        distance: 400,
+      },
+    ]);
+
+    helper.destroy();
+  });
+});


### PR DESCRIPTION
Touch events are dispatched for the changed touches' targets, but evt.touches is global.

Track the identifiers that started on this manager's container and derive pinch state from that set. Unrelated fingers then neither keep editor pinch-resize alive nor become part of its pair.