### PR TITLE
Replace most `toBeTruthy()`/`toBeFalsy()` matchers with more specific ones in the unit-tests

### DIFF
--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1129,7 +1129,7 @@ describe("annotation", function () {
       expect(data.url).toEqual("http://www.example.com/test.pdf#15");
       expect(data.unsafeUrl).toEqual("http://www.example.com/test.pdf#15");
       expect(data.dest).toBeUndefined();
-      expect(data.newWindow).toBeFalsy();
+      expect(data.newWindow).toBeUndefined();
     });
 
     it("should correctly parse a GoToR action, with explicit destination array", async function () {
@@ -1165,7 +1165,7 @@ describe("annotation", function () {
           '[14,{"name":"XYZ"},null,298.043,null]'
       );
       expect(data.dest).toBeUndefined();
-      expect(data.newWindow).toBeFalsy();
+      expect(data.newWindow).toBeUndefined();
     });
 
     it(

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -5535,7 +5535,7 @@ have written that much by now. So, here’s to squashing bugs.`);
           }
         }
       }
-      expect(checkedCopyLocalImage).toBeFalsy();
+      expect(checkedCopyLocalImage).toBeUndefined();
 
       firstImgData = null;
       await loadingTask.destroy();
@@ -5588,7 +5588,7 @@ have written that much by now. So, here’s to squashing bugs.`);
           break;
         }
       }
-      expect(checkedCopyLocalImage).toBeTruthy();
+      expect(checkedCopyLocalImage).toBeTrue();
 
       await loadingTask.destroy();
     });
