### PR TITLE
Improve glyph mapping for non-embedded CID fonts

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -48,12 +48,14 @@ import {
   ZapfDingbatsEncoding,
 } from "./encodings.js";
 import {
+  getGlyphMapForMacOrderedFonts,
   getGlyphMapForStandardFonts,
   getNonStdFontMap,
   getSerifFonts,
   getStdFontMap,
   getSupplementalGlyphMapForArialBlack,
   getSupplementalGlyphMapForCalibri,
+  getSupplementalGlyphMapForTrebuchetMS,
 } from "./standard_fonts.js";
 import { GlyfTable, pruneCompositeGlyphCycles } from "./glyf.js";
 import { IdentityToUnicodeMap, ToUnicodeMap } from "./to_unicode_map.js";
@@ -385,6 +387,23 @@ function applyStandardFontGlyphMap(map, glyphMap) {
   for (const charCode in glyphMap) {
     map[+charCode] = glyphMap[charCode];
   }
+}
+
+// The glyphs of the (Windows) Symbol font are ordered by char code, hence build
+// an encoding indexed by glyph id; note that the char codes 0x7F-0xA0 are
+// unused and that the glyph ids 0-2 are `.notdef`/`.null`/`nonmarkingreturn`.
+function buildSymbolGlyphIdEncoding() {
+  const encoding = [];
+  let glyphId = 3;
+  for (const [firstCharCode, lastCharCode] of [
+    [0x20, 0x7e],
+    [0xa1, 0xfe],
+  ]) {
+    for (let charCode = firstCharCode; charCode <= lastCharCode; charCode++) {
+      encoding[glyphId++] = SymbolSetEncoding[charCode];
+    }
+  }
+  return encoding;
 }
 
 function buildToFontChar(encoding, glyphsUnicodeMap, differences) {
@@ -1288,12 +1307,22 @@ class Font {
       // Standard fonts might be embedded as CID font without glyph mapping.
       // Building one based on GlyphMapForStandardFonts.
       const map = [];
-      applyStandardFontGlyphMap(map, getGlyphMapForStandardFonts());
+      if (/Trebuchet/i.test(name)) {
+        // TrebuchetMS doesn't share the glyph ordering of the standard fonts,
+        // hence using the latter would map e.g. "š" to "ž" (issue 21713).
+        applyStandardFontGlyphMap(map, getGlyphMapForMacOrderedFonts());
+        applyStandardFontGlyphMap(map, getSupplementalGlyphMapForTrebuchetMS());
+      } else {
+        applyStandardFontGlyphMap(map, getGlyphMapForStandardFonts());
 
-      if (/Arial-?Black/i.test(name)) {
-        applyStandardFontGlyphMap(map, getSupplementalGlyphMapForArialBlack());
-      } else if (/Calibri/i.test(name)) {
-        applyStandardFontGlyphMap(map, getSupplementalGlyphMapForCalibri());
+        if (/Arial-?Black/i.test(name)) {
+          applyStandardFontGlyphMap(
+            map,
+            getSupplementalGlyphMapForArialBlack()
+          );
+        } else if (/Calibri/i.test(name)) {
+          applyStandardFontGlyphMap(map, getSupplementalGlyphMapForCalibri());
+        }
       }
 
       // Always update the glyph mapping with the `cidToGidMap` when it exists
@@ -1329,8 +1358,13 @@ class Font {
       this.toFontChar = map;
       this.toUnicode = new ToUnicodeMap(map);
     } else if (/Symbol/i.test(fontName)) {
+      // The non-embedded SymbolMT font in issue 21713 uses Identity encoding
+      // and an Identity CIDToGIDMap, hence its CIDs are glyph ids.
+      const isCidKeyed =
+        this.composite && this.cidEncoding.startsWith("Identity-");
+
       this.toFontChar = buildToFontChar(
-        SymbolSetEncoding,
+        isCidKeyed ? buildSymbolGlyphIdEncoding() : SymbolSetEncoding,
         getGlyphsUnicode(),
         this.differences
       );

--- a/src/core/standard_fonts.js
+++ b/src/core/standard_fonts.js
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
+import { MacStandardGlyphOrdering, normalizeFontName } from "./fonts_utils.js";
+import { getGlyphsUnicode } from "./glyphlist.js";
 import { getLookupTableFactory } from "./core_utils.js";
-import { normalizeFontName } from "./fonts_utils.js";
 
 /**
  * Hold a map of decoded fonts and of the standard fourteen Type1
@@ -321,6 +322,20 @@ const getSymbolsFonts = getLookupTableFactory(function (t) {
   t.Wingdings = true;
   t["Wingdings-Bold"] = true;
   t["Wingdings-Regular"] = true;
+});
+
+// Base glyph map for fonts whose glyph ids follow the standard Macintosh
+// ordering implied by a `post` table of format 1. Fonts such as TrebuchetMS can
+// use part of this ordering with supplemental overrides.
+const getGlyphMapForMacOrderedFonts = getLookupTableFactory(function (t) {
+  const glyphsUnicode = getGlyphsUnicode();
+  t[2] = 10;
+  for (let gid = 3; gid < MacStandardGlyphOrdering.length; gid++) {
+    const unicode = glyphsUnicode[MacStandardGlyphOrdering[gid]];
+    if (unicode !== undefined) {
+      t[gid] = unicode;
+    }
+  }
 });
 
 // Glyph map for well-known standard fonts. Sometimes Ghostscript uses CID
@@ -825,6 +840,92 @@ const getGlyphMapForStandardFonts = getLookupTableFactory(function (t) {
   t[3416] = 8377;
 });
 
+// TrebuchetMS largely follows the standard Macintosh glyph ordering through
+// glyph id 235, with the exceptions below. Additional mappings for the affected
+// Latin glyph repertoire follow.
+const getSupplementalGlyphMapForTrebuchetMS = getLookupTableFactory(
+  function (t) {
+    // A few of the standard Macintosh glyph slots hold a different, but
+    // similar looking, glyph in TrebuchetMS.
+    t[151] = 956;
+    t[159] = 937;
+    t[168] = 916;
+    t[189] = 8364;
+    t[195] = 8729;
+    t[218] = 713;
+
+    t[236] = 222;
+    t[237] = 254;
+    t[238] = 8722;
+    t[239] = 185;
+    t[240] = 178;
+    t[241] = 179;
+    t[242] = 189;
+    t[243] = 188;
+    t[244] = 190;
+    t[245] = 181;
+    t[246] = 8486;
+    t[247] = 8710;
+    t[248] = 253;
+    t[249] = 215;
+    t[250] = 173;
+    t[253] = 8355;
+    t[254] = 286;
+    t[255] = 287;
+    t[256] = 304;
+    t[257] = 350;
+    t[258] = 351;
+    t[259] = 262;
+    t[260] = 263;
+    t[261] = 268;
+    t[262] = 269;
+    t[263] = 273;
+    t[264] = 175;
+    t[266] = 183;
+    t[267] = 258;
+    t[268] = 259;
+    t[269] = 260;
+    t[270] = 261;
+    t[271] = 270;
+    t[272] = 271;
+    t[273] = 272;
+    t[274] = 280;
+    t[275] = 281;
+    t[276] = 282;
+    t[277] = 283;
+    t[278] = 313;
+    t[279] = 314;
+    t[280] = 317;
+    t[281] = 318;
+    t[282] = 319;
+    t[283] = 320;
+    t[284] = 323;
+    t[285] = 324;
+    t[286] = 327;
+    t[287] = 328;
+    t[288] = 336;
+    t[289] = 337;
+    t[290] = 340;
+    t[291] = 341;
+    t[292] = 344;
+    t[293] = 345;
+    t[294] = 346;
+    t[295] = 347;
+    t[296] = 538;
+    t[297] = 539;
+    t[298] = 356;
+    t[299] = 357;
+    t[300] = 366;
+    t[301] = 367;
+    t[302] = 368;
+    t[303] = 369;
+    t[304] = 377;
+    t[305] = 378;
+    t[306] = 379;
+    t[307] = 380;
+  }
+);
+
 // The glyph map for ArialBlack differs slightly from the glyph map used for
 // other well-known standard fonts. Hence we use this (incomplete) CID to GID
 // mapping to adjust the glyph map for non-embedded ArialBlack fonts.
@@ -977,6 +1078,7 @@ function isKnownFontName(name) {
 
 export {
   getFontNameToFileMap,
+  getGlyphMapForMacOrderedFonts,
   getGlyphMapForStandardFonts,
   getNonStdFontMap,
   getSerifFonts,
@@ -984,6 +1086,7 @@ export {
   getStdFontMap,
   getSupplementalGlyphMapForArialBlack,
   getSupplementalGlyphMapForCalibri,
+  getSupplementalGlyphMapForTrebuchetMS,
   getSymbolsFonts,
   isKnownFontName,
 };

--- a/src/core/unicode.js
+++ b/src/core/unicode.js
@@ -25,6 +25,9 @@ const getSpecialPUASymbols = getLookupTableFactory(function (t) {
   t[63194] = 0x00ae; // registerserif (0xF6DA) => registered
   t[63722] = 0x2122; // trademarksans (0xF8EA) => trademark
   t[63195] = 0x2122; // trademarkserif (0xF6DB) => trademark
+  t[63718] = 0x23d0; // arrowvertex (0xF8E6)
+  t[63719] = 0x23af; // arrowhorizex (0xF8E7)
+  t[63733] = 0x23ae; // integralex (0xF8F5)
   t[63729] = 0x23a7; // bracelefttp (0xF8F1)
   t[63730] = 0x23a8; // braceleftmid (0xF8F2)
   t[63731] = 0x23a9; // braceleftbt (0xF8F3)


### PR DESCRIPTION
When a non-embedded CID font lacks both a glyph map and a ToUnicode entry, its CIDs are glyph IDs and PDF.js must infer an ordering. The standard-font map does not match Trebuchet MS or Windows Symbol.

Build the Trebuchet MS mapping from MacStandardGlyphOrdering plus supplemental entries, and map Windows Symbol glyph IDs by character code. Also map Adobe arrow and integral extenders from private-use code points to Unicode.

It fixes #21713.