### PR TITLE
Avoid spilling xref entries into dynamically allocated slots (bug 2060459)

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -273,6 +273,8 @@ class XRef {
         const entry = {
           offset: parser.getObj(),
           gen: parser.getObj(),
+          free: false,
+          uncompressed: false,
         };
         const type = parser.getObj();
 
@@ -400,6 +402,8 @@ class XRef {
         const entry = {
           offset,
           gen: generation,
+          free: false,
+          uncompressed: false,
         };
         switch (type) {
           case 0:
@@ -542,6 +546,7 @@ class XRef {
           this.#entries[num] = {
             offset: position - stream.start,
             gen,
+            free: false,
             uncompressed: true,
           };
         }


### PR DESCRIPTION
SpiderMonkey sizes an object literal's inline slots to the properties it declares: `{ offset, gen }` gets two, so adding `free`/`uncompressed` afterwards spills into a separate allocation — once per entry, i.e. 333276 times for pdf.pdf. An empty literal gets four slots instead, which is why the previous `const entry = {}` plus assignments didn't pay this cost.

Takes `getDocument()` + `getPage(1)` on pdf.pdf from 302ms to 293ms.