### PR TITLE
Fix the two MathClamp calls the prefer-math-clamp fixer mis-ordered

### DIFF
--- a/external/eslint_plugins/prefer-math-clamp.mjs
+++ b/external/eslint_plugins/prefer-math-clamp.mjs
@@ -5,8 +5,16 @@
  * Detected patterns and their fixes:
  *   Math.min(Math.max(A, B), C)  →  MathClamp(A, B, C)
  *   Math.min(C, Math.max(A, B))  →  MathClamp(A, B, C)
- *   Math.max(Math.min(A, B), C)  →  MathClamp(A, C, B)
- *   Math.max(C, Math.min(A, B))  →  MathClamp(A, C, B)
+ *   Math.max(Math.min(A, B), C)  →  flagged as a possible clamp, not fixed
+ *   Math.max(C, Math.min(A, B))  →  flagged as a possible clamp, not fixed
+ *
+ * The min-outer patterns are exact: `Math.min(Math.max(A, B), C)` is what
+ * `MathClamp(A, B, C)` expands to, whichever inner operand is the value.
+ *
+ * The max-outer ones are not. `Math.min` is commutative, so the value can be A
+ * or B, and `MathClamp(A, C, B)` only agrees with `Math.max(C, Math.min(A, B))`
+ * when C <= B. The rule can't tell, so it reports these with a message saying
+ * as much and leaves the rewrite to a human.
  */
 
 function isMathCall(node, method) {
@@ -39,6 +47,9 @@ const preferMathClampRule = {
     messages: {
       useClamp:
         "Use MathClamp(v, min, max) instead of nested Math.min/Math.max.",
+      maybeClamp:
+        "Math.max(C, Math.min(A, B)) is MathClamp(A, C, B) only when C <= B; " +
+        "rewrite it by hand if that holds.",
     },
     schema: [],
   },
@@ -79,32 +90,17 @@ const preferMathClampRule = {
         }
 
         // Pattern: Math.max(Math.min(A, B), C) or Math.max(C, Math.min(A, B)).
-        // Fix as MathClamp(A, C, B) where A,B are inner args, C is outer arg.
+        // Only a clamp when the bounds are ordered, so this is reported as a
+        // candidate and not fixed, see the file header.
         if (isMathCall(node, "max")) {
           const [arg0, arg1] = node.arguments;
-          let outerArg, innerNode;
 
-          if (isMathCall(arg0, "min") && !isMathMinMax(arg1)) {
-            innerNode = arg0;
-            outerArg = arg1;
-          } else if (isMathCall(arg1, "min") && !isMathMinMax(arg0)) {
-            innerNode = arg1;
-            outerArg = arg0;
-          } else {
-            return;
+          if (
+            (isMathCall(arg0, "min") && !isMathMinMax(arg1)) ||
+            (isMathCall(arg1, "min") && !isMathMinMax(arg0))
+          ) {
+            context.report({ node, messageId: "maybeClamp" });
           }
-
-          const v = src.getText(innerNode.arguments[0]);
-          const max = src.getText(innerNode.arguments[1]);
-          const min = src.getText(outerArg);
-
-          context.report({
-            node,
-            messageId: "useClamp",
-            fix(fixer) {
-              return fixer.replaceText(node, `MathClamp(${v}, ${min}, ${max})`);
-            },
-          });
         }
       },
     };

--- a/src/core/postscript/js_evaluator.js
+++ b/src/core/postscript/js_evaluator.js
@@ -781,7 +781,7 @@ class PSStackBasedInterpreter {
       const base = this.#sp - nOut;
       for (let i = 0; i < nOut; i++) {
         const v = base + i >= 0 ? this.#stack[base + i] : 0;
-        dest[destOffset + i] = MathClamp(range[i * 2 + 1], range[i * 2], v);
+        dest[destOffset + i] = MathClamp(v, range[i * 2], range[i * 2 + 1]);
       }
     };
   }