@@ -5648,7 +5648,7 @@ have written that much by now. So, here’s to squashing bugs.`);
           checkedGlobalDecodeFailed = true;
         }
       }
-      expect(checkedGlobalDecodeFailed).toBeTruthy();
+      expect(checkedGlobalDecodeFailed).toBeTrue();
 
       await loadingTask.destroy();
     });

--- a/test/unit/cmap_spec.js
+++ b/test/unit/cmap_spec.js
@@ -141,7 +141,7 @@ describe("cmap", function () {
     });
     expect(cmap).toBeInstanceOf(CMap);
     expect(cmap.useCMap).not.toBeNull();
-    expect(cmap.builtInCMap).toBeFalsy();
+    expect(cmap.builtInCMap).toBeFalse();
     expect(cmap.length).toEqual(0x20a7);
     expect(cmap.isIdentityCMap).toBeFalse();
   });
@@ -168,7 +168,7 @@ describe("cmap", function () {
     });
     expect(cmap).toBeInstanceOf(CMap);
     expect(cmap.useCMap).toBeNull();
-    expect(cmap.builtInCMap).toBeTruthy();
+    expect(cmap.builtInCMap).toBeTrue();
     expect(cmap.length).toEqual(0x20a7);
     expect(cmap.isIdentityCMap).toBeFalse();
   });

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -27,29 +27,29 @@ import { XRefMock } from "./test_utils.js";
 describe("colorspace", function () {
   describe("ColorSpace.isDefaultDecode", function () {
     it("should be true if decode is not an array", function () {
-      expect(ColorSpace.isDefaultDecode("string", 0)).toBeTruthy();
+      expect(ColorSpace.isDefaultDecode("string", 0)).toBeTrue();
     });
 
     it("should be true if length of decode array is not correct", function () {
-      expect(ColorSpace.isDefaultDecode([0], 1)).toBeTruthy();
-      expect(ColorSpace.isDefaultDecode([0, 1, 0], 1)).toBeTruthy();
+      expect(ColorSpace.isDefaultDecode([0], 1)).toBeTrue();
+      expect(ColorSpace.isDefaultDecode([0, 1, 0], 1)).toBeTrue();
     });
 
     it("should be true if decode map matches the default decode map", function () {
-      expect(ColorSpace.isDefaultDecode([], 0)).toBeTruthy();
+      expect(ColorSpace.isDefaultDecode([], 0)).toBeTrue();
 
-      expect(ColorSpace.isDefaultDecode([0, 0], 1)).toBeFalsy();
-      expect(ColorSpace.isDefaultDecode([0, 1], 1)).toBeTruthy();
+      expect(ColorSpace.isDefaultDecode([0, 0], 1)).toBeFalse();
+      expect(ColorSpace.isDefaultDecode([0, 1], 1)).toBeTrue();
 
-      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 0, 1], 3)).toBeTruthy();
-      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 1, 1], 3)).toBeFalsy();
+      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 0, 1], 3)).toBeTrue();
+      expect(ColorSpace.isDefaultDecode([0, 1, 0, 1, 1, 1], 3)).toBeFalse();
 
       expect(
         ColorSpace.isDefaultDecode([0, 1, 0, 1, 0, 1, 0, 1], 4)
-      ).toBeTruthy();
+      ).toBeTrue();
       expect(
         ColorSpace.isDefaultDecode([1, 0, 0, 1, 0, 1, 0, 1], 4)
-      ).toBeFalsy();
+      ).toBeFalse();
     });
   });
 
@@ -268,7 +268,7 @@ describe("colorspace", function () {
         new Uint8ClampedArray([26, 26, 26])
       );
       expect(colorSpace.getOutputLength(2, 0)).toEqual(6);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
     it("should handle the case when cs is an indirect object", function () {
@@ -313,7 +313,7 @@ describe("colorspace", function () {
         new Uint8ClampedArray([51, 51, 51])
       );
       expect(colorSpace.getOutputLength(3, 1)).toEqual(12);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -384,7 +384,7 @@ describe("colorspace", function () {
         new Uint8ClampedArray([26, 51, 77])
       );
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
-      expect(colorSpace.isPassthrough(8)).toBeTruthy();
+      expect(colorSpace.isPassthrough(8)).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
     it("should handle the case when cs is an indirect object", function () {
@@ -435,7 +435,7 @@ describe("colorspace", function () {
         new Uint8ClampedArray([26, 51, 77])
       );
       expect(colorSpace.getOutputLength(4, 1)).toEqual(5);
-      expect(colorSpace.isPassthrough(8)).toBeTruthy();
+      expect(colorSpace.isPassthrough(8)).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -506,7 +506,7 @@ describe("colorspace", function () {
         colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]), 0)
       ).toEqual(new Uint8ClampedArray([32, 28, 21]));
       expect(colorSpace.getOutputLength(4, 0)).toEqual(3);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
     it("should handle the case when cs is an indirect object", function () {
@@ -557,7 +557,7 @@ describe("colorspace", function () {
         colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]), 0)
       ).toEqual(new Uint8ClampedArray([32, 28, 21]));
       expect(colorSpace.getOutputLength(4, 1)).toEqual(4);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -627,7 +627,7 @@ describe("colorspace", function () {
         new Uint8ClampedArray([255, 255, 255])
       );
       expect(colorSpace.getOutputLength(4, 0)).toEqual(12);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -697,7 +697,7 @@ describe("colorspace", function () {
         new Uint8ClampedArray([0, 147, 151])
       );
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -766,8 +766,8 @@ describe("colorspace", function () {
         new Uint8ClampedArray([188, 100, 61])
       );
       expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
-      expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
+      expect(colorSpace.isDefaultDecode([0, 1])).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -832,8 +832,8 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb([2], 0)).toEqual(
         new Uint8ClampedArray([255, 109, 70])
       );
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
-      expect(colorSpace.isDefaultDecode([0, 1], 1)).toBeTruthy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
+      expect(colorSpace.isDefaultDecode([0, 1], 1)).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
   });
@@ -910,8 +910,8 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb([0.1], 0)).toEqual(
         new Uint8ClampedArray([228, 243, 242])
       );
-      expect(colorSpace.isPassthrough(8)).toBeFalsy();
-      expect(colorSpace.isDefaultDecode([0, 1])).toBeTruthy();
+      expect(colorSpace.isPassthrough(8)).toBeFalse();
+      expect(colorSpace.isDefaultDecode([0, 1])).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
   });

--- a/test/unit/custom_spec.js
+++ b/test/unit/custom_spec.js
@@ -166,7 +166,7 @@ describe("custom ownerDocument", function () {
     }).promise;
 
     const style = elements.find(element => element.tagName === "style");
-    expect(style).toBeFalsy();
+    expect(style).toBeUndefined();
     expect(ownerDocument.fonts.size).toBeGreaterThanOrEqual(1);
     expect(Array.from(ownerDocument.fonts).find(checkFont)).toBeTruthy();
 

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -90,8 +90,8 @@ describe("primitives", function () {
 
   describe("Dict", function () {
     const checkInvalidHasValues = function (dict) {
-      expect(dict.has()).toBeFalsy();
-      expect(dict.has("Prev")).toBeFalsy();
+      expect(dict.has()).toBeFalse();
+      expect(dict.has("Prev")).toBeFalse();
     };
 
     const checkInvalidKeyValues = function (dict) {
@@ -149,7 +149,7 @@ describe("primitives", function () {
     });
 
     it("should return correct value for stored Size key", function () {
-      expect(dictWithSizeKey.has("Size")).toBeTruthy();
+      expect(dictWithSizeKey.has("Size")).toBeTrue();
 
       expect(dictWithSizeKey.get("Size")).toEqual(storedSize);
       expect(dictWithSizeKey.get("Prev", "Size")).toEqual(storedSize);
@@ -167,7 +167,7 @@ describe("primitives", function () {
         dict.set(123, "val");
       }).toThrowError('Dict.set: The "key" must be a string.');
 
-      expect(dict.has(123)).toBeFalsy();
+      expect(dict.has(123)).toBeFalse();
 
       checkInvalidKeyValues(dict);
     });
@@ -178,15 +178,15 @@ describe("primitives", function () {
         dict.set("Size");
       }).toThrowError('Dict.set: The "value" cannot be undefined.');
 
-      expect(dict.has("Size")).toBeFalsy();
+      expect(dict.has("Size")).toBeFalse();
 
       checkInvalidKeyValues(dict);
     });
 
     it("should return correct values for multiple stored keys", function () {
-      expect(dictWithManyKeys.has("FontFile")).toBeTruthy();
-      expect(dictWithManyKeys.has("FontFile2")).toBeTruthy();
-      expect(dictWithManyKeys.has("FontFile3")).toBeTruthy();
+      expect(dictWithManyKeys.has("FontFile")).toBeTrue();
+      expect(dictWithManyKeys.has("FontFile2")).toBeTrue();
+      expect(dictWithManyKeys.has("FontFile3")).toBeTrue();
 
       expect(dictWithManyKeys.get("FontFile3")).toEqual(testFontFile3);
       expect(dictWithManyKeys.get("FontFile2", "FontFile3")).toEqual(
@@ -487,13 +487,13 @@ describe("primitives", function () {
 
     it("should have a stored value", function () {
       refSet.put(ref1);
-      expect(refSet.has(ref1)).toBeTruthy();
+      expect(refSet.has(ref1)).toBeTrue();
     });
 
     it("should not have an unknown value", function () {
-      expect(refSet.has(ref1)).toBeFalsy();
+      expect(refSet.has(ref1)).toBeFalse();
       refSet.put(ref1);
-      expect(refSet.has(ref2)).toBeFalsy();
+      expect(refSet.has(ref2)).toBeFalse();
     });
 
     it("should support iteration", function () {
@@ -520,16 +520,16 @@ describe("primitives", function () {
 
     it("should put, have and get a value", function () {
       cache.put(ref1, obj1);
-      expect(cache.has(ref1)).toBeTruthy();
-      expect(cache.has(ref2)).toBeFalsy();
+      expect(cache.has(ref1)).toBeTrue();
+      expect(cache.has(ref2)).toBeFalse();
       expect(cache.get(ref1)).toBe(obj1);
     });
 
     it("should put, have and get a value by alias", function () {
       cache.put(ref1, obj1);
       cache.putAlias(ref2, ref1);
-      expect(cache.has(ref1)).toBeTruthy();
-      expect(cache.has(ref2)).toBeTruthy();
+      expect(cache.has(ref1)).toBeTrue();
+      expect(cache.has(ref2)).toBeTrue();
       expect(cache.get(ref1)).toBe(obj1);
       expect(cache.get(ref2)).toBe(obj1);
     });


### PR DESCRIPTION
Generally speaking it seems like a good idea to have the unit-tests be *explicit* about their expected values, rather than accepting "arbitrary" truthy/falsy values.