### PR TITLE
Fix intermittent thumbnail dragging integration test

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -101,6 +101,29 @@ function waitForPagesEdited(page, type) {
   );
 }
 
+function getDraggingStateOnPointerUp(page) {
+  return createPromise(page, resolve => {
+    const view = document.getElementById("thumbnailsView");
+    const isDragging = () => view.classList.contains("isDragging");
+    let dragged = isDragging();
+    const observer = new MutationObserver(() => {
+      dragged ||= isDragging();
+    });
+    observer.observe(view, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    window.addEventListener(
+      "pointerup",
+      () => {
+        observer.disconnect();
+        resolve(dragged || isDragging());
+      },
+      { capture: true, once: true }
+    );
+  });
+}
+
 async function drawInkLine(page, pageNumber) {
   const rect = await getRect(
     page,
@@ -2066,16 +2089,12 @@ describe("Reorganize Pages View", () => {
         pages.map(async ([browserName, page]) => {
           await waitForThumbnailVisible(page, 1);
 
-          await Promise.all([
-            page.waitForSelector(`#thumbnailsView.isDragging`, {
-              visible: true,
-            }),
-            dragAndDrop(page, getThumbnailSelector(1), [[0, 10]], 10),
-          ]);
+          let handleDraggingState = await getDraggingStateOnPointerUp(page);
+          await dragAndDrop(page, getThumbnailSelector(1), [[0, 10]], 10);
+          expect(await awaitPromise(handleDraggingState))
+            .withContext(`In ${browserName}, dragging should be enabled`)
+            .toBeTrue();
 
-          await page.waitForSelector(`#thumbnailsView.isDragging`, {
-            hidden: true,
-          });
           await waitAndClick(
             page,
             `.thumbnail:has(${getThumbnailSelector(1)}) input`
@@ -2083,28 +2102,13 @@ describe("Reorganize Pages View", () => {
           await waitAndClick(page, "#viewsManagerStatusActionButton");
           await waitAndClick(page, "#viewsManagerStatusActionCopy");
 
-          // If dragging isn't disabled, the promise will resolve with the
-          // selector. Otherwise, it will resolve with undefined (dragAndDrop
-          // has no return), which is the expected behavior.
-          const abortController = new AbortController();
-          const first = await Promise.race([
-            page.waitForSelector(`#thumbnailsView.isDragging`, {
-              visible: true,
-              signal: abortController.signal,
-            }),
-            dragAndDrop(page, getThumbnailSelector(1), [[0, 10]], 10),
-          ]);
-          abortController.abort();
-
-          expect(first)
+          handleDraggingState = await getDraggingStateOnPointerUp(page);
+          await dragAndDrop(page, getThumbnailSelector(1), [[0, 10]], 10);
+          expect(await awaitPromise(handleDraggingState))
             .withContext(
               `In ${browserName}, dragging should be disabled when pasting`
             )
-            .toBeUndefined();
-
-          // Wait a tick to ensure that the controller.abort() has taken effect
-          // before leaving.
-          await waitForBrowserTrip(page);
+            .toBeFalse();
         })
       );
     });


### PR DESCRIPTION
Waiting for the transient `isDragging` class with `waitForSelector` is unreliable under WebDriver BiDi. The negative `Promise.race` could also resolve ambiguously when the drag finished first.

Track the class in the page and read the result on `pointerup`, before the thumbnail viewer clears it.

Fixes #21484.