### PR TITLE
Cache the result of `buildSymbolGlyphIdEncoding` (PR 21726 follow-up)

### DIFF
--- a/src/core/core_utils.js
+++ b/src/core/core_utils.js
@@ -48,11 +48,11 @@ const RESOURCES_KEYS_TEXT_CONTENT = [
   "XObject",
 ];
 
-function getLookupTableFactory(initializer) {
+function getLookupTableFactory(initializer, useArray = false) {
   let lookup;
   return function () {
     if (initializer) {
-      lookup = Object.create(null);
+      lookup = useArray ? [] : Object.create(null);
       initializer(lookup);
       initializer = null;
     }

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -64,6 +64,7 @@ import { compileFontInfo } from "./obj_bin_transform_core.js";
 import { DataBuilder } from "./data_builder.js";
 import { FontRendererFactory } from "./font_renderer.js";
 import { getFontBasicMetrics } from "./metrics.js";
+import { getLookupTableFactory } from "./core_utils.js";
 import { OpenTypeFileBuilder } from "./opentype_file_builder.js";
 import { Stream } from "./stream.js";
 import { Type1Font } from "./type1_font.js";
@@ -392,19 +393,17 @@ function applyStandardFontGlyphMap(map, glyphMap) {
 // The glyphs of the (Windows) Symbol font are ordered by char code, hence build
 // an encoding indexed by glyph id; note that the char codes 0x7F-0xA0 are
 // unused and that the glyph ids 0-2 are `.notdef`/`.null`/`nonmarkingreturn`.
-function buildSymbolGlyphIdEncoding() {
-  const encoding = [];
+const getSymbolGlyphIdEncoding = getLookupTableFactory(t => {
   let glyphId = 3;
   for (const [firstCharCode, lastCharCode] of [
     [0x20, 0x7e],
     [0xa1, 0xfe],
   ]) {
     for (let charCode = firstCharCode; charCode <= lastCharCode; charCode++) {
-      encoding[glyphId++] = SymbolSetEncoding[charCode];
+      t[glyphId++] = SymbolSetEncoding[charCode];
     }
   }
-  return encoding;
-}
+}, /* useArray = */ true);
 
 function buildToFontChar(encoding, glyphsUnicodeMap, differences) {
   const toFontChar = [];
@@ -1358,13 +1357,13 @@ class Font {
       this.toFontChar = map;
       this.toUnicode = new ToUnicodeMap(map);
     } else if (/Symbol/i.test(fontName)) {
-      // The non-embedded SymbolMT font in issue 21713 uses Identity encoding
+      // The non-embedded SymbolMT font in issue 21523 uses Identity encoding
       // and an Identity CIDToGIDMap, hence its CIDs are glyph ids.
       const isCidKeyed =
         this.composite && this.cidEncoding.startsWith("Identity-");
 
       this.toFontChar = buildToFontChar(
-        isCidKeyed ? buildSymbolGlyphIdEncoding() : SymbolSetEncoding,
+        isCidKeyed ? getSymbolGlyphIdEncoding() : SymbolSetEncoding,
         getGlyphsUnicode(),
         this.differences
       );


### PR DESCRIPTION
If a PDF document contains multiple (different) non-embedded /Identity encoded Symbol fonts, or once cleanup has been triggered by the viewer, the "SymbolGlyphIdEncoding" would need to be recomputed more than once.
By updating the `getLookupTableFactory` helper to be able to create an Array, and not just an Object, it's easy enough to both lazily initialize *and* cache the "SymbolGlyphIdEncoding" (similar to e.g. the existing glyph-maps).