### PR TITLE
Remove overridden/duplicated `[$getChildren]` methods

### DIFF
--- a/src/core/xfa/xfa_object.js
+++ b/src/core/xfa/xfa_object.js
@@ -327,10 +327,6 @@ class XFAObject {
     return this[$getParent]();
   }
 
-  [$getChildren](name = null) {
-    return !name ? this[_children] : this[name];
-  }
-
   [$dump]() {
     const dumped = Object.create(null);
     if (this[$content]) {
@@ -899,12 +895,6 @@ class XmlObject extends XFAObject {
     }
 
     return HTMLResult.EMPTY;
-  }
-
-  [$getChildren](name = null) {
-    return !name
-      ? this[_children]
-      : this[_children].filter(c => c[$nodeName] === name);
   }
 
   [$getAttributes]() {


### PR DESCRIPTION
Note how the `XFAObject` class has *two separate* `[$getChildren]` methods, which means that the later one will override the former. Looking at [the coverage data](https://app.codecov.io/gh/mozilla/pdf.js/commit/022e9588728346cde58088a9925120293af1c8f4/blob/src/core/xfa/xfa_object.js?dropdown=coverage#L330) confirms that the former method is indeed unused.
Note that normally ESLint will catch that sort of thing, but I guess that the name being determined from a `Symbol` prevents that (since ESLint is only a static code analyser).

Furthermore the `XmlObject` class extends `XFAObject`, however it still defines its own `[$getChildren]` method that is *identical* to the one in the base class.