### PR TITLE
[api-minor] Convert `getPermissions` to return data in a Set

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -516,11 +516,10 @@ class Catalog {
     // complement binary integer so we can use regular bitwise operations on it.
     flags += 2 ** 32;
 
-    const permissions = [];
-    for (const key in PermissionFlag) {
-      const value = PermissionFlag[key];
+    const permissions = new Set();
+    for (const value of Object.values(PermissionFlag)) {
       if (flags & value) {
-        permissions.push(value);
+        permissions.add(value);
       }
     }
     return permissions;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -924,9 +924,9 @@ class PDFDocumentProxy {
   }
 
   /**
-   * @returns {Promise<Array<number> | null>} A promise that is resolved with
-   *   an {Array} that contains the permission flags for the PDF document, or
-   *   `null` when no permissions are present in the PDF file.
+   * @returns {Promise<Set<number> | null>} A promise that is resolved with
+   *   a {Set} that contains the permission flags for the PDF document,
+   *   or `null` when no permissions are present in the PDF file.
    */
   getPermissions() {
     return this._transport.getPermissions();

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2691,19 +2691,15 @@ describe("api", function () {
       const totalPermissionCount = Object.keys(PermissionFlag).length;
       const permissions = await Promise.all([promise0, promise1, promise2]);
 
-      expect(permissions[0].length).toEqual(totalPermissionCount - 1);
-      expect(
-        permissions[0].includes(PermissionFlag.MODIFY_CONTENTS)
-      ).toBeFalsy();
+      expect(permissions[0].size).toEqual(totalPermissionCount - 1);
+      expect(permissions[0].has(PermissionFlag.MODIFY_CONTENTS)).toBeFalse();
 
-      expect(permissions[1].length).toEqual(totalPermissionCount - 2);
-      expect(permissions[1].includes(PermissionFlag.PRINT)).toBeFalsy();
-      expect(
-        permissions[1].includes(PermissionFlag.PRINT_HIGH_QUALITY)
-      ).toBeFalsy();
+      expect(permissions[1].size).toEqual(totalPermissionCount - 2);
+      expect(permissions[1].has(PermissionFlag.PRINT)).toBeFalse();
+      expect(permissions[1].has(PermissionFlag.PRINT_HIGH_QUALITY)).toBeFalse();
 
-      expect(permissions[2].length).toEqual(totalPermissionCount - 1);
-      expect(permissions[2].includes(PermissionFlag.COPY)).toBeFalsy();
+      expect(permissions[2].size).toEqual(totalPermissionCount - 1);
+      expect(permissions[2].has(PermissionFlag.COPY)).toBeFalse();
 
       await Promise.all([
         loadingTask0.destroy(),

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -741,24 +741,24 @@ class PDFViewer {
     }
 
     this.#setPrintingAllowed(
-      permissions.includes(PermissionFlag.PRINT_HIGH_QUALITY) ||
-        permissions.includes(PermissionFlag.PRINT)
+      permissions.has(PermissionFlag.PRINT_HIGH_QUALITY) ||
+        permissions.has(PermissionFlag.PRINT)
     );
 
     if (
-      !permissions.includes(PermissionFlag.COPY) &&
+      !permissions.has(PermissionFlag.COPY) &&
       this.#textLayerMode === TextLayerMode.ENABLE
     ) {
       params.textLayerMode = TextLayerMode.ENABLE_PERMISSIONS;
     }
 
-    if (!permissions.includes(PermissionFlag.MODIFY_CONTENTS)) {
+    if (!permissions.has(PermissionFlag.MODIFY_CONTENTS)) {
       params.annotationEditorMode = AnnotationEditorType.DISABLE;
     }
 
     if (
-      !permissions.includes(PermissionFlag.MODIFY_ANNOTATIONS) &&
-      !permissions.includes(PermissionFlag.FILL_INTERACTIVE_FORMS) &&
+      !permissions.has(PermissionFlag.MODIFY_ANNOTATIONS) &&
+      !permissions.has(PermissionFlag.FILL_INTERACTIVE_FORMS) &&
       this.#annotationMode === AnnotationMode.ENABLE_FORMS
     ) {
       params.annotationMode = AnnotationMode.ENABLE;


### PR DESCRIPTION
This allows the viewer to check for enabled/disabled permissions using `Set.prototype.has()`, which is generally more efficient than `Array.prototype.includes()`.

*Note:* Permissions are not enabled by default in the viewer.