### PR TITLE
Keep pinching when the touch set changes

### DIFF
--- a/src/display/touch_manager.js
+++ b/src/display/touch_manager.js
@@ -96,36 +96,7 @@ class TouchManager {
     }
 
     if (touchIds.size === 1) {
-      if (this.#pointerDownAC) {
-        return;
-      }
-      const pointerDownAC = (this.#pointerDownAC = new AbortController());
-      const signal = AbortSignal.any([this.#signal, pointerDownAC.signal]);
-      const container = this.#container;
-
-      // We want to have the events at the capture phase to make sure we can
-      // cancel them.
-      const opts = { capture: true, signal, passive: false };
-      const cancelPointerDown = e => {
-        if (e.pointerType === "touch") {
-          this.#pointerDownAC?.abort();
-          this.#pointerDownAC = null;
-        }
-      };
-      container.addEventListener(
-        "pointerdown",
-        e => {
-          if (e.pointerType === "touch") {
-            // This is the second finger so we don't want it select something
-            // or whatever.
-            stopEvent(e);
-            cancelPointerDown(e);
-          }
-        },
-        opts
-      );
-      container.addEventListener("pointerup", cancelPointerDown, opts);
-      container.addEventListener("pointercancel", cancelPointerDown, opts);
+      this.#armPointerDown();
       return;
     }
 
@@ -159,6 +130,49 @@ class TouchManager {
 
     stopEvent(evt);
     this.#setTouchInfo(evt);
+  }
+
+  /**
+   * Swallow the `pointerdown` of the next finger to land while one is already
+   * down on the container.
+   *
+   * That finger is about to become the second one of a two-finger gesture, so
+   * it must neither select anything nor start a session of its own, e.g. an
+   * editor drag: the latter listens on `window`, hence the capture-phase
+   * listeners which `#touchMoveAC` adds on the container run too late to stop
+   * it, and swallowing the `pointerdown` itself is the only chance to.
+   */
+  #armPointerDown() {
+    if (this.#pointerDownAC) {
+      return;
+    }
+    const pointerDownAC = (this.#pointerDownAC = new AbortController());
+    const signal = AbortSignal.any([this.#signal, pointerDownAC.signal]);
+    const container = this.#container;
+
+    // We want to have the events at the capture phase to make sure we can
+    // cancel them.
+    const opts = { capture: true, signal, passive: false };
+    const cancelPointerDown = e => {
+      if (e.pointerType === "touch") {
+        this.#pointerDownAC?.abort();
+        this.#pointerDownAC = null;
+      }
+    };
+    container.addEventListener(
+      "pointerdown",
+      e => {
+        if (e.pointerType === "touch") {
+          // This is the second finger so we don't want it select something
+          // or whatever.
+          stopEvent(e);
+          cancelPointerDown(e);
+        }
+      },
+      opts
+    );
+    container.addEventListener("pointerup", cancelPointerDown, opts);
+    container.addEventListener("pointercancel", cancelPointerDown, opts);
   }
 
   /**
@@ -198,11 +212,19 @@ class TouchManager {
     return touches;
   }
 
+  /**
+   * Take the current position of the two tracked fingers as the new baseline.
+   *
+   * `#isPinching` is deliberately left as it is, and is only reset when the
+   * gesture ends: a pinch in progress mustn't have to earn
+   * `MIN_TOUCH_DISTANCE_TO_PINCH` all over again because a third finger landed
+   * and was lifted.
+   * @param {TouchEvent} evt
+   */
   #setTouchInfo(evt) {
     const touches = this.#getTrackedTouches(evt);
     if (touches.length !== 2 || this.#isPinchingStopped?.()) {
       this.#touchInfo = null;
-      this.#isPinching = false;
       return;
     }
 
@@ -290,12 +312,23 @@ class TouchManager {
       this.#onPinchEnd?.();
     }
 
-    if (!this.#touchInfo) {
-      return;
-    }
-    stopEvent(evt);
+    // The flag is reset here, and only here, hence unconditionally: a pinch
+    // whose pair was broken, e.g. by a third finger or by `isPinchingStopped`,
+    // has no `#touchInfo` anymore but mustn't leak its state into the next
+    // gesture.
+    const wasTracking = !!this.#touchInfo;
     this.#touchInfo = null;
     this.#isPinching = false;
+    if (this.#touchIds.size === 1) {
+      // A finger which started on the container is still down, so the gesture
+      // is back to its one-finger state: the next finger to land must be
+      // swallowed again. Without this, lifting one finger of a pinch and
+      // putting it back down would let its `pointerdown` through.
+      this.#armPointerDown();
+    }
+    if (wasTracking) {
+      stopEvent(evt);
+    }
   }
 
   destroy() {

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -1568,6 +1568,64 @@ describe("Resize with a touchscreen", () => {
       })
     );
   });
+
+  it("must keep pinch-resizing when a finger is lifted and put down again", async () => {
+    await Promise.all(
+      pages.map(async ([browserName, page]) => {
+        const { editor } = await drawAndSelectEditor(page);
+        const editorSelector = getEditorSelector(0);
+        // Keep every finger inside the editor body.
+        const fingerY = editor.y + 0.8 * editor.height;
+        const getCenter = async () => {
+          const { x, y, width, height } = await getRect(page, editorSelector);
+          return [x + width / 2, y + height / 2];
+        };
+        let finger0, finger1;
+
+        try {
+          finger0 = await page.touchscreen.touchStart(
+            editor.x + 0.15 * editor.width,
+            fingerY
+          );
+          finger1 = await page.touchscreen.touchStart(
+            editor.x + 0.85 * editor.width,
+            fingerY
+          );
+          await page.waitForSelector(".annotationEditorLayer.disabled");
+
+          // The second finger is lifted, which ends the session, and put down
+          // again next to the first one, which starts a new one.
+          await finger1.end();
+          await page.waitForSelector(".annotationEditorLayer:not(.disabled)");
+          finger1 = await page.touchscreen.touchStart(
+            editor.x + 0.5 * editor.width,
+            fingerY
+          );
+          await page.waitForSelector(".annotationEditorLayer.disabled");
+
+          // Spreading the fingers must resize the editor around its center and
+          // not drag it: the `pointerdown` of the returning finger mustn't have
+          // started a drag session. The editor is deliberately grown by little,
+          // else it would hit the page borders and be moved to fit in them.
+          const [centerX, centerY] = await getCenter();
+          for (let i = 1; i <= 6; i++) {
+            await finger1.move(editor.x + 0.5 * editor.width + 10 * i, fingerY);
+          }
+
+          const [newCenterX, newCenterY] = await getCenter();
+          expect(Math.abs(newCenterX - centerX))
+            .withContext(`In ${browserName}`)
+            .toBeLessThan(2);
+          expect(Math.abs(newCenterY - centerY))
+            .withContext(`In ${browserName}`)
+            .toBeLessThan(2);
+        } finally {
+          await finger0?.end();
+          await finger1?.end();
+        }
+      })
+    );
+  });
 });
 
 describe("Tap after a two-finger gesture", () => {

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -1624,6 +1624,55 @@ describe("PDF viewer", () => {
         })
       );
     });
