### PR TITLE
Remove unnecessary `rect` modification in the `CanvasGraphics.prototype.beginAnnotation` method

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -3704,11 +3704,6 @@ class CanvasGraphics {
         transform[4] -= rect[0];
         transform[5] -= rect[1];
 
-        rect = rect.slice();
-        rect[0] = rect[1] = 0;
-        rect[2] = width;
-        rect[3] = height;
-
         Util.singularValueDecompose2dScale(getCurrentTransform(this.ctx), XY);
         const { viewportScale } = this;
         const canvasWidth = Math.ceil(


### PR DESCRIPTION
This code was added in PR #14247, however it appears that it was unnecessary even back then.
Note how the `rect` variable isn't actually being used after it's been copied/updated inside of the `hasOwnCanvas && this.annotationCanvasMap`-branch, and it's also not used at the end of the `beginAnnotation` method.