### PR TITLE
Change the inline image cache, in the `Parser` class, to a Map

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -71,14 +71,16 @@ function getInlineImageCacheKey(bytes) {
 }
 
 class Parser {
+  #imageCache = null;
+
+  #imageId = 0;
+
   constructor({ lexer, xref, allowStreams = false, recoveryMode = false }) {
     this.lexer = lexer;
     this.xref = xref;
     this.allowStreams = allowStreams;
     this.recoveryMode = recoveryMode;
 
-    this.imageCache = Object.create(null);
-    this._imageId = 0;
     this.refill();
   }
 
@@ -599,8 +601,8 @@ class Parser {
       // Finally, don't forget to reset the stream position.
       stream.pos = initialStreamPos;
 
-      const cacheEntry = this.imageCache[cacheKey];
-      if (cacheEntry !== undefined) {
+      const cacheEntry = this.#imageCache?.get(cacheKey);
+      if (cacheEntry) {
         this.buf2 = Cmd.get("EI");
         this.shift();
 
@@ -620,9 +622,9 @@ class Parser {
 
     imageStream = this.filter(imageStream, dict, length, cipherTransform);
     imageStream.dict = dict;
-    if (cacheKey !== undefined) {
-      imageStream.cacheKey = `inline_img_${++this._imageId}`;
-      this.imageCache[cacheKey] = imageStream;
+    if (cacheKey) {
+      imageStream.cacheKey = `inline_img_${++this.#imageId}`;
+      (this.#imageCache ??= new Map()).set(cacheKey, imageStream);
     }
 
     this.buf2 = Cmd.get("EI");

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -538,9 +538,7 @@ class Parser {
     const lexer = this.lexer;
     const stream = lexer.stream;
 
-    // Parse dictionary, but initialize it lazily to improve performance with
-    // cached inline images (see issue 2618).
-    const dictMap = Object.create(null);
+    const dict = new Dict(this.xref);
     let dictLength;
     while (!isCmd(this.buf1, "ID") && this.buf1 !== EOF) {
       if (!(this.buf1 instanceof Name)) {
@@ -551,14 +549,14 @@ class Parser {
       if (this.buf1 === EOF) {
         break;
       }
-      dictMap[key] = this.getObj(cipherTransform);
+      dict.set(key, this.getObj(cipherTransform));
     }
     if (lexer.beginInlineImagePos !== -1) {
       dictLength = stream.pos - lexer.beginInlineImagePos;
     }
 
     // Extract the name of the first (i.e. the current) image filter.
-    const filter = this.#fetchIfRef(dictMap.F || dictMap.Filter);
+    const filter = dict.get("F", "Filter");
     let filterName;
     if (filter instanceof Name) {
       filterName = filter.name;
@@ -611,10 +609,6 @@ class Parser {
       }
     }
 
-    const dict = new Dict(this.xref);
-    for (const key in dictMap) {
-      dict.set(key, dictMap[key]);
-    }
     let imageStream = stream.makeSubStream(startPos, length, dict);
     if (cipherTransform && !this.#hasCryptFilter(filter)) {
       imageStream = cipherTransform.createStream(imageStream, length);


### PR DESCRIPTION
 - **Change the inline image cache, in the `Parser` class, to a Map**

   Additionally the cache is now initialized lazily, since most PDF documents don't have inline images.

 - **No longer initialize the dictionary *lazily* when parsing inline images**

   This reverts one of the patches from PR #15679, since it no longer appear to be necessary. Most likely improved JavaScript performance in Firefox, e.g. with `Map`s, have made this unnecessary.

   Note that this patch-series was tested with the following manifest file:
   ```
   [
     {
       "id": "issue2618",
       "file": "pdfs/issue2618.pdf",
       "md5": "2c554a99a52288ca1a44a422eeafb8fb",
       "rounds": 200,
       "type": "eq"
     }
   ]
   ```
   which gave the following results, indicating no significant regression, when comparing this patch-series against the `master` branch:
   ```
   -- Grouped By browser, pdf, stat --
   browser | pdf       | stat         | Count | Baseline(ms) | Current(ms) | +/- |    %  | Result(P<.05)
   ------- | --------- | ------------ | ----- | ------------ | ----------- | --- | ----- | -------------
   firefox | issue2618 | Overall      |   200 |          478 |         469 |  -9 | -1.79 |
   firefox | issue2618 | Page Request |   200 |           14 |          13 |  -1 | -5.05 |
   firefox | issue2618 | Rendering    |   200 |          464 |         456 |  -8 | -1.70 |
   ```