--- a/test/unit/postscript_spec.js
+++ b/test/unit/postscript_spec.js
@@ -733,6 +733,12 @@ describe("PostScript Type 4 lexer, parser, and Wasm compiler", function () {
       expect(r).toBeCloseTo(0.5, 9);
     });
 
+    it("clamps output to the bottom of the declared range", async function () {
+      // sub falls below range [0, 1] → result clamped
+      const r = compileAndRun("{ sub }", [0, 1, 0, 1], [0, 1], [0.25, 0.75]);
+      expect(r).toBeCloseTo(0, 9);
+    });
+
     // Bitwise.
 
     it("compiles bitshift left (literal shift)", async function () {

--- a/web/internal/split_view.js
+++ b/web/internal/split_view.js
@@ -107,9 +107,9 @@ class SplitView {
       return 0;
     }
     if (total <= this.#minSize * 2) {
-      return MathClamp(0, requestedFirst, total);
+      return MathClamp(requestedFirst, 0, total);
     }
-    return MathClamp(total - this.#minSize, this.#minSize, requestedFirst);
+    return MathClamp(requestedFirst, this.#minSize, total - this.#minSize);
   }
 
   #resize(newFirst) {


### PR DESCRIPTION
The `prefer-math-clamp` fixer can swap a value with a bound, and it did so at both of the call sites it rewrote in #21030.

### The rule

`MathClamp(v, min, max)` is `Math.min(Math.max(v, min), max)`, so the two min-outer patterns are exact — whichever inner operand is the value, `Math.min(Math.max(A, B), C)` *is* `MathClamp(A, B, C)`.

The max-outer ones aren't. The fixer turns `Math.max(C, Math.min(A, B))` into `MathClamp(A, C, B)`, always assuming the inner call's first operand is the value. `Math.min` is commutative, so it's just as often the second one, and then `A` is really the upper bound: the emitted call is `Math.min(Math.max(max, min), v)` — `Math.min(max, v)` — which drops the lower bound entirely. This PR reports those two patterns without offering a fix.

### `PSStackBasedInterpreter.build`

```js
Math.max(range[i * 2], Math.min(range[i * 2 + 1], v))   // before #21030
MathClamp(range[i * 2 + 1], range[i * 2], v)            // on master
```

Outputs were clamped down to the Range maximum but never up to the Range minimum. `PSStackBasedInterpreter` is the fallback used whenever `PSStackToTree` can't build a tree — a stack-shrinking `if`, or a `copy`/`index`/`roll` whose operand isn't a constant — and the Wasm compiler bails on exactly the same programs, so nothing else catches it:

| function | `/Range` | input | master | this PR |
| --- | --- | --- | --- | --- |
| `{ dup 0 lt { pop } if 2 sub }` | `[0 1]` | 0.5 | -1.5 | 0 |
| `{ dup cvi index 1 sub }` | `[0.25 0.75]` | 0.5, 0.5 | -0.5 | 0.25 |

The existing "clamps output to declared range" test only exercises the upper bound, which is the one the wrong order preserves — hence the lower-bound case added here. It fails on master with `Expected -0.5 to be close to 0`, through the same `compileAndRun` helper that already cross-checks the three implementations.

### `SplitView.#clampFirstSize`

```js
Math.max(this.#minSize, Math.min(total - this.#minSize, requestedFirst))  // before #21030
MathClamp(total - this.#minSize, this.#minSize, requestedFirst)           // on master
```

Same shape, so the first pane is never clamped up to `#minSize`. With `#minSize` 120 and `total` 800, dragging the resizer to a requested size of -60 sets `flexGrow` to -60 instead of 120. The other call in that method changed order too, but `Math.max(0, requestedFirst)` survives the swap, so that one is equivalent — it's reordered here only to read as a clamp.

`npx gulp lint` is clean and `test/unit/postscript_spec.js` passes (208 specs).