+
+    it("keeps pinching when going from three fingers back to two", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const getScale = () =>
+            page.evaluate(
+              () => window.PDFViewerApplication.pdfViewer.currentScale
+            );
+          const centerX = 300,
+            centerY = 400;
+          const initialScale = await getScale();
+          const minDistance = await page.evaluate(
+            () =>
+              window.PDFViewerApplication._touchManager
+                .MIN_TOUCH_DISTANCE_TO_PINCH
+          );
+          let scale;
+
+          // Spread the two fingers well past the dead zone, which zooms in.
+          await pinch(page, {
+            centerX,
+            centerY,
+            startGap: 25,
+            endGap: 100,
+            beforeEnd: async ([finger0, finger1]) => {
+              scale = await getScale();
+              expect(scale)
+                .withContext(`In ${browserName}`)
+                .toBeGreaterThan(initialScale);
+
+              // A third finger lands and is lifted right away: the pinch in
+              // progress mustn't have to earn the dead zone all over again.
+              const finger2 = await page.touchscreen.touchStart(
+                centerX,
+                centerY + 200
+              );
+              await finger2.end();
+
+              // Hence this move, at half the dead-zone distance, still zooms.
+              await finger1.move(centerX + 100 + minDistance / 2, centerY);
+            },
+          });
+
+          expect(await getScale())
+            .withContext(`In ${browserName}`)
+            .toBeGreaterThan(scale);
+        })
+      );
+    });
   });
 
   describe("Outline tree shift-click toggle (PR 20740)", () => {

--- a/test/unit/touch_manager_spec.js
+++ b/test/unit/touch_manager_spec.js
@@ -123,4 +123,76 @@ describe("TouchManager", function () {
 
     helper.destroy();
   });
+
+  it("keeps pinching when the tracked pair changes", function () {
+    const helper = new TouchManagerHelper();
+    const { MIN_TOUCH_DISTANCE_TO_PINCH: minDistance } = helper.manager;
+    const touch0 = makeTouch(0, 0);
+    const touch1 = makeTouch(1, 200);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    // Past the dead zone: the first move only re-baselines...
+    const spread1 = makeTouch(1, 400);
+    helper.dispatch("touchmove", [touch0, spread1], [spread1]);
+    expect(helper.pinchings).toEqual([]);
+
+    // ...and the second one is reported, hence pinching is in progress.
+    const spread2 = makeTouch(1, 600);
+    helper.dispatch("touchmove", [touch0, spread2], [spread2]);
+    expect(helper.pinchings.length).toEqual(1);
+
+    // A third finger lands and is lifted right away.
+    const touch2 = makeTouch(2, 500, 400);
+    helper.dispatch("touchstart", [touch0, spread2, touch2], [touch2]);
+    helper.dispatch("touchend", [touch0, spread2], [touch2]);
+
+    // The pinch is still in progress, hence a move well inside the dead zone is
+    // still reported instead of having to earn it all over again.
+    const nudge = minDistance / 2;
+    const spread3 = makeTouch(1, 600 + nudge);
+    helper.dispatch("touchmove", [touch0, spread3], [spread3]);
+    expect(helper.pinchings.length).toEqual(2);
+    expect(helper.pinchings[1].prevDistance).toEqual(600);
+    expect(helper.pinchings[1].distance).toBeCloseTo(600 + nudge);
+
+    helper.destroy();
+  });
+
+  it("doesn't keep pinching into the next gesture", function () {
+    const helper = new TouchManagerHelper();
+    const { MIN_TOUCH_DISTANCE_TO_PINCH: minDistance } = helper.manager;
+    const touch0 = makeTouch(0, 0);
+    const touch1 = makeTouch(1, 200);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+    const spread1 = makeTouch(1, 400);
+    const spread2 = makeTouch(1, 600);
+    helper.dispatch("touchmove", [touch0, spread1], [spread1]);
+    helper.dispatch("touchmove", [touch0, spread2], [spread2]);
+    expect(helper.pinchings.length).toEqual(1);
+
+    // A third finger breaks the pair, and then everything is lifted.
+    const touch2 = makeTouch(2, 500, 400);
+    helper.dispatch("touchstart", [touch0, spread2, touch2], [touch2]);
+    helper.dispatch("touchend", [touch0], [spread2, touch2]);
+    helper.dispatch("touchend", [], [touch0]);
+    expect(helper.pinchEnds).toEqual(1);
+
+    // The next gesture must earn the dead zone again.
+    const next0 = makeTouch(3, 0);
+    const next1 = makeTouch(4, 200);
+    helper.dispatch("touchstart", [next0], [next0]);
+    helper.dispatch("touchstart", [next0, next1], [next1]);
+    helper.dispatch(
+      "touchmove",
+      [next0, makeTouch(4, 200 + minDistance / 2)],
+      []
+    );
+    expect(helper.pinchings.length).toEqual(1);
+
+    helper.destroy();
+  });
 });


### PR DESCRIPTION
Preserve the pinch state across tracked-pair changes so scaling resumes without crossing the dead zone again. Reset it once fewer than two tracked touches remain.

Also re-arm the pointerdown guard when one touch remains, preventing a returning finger from starting an editor drag.