### PR TITLE
Improve some `Array.from()` usage

### DIFF
--- a/test/integration/accessibility_spec.mjs
+++ b/test/integration/accessibility_spec.mjs
@@ -471,11 +471,11 @@ describe("accessibility", () => {
         pages.map(async ([browserName, page]) => {
           const ariaHidden = await page.evaluate(() =>
             Array.from(
-              document.querySelectorAll(".structTree :has(> math)")
-            ).map(el =>
-              document
-                .getElementById(el.getAttribute("aria-owns"))
-                .getAttribute("aria-hidden")
+              document.querySelectorAll(".structTree :has(> math)"),
+              el =>
+                document
+                  .getElementById(el.getAttribute("aria-owns"))
+                  .getAttribute("aria-hidden")
             )
           );
           expect(ariaHidden)
@@ -557,8 +557,9 @@ describe("accessibility", () => {
         pages.map(async ([browserName, page]) => {
           let elementRole = await page.evaluate(() =>
             Array.from(
-              document.querySelector(".structTree [role='table']").children
-            ).map(child => child.getAttribute("role"))
+              document.querySelector(".structTree [role='table']").children,
+              child => child.getAttribute("role")
+            )
           );
 
           // THeader and TBody must be rowgroup.
@@ -570,8 +571,9 @@ describe("accessibility", () => {
             Array.from(
               document.querySelector(
                 ".structTree [role='table'] > [role='rowgroup'] > [role='row']"
-              ).children
-            ).map(child => child.getAttribute("role"))
+              ).children,
+              child => child.getAttribute("role")
+            )
           );
 
           // THeader has 3 columnheader.
@@ -583,8 +585,9 @@ describe("accessibility", () => {
             Array.from(
               document.querySelector(
                 ".structTree [role='table'] > [role='rowgroup']:nth-child(2)"
-              ).children
-            ).map(child => child.getAttribute("role"))
+              ).children,
+              child => child.getAttribute("role")
+            )
           );
 
           // TBody has 5 rows.
@@ -596,8 +599,9 @@ describe("accessibility", () => {
             Array.from(
               document.querySelector(
                 ".structTree [role='table'] > [role='rowgroup']:nth-child(2) > [role='row']:first-child"
-              ).children
-            ).map(child => child.getAttribute("role"))
+              ).children,
+              child => child.getAttribute("role")
+            )
           );
           // First row has a rowheader and 2 cells.
           expect(elementRole)

--- a/test/integration/comment_spec.mjs
+++ b/test/integration/comment_spec.mjs
@@ -621,8 +621,9 @@ describe("Comment", () => {
               Array.from(
                 document.querySelectorAll(
                   `#editorCommentParamsToolbar ul > li > time`
-                )
-              ).map(time => new Date(time.getAttribute("datetime")))
+                ),
+                time => new Date(time.getAttribute("datetime"))
+              )
             );
             for (let i = 0; i < dates.length - 1; i++) {
               expect(dates[i])

--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -177,10 +177,7 @@ function getSearchResults(page) {
       if (highlights.length === 0) {
         continue;
       }
-      results.push([
-        i + 1,
-        Array.from(highlights).map(span => span.textContent),
-      ]);
+      results.push([i + 1, Array.from(highlights, span => span.textContent)]);
     }
     return results;
   });

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -2063,7 +2063,8 @@ describe("PDF viewer", () => {
                   // Just verify the images rendered correctly.
                   const imgs = document.querySelectorAll("#printContainer img");
                   window._printImagesAccessible = Promise.resolve(
-                    Array.from(imgs).map(
+                    Array.from(
+                      imgs,
                       img => img.complete && img.naturalWidth > 0
                     )
                   );

--- a/web/internal/draw_ops_view.js
+++ b/web/internal/draw_ops_view.js
@@ -186,7 +186,7 @@ function formatArg(arg, full) {
       return `<${arg.length} values>`;
     }
     const fmt = n => (Number.isInteger(n) ? n : Math.round(n * 1000) / 1000);
-    return `[${Array.from(arg).map(fmt).join(" ")}]`;
+    return `[${Array.from(arg, fmt).join(" ")}]`;
   }
   if (Array.isArray(arg)) {
     if (arg.length === 0) {


### PR DESCRIPTION
Rather than doing `Array.from(...).map(mapFn)` we can use the more efficient `Array.from(..., mapFn)` format instead since that avoids creating an intermediate Array; see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#description