### PR TITLE
[Editor] End active touch gestures on destroy

### DIFF
--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -1931,6 +1931,11 @@ class AnnotationEditor {
       // undo/redo so we must commit it before.
       this.commit();
     }
+    // End an active pinch before detaching: its callback uses `parent` and
+    // records the resize.
+    this.#touchManager?.destroy();
+    this.#touchManager = null;
+
     if (this.parent) {
       this.parent.remove(this);
     } else {
@@ -1951,8 +1956,6 @@ class AnnotationEditor {
       this.#telemetryTimeouts = null;
     }
     this.parent = null;
-    this.#touchManager?.destroy();
-    this.#touchManager = null;
     this.#fakeAnnotation?.remove();
     this.#fakeAnnotation = null;
   }

--- a/src/display/touch_manager.js
+++ b/src/display/touch_manager.js
@@ -305,20 +305,10 @@ class TouchManager {
     }
     // Fewer than two tracked touches remain, so this manager's gesture is over;
     // unrelated entries in the document-wide touch list must not keep it alive.
-    // #touchMoveAC shouldn't be null but it seems that irl it can (see #19793).
-    if (this.#touchMoveAC) {
-      this.#touchMoveAC.abort();
-      this.#touchMoveAC = null;
-      this.#onPinchEnd?.();
-    }
-
-    // The flag is reset here, and only here, hence unconditionally: a pinch
-    // whose pair was broken, e.g. by a third finger or by `isPinchingStopped`,
-    // has no `#touchInfo` anymore but mustn't leak its state into the next
-    // gesture.
+    // Swallow the end only while a two-touch baseline is active.
     const wasTracking = !!this.#touchInfo;
-    this.#touchInfo = null;
-    this.#isPinching = false;
+    this.#endGesture();
+
     if (this.#touchIds.size === 1) {
       // A finger which started on the container is still down, so the gesture
       // is back to its one-finger state: the next finger to land must be
@@ -331,7 +321,20 @@ class TouchManager {
     }
   }
 
+  #endGesture() {
+    // `#setTouchInfo` may already have cleared the baseline.
+    this.#touchInfo = null;
+    this.#isPinching = false;
+    if (this.#touchMoveAC) {
+      this.#touchMoveAC.abort();
+      this.#touchMoveAC = null;
+      this.#onPinchEnd?.();
+    }
+  }
+
   destroy() {
+    this.#endGesture();
+    this.#touchIds.clear();
     this.#touchManagerAC?.abort();
     this.#touchManagerAC = null;
     this.#pointerDownAC?.abort();

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -1824,3 +1824,45 @@ describe("Tap after a two-finger gesture", () => {
     );
   });
 });
+
+describe("Removal during a pinch-resize", () => {
+  let pages;
+
+  beforeEach(async () => {
+    pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+  });
+
+  afterEach(async () => {
+    await closePages(pages);
+  });
+
+  it("must check that removing the editor being pinch-resized ends the gesture", async () => {
+    await Promise.all(
+      pages.map(async ([browserName, page]) => {
+        const { editor } = await drawAndSelectEditor(page);
+        const fingerY = editor.y + 0.8 * editor.height;
+        let finger0, finger1;
+
+        try {
+          finger0 = await page.touchscreen.touchStart(
+            editor.x + 0.2 * editor.width,
+            fingerY
+          );
+          finger1 = await page.touchscreen.touchStart(
+            editor.x + 0.55 * editor.width,
+            fingerY
+          );
+          await page.waitForSelector(".annotationEditorLayer.disabled");
+
+          // Removal must re-enable the layer before the touches end.
+          await page.keyboard.press("Backspace");
+          await waitForStorageEntries(page, 0);
+          await page.waitForSelector(".annotationEditorLayer:not(.disabled)");
+        } finally {
+          await finger0?.end();
+          await finger1?.end();
+        }
+      })
+    );
+  });
+});

--- a/test/unit/touch_manager_spec.js
+++ b/test/unit/touch_manager_spec.js
@@ -195,4 +195,25 @@ describe("TouchManager", function () {
 
     helper.destroy();
   });
+
+  it("ends the gesture in flight when destroyed", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 100);
+    const touch1 = makeTouch(1, 300);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+    expect(helper.pinchStarts).toEqual(1);
+    expect(helper.pinchEnds).toEqual(0);
+
+    // Destroy the manager while both touches are active.
+    helper.manager.destroy();
+    expect(helper.pinchEnds).toEqual(1);
+
+    // A later `touchend` must not call `onPinchEnd` again.
+    helper.dispatch("touchend", [], [touch0, touch1]);
+    expect(helper.pinchEnds).toEqual(1);
+
+    helper.destroy();
+  });
 });


### PR DESCRIPTION
Destroy an editor's touch manager before detaching it so `onPinchEnd` can restore pointer events and record any resize.