### PR TITLE
Let the `StructElementNode.prototype.tableAttributes` getter return a Map

### DIFF
--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -691,7 +691,7 @@ class StructElementNode {
       return null;
     }
 
-    const result = Object.create(null);
+    const map = new Map();
     for (const attributes of this.attributes) {
       if (!isName(attributes.get("O"), "Table")) {
         continue;
@@ -701,9 +701,9 @@ class StructElementNode {
         if (attributes.has("Summary")) {
           const summary = attributes.get("Summary");
           if (typeof summary === "string" && summary) {
-            result.summary = stringToPDFString(summary);
+            map.set("summary", stringToPDFString(summary));
           } else {
-            delete result.summary;
+            map.delete("summary");
           }
         }
         continue;
@@ -715,46 +715,46 @@ class StructElementNode {
         }
         const value = attributes.get(key);
         if (Number.isInteger(value) && value > 1) {
-          result[name] = value;
+          map.set(name, value);
         } else {
           // Omit default and invalid values, clearing any earlier class value.
-          delete result[name];
+          map.delete(name);
         }
       }
 
       if (attributes.has("Headers")) {
-        delete result.headers;
+        map.delete("headers");
         const headers = attributes.getArray("Headers");
         if (Array.isArray(headers)) {
           const ids = headers
             .filter(header => typeof header === "string")
             .map(header => stringToPDFString(header));
           if (ids.length > 0) {
-            result.headers = ids;
+            map.set("headers", ids);
           }
         }
       }
 
       if (role === "TH" && attributes.has("Scope")) {
-        delete result.scope;
+        map.delete("scope");
         const scope = attributes.get("Scope");
         if (
           scope instanceof Name &&
           ["Row", "Column", "Both"].includes(scope.name)
         ) {
-          result.scope = scope.name;
+          map.set("scope", scope.name);
         }
       }
 
       if (role === "TH" && attributes.has("Short")) {
-        delete result.short;
+        map.delete("short");
         const short = attributes.get("Short");
         if (typeof short === "string" && short) {
-          result.short = stringToPDFString(short);
+          map.set("short", stringToPDFString(short));
         }
       }
     }
-    return Object.keys(result).length > 0 ? result : null;
+    return map.size ? map : null;
   }
 
   parseKids() {
@@ -1044,10 +1044,10 @@ class StructTreePage {
       if (obj.role === "TH" && typeof structId === "string" && structId) {
         obj.structId = stringToPDFString(structId);
       }
-      const tableAttributes = node.tableAttributes;
-      if (tableAttributes) {
-        Object.assign(obj, tableAttributes);
-      }
+      node.tableAttributes?.forEach((val, key) => {
+        obj[key] = val;
+      });
+
       if (obj.role === "Formula") {
         try {
           const { mathML } = node;


### PR DESCRIPTION
Using a Map seems more appropriate given that there's a bunch of adding/removing of entries, and it's especially helpful at the end of the getter since it's easy/efficient to determine its size (whereas an Object requires iterating though it to do that).