### PR TITLE
Show existing keyboard shortcuts in toolbar tooltips

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -5,15 +5,19 @@
 ## Main toolbar buttons (tooltips and alt text for images)
 
 pdfjs-previous-button =
-    .title = Previous Page
+    .title = Previous Page (P / K)
 pdfjs-previous-button-label = Previous
 pdfjs-next-button =
-    .title = Next Page
+    .title = Next Page (N / J)
 pdfjs-next-button-label = Next
 
 # .title: Tooltip for the pageNumber input.
 pdfjs-page-input =
-    .title = Page
+    .title =
+        { PLATFORM() ->
+            [macos] Page (⌥⌘G)
+           *[other] Page (Ctrl+Alt+G)
+        }
 
 # Variables:
 #   $pagesCount (Number) - the total number of pages in the document
@@ -26,24 +30,44 @@ pdfjs-of-pages = of { $pagesCount }
 pdfjs-page-of-pages = ({ $pageNumber } of { $pagesCount })
 
 pdfjs-zoom-out-button =
-    .title = Zoom Out
+    .title =
+        { PLATFORM() ->
+            [macos] Zoom Out (⌘-)
+           *[other] Zoom Out (Ctrl+-)
+        }
 pdfjs-zoom-out-button-label = Zoom Out
 pdfjs-zoom-in-button =
-    .title = Zoom In
+    .title =
+        { PLATFORM() ->
+            [macos] Zoom In (⌘=)
+           *[other] Zoom In (Ctrl+=)
+        }
 pdfjs-zoom-in-button-label = Zoom In
 pdfjs-zoom-select =
     .title = Zoom
 pdfjs-presentation-mode-button =
-    .title = Switch to Presentation Mode
+    .title =
+        { PLATFORM() ->
+            [macos] Switch to Presentation Mode (⌥⌘P)
+           *[other] Switch to Presentation Mode (Ctrl+Alt+P)
+        }
 pdfjs-presentation-mode-button-label = Presentation Mode
 pdfjs-open-file-button =
     .title = Open File
 pdfjs-open-file-button-label = Open
 pdfjs-print-button =
-    .title = Print
+    .title =
+        { PLATFORM() ->
+            [macos] Print (⌘P)
+           *[other] Print (Ctrl+P)
+        }
 pdfjs-print-button-label = Print
 pdfjs-save-button =
-    .title = Save
+    .title =
+        { PLATFORM() ->
+            [macos] Save (⌘S)
+           *[other] Save (Ctrl+S)
+        }
 pdfjs-save-button-label = Save
 
 # Used in Firefox for Android as a tooltip for the download button (“download” is a verb).
@@ -71,16 +95,16 @@ pdfjs-last-page-button =
     .title = Go to Last Page
 pdfjs-last-page-button-label = Go to Last Page
 pdfjs-page-rotate-cw-button =
-    .title = Rotate Clockwise
+    .title = Rotate Clockwise (R)
 pdfjs-page-rotate-cw-button-label = Rotate Clockwise
 pdfjs-page-rotate-ccw-button =
-    .title = Rotate Counterclockwise
+    .title = Rotate Counterclockwise (Shift+R)
 pdfjs-page-rotate-ccw-button-label = Rotate Counterclockwise
 pdfjs-cursor-text-select-tool-button =
-    .title = Enable Text Selection Tool
+    .title = Enable Text Selection Tool (S)
 pdfjs-cursor-text-select-tool-button-label = Text Selection Tool
 pdfjs-cursor-hand-tool-button =
-    .title = Enable Hand Tool
+    .title = Enable Hand Tool (H)
 pdfjs-cursor-hand-tool-button-label = Hand Tool
 pdfjs-scroll-page-button =
     .title = Use Page Scrolling
@@ -184,7 +208,11 @@ pdfjs-current-outline-item-button =
     .title = Find Current Outline Item
 pdfjs-current-outline-item-button-label = Current Outline Item
 pdfjs-findbar-button =
-    .title = Find in Document
+    .title =
+        { PLATFORM() ->
+            [macos] Find in Document (⌘F)
+           *[other] Find in Document (Ctrl+F)
+        }
 pdfjs-findbar-button-label = Find
 pdfjs-additional-layers = Additional Layers
 
@@ -212,10 +240,18 @@ pdfjs-find-input =
     .title = Find
     .placeholder = Find in document…
 pdfjs-find-previous-button =
