### PR TITLE
Convert the `charProcOperatorList`, used with Type3 fonts, to a Map

### DIFF
--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4908,7 +4908,7 @@ class TranslatedFont {
 
     const charProcs = dict.get("CharProcs");
     const fontResources = dict.get("Resources") || resources;
-    const charProcOperatorList = Object.create(null);
+    const charProcOperatorList = new Map();
 
     const [x0, y0, x1, y1] = font.bbox;
     const fontBBoxSize = Math.hypot(x1 - x0, y1 - y0);
@@ -4940,14 +4940,14 @@ class TranslatedFont {
             }
             break;
         }
-        charProcOperatorList[key] = operatorList.getIR();
+        charProcOperatorList.set(key, operatorList.getIR());
 
         for (const dependency of operatorList.dependencies) {
           type3Dependencies.add(dependency);
         }
       } catch {
         warn(`Type3 font resource "${key}" is not available.`);
-        charProcOperatorList[key] = new OperatorList().getIR();
+        charProcOperatorList.set(key, new OperatorList().getIR());
       }
     }
 

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -4901,7 +4901,7 @@ class TranslatedFont {
     const type3Evaluator = evaluator.clone({ ignoreErrors: false });
     // Prevent circular references in Type3 fonts.
     const type3FontRefs = new RefSet(evaluator.type3FontRefs);
-    if (dict.objId && !type3FontRefs.has(dict.objId)) {
+    if (dict.objId) {
       type3FontRefs.put(dict.objId);
     }
     type3Evaluator.type3FontRefs = type3FontRefs;

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -2960,7 +2960,7 @@ class CanvasGraphics {
       }
 
       const spacing = (glyph.isSpace ? wordSpacing : 0) + charSpacing;
-      const operatorList = font.charProcOperatorList[glyph.operatorListId];
+      const operatorList = font.charProcOperatorList.get(glyph.operatorListId);
       if (!operatorList) {
         warn(`Type3 character "${glyph.operatorListId}" is not available.`);
       } else if (this.contentVisible) {


### PR DESCRIPTION
 - **Remove unnecessary `RefSet.prototype.has` call from `TranslatedFont.prototype.loadType3Data`**

   The `RefSet` class stores its data in a Set and in those a value can only occur exactly once, hence we can simply invoke `RefSet.prototype.put` unconditionally.

 - **Convert the `charProcOperatorList`, used with Type3 fonts, to a Map**