### PR TITLE
Support two-finger panning

### DIFF
--- a/src/display/touch_manager.js
+++ b/src/display/touch_manager.js
@@ -24,6 +24,35 @@ function preventDefault(evt) {
 // https://searchfox.org/mozilla-central/source/gfx/layers/apz/src/Axis.h#21
 const MIN_TOUCH_SPAN = 1e-4;
 
+/**
+ * @param {TouchEvent} evt
+ * @returns {boolean} Whether the event was cancelable.
+ */
+function stopTouchEvent(evt) {
+  if (evt.cancelable) {
+    stopEvent(evt);
+    return true;
+  }
+  // `preventDefault()` has no effect; still hide it from an outer manager.
+  evt.stopPropagation();
+  return false;
+}
+
+/**
+ * @typedef {Object} TouchManagerOptions
+ * @property {HTMLElement | Window} container
+ * @property {function} [isPinchingDisabled]
+ * @property {function} [isPinchingStopped]
+ * @property {function} [onPinchStart]
+ * @property {function} [onPinching] - Called with the previous client
+ *   midpoint, the previous/current screen distance, and the client midpoint
+ *   delta.
+ * @property {function} [onPinchEnd]
+ * @property {function} [onPanning] - Called with the client midpoint delta
+ *   when no scale update is emitted.
+ * @property {AbortSignal} signal
+ */
+
 class TouchManager {
   #container;
 
@@ -39,6 +68,10 @@ class TouchManager {
 
   #onPinchEnd;
 
+  #onPanning;
+
+  #ownsGesture = false;
+
   #pointerDownAC = null;
 
   #signal;
@@ -51,6 +84,9 @@ class TouchManager {
 
   #touchMoveAC = null;
 
+  /**
+   * @param {TouchManagerOptions} options
+   */
   constructor({
     container,
     isPinchingDisabled = null,
@@ -58,6 +94,7 @@ class TouchManager {
     onPinchStart = null,
     onPinching = null,
     onPinchEnd = null,
+    onPanning = null,
     signal,
   }) {
     this.#container = container;
@@ -66,6 +103,7 @@ class TouchManager {
     this.#onPinchStart = onPinchStart;
     this.#onPinching = onPinching;
     this.#onPinchEnd = onPinchEnd;
+    this.#onPanning = onPanning;
     this.#touchManagerAC = new AbortController();
     this.#signal = AbortSignal.any([signal, this.#touchManagerAC.signal]);
 
@@ -133,7 +171,8 @@ class TouchManager {
       this.#onPinchStart?.();
     }
 
-    stopEvent(evt);
+    // Cancelability can change during a touch sequence.
+    this.#ownsGesture = stopTouchEvent(evt);
     this.#setTouchInfo(evt);
   }
 
@@ -239,6 +278,9 @@ class TouchManager {
       touch0Y: touch0.screenY,
       touch1X: touch1.screenX,
       touch1Y: touch1.screenY,
+      // Distances use screen coordinates; zoom and scrolling use client ones.
+      panX: (touch0.clientX + touch1.clientX) / 2,
+      panY: (touch0.clientY + touch1.clientY) / 2,
     };
   }
 
@@ -251,7 +293,16 @@ class TouchManager {
       return;
     }
 
-    stopEvent(evt);
+    const wasOwned = this.#ownsGesture;
+    this.#ownsGesture = stopTouchEvent(evt);
+    if (!this.#ownsGesture) {
+      return;
+    }
+    if (!wasOwned) {
+      // Drop movement accumulated while events could not be canceled.
+      this.#setTouchInfo(evt);
+      return;
+    }
 
     const [touch0, touch1] = touches;
     const { screenX: screen0X, screenY: screen0Y } = touch0;
@@ -262,12 +313,22 @@ class TouchManager {
       touch0Y: pTouch0Y,
       touch1X: pTouch1X,
       touch1Y: pTouch1Y,
+      panX: pPanX,
+      panY: pPanY,
     } = touchInfo;
 
     const prevGapX = pTouch1X - pTouch0X;
     const prevGapY = pTouch1Y - pTouch0Y;
     const currGapX = screen1X - screen0X;
     const currGapY = screen1Y - screen0Y;
+
+    // Advance the panning baseline independently of the pinch threshold.
+    const panX = (touch0.clientX + touch1.clientX) / 2;
+    const panY = (touch0.clientY + touch1.clientY) / 2;
+    touchInfo.panX = panX;
+    touchInfo.panY = panY;
+    const dx = panX - pPanX;
+    const dy = panY - pPanY;
 
     const distance = Math.hypot(currGapX, currGapY);
     const pDistance = Math.hypot(prevGapX, prevGapY);
@@ -277,6 +338,11 @@ class TouchManager {
       (!this.#isPinching &&
         Math.abs(pDistance - distance) <= this.MIN_TOUCH_DISTANCE_TO_PINCH)
     ) {
+      // Keep the distance baseline so a slow pinch can cross the threshold, or
+      // a degenerate span recover, but the midpoint still moved.
+      if (dx || dy) {
+        this.#onPanning?.(dx, dy);
+      }
       return;
     }
 
@@ -289,17 +355,18 @@ class TouchManager {
       // Start pinching.
       this.#isPinching = true;
 
-      // We return here else the first pinch is a bit too much
+      // Skip the first scale update, as before, but keep its translation.
+      if (dx || dy) {
+        this.#onPanning?.(dx, dy);
+      }
       return;
     }
 
     // The distances are in screen CSS pixels, but the origin must be in client
     // coordinates, like the one coming from a wheel event.
-    const origin = [
-      (touch0.clientX + touch1.clientX) / 2,
-      (touch0.clientY + touch1.clientY) / 2,
-    ];
-    this.#onPinching?.(origin, pDistance, distance);
+    // Zoom around the previous midpoint and apply its movement in the same
+    // update. Using the current midpoint would add `(ratio - 1) * delta`.
+    this.#onPinching?.([pPanX, pPanY], pDistance, distance, dx, dy);
   }
 
   #onTouchEnd(evt) {
@@ -324,7 +391,7 @@ class TouchManager {
       this.#armPointerDown();
     }
     if (wasTracking) {
-      stopEvent(evt);
+      stopTouchEvent(evt);
     }
   }
 
@@ -332,6 +399,7 @@ class TouchManager {
     // `#setTouchInfo` may already have cleared the baseline.
     this.#touchInfo = null;
     this.#isPinching = false;
+    this.#ownsGesture = false;
     if (this.#touchMoveAC) {
       this.#touchMoveAC.abort();
       this.#touchMoveAC = null;

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -23,6 +23,7 @@ import {
   pinch,
   scrollIntoView,
   showViewsManager,
+  switchToEditor,
   waitAndClick,
   waitForPageChanging,
   waitForPageRendered,
@@ -1625,6 +1626,48 @@ describe("PDF viewer", () => {
       );
     });
 
+    it("keeps the content under the fingers when they also move", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const rect = await getSpanRectFromText(page, 1, "type-stable");
+          const originX = rect.x + rect.width / 2;
+          const originY = rect.y + rect.height / 2;
+          const centerDeltaY = -100;
+          const rendered = await createPromise(page, resolve => {
+            const cb = e => {
+              if (e.pageNumber === 1) {
+                window.PDFViewerApplication.eventBus.off(
+                  "textlayerrendered",
+                  cb
+                );
+                resolve();
+              }
+            };
+            window.PDFViewerApplication.eventBus.on("textlayerrendered", cb);
+          });
+          // Spread the fingers, like above, but move them up at the same time:
+          // the zoom origin then follows the gesture instead of being fixed.
+          await pinch(page, {
+            centerX: originX,
+            centerY: originY,
+            centerDeltaY,
+            startGap: 25,
+            endGap: 100,
+          });
+          await awaitPromise(rendered);
+
+          // The text which was under the fingers must have followed them, hence
+          // the same tolerance as above applies.
+          const newRect = await getSpanRectFromText(page, 1, "type-stable");
+          expect(
+            Math.abs(newRect.y + newRect.height / 2 - (originY + centerDeltaY))
+          )
+            .withContext(`In ${browserName}`)
+            .toBeLessThan(5);
+        })
+      );
+    });
+
     it("keeps pinching when going from three fingers back to two", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
@@ -1670,6 +1713,99 @@ describe("PDF viewer", () => {
           expect(await getScale())
             .withContext(`In ${browserName}`)
             .toBeGreaterThan(scale);
+        })
+      );
+    });
+  });
+
+  describe("Two-finger pan", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        `.page[data-page-number = "1"] .endOfContent`
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    const getScrollTop = page =>
+      page.evaluate(() => document.querySelector("#viewerContainer").scrollTop);
+
+    // Return the scroll delta for a two-finger translation without scaling.
+    async function twoFingerDrag(page, dy) {
+      const before = await getScrollTop(page);
+      await pinch(page, {
+        centerX: 200,
+        centerY: 400,
+        centerDeltaY: dy,
+        startGap: 50,
+      });
+      return (await getScrollTop(page)) - before;
+    }
+
+    it("scrolls the viewer when two fingers move together", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const scale = await page.evaluate(
+            () => window.PDFViewerApplication.pdfViewer.currentScale
+          );
+
+          const scrolled = await twoFingerDrag(page, -150);
+
+          // A pure pan changes the scroll position, not the scale. The content
+          // follows the fingers, hence the scrolling matches their movement: a
+          // few pixels are tolerated because Chrome snaps the scroll offsets to
+          // the device pixels.
+          expect(scrolled)
+            .withContext(`In ${browserName}`)
+            .toBeGreaterThan(145);
+          expect(scrolled).withContext(`In ${browserName}`).toBeLessThan(155);
+          expect(
+            await page.evaluate(
+              () => window.PDFViewerApplication.pdfViewer.currentScale
+            )
+          )
+            .withContext(`In ${browserName}`)
+            .toEqual(scale);
+        })
+      );
+    });
+
+    it("scrolls the viewer in highlighting mode", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // The text layer sets `touch-action: none` in this mode, hence the
+          // scrolling below can only come from this manager, not from the
+          // browser.
+          await switchToEditor("Highlight", page);
+          await page.waitForSelector(".textLayer.highlighting");
+
+          const scrolled = await twoFingerDrag(page, -150);
+          expect(scrolled)
+            .withContext(`In ${browserName}`)
+            .toBeGreaterThan(145);
+          expect(scrolled).withContext(`In ${browserName}`).toBeLessThan(155);
+        })
+      );
+    });
+
+    it("doesn't pan while a dialog is open", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await page.click("#secondaryToolbarToggleButton");
+          await page.waitForSelector("#secondaryToolbar", { hidden: false });
+          await page.click("#documentProperties");
+          await page.waitForSelector("#documentPropertiesDialog", {
+            hidden: false,
+          });
+
+          expect(await twoFingerDrag(page, -150))
+            .withContext(`In ${browserName}`)
+            .toEqual(0);
         })
       );
     });