-    .title = Find the previous occurrence of the phrase
+    .title =
+        { PLATFORM() ->
+            [macos] Find the previous occurrence of the phrase (⇧⌘G)
+           *[other] Find the previous occurrence of the phrase (Ctrl+Shift+G)
+        }
 pdfjs-find-previous-button-label = Previous
 pdfjs-find-next-button =
-    .title = Find the next occurrence of the phrase
+    .title =
+        { PLATFORM() ->
+            [macos] Find the next occurrence of the phrase (⌘G)
+           *[other] Find the next occurrence of the phrase (Ctrl+G)
+        }
 pdfjs-find-next-button-label = Next
 pdfjs-find-highlight-checkbox = Highlight All
 pdfjs-find-match-case-checkbox-label = Match Case
@@ -692,7 +728,7 @@ pdfjs-editor-add-comment-button =
 ## The thumbnails view is used to edit the pdf: remove/insert pages, ...
 
 pdfjs-toggle-views-manager-button1 =
-    .title = Manage pages
+    .title = Manage pages (F4)
 pdfjs-toggle-views-manager-notification-button =
     .title = Toggle Sidebar (document contains thumbnails/outline/attachments/layers)
 pdfjs-toggle-views-manager-button1-label = Manage pages

--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -4,15 +4,15 @@
 
 ## Main toolbar buttons (tooltips and alt text for images)
 
-pdfjs-previous-button =
+pdfjs-previous-button1 =
     .title = Previous Page (P / K)
 pdfjs-previous-button-label = Previous
-pdfjs-next-button =
+pdfjs-next-button1 =
     .title = Next Page (N / J)
 pdfjs-next-button-label = Next
 
 # .title: Tooltip for the pageNumber input.
