### PR TITLE
Enable the `unicorn/no-incorrect-query-selector` ESLint plugin rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,6 +161,7 @@ export default [
       "unicorn/no-abusive-eslint-disable": "error",
       "unicorn/no-array-reduce": ["error", { allowSimpleOperations: true }],
       "unicorn/no-console-spaces": "error",
+      "unicorn/no-incorrect-query-selector": "error",
       "unicorn/no-instanceof-builtins": "error",
       "unicorn/no-invalid-remove-event-listener": "error",
       "unicorn/no-new-buffer": "error",

--- a/test/integration/annotation_spec.mjs
+++ b/test/integration/annotation_spec.mjs
@@ -327,7 +327,7 @@ describe("Annotation and storage", () => {
           ]) {
             await page.evaluate(n => {
               window.document
-                .querySelectorAll(`[data-page-number="${n}"][class="page"]`)[0]
+                .querySelector(`[data-page-number="${n}"][class="page"]`)
                 .scrollIntoView();
             }, pageNumber);
 
@@ -366,7 +366,7 @@ describe("Annotation and storage", () => {
           ]) {
             await page.evaluate(n => {
               window.document
-                .querySelectorAll(`[data-page-number="${n}"][class="page"]`)[0]
+                .querySelector(`[data-page-number="${n}"][class="page"]`)
                 .scrollIntoView();
             }, pageNumber);
 


### PR DESCRIPTION
This should be a *tiny* bit more efficient; please see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-incorrect-query-selector.md