### PR TITLE
Avoid a race in the thumbnail drag test

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -2066,12 +2066,24 @@ describe("Reorganize Pages View", () => {
         pages.map(async ([browserName, page]) => {
           await waitForThumbnailVisible(page, 1);
 
-          await Promise.all([
-            page.waitForSelector(`#thumbnailsView.isDragging`, {
-              visible: true,
-            }),
-            dragAndDrop(page, getThumbnailSelector(1), [[0, 10]], 10),
-          ]);
+          let isDragging = false;
+          const checkDragging = async () => {
+            isDragging = await page.$eval("#thumbnailsView", ({ classList }) =>
+              classList.contains("isDragging")
+            );
+          };
+
+          await dragAndDrop(
+            page,
+            getThumbnailSelector(1),
+            [[0, 10]],
+            10,
+            checkDragging
+          );
+
+          expect(isDragging)
+            .withContext(`In ${browserName}, dragging should be enabled`)
+            .toBeTrue();
 
           await page.waitForSelector(`#thumbnailsView.isDragging`, {
             hidden: true,
@@ -2083,28 +2095,19 @@ describe("Reorganize Pages View", () => {
           await waitAndClick(page, "#viewsManagerStatusActionButton");
           await waitAndClick(page, "#viewsManagerStatusActionCopy");
 
-          // If dragging isn't disabled, the promise will resolve with the
-          // selector. Otherwise, it will resolve with undefined (dragAndDrop
-          // has no return), which is the expected behavior.
-          const abortController = new AbortController();
-          const first = await Promise.race([
-            page.waitForSelector(`#thumbnailsView.isDragging`, {
-              visible: true,
-              signal: abortController.signal,
-            }),
-            dragAndDrop(page, getThumbnailSelector(1), [[0, 10]], 10),
-          ]);
-          abortController.abort();
+          await dragAndDrop(
+            page,
+            getThumbnailSelector(1),
+            [[0, 10]],
+            10,
+            checkDragging
+          );
 
-          expect(first)
+          expect(isDragging)
             .withContext(
               `In ${browserName}, dragging should be disabled when pasting`
             )
-            .toBeUndefined();
-
-          // Wait a tick to ensure that the controller.abort() has taken effect
-          // before leaving.
-          await waitForBrowserTrip(page);
+            .toBeFalse();
         })
       );
     });

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -587,7 +587,13 @@ async function serializeBitmapDimensions(page) {
   });
 }
 
-async function dragAndDrop(page, selector, translations, steps = 1) {
+async function dragAndDrop(
+  page,
+  selector,
+  translations,
+  steps = 1,
+  beforeMouseUp = null
+) {
   const rect = await getRect(page, selector);
   const startX = rect.x + rect.width / 2;
   const startY = rect.y + rect.height / 2;
@@ -596,7 +602,11 @@ async function dragAndDrop(page, selector, translations, steps = 1) {
   for (const [tX, tY] of translations) {
     await page.mouse.move(startX + tX, startY + tY, { steps });
   }
-  await page.mouse.up();
+  try {
+    await beforeMouseUp?.();
+  } finally {
+    await page.mouse.up();
+  }
   await page.waitForSelector("#viewer:not(.noUserSelect)");
 }
 


### PR DESCRIPTION
The drag helper was releasing the pointer too early. On Windows with Firefox, `.isDragging` could be added and removed before Puppeteer detected it, causing the test to fail intermittently.

This updates the drag helper so the test can check `.isDragging` while the pointer is still down, then always releases the pointer with `finally`.

It also verifies that dragging works normally and stays disabled in paste mode.

No production code, delays, or retries were added.

Tested with:

* Firefox integration test
* 10 Firefox stress runs
* Chrome integration test
* `npx gulp lint`

Fixes #21484