--- a/test/unit/clitests.json
+++ b/test/unit/clitests.json
@@ -60,6 +60,7 @@
     "svg_factory_spec.js",
     "text_layer_spec.js",
     "to_unicode_map_spec.js",
+    "touch_manager_spec.js",
     "type1_parser_spec.js",
     "ui_utils_spec.js",
     "unicode_spec.js",

--- a/test/unit/touch_manager_spec.js
+++ b/test/unit/touch_manager_spec.js
@@ -16,11 +16,14 @@
 import { TouchManager } from "../../src/display/touch_manager.js";
 
 describe("TouchManager", function () {
+  // Offset screen coordinates so origin tests catch screen/client mix-ups.
+  const SCREEN_OFFSET = 1000;
+
   function makeTouch(identifier, x, y = 0) {
     return {
       identifier,
-      screenX: x,
-      screenY: y,
+      screenX: x + SCREEN_OFFSET,
+      screenY: y + SCREEN_OFFSET,
       clientX: x,
       clientY: y,
     };
@@ -29,33 +32,40 @@ describe("TouchManager", function () {
   class TouchManagerHelper {
     #ac = new AbortController();
 
-    constructor() {
+    constructor(options = {}) {
       this.container = new EventTarget();
+      this.pannings = [];
       this.pinchings = [];
       this.pinchStarts = 0;
       this.pinchEnds = 0;
+      this.defaultPrevented = [];
 
       this.manager = new TouchManager({
         container: this.container,
         onPinchStart: () => {
           this.pinchStarts += 1;
         },
-        onPinching: (origin, prevDistance, distance) => {
-          this.pinchings.push({ origin, prevDistance, distance });
+        onPinching: (origin, prevDistance, distance, panX, panY) => {
+          this.pinchings.push({ origin, prevDistance, distance, panX, panY });
         },
         onPinchEnd: () => {
           this.pinchEnds += 1;
         },
+        onPanning: (dx, dy) => {
+          this.pannings.push([dx, dy]);
+        },
         signal: this.#ac.signal,
+        ...options,
       });
     }
 
-    dispatch(type, touches, changedTouches) {
-      const event = Object.assign(new Event(type, { cancelable: true }), {
+    dispatch(type, touches, changedTouches, { cancelable = true } = {}) {
+      const event = Object.assign(new Event(type, { cancelable }), {
         touches,
         changedTouches,
       });
       this.container.dispatchEvent(event);
+      this.defaultPrevented.push(event.defaultPrevented);
       return event;
     }
 
@@ -118,6 +128,8 @@ describe("TouchManager", function () {
         origin: [100, 0],
         prevDistance: 300,
         distance: 400,
+        panX: 0,
+        panY: 0,
       },
     ]);
 
@@ -244,6 +256,205 @@ describe("TouchManager", function () {
     // A later `touchend` must not call `onPinchEnd` again.
     helper.dispatch("touchend", [], [touch0, touch1]);
     expect(helper.pinchEnds).toEqual(1);
+
+    helper.destroy();
+  });
+
+  it("pans when both fingers move together", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 100, 100);
+    const touch1 = makeTouch(1, 300, 100);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    const moved0 = makeTouch(0, 120, 130);
+    const moved1 = makeTouch(1, 320, 130);
+    helper.dispatch("touchmove", [moved0, moved1], [moved0, moved1]);
+
+    expect(helper.pannings).toEqual([[20, 30]]);
+    expect(helper.pinchings).toEqual([]);
+    expect(helper.pinchStarts).toEqual(1);
+
+    helper.destroy();
+  });
+
+  it("pans, without zooming, inside the dead zone", function () {
+    const helper = new TouchManagerHelper();
+    const { MIN_TOUCH_DISTANCE_TO_PINCH: minDistance } = helper.manager;
+    expect(minDistance).toBeGreaterThan(0);
+    const touch0 = makeTouch(0, 0);
+    const touch1 = makeTouch(1, 200);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    // Stay below the pinch threshold; only midpoint movement is reported.
+    const nearly = makeTouch(1, 200 + minDistance - 1);
+    helper.dispatch("touchmove", [touch0, nearly], [nearly]);
+    expect(helper.pinchings).toEqual([]);
+    expect(helper.pannings.length).toEqual(1);
+
+    // The original distance baseline lets this move cross the threshold.
+    const past = makeTouch(1, 200 + minDistance + 1);
+    helper.dispatch("touchmove", [touch0, past], [past]);
+    expect(helper.pinchings).toEqual([]);
+    expect(helper.pannings.length).toEqual(2);
+
+    const further = makeTouch(1, 200 + minDistance + 21);
+    helper.dispatch("touchmove", [touch0, further], [further]);
+    expect(helper.pinchings.length).toEqual(1);
+    expect(
+      helper.pinchings[0].distance - helper.pinchings[0].prevDistance
+    ).toEqual(20);
+
+    helper.destroy();
+  });
+
+  it("reports the previous midpoint, in client coordinates, as the origin", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 0, 500);
+    const touch1 = makeTouch(1, 200, 500);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    // Spread the fingers past the dead zone, to start pinching.
+    const spread0 = makeTouch(0, -100, 500);
+    const spread1 = makeTouch(1, 300, 500);
+    helper.dispatch("touchmove", [spread0, spread1], [spread0, spread1]);
+    expect(helper.pinchings).toEqual([]);
+
+    // Spread them further, while also translating them by (10, 20).
+    const further0 = makeTouch(0, -190, 520);
+    const further1 = makeTouch(1, 410, 520);
+    helper.dispatch("touchmove", [further0, further1], [further0, further1]);
+
+    expect(helper.pinchings.length).toEqual(1);
+    const { origin, panX, panY } = helper.pinchings[0];
+    // A screen-coordinate origin would be off by SCREEN_OFFSET.
+    expect(origin).toEqual([100, 500]);
+    expect([panX, panY]).toEqual([10, 20]);
+
+    helper.destroy();
+  });
+
+  it("doesn't act on a non-cancelable touchmove", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 0);
+    const touch1 = makeTouch(1, 200);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    // Ignore moves that PDF.js cannot claim with `preventDefault()`, even when
+    // they both translate the fingers and spread them past the dead zone.
+    const spread1 = makeTouch(1, 400, 30);
+    helper.dispatch("touchmove", [touch0, spread1], [spread1], {
+      cancelable: false,
+    });
+    const spread2 = makeTouch(1, 600, 60);
+    helper.dispatch("touchmove", [touch0, spread2], [spread2], {
+      cancelable: false,
+    });
+
+    expect(helper.pannings).toEqual([]);
+    expect(helper.pinchings).toEqual([]);
+
+    helper.destroy();
+  });
+
+  it("takes the gesture back when the events are cancelable again", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 100, 100);
+    const touch1 = makeTouch(1, 300, 100);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    const moved0 = makeTouch(0, 120, 130);
+    const moved1 = makeTouch(1, 320, 130);
+    helper.dispatch("touchmove", [moved0, moved1], [moved0, moved1], {
+      cancelable: false,
+    });
+
+    // Re-baseline when the event becomes cancelable again.
+    const back0 = makeTouch(0, 140, 160);
+    const back1 = makeTouch(1, 340, 160);
+    helper.dispatch("touchmove", [back0, back1], [back0, back1]);
+    expect(helper.pannings).toEqual([]);
+
+    // The next delta is relative to the new baseline.
+    const next0 = makeTouch(0, 145, 170);
+    const next1 = makeTouch(1, 345, 170);
+    helper.dispatch("touchmove", [next0, next1], [next0, next1]);
+    expect(helper.pannings).toEqual([[5, 10]]);
+    expect(helper.defaultPrevented).toEqual([false, true, false, true, true]);
+
+    helper.destroy();
+  });
+
+  it("re-baselines the panning when a third finger comes and goes", function () {
+    const helper = new TouchManagerHelper();
+    const touch0 = makeTouch(0, 100, 100);
+    const touch1 = makeTouch(1, 300, 100);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    const moved0 = makeTouch(0, 110, 100);
+    const moved1 = makeTouch(1, 310, 100);
+    helper.dispatch("touchmove", [moved0, moved1], [moved0, moved1]);
+    expect(helper.pannings).toEqual([[10, 0]]);
+
+    // A third finger suspends the two-finger gesture.
+    const touch2 = makeTouch(2, 500, 400);
+    helper.dispatch("touchstart", [moved0, moved1, touch2], [touch2]);
+    const three0 = makeTouch(0, 200, 100);
+    const three1 = makeTouch(1, 400, 100);
+    const threeFingersMove = helper.dispatch(
+      "touchmove",
+      [three0, three1, touch2],
+      [three0, three1]
+    );
+    expect(helper.pannings.length).toEqual(1);
+    // This manager only handles two-finger gestures.
+    expect(threeFingersMove.defaultPrevented).toEqual(false);
+
+    // Resume from the current positions, excluding the three-finger movement.
+    helper.dispatch("touchend", [three0, three1], [touch2]);
+    const last0 = makeTouch(0, 205, 100);
+    const last1 = makeTouch(1, 405, 100);
+    helper.dispatch("touchmove", [last0, last1], [last0, last1]);
+    expect(helper.pannings).toEqual([
+      [10, 0],
+      [5, 0],
+    ]);
+
+    helper.destroy();
+  });
+
+  it("behaves as before when onPanning is omitted", function () {
+    // Editors omit onPanning.
+    const helper = new TouchManagerHelper({ onPanning: null });
+    const touch0 = makeTouch(0, 0);
+    const touch1 = makeTouch(1, 200);
+
+    helper.dispatch("touchstart", [touch0], [touch0]);
+    helper.dispatch("touchstart", [touch0, touch1], [touch1]);
+
+    const spread0 = makeTouch(0, -100, 20);
+    const spread1 = makeTouch(1, 300, 20);
+    helper.dispatch("touchmove", [spread0, spread1], [spread0, spread1]);
+    const further0 = makeTouch(0, -150, 40);
+    const further1 = makeTouch(1, 350, 40);
+    helper.dispatch("touchmove", [further0, further1], [further0, further1]);
+
+    expect(helper.pannings).toEqual([]);
+    expect(helper.pinchings.length).toEqual(1);
+    const { prevDistance, distance } = helper.pinchings[0];
+    expect(prevDistance).toEqual(400);
+    expect(distance).toEqual(500);
 
     helper.destroy();
   });

--- a/web/app.js
+++ b/web/app.js
@@ -1005,7 +1005,7 @@ const PDFViewerApplication = {
     return this._initializedCapability.promise;
   },
 
-  updateZoom(steps, scaleFactor, origin) {
+  updateZoom(steps, scaleFactor, origin, pan = null) {
     if (this.pdfViewer.isInPresentationMode) {
       return;
     }
@@ -1014,6 +1014,7 @@ const PDFViewerApplication = {
       steps,
       scaleFactor,
       origin,
+      pan,
     });
   },
 
@@ -1032,22 +1033,33 @@ const PDFViewerApplication = {
     this.pdfViewer.currentScaleValue = DEFAULT_SCALE_VALUE;
   },
 
-  touchPinchCallback(origin, prevDistance, distance) {
+  touchPinchCallback(origin, prevDistance, distance, panX, panY) {
+    // A scale update which is a no-op, e.g. one rounded or clamped away, still
+    // applies the panning, hence there's nothing to special-case here.
+    const pan = [panX, panY];
     if (this.supportsPinchToZoom) {
       const newScaleFactor = this._accumulateFactor(
         this.pdfViewer.currentScale,
         distance / prevDistance,
         "_touchUnusedFactor"
       );
-      this.updateZoom(null, newScaleFactor, origin);
+      this.updateZoom(null, newScaleFactor, origin, pan);
     } else {
       const PIXELS_PER_LINE_SCALE = 30;
       const ticks = this._accumulateTicks(
         (distance - prevDistance) / PIXELS_PER_LINE_SCALE,
         "_touchUnusedTicks"
       );
-      this.updateZoom(ticks, null, origin);
+      this.updateZoom(ticks, null, origin, pan);
     }
+  },
+
+  touchPanCallback(dx, dy) {
+    const { pdfViewer } = this;
+    if (!this.pdfDocument || pdfViewer.isInPresentationMode) {
+      return;
+    }
+    pdfViewer.panBy(dx, dy);
   },
 
   touchPinchEndCallback() {
@@ -2405,6 +2417,7 @@ const PDFViewerApplication = {
       isPinchingStopped: () => this.overlayManager?.active,
       onPinching: this.touchPinchCallback.bind(this),
       onPinchEnd: this.touchPinchEndCallback.bind(this),
+      onPanning: this.touchPanCallback.bind(this),
       signal,
     });
 

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -265,9 +265,14 @@ class PDFViewer {
 
   #mlManager = null;
 
+  // The scroll position wanted by `panBy`, with its fractions.
+  #panPosition = [NaN, NaN];
+
   #printingAllowed = true;
 
   #scrollTimeoutId = null;
+
+  #staleLocation = false;
 
   #switchAnnotationEditorModeAC = null;
 
@@ -1516,15 +1521,68 @@ class PDFViewer {
     );
   }
 
+  /**
+   * Scroll the viewer by the given gesture deltas: like `GrabToPan` does, the
+   * content follows the gesture.
+   * @param {number} dx - Horizontal delta.
+   * @param {number} dy - Vertical delta.
+   */
+  panBy(dx, dy) {
+    const { container } = this;
+    const position = this.#panPosition;
+    const { scrollLeft, scrollTop } = container;
+
+    // Keep the fractions which the browser dropped when it snapped the offsets
+    // to the device pixels, else they'd be lost on every move and the content
+    // would drift away from the gesture. Anything else which moved the
+    // container, e.g. a scale update or a boundary being hit, wins: the
+    // comparison is false as long as the position is unknown, hence NaN.
+    const left =
+      (Math.abs(scrollLeft - position[0]) < 1 ? position[0] : scrollLeft) - dx;
+    const top =
+      (Math.abs(scrollTop - position[1]) < 1 ? position[1] : scrollTop) - dy;
+    position[0] = left;
+    position[1] = top;
+    container.scrollLeft = left;
+    container.scrollTop = top;
+    this.#staleLocation = true;
+  }
+
+  /**
+   * Recompute `this._location` when a panning invalidated it.
+   *
+   * It's normally refreshed on an animation frame, hence panning several times
+   * in a row, e.g. once per touch move, leaves it behind: restoring the
+   * position from it would then undo those pannings.
+   */
+  #refreshLocation() {
+    if (!this.#staleLocation) {
+      return;
+    }
+    const { first } = this._getVisiblePages();
+    if (first) {
+      this._updateLocation(first);
+    }
+  }
+
   #setScaleUpdatePages(
     newScale,
     newValue,
-    { noScroll = false, preset = false, drawingDelay = -1, origin = null }
+    {
+      noScroll = false,
+      preset = false,
+      drawingDelay = -1,
+      origin = null,
+      pan = null,
+    }
   ) {
-    this.clearSelection();
     this._currentScaleValue = newValue.toString();
 
     if (this.#isSameScale(newScale)) {
+      if (pan && !noScroll) {
+        // Preserve panning when zoom is rounded or clamped away.
+        this.panBy(pan[0], pan[1]);
+      }
       if (preset) {
         this.eventBus.dispatch("scalechanging", {
           source: this,
@@ -1534,6 +1592,7 @@ class PDFViewer {
       }
       return;
     }
+    this.clearSelection();
 
     this.viewer.style.setProperty(
       "--scale-factor",
@@ -1557,6 +1616,8 @@ class PDFViewer {
     this._currentScale = newScale;
 
     if (!noScroll) {
+      this.#refreshLocation();
+
       let page = this._currentPageNumber,
         dest;
       if (
@@ -1577,14 +1638,24 @@ class PDFViewer {
         destArray: dest,
         allowNegativeOffset: true,
       });
+      // The gesture movement, if any, is applied together with the origin
+      // below: both are relative to the position which `scrollPageIntoView`
+      // just restored from `this._location`, and a single scroll update only
+      // loses the fractions once.
+      let dx = pan?.[0] ?? 0,
+        dy = pan?.[1] ?? 0;
       if (Array.isArray(origin)) {
         // If the origin of the scaling transform is specified, preserve its
         // location on screen. If not specified, scaling will fix the top-left
         // corner of the visible PDF area.
         const scaleDiff = newScale / previousScale - 1;
         const [top, left] = this.containerTopLeft;
-        this.container.scrollLeft += (origin[0] - left) * scaleDiff;
-        this.container.scrollTop += (origin[1] - top) * scaleDiff;
+        dx -= (origin[0] - left) * scaleDiff;
+        dy -= (origin[1] - top) * scaleDiff;
+      }
+      if (dx || dy) {
+        // Applied before `scalechanging` listeners update `this._location`.
+        this.panBy(dx, dy);
       }
     }
 
@@ -1873,6 +1944,8 @@ class PDFViewer {
   }
 
   _updateLocation(firstPage) {
+    this.#staleLocation = false;
+
     const currentScale = this._currentScale;
     const currentScaleValue = this._currentScaleValue;
     const normalizedScaleValue =
@@ -2494,13 +2567,20 @@ class PDFViewer {
    * @property {number} [steps]
    * @property {Array} [origin] x and y coordinates of the scale
    *                            transformation origin.
+   * @property {Array<number>} [pan] - Horizontal and vertical gesture deltas.
    */
 
   /**
    * Changes the current zoom level by the specified amount.
    * @param {ChangeScaleOptions} [options]
    */
-  updateScale({ drawingDelay, scaleFactor = null, steps = null, origin }) {
+  updateScale({
+    drawingDelay,
+    scaleFactor = null,
+    steps = null,
+    origin,
+    pan = null,
+  }) {
     if (steps === null && scaleFactor === null) {
       throw new Error(
         "Invalid updateScale options: either `steps` or `scaleFactor` must be provided."
@@ -2521,7 +2601,7 @@ class PDFViewer {
       } while (--steps > 0);
     }
     newScale = MathClamp(newScale, MIN_SCALE, MAX_SCALE);
-    this.#setScale(newScale, { noScroll: false, drawingDelay, origin });
+    this.#setScale(newScale, { noScroll: false, drawingDelay, origin, pan });
   }
 
   /**


### PR DESCRIPTION
Pan by the midpoint delta and apply it with pinch zoom, keeping content under the fingers. Ignore non-cancelable moves, then re-baseline.