### PR TITLE
Add a simple integration-test for the "updatedPreference" event

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -2352,4 +2352,54 @@ describe("PDF viewer", () => {
       );
     });
   });
+
+  describe("Preferences", () => {
+    describe('handles "updatedPreference" event correctly', () => {
+      let pages;
+
+      beforeEach(async () => {
+        pages = await loadAndWait("empty.pdf", ".textLayer .endOfContent");
+      });
+
+      afterEach(async () => {
+        await closePages(pages);
+      });
+
+      async function getToolbarState(page) {
+        return page.evaluate(() => ({
+          density: document
+            .getElementsByTagName("html")[0]
+            .getAttribute("data-toolbar-density"),
+          height: document.getElementById("toolbarContainer").clientHeight,
+        }));
+      }
+
+      it("changes the toolbar height", async () => {
+        await Promise.all(
+          pages.map(async ([browserName, page]) => {
+            const initial = await getToolbarState(page);
+            expect(initial.density).toEqual("normal");
+            expect(initial.height).toEqual(32);
+
+            // Update the preference to change the toolbar height.
+            await page.evaluate(() => {
+              const event = new CustomEvent("updatedPreference", {
+                bubbles: true,
+                cancelable: true,
+                detail: { name: "toolbarDensity", value: 2 },
+              });
+              window.dispatchEvent(event);
+            });
+            await page.waitForFunction(
+              `document.getElementsByTagName("html")[0].getAttribute("data-toolbar-density") !== "normal"`
+            );
+
+            const changed = await getToolbarState(page);
+            expect(changed.density).toEqual("touch");
+            expect(changed.height).toEqual(44);
+          })
+        );
+      });
+    });
+  });
 });

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -1077,16 +1077,14 @@ class AppOptions {
         continue;
       }
       if (this.eventBus && kind & OptionKind.EVENT_DISPATCH) {
-        (events ||= new Map()).set(name, userOpt);
+        (events ??= new Map()).set(name, userOpt);
       }
       this.#opts.set(name, userOpt);
     }
 
-    if (events) {
-      for (const [name, value] of events) {
-        this.eventBus.dispatch(name.toLowerCase(), { source: this, value });
-      }
-    }
+    events?.forEach((value, name) => {
+      this.eventBus.dispatch(name.toLowerCase(), { source: this, value });
+    });
   }
 }
 

--- a/web/preferences.js
+++ b/web/preferences.js
@@ -47,7 +47,10 @@ class BasePreferences {
       }
     );
 
-    if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
+    if (
+      typeof PDFJSDev === "undefined" ||
+      PDFJSDev.test("(TESTING && !LIB) || MOZCENTRAL")
+    ) {
       window.addEventListener(
         "updatedPreference",
         async ({ detail: { name, value } }) => {


### PR DESCRIPTION
The Firefox PDF Viewer is expected to react appropriately on a global "updatedPreference" event, however it doesn't appear that we have any tests for that.

Also, shorten the `EventBus` dispatching in the `AppOptions.setAll` method.