### PR TITLE
Re-name the `RefSetCache` class to `RefMap`

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -42,8 +42,8 @@ import {
   isRefsEqual,
   Name,
   Ref,
+  RefMap,
   RefSet,
-  RefSetCache,
 } from "./primitives.js";
 import { GlobalColorSpaceCache, GlobalImageCache } from "./image_utils.js";
 import { NameTree, NumberTree } from "./name_number_tree.js";
@@ -120,7 +120,7 @@ function fetchRemoteDest(action) {
 class Catalog {
   #actualNumPages = null;
 
-  #annotationAttachmentIdByRef = new RefSetCache();
+  #annotationAttachmentIdByRef = new RefMap();
 
   #annotationAttachmentRefById = new Map();
 
@@ -130,7 +130,7 @@ class Catalog {
 
   builtInCMapCache = new Map();
 
-  fontCache = new RefSetCache();
+  fontCache = new RefMap();
 
   globalColorSpaceCache = new GlobalColorSpaceCache();
 
@@ -138,11 +138,11 @@ class Catalog {
 
   nonBlendModesSet = new RefSet();
 
-  pageDictCache = new RefSetCache();
+  pageDictCache = new RefMap();
 
-  pageIndexCache = new RefSetCache();
+  pageIndexCache = new RefMap();
 
-  pageKidsCountCache = new RefSetCache();
+  pageKidsCountCache = new RefMap();
 
   standardFontDataCache = new Map();
 
@@ -541,7 +541,7 @@ class Catalog {
       if (!Array.isArray(groupsData)) {
         return shadow(this, "optionalContentConfig", null);
       }
-      const groupRefCache = new RefSetCache();
+      const groupRefCache = new RefMap();
       // Ensure all the optional content groups are valid.
       for (const groupRef of groupsData) {
         if (!(groupRef instanceof Ref) || groupRefCache.has(groupRef)) {

--- a/src/core/document.js
+++ b/src/core/document.js
@@ -56,8 +56,8 @@ import {
   isRefsEqual,
   Name,
   Ref,
+  RefMap,
   RefSet,
-  RefSetCache,
 } from "./primitives.js";
 import { FunctionType, PDFFunctionFactory } from "./function.js";
 import { getXfaFontDict, getXfaFontName } from "./xfa_fonts.js";
@@ -375,7 +375,7 @@ class Page {
     }
     const partialEvaluator = this.#createPartialEvaluator(handler);
 
-    const deletedAnnotations = new RefSetCache();
+    const deletedAnnotations = new RefMap();
     const existingAnnotations = new RefSet();
     await this.#replaceIdByRef(
       annotations,
@@ -1963,7 +1963,7 @@ class PDFDocument {
         const visitedRefs = new RefSet();
         const allFields = new Map();
         const fieldPromises = new Map();
-        const orphanFields = new RefSetCache();
+        const orphanFields = new RefMap();
         for (const fieldRef of acroForm.get("Fields")) {
           await this.#collectFieldObjects(
             "",

--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -33,8 +33,8 @@ import {
   isName,
   Name,
   Ref,
+  RefMap,
   RefSet,
-  RefSetCache,
 } from "../primitives.js";
 import { incrementalUpdate, writeValue } from "../writer.js";
 import { isArrayEqual, makeArr, stringToBytes } from "../../shared/util.js";
@@ -69,11 +69,11 @@ class DocumentData {
     this.document = document;
     this.destinations = null;
     this.pageLabels = null;
-    this.pagesMap = new RefSetCache();
-    this.oldRefMapping = new RefSetCache();
+    this.pagesMap = new RefMap();
+    this.oldRefMapping = new RefMap();
     this.dedupNamedDestinations = new Map();
     this.usedNamedDestinations = new Set();
-    this.postponedRefCopies = new RefSetCache();
+    this.postponedRefCopies = new RefMap();
     this.resourceStreamPromises = new Map();
     this.usedStructParents = new Set();
     this.oldStructParentMapping = new Map();
@@ -90,7 +90,7 @@ class DocumentData {
     this.acroFormDefaultResources = null;
     this.acroFormQ = 0;
     this.hasSignatureAnnotations = false;
-    this.fieldToParent = new RefSetCache();
+    this.fieldToParent = new RefMap();
     this.outline = null;
     this.embeddedFiles = null;
   }
@@ -2142,7 +2142,7 @@ class PDFEditor {
    * If the document has some fields but no Fields entry in the AcroForm, we
    * need to fix that by creating a Fields entry with the oldest parent field
    * for each field.
-   * @param {RefSetCache} fieldToParent
+   * @param {RefMap} fieldToParent
    * @param {XRef} xref
    * @returns {Array<Ref>}
    */
@@ -2508,7 +2508,7 @@ class PDFEditor {
         : null;
     if (newAnnotations?.length) {
       const { handler, task, imagesPromises } = this.#newAnnotationsParams;
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       const newData = await AnnotationFactory.saveNewAnnotations(
         page.createAnnotationEvaluator(handler),
         this.xrefWrapper,
@@ -3047,10 +3047,10 @@ class PDFEditor {
 
   /**
    * Create the changes required to write the new PDF document.
-   * @returns {Promise<[RefSetCache, Ref]>}
+   * @returns {Promise<[RefMap, Ref]>}
    */
   async #createChanges() {
-    const changes = new RefSetCache();
+    const changes = new RefMap();
     changes.put(Ref.get(0, 0xffff), { data: null });
     for (let i = 1, ii = this.xref.length; i < ii; i++) {
       if (this.objStreamRefs?.has(i)) {
@@ -3067,7 +3067,7 @@ class PDFEditor {
    * Create an object stream containing the given objects.
    * @param {Ref} objStreamRef
    * @param {Array<Ref>} objRefs
-   * @param {RefSetCache} changes
+   * @param {RefMap} changes
    */
   async #createObjectStream(objStreamRef, objRefs, changes) {
     const streamBuffer = [""];

--- a/src/core/evaluator.js
+++ b/src/core/evaluator.js
@@ -1356,7 +1356,7 @@ class PartialEvaluator {
     // Workaround for bad PDF generators that reference fonts incorrectly,
     // where `fontRef` is a `Dict` rather than a `Ref` (fixes bug946506.pdf).
     // In this case we cannot put the font into `this.fontCache` (which is
-    // a `RefSetCache`), since it's not possible to use a `Dict` as a key.
+    // a `RefMap`), since it's not possible to use a `Dict` as a key.
     //
     // However, if we don't cache the font it's not possible to remove it
     // when `cleanup` is triggered from the API, which causes issues on
@@ -1365,8 +1365,8 @@ class PartialEvaluator {
     //
     // Instead, we cheat a bit by using a modified `fontID` as a key in
     // `this.fontCache`, to allow the font to be cached.
-    // NOTE: This works because `RefSetCache` calls `toString()` on provided
-    //       keys. Also, since `fontRef` is used when getting cached fonts,
+    // NOTE: This works because `RefMap` calls `toString()` on provided keys.
+    //       Also, since `fontRef` is used when getting cached fonts,
     //       we'll not accidentally match fonts cached with the `fontID`.
     if (fontRefIsRef) {
       this.fontCache.put(fontRef, promise);

--- a/src/core/image_utils.js
+++ b/src/core/image_utils.js
@@ -14,7 +14,7 @@
  */
 
 import { assert, makeSet, unreachable, warn } from "../shared/util.js";
-import { RefSet, RefSetCache } from "./primitives.js";
+import { RefMap, RefSet } from "./primitives.js";
 
 class BaseLocalCache {
   constructor(options) {
@@ -30,7 +30,7 @@ class BaseLocalCache {
       this._nameRefMap = new Map();
       this._imageMap = new Map();
     }
-    this._imageCache = new RefSetCache();
+    this._imageCache = new RefMap();
   }
 
   getByName(name) {
@@ -205,8 +205,8 @@ class GlobalImageCache {
         "GlobalImageCache - invalid NUM_PAGES_THRESHOLD constant."
       );
     }
-    this._refCache = new RefSetCache();
-    this._imageCache = new RefSetCache();
+    this._refCache = new RefMap();
+    this._imageCache = new RefMap();
   }
 
   get #byteSize() {

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -373,7 +373,7 @@ class RefSet {
   }
 }
 
-class RefSetCache {
+class RefMap {
   _map = new Map();
 
   get size() {
@@ -467,6 +467,6 @@ export {
   isRefsEqual,
   Name,
   Ref,
+  RefMap,
   RefSet,
-  RefSetCache,
 };

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -26,8 +26,8 @@ import {
   isName,
   Name,
   Ref,
+  RefMap,
   RefSet,
-  RefSetCache,
 } from "./primitives.js";
 import { lookupNormalRect, MissingDataException } from "./core_utils.js";
 import { stringToAsciiOrUTF16BE, stringToPDFString } from "./string_utils.js";
@@ -105,8 +105,9 @@ class StructTreeRoot {
     if (!(pageRef instanceof Ref) || id < 0) {
       return;
     }
-    this.structParentIds ||= new RefSetCache();
-    this.structParentIds.getOrPutComputed(pageRef, makeArr).push([id, type]);
+    (this.structParentIds ??= new RefMap())
+      .getOrPutComputed(pageRef, makeArr)
+      .push([id, type]);
   }
 
   addAnnotationIdToPage(pageRef, id) {
@@ -162,7 +163,7 @@ class StructTreeRoot {
     changes,
   }) {
     const root = await pdfManager.ensureCatalog("cloneDict");
-    const cache = new RefSetCache();
+    const cache = new RefMap();
     cache.put(catalogRef, root);
 
     const structTreeRootRef = xref.getNewTemporaryRef();
@@ -279,7 +280,7 @@ class StructTreeRoot {
   async updateStructureTree({ newAnnotationsByPage, pdfManager, changes }) {
     const { ref: structTreeRootRef, xref } = this;
     const structTreeRoot = this.dict.clone();
-    const cache = new RefSetCache();
+    const cache = new RefMap();
     cache.put(structTreeRootRef, structTreeRoot);
 
     let parentTreeRef = structTreeRoot.getRaw("ParentTree");

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -29,7 +29,7 @@ import {
   getNewAnnotationsMap,
   XRefParseException,
 } from "./core_utils.js";
-import { Dict, isDict, Ref, RefSetCache } from "./primitives.js";
+import { Dict, isDict, Ref, RefMap } from "./primitives.js";
 import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
 import { MessageHandler, wrapReason } from "../shared/message_handler.js";
 import { AnnotationFactory } from "./annotation.js";
@@ -694,7 +694,7 @@ class WorkerMessageHandler {
           pdfManager.ensureDoc("xref"),
           pdfManager.ensureCatalog("structTreeRoot"),
         ];
-        const changes = new RefSetCache();
+        const changes = new RefMap();
         const promises = [];
 
         const newAnnotationsByPage = !isPureXfa

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -44,7 +44,7 @@ import {
   STANDARD_FONT_DATA_URL,
   XRefMock,
 } from "./test_utils.js";
-import { Dict, Name, Ref, RefSetCache } from "../../src/core/primitives.js";
+import { Dict, Name, Ref, RefMap } from "../../src/core/primitives.js";
 import { Lexer, Parser } from "../../src/core/parser.js";
 import { Catalog } from "../../src/core/catalog.js";
 import { FlateStream } from "../../src/core/flate_stream.js";
@@ -135,7 +135,7 @@ describe("annotation", function () {
       handler: new HandlerMock(),
       pageIndex: 0,
       idFactory: createIdFactory(/* pageIndex = */ 0),
-      fontCache: new RefSetCache(),
+      fontCache: new RefMap(),
       builtInCMapCache,
       standardFontDataCache: new Map(),
       systemFontCache: new Map(),
@@ -2190,7 +2190,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: "hello world" });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -2249,7 +2249,7 @@ describe("annotation", function () {
       const annotationStorage = new Map();
       annotationStorage.set(annotation1.data.id, { value: "hello world" });
       annotationStorage.set(annotation2.data.id, { value: "hello world" });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation1.save(
         partialEvaluator,
@@ -2309,7 +2309,7 @@ describe("annotation", function () {
         value: "hello world",
         rotation: 90,
       });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -2351,7 +2351,7 @@ describe("annotation", function () {
       const annotationStorage = new Map();
       const value = "a".repeat(256);
       annotationStorage.set(annotation.data.id, { value });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -2492,7 +2492,7 @@ describe("annotation", function () {
       annotationStorage.set(annotation.data.id, {
         value: "こんにちは世界の",
       });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -3028,7 +3028,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: true });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const [oldData] = await writeChanges(changes, xref);
@@ -3074,7 +3074,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: true, rotation: 180 });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const [oldData] = await writeChanges(changes, xref);
@@ -3494,7 +3494,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: true });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -3561,7 +3561,7 @@ describe("annotation", function () {
 
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: true });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -3612,7 +3612,7 @@ describe("annotation", function () {
 
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: true });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const [data] = await writeChanges(changes, xref);
@@ -3664,7 +3664,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: true });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -3698,7 +3698,7 @@ describe("annotation", function () {
         idFactoryMock
       );
       const annotationStorage = new Map();
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       expect(changes.size).toEqual(0);
@@ -4213,7 +4213,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: "C", rotation: 270 });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -4272,7 +4272,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: "C" });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -4335,7 +4335,7 @@ describe("annotation", function () {
       );
       const annotationStorage = new Map();
       annotationStorage.set(annotation.data.id, { value: ["B", "C"] });
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       await annotation.save(partialEvaluator, task, annotationStorage, changes);
       const data = await writeChanges(changes, xref);
@@ -5517,7 +5517,7 @@ describe("annotation", function () {
     it("should create a new FreeText annotation", async () => {
       const xref = (partialEvaluator.xref = new XRefMock());
       const task = new WorkerTask("test FreeText creation");
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       await AnnotationFactory.saveNewAnnotations(
         partialEvaluator,
         xref,
@@ -5633,7 +5633,7 @@ describe("annotation", function () {
       const xref = (partialEvaluator.xref = new XRefMock([
         { ref: freeTextRef, data: freeTextDict },
       ]));
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       const task = new WorkerTask("test FreeText update");
       await AnnotationFactory.saveNewAnnotations(
@@ -5750,7 +5750,7 @@ describe("annotation", function () {
 
     it("should create a new Ink annotation", async function () {
       const xref = (partialEvaluator.xref = new XRefMock());
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       const task = new WorkerTask("test Ink creation");
       await AnnotationFactory.saveNewAnnotations(
         partialEvaluator,
@@ -5848,7 +5848,7 @@ describe("annotation", function () {
 
     it("should create a new Ink annotation with some transparency", async function () {
       const xref = (partialEvaluator.xref = new XRefMock());
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       const task = new WorkerTask("test Ink creation");
       await AnnotationFactory.saveNewAnnotations(
         partialEvaluator,
@@ -6081,7 +6081,7 @@ describe("annotation", function () {
 
     it("should create a new Highlight annotation", async function () {
       const xref = (partialEvaluator.xref = new XRefMock());
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       const task = new WorkerTask("test Highlight creation");
       await AnnotationFactory.saveNewAnnotations(
         partialEvaluator,
@@ -6175,7 +6175,7 @@ describe("annotation", function () {
 
     it("should create a new free Highlight annotation", async function () {
       const xref = (partialEvaluator.xref = new XRefMock());
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       const task = new WorkerTask("test free Highlight creation");
       await AnnotationFactory.saveNewAnnotations(
         partialEvaluator,
@@ -6306,7 +6306,7 @@ describe("annotation", function () {
       const xref = (partialEvaluator.xref = new XRefMock([
         { ref: highlightRef, data: highlightDict },
       ]));
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       const task = new WorkerTask("test Highlight update");
       await AnnotationFactory.saveNewAnnotations(
@@ -6370,7 +6370,7 @@ describe("annotation", function () {
         { ref: highlightRef, data: highlightDict },
         { ref: popupRef, data: highlightPopupDict },
       ]));
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       const task = new WorkerTask("test Highlight update");
       await AnnotationFactory.saveNewAnnotations(
@@ -6536,7 +6536,7 @@ describe("annotation", function () {
   describe("StampAnnotation for signatures", function () {
     it("should create a new Stamp annotation", async function () {
       const xref = (partialEvaluator.xref = new XRefMock());
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       const task = new WorkerTask("test Stamp creation");
       await AnnotationFactory.saveNewAnnotations(
         partialEvaluator,

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -22,8 +22,8 @@ import {
   isRefsEqual,
   Name,
   Ref,
+  RefMap,
   RefSet,
-  RefSetCache,
 } from "../../src/core/primitives.js";
 import { StringStream } from "../../src/core/stream.js";
 import { XRefMock } from "./test_utils.js";
@@ -503,7 +503,7 @@ describe("primitives", function () {
     });
   });
 
-  describe("RefSetCache", function () {
+  describe("RefMap", function () {
     const ref1 = Ref.get(4, 2),
       ref2 = Ref.get(5, 2),
       obj1 = Name.get("foo"),
@@ -511,7 +511,7 @@ describe("primitives", function () {
     let cache;
 
     beforeEach(function () {
-      cache = new RefSetCache();
+      cache = new RefMap();
     });
 
     afterEach(function () {

--- a/test/unit/writer_spec.js
+++ b/test/unit/writer_spec.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Dict, Name, Ref, RefSetCache } from "../../src/core/primitives.js";
+import { Dict, Name, Ref, RefMap } from "../../src/core/primitives.js";
 import {
   incrementalUpdate,
   writeDict,
@@ -35,7 +35,7 @@ describe("Writer", function () {
   describe("Incremental update", function () {
     it("should update a file with new objects", async function () {
       const originalData = new Uint8Array();
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       changes.put(Ref.get(123, 0x2d), { data: "abc\n" });
       changes.put(Ref.get(456, 0x4e), { data: "defg\n" });
       const xrefInfo = {
@@ -105,7 +105,7 @@ describe("Writer", function () {
 
     it("should update a file, missing the /ID-entry, with new objects", async function () {
       const originalData = new Uint8Array();
-      const changes = new RefSetCache();
+      const changes = new RefMap();
       changes.put(Ref.get(123, 0x2d), { data: "abc\n" });
       const xrefInfo = {
         newRef: Ref.get(789, 0),
@@ -200,7 +200,7 @@ describe("Writer", function () {
   describe("XFA", function () {
     it("should update AcroForm when no datasets in XFA array", async function () {
       const originalData = new Uint8Array();
-      const changes = new RefSetCache();
+      const changes = new RefMap();
 
       const acroForm = new Dict(null);
       acroForm.set("XFA", [
@@ -326,7 +326,7 @@ describe("Writer", function () {
 
   it("should update a file with a deleted object", async function () {
     const originalData = new Uint8Array();
-    const changes = new RefSetCache();
+    const changes = new RefMap();
     changes.put(Ref.get(123, 0x2d), { data: null });
     changes.put(Ref.get(456, 0x4e), { data: "abc\n" });
     const xrefInfo = {


### PR DESCRIPTION
The `RefSet` and `RefSetCache` classes are old enough that they predate a lot of modern JavaScript features, e.g. originally they stored their data in regular Objects.
About six years ago, see PRs #11977 and #12089, these classes were converted to use a Set respectively a Map internally.

Given that `RefSet` is a wrapper around a standard Set, it seems reasonable to re-name `RefSetCache` to `RefMap` when it's a wrapper around a standard Map.