-pdfjs-page-input =
+pdfjs-page-input1 =
     .title =
         { PLATFORM() ->
             [macos] Page (⌥⌘G)
@@ -29,14 +29,14 @@ pdfjs-of-pages = of { $pagesCount }
 #   $pagesCount (Number) - the total number of pages in the document
 pdfjs-page-of-pages = ({ $pageNumber } of { $pagesCount })
 
-pdfjs-zoom-out-button =
+pdfjs-zoom-out-button1 =
     .title =
         { PLATFORM() ->
             [macos] Zoom Out (⌘-)
            *[other] Zoom Out (Ctrl+-)
         }
 pdfjs-zoom-out-button-label = Zoom Out
-pdfjs-zoom-in-button =
+pdfjs-zoom-in-button1 =
     .title =
         { PLATFORM() ->
             [macos] Zoom In (⌘=)
@@ -45,7 +45,7 @@ pdfjs-zoom-in-button =
 pdfjs-zoom-in-button-label = Zoom In
 pdfjs-zoom-select =
     .title = Zoom
-pdfjs-presentation-mode-button =
+pdfjs-presentation-mode-button1 =
     .title =
         { PLATFORM() ->
             [macos] Switch to Presentation Mode (⌥⌘P)
@@ -55,14 +55,14 @@ pdfjs-presentation-mode-button-label = Presentation Mode
 pdfjs-open-file-button =
     .title = Open File
 pdfjs-open-file-button-label = Open
-pdfjs-print-button =
+pdfjs-print-button1 =
     .title =
         { PLATFORM() ->
             [macos] Print (⌘P)
            *[other] Print (Ctrl+P)
         }
 pdfjs-print-button-label = Print
-pdfjs-save-button =
+pdfjs-save-button1 =
     .title =
         { PLATFORM() ->
             [macos] Save (⌘S)
@@ -94,16 +94,16 @@ pdfjs-first-page-button-label = Go to First Page
 pdfjs-last-page-button =
     .title = Go to Last Page
 pdfjs-last-page-button-label = Go to Last Page
-pdfjs-page-rotate-cw-button =
+pdfjs-page-rotate-cw-button1 =
     .title = Rotate Clockwise (R)
 pdfjs-page-rotate-cw-button-label = Rotate Clockwise
-pdfjs-page-rotate-ccw-button =
+pdfjs-page-rotate-ccw-button1 =
     .title = Rotate Counterclockwise (Shift+R)
 pdfjs-page-rotate-ccw-button-label = Rotate Counterclockwise
-pdfjs-cursor-text-select-tool-button =
+pdfjs-cursor-text-select-tool-button1 =
     .title = Enable Text Selection Tool (S)
 pdfjs-cursor-text-select-tool-button-label = Text Selection Tool
-pdfjs-cursor-hand-tool-button =
+pdfjs-cursor-hand-tool-button1 =
     .title = Enable Hand Tool (H)
 pdfjs-cursor-hand-tool-button-label = Hand Tool
 pdfjs-scroll-page-button =
@@ -207,7 +207,7 @@ pdfjs-printing-not-ready = Warning: The PDF is not fully loaded for printing.
 pdfjs-current-outline-item-button =
     .title = Find Current Outline Item
 pdfjs-current-outline-item-button-label = Current Outline Item
-pdfjs-findbar-button =
+pdfjs-findbar-button1 =
     .title =
         { PLATFORM() ->
             [macos] Find in Document (⌘F)
@@ -239,14 +239,14 @@ pdfjs-thumb-page-checkbox1 =
 pdfjs-find-input =
     .title = Find
     .placeholder = Find in document…
-pdfjs-find-previous-button =
+pdfjs-find-previous-button1 =
     .title =
         { PLATFORM() ->
             [macos] Find the previous occurrence of the phrase (⇧⌘G)
            *[other] Find the previous occurrence of the phrase (Ctrl+Shift+G)
         }
 pdfjs-find-previous-button-label = Previous
-pdfjs-find-next-button =
+pdfjs-find-next-button1 =
     .title =
         { PLATFORM() ->
             [macos] Find the next occurrence of the phrase (⌘G)
@@ -727,7 +727,7 @@ pdfjs-editor-add-comment-button =
 ##  - layers.
 ## The thumbnails view is used to edit the pdf: remove/insert pages, ...
 
-pdfjs-toggle-views-manager-button1 =
+pdfjs-toggle-views-manager-button2 =
     .title = Manage pages (F4)
 pdfjs-toggle-views-manager-notification-button =
     .title = Toggle Sidebar (document contains thumbnails/outline/attachments/layers)

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -133,7 +133,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                   class="toolbarButton"
                   type="button"
                   tabindex="0"
-                  data-l10n-id="pdfjs-toggle-views-manager-button1"
+                  data-l10n-id="pdfjs-toggle-views-manager-button2"
                   aria-expanded="false"
                   aria-haspopup="true"
                   aria-controls="viewsManager"
@@ -314,7 +314,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     class="toolbarButton"
                     type="button"
                     tabindex="0"
-                    data-l10n-id="pdfjs-findbar-button"
+                    data-l10n-id="pdfjs-findbar-button1"
                     aria-expanded="false"
                     aria-controls="findbar"
                   >
@@ -326,11 +326,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                         <input id="findInput" class="toolbarField" tabindex="0" data-l10n-id="pdfjs-find-input" aria-invalid="false" />
                       </span>
                       <div class="toolbarHorizontalGroup">
-                        <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-previous-button">
+                        <button id="findPreviousButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-previous-button1">
                           <span data-l10n-id="pdfjs-find-previous-button-label"></span>
                         </button>
                         <div class="splitToolbarButtonSeparator"></div>
-                        <button id="findNextButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-next-button">
+                        <button id="findNextButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-find-next-button1">
                           <span data-l10n-id="pdfjs-find-next-button-label"></span>
                         </button>
                       </div>
@@ -365,11 +365,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <!-- findbar -->
                 </div>
                 <div class="toolbarHorizontalGroup hiddenSmallView">
-                  <button class="toolbarButton" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button">
+                  <button class="toolbarButton" type="button" id="previous" tabindex="0" data-l10n-id="pdfjs-previous-button1">
                     <span data-l10n-id="pdfjs-previous-button-label"></span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button">
+                  <button class="toolbarButton" type="button" id="next" tabindex="0" data-l10n-id="pdfjs-next-button1">
                     <span data-l10n-id="pdfjs-next-button-label"></span>
                   </button>
                 </div>
@@ -382,7 +382,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       value="1"
                       min="1"
                       tabindex="0"
-                      data-l10n-id="pdfjs-page-input"
+                      data-l10n-id="pdfjs-page-input1"
                       autocomplete="off"
                     />
                   </span>
@@ -391,11 +391,11 @@ See https://github.com/adobe-type-tools/cmap-resources
               </div>
               <div id="toolbarViewerMiddle" class="toolbarHorizontalGroup">
                 <div class="toolbarHorizontalGroup">
-                  <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button">
+                  <button id="zoomOutButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-out-button1">
                     <span data-l10n-id="pdfjs-zoom-out-button-label"></span>
                   </button>
                   <div class="splitToolbarButtonSeparator"></div>
-                  <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-in-button">
+                  <button id="zoomInButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-zoom-in-button1">
                     <span data-l10n-id="pdfjs-zoom-in-button-label"></span>
                   </button>
                 </div>
@@ -654,11 +654,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
 
                 <div class="toolbarHorizontalGroup hiddenMediumView">
-                  <button id="printButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
+                  <button id="printButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-print-button1">
                     <span data-l10n-id="pdfjs-print-button-label"></span>
                   </button>
 
-                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
+                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button1">
                     <span data-l10n-id="pdfjs-save-button-label"></span>
                   </button>
                 </div>
@@ -687,11 +687,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <!--#endif-->
 
                       <div class="visibleMediumView">
-                        <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-print-button">
+                        <button id="secondaryPrint" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-print-button1">
                           <span data-l10n-id="pdfjs-print-button-label"></span>
                         </button>
 
-                        <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
+                        <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-save-button1">
                           <span data-l10n-id="pdfjs-save-button-label"></span>
                         </button>
 
@@ -704,7 +704,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <div class="horizontalToolbarSeparator"></div>
                       <!--#endif-->
 
-                      <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button">
+                      <button id="presentationMode" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button1">
                         <span data-l10n-id="pdfjs-presentation-mode-button-label"></span>
                       </button>
 
@@ -723,10 +723,10 @@ See https://github.com/adobe-type-tools/cmap-resources
 
                       <div class="horizontalToolbarSeparator"></div>
 
-                      <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button">
+                      <button id="pageRotateCw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-cw-button1">
                         <span data-l10n-id="pdfjs-page-rotate-cw-button-label"></span>
                       </button>
-                      <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-ccw-button">
+                      <button id="pageRotateCcw" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-page-rotate-ccw-button1">
                         <span data-l10n-id="pdfjs-page-rotate-ccw-button-label"></span>
                       </button>
 
@@ -738,7 +738,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                           class="toolbarButton labeled toggled"
                           type="button"
                           tabindex="0"
-                          data-l10n-id="pdfjs-cursor-text-select-tool-button"
+                          data-l10n-id="pdfjs-cursor-text-select-tool-button1"
                           role="radio"
                           aria-checked="true"
                         >
@@ -749,7 +749,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                           class="toolbarButton labeled"
                           type="button"
                           tabindex="0"
-                          data-l10n-id="pdfjs-cursor-hand-tool-button"
+                          data-l10n-id="pdfjs-cursor-hand-tool-button1"
                           role="radio"
                           aria-checked="false"
                         >


### PR DESCRIPTION
## Summary

This PR makes 16 existing keyboard shortcuts **visible on the toolbar itself**, by adding each one directly into the tooltip text of the button it belongs to — the text that pops up on hover. For example, hovering the Presentation Mode button currently just says "Switch to Presentation Mode"; after this change it says "Switch to Presentation Mode (Ctrl+Alt+P)" (or "(⌥⌘P)" on macOS), so the shortcut is discoverable right there, without already knowing to go check the wiki FAQ.

**To be explicit about what this PR does and doesn't do: none of the 16 shortcuts are new, and none of their behavior changes.** `Ctrl+Alt+P` already calls `requestPresentationMode()` today and has since #3422 (2013) — this PR only changes what each button's tooltip *displays*. It's a pure discoverability/UI-copy change, not a keybinding change.

### Button-by-button, tooltip before → after

(showing the non-macOS text; macOS gets the equivalent `⌘`/`⌥` glyphs via the existing `PLATFORM()` pattern, e.g. `pdfjs-editor-add-signature-image-browse-link`)

| Button (`id` in `viewer.html`) | Tooltip **before** | Tooltip **after** |
|---|---|---|
| `presentationMode` | "Switch to Presentation Mode" | "Switch to Presentation Mode **(Ctrl+Alt+P)**" |
| `zoomInButton` | "Zoom In" | "Zoom In **(Ctrl+=)**" |
| `zoomOutButton` | "Zoom Out" | "Zoom Out **(Ctrl+-)**" |
| `downloadButton` | "Save" | "Save **(Ctrl+S)**" |
| `printButton` | "Print" | "Print **(Ctrl+P)**" |
| `pageRotateCw` | "Rotate Clockwise" | "Rotate Clockwise **(R)**" |
| `pageRotateCcw` | "Rotate Counterclockwise" | "Rotate Counterclockwise **(Shift+R)**" |
| `cursorSelectTool` | "Enable Text Selection Tool" | "Enable Text Selection Tool **(S)**" |
| `cursorHandTool` | "Enable Hand Tool" | "Enable Hand Tool **(H)**" |
| `viewsManagerToggleButton` | "Manage pages" | "Manage pages **(F4)**" |
| `viewFindButton` | "Find in Document" | "Find in Document **(Ctrl+F)**" |
| `findNextButton` | "Find the next occurrence of the phrase" | "Find the next occurrence of the phrase **(Ctrl+G)**" |
| `findPreviousButton` | "Find the previous occurrence of the phrase" | "Find the previous occurrence of the phrase **(Ctrl+Shift+G)**" |
| `pageNumber` (input) | "Page" | "Page **(Ctrl+Alt+G)**" |
| `previous` | "Previous Page" | "Previous Page **(P / K)**" |
| `next` | "Next Page" | "Next Page **(N / J)**" |

Each row was traced to its real key binding in `web/app.js` and its real `data-l10n-id` in `web/viewer.html` directly — not assumed from the wiki, which is stale in a couple of places (e.g. it still calls the sidebar toggle by an older name, whereas the code now calls it `viewsManager`). One correction that tracing caught: `Ctrl+S`'s button is `downloadButton`, whose `data-l10n-id` is `pdfjs-save-button` ("Save") — not `pdfjs-download-button` ("Download"), which is Android-Firefox-only and isn't shown in this build at all.

Per the Fluent convention of bumping a message ID whenever its en-US text content changes (confirmed against a recent maintainer commit, aa928105, which did exactly this for a tooltip text change), all 16 touched `.title` messages are on new IDs (`...1`, or `...2` for the one that already had a `1` suffix). Their untouched `-label` sibling messages (the visible on-page text, not the tooltip) keep their original IDs since that text didn't change.

Deliberately scoped to only the shortcuts I could verify end-to-end (see Test plan below) — not attempting the arrow-key/Home/End/PgUp/PgDn navigation set, since those are generic scrolling behavior rather than a discoverable "shortcut," matching how the wiki itself treats them.

## Disclosure

This PR — the research, the code, and the verification below — was produced by Claude (Anthropic) working with me. I reviewed and tested it myself before opening this, but wanted that stated plainly upfront rather than left for reviewers to guess at.

## Test plan

Verified live against `npx gulp server` (same `app.js` handler and `viewer.ftl` strings a built extension uses) by dispatching each shortcut and asserting the actual state change, not just "no error thrown":

- [x] Zoom In/Out — `pdfViewer.currentScale` changed both directions
- [x] Rotate CW/CCW — `pdfViewer.pagesRotation` 0→90→0
- [x] Hand/Select tool — `pdfCursorTools.activeTool` toggled correctly
- [x] Sidebar (F4) — `viewsManager.isOpen` toggled open and closed
- [x] Find / Find Next / Find Previous — find bar opened, match index moved 0→1→0
- [x] Go-to-page field (Ctrl+Alt+G) — focus moved to the `pageNumber` input
- [x] Previous/Next page, all four keys (N/J/P/K) — page number changed correctly
- [x] Presentation Mode — traced the real, OS-trusted keypress through to `requestPresentationMode()` being called correctly; the actual `requestFullscreen()` call was rejected by the browser in my scripted/automated window (no genuine OS window focus), which is an automation-environment limitation, not something this PR touches
- [x] Save/Print — confirmed by tracing the exact event wiring in `app.js`/`secondary_toolbar.js` rather than live-triggering (Ctrl+S would download a real file; Ctrl+P opens a blocking native dialog)
- [x] After renaming the 16 message IDs, re-verified live that every tooltip still resolves correctly (no blank/fallback text from a mismatched ID)
- [x] `moz-fluent-lint` clean, `npx gulp lint` clean, `npx gulp chromium` builds clean

I don't have PDF-viewer commit history here, so I can't speak to whether this is the direction you'd want for exposing shortcuts more broadly (e.g. arrow keys, or a full shortcuts list somewhere) — happy to adjust scope based on feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)