### PR TITLE
Use the structure tree to position annotations

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -757,7 +757,8 @@ class Annotation {
 
       annotationGlobals.structTreeRoot.addAnnotationIdToPage(
         params.pageRef,
-        structParent
+        structParent,
+        this.ref
       );
     }
 

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -101,17 +101,22 @@ class StructTreeRoot {
       : -1;
   }
 
-  #addIdToPage(pageRef, id, type) {
+  #addIdToPage(pageRef, id, type, objId) {
     if (!(pageRef instanceof Ref) || id < 0) {
       return;
     }
     (this.structParentIds ??= new RefMap())
       .getOrPutComputed(pageRef, makeArr)
-      .push([id, type]);
+      .push([id, type, objId]);
   }
 
-  addAnnotationIdToPage(pageRef, id) {
-    this.#addIdToPage(pageRef, id, StructElementType.ANNOTATION);
+  addAnnotationIdToPage(pageRef, id, ref) {
+    this.#addIdToPage(
+      pageRef,
+      id,
+      StructElementType.ANNOTATION,
+      ref instanceof Ref ? ref.toString() : null
+    );
   }
 
   static async canCreateStructureTree({
@@ -924,18 +929,20 @@ class StructTreePage {
     if (!ids) {
       return;
     }
-    for (const [elemId, type] of ids) {
+    for (const [elemId, type, objId] of ids) {
       const obj = parentTree.get(elemId);
-      if (obj) {
-        const elem = this.addNode(this.xref.fetchIfRef(obj), map);
-        if (
-          elem?.kids?.length === 1 &&
-          elem.kids[0].type === StructElementType.OBJECT
-        ) {
-          // The node in the struct tree is wrapping an object (annotation
-          // or xobject), so we need to update the type of the node to match
-          // the type of the object.
-          elem.kids[0].type = type;
+      if (!obj) {
+        continue;
+      }
+      const elem = this.addNode(this.xref.fetchIfRef(obj), map);
+      if (!elem || !objId) {
+        continue;
+      }
+      // Match the annotation by object reference because its structure
+      // element may have other children.
+      for (const kid of elem.kids) {
+        if (kid.type === StructElementType.OBJECT && kid.refObjId === objId) {
+          kid.type = type;
         }
       }
     }

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -4212,9 +4212,14 @@ class AnnotationLayer {
     this.div.append(fragment);
     await Promise.all(promises);
     if (this.#accessibilityManager) {
-      for (const element of this.#elements) {
+      const annotationIds = await this.#structTreeLayer?.getAnnotationIds();
+      for (const { contentElement } of this.#elements) {
+        if (annotationIds?.has(contentElement.id)) {
+          // The structure tree already positions this annotation.
+          continue;
+        }
         this.#accessibilityManager.addPointerInTextLayer(
-          element.contentElement,
+          contentElement,
           /* isRemovable = */ false
         );
       }

--- a/test/integration/accessibility_spec.mjs
+++ b/test/integration/accessibility_spec.mjs
@@ -230,16 +230,12 @@ describe("accessibility", () => {
         pages.map(async ([browserName, page]) => {
           await page.waitForSelector(".structTree");
 
-          const isLinkedToStampAnnotation = await page.$eval(
-            ".structTree [role='figure']",
-            el =>
-              document
-                .getElementById(el.getAttribute("aria-owns"))
-                .classList.contains("stampAnnotation")
+          const owners = await page.$$eval(
+            `[aria-owns~="pdfjs_internal_id_20R"]`,
+            elements =>
+              elements.map(element => element.closest(".structTree") !== null)
           );
-          expect(isLinkedToStampAnnotation)
-            .withContext(`In ${browserName}`)
-            .toBeTrue();
+          expect(owners).withContext(`In ${browserName}`).toEqual([true]);
         })
       );
     });

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -4899,7 +4899,10 @@ have written that much by now. So, here’s to squashing bugs.`);
                               {
                                 role: "Link",
                                 children: [
-                                  { type: "object", id: "432R" },
+                                  {
+                                    type: "annotation",
+                                    id: "pdfjs_internal_id_432R",
+                                  },
                                   { type: "content", id: "p406R_mc34" },
                                 ],
                               },
@@ -4922,7 +4925,10 @@ have written that much by now. So, here’s to squashing bugs.`);
                               {
                                 role: "Link",
                                 children: [
-                                  { type: "object", id: "433R" },
+                                  {
+                                    type: "annotation",
+                                    id: "pdfjs_internal_id_433R",
+                                  },
                                   { type: "content", id: "p406R_mc36" },
                                 ],
                               },
@@ -4948,7 +4954,7 @@ have written that much by now. So, here’s to squashing bugs.`);
                       {
                         role: "Link",
                         children: [
-                          { type: "object", id: "434R" },
+                          { type: "annotation", id: "pdfjs_internal_id_434R" },
                           { type: "content", id: "p406R_mc10" },
                         ],
                       },

--- a/test/unit/struct_tree_layer_builder_spec.js
+++ b/test/unit/struct_tree_layer_builder_spec.js
@@ -17,10 +17,14 @@ import { isNodeJS } from "../../src/shared/util.js";
 import { StructTreeLayerBuilder } from "../../web/struct_tree_layer_builder.js";
 
 describe("StructTreeLayerBuilder", function () {
-  function render(structTree) {
+  function build(structTree) {
     return new StructTreeLayerBuilder({
       getStructTree: async () => structTree,
-    }).render();
+    });
+  }
+
+  function render(structTree) {
+    return build(structTree).render();
   }
 
   beforeEach(function () {
@@ -354,6 +358,67 @@ describe("StructTreeLayerBuilder", function () {
     expect(row.getAttribute("aria-colspan")).toBeNull();
     expect(row.getAttribute("aria-owns")).toBeNull();
     expect(row.id).toEqual("");
+  });
+
+  it("keeps structured annotations in the structure tree", async function () {
+    const builder = build({
+      role: "Root",
+      children: [
+        {
+          role: "P",
+          children: [
+            { type: "content", id: "p1R_mc0" },
+            {
+              role: "Link",
+              children: [
+                {
+                  role: "Figure",
+                  children: [{ type: "content", id: "p1R_mc1" }],
+                },
+                { type: "annotation", id: "pdfjs_internal_id_1R" },
+              ],
+            },
+            {
+              role: "Link",
+              children: [
+                { type: "content", id: "p1R_mc2" },
+                { type: "annotation", id: "pdfjs_internal_id_2R" },
+                { type: "content", id: "p1R_mc3" },
+                { type: "annotation", id: "pdfjs_internal_id_3R" },
+              ],
+            },
+            {
+              role: "Link",
+              children: [{ type: "annotation", id: "pdfjs_internal_id_4R" }],
+            },
+          ],
+        },
+      ],
+    });
+    const tree = await builder.render();
+
+    expect(await builder.getAnnotationIds()).toEqual(
+      new Set([
+        "pdfjs_internal_id_1R",
+        "pdfjs_internal_id_2R",
+        "pdfjs_internal_id_3R",
+        "pdfjs_internal_id_4R",
+      ])
+    );
+    expect(
+      [...tree.querySelectorAll("[aria-owns]")].map(e =>
+        e.getAttribute("aria-owns")
+      )
+    ).toEqual([
+      "p1R_mc0",
+      "p1R_mc1",
+      "pdfjs_internal_id_1R",
+      "p1R_mc2",
+      "pdfjs_internal_id_2R",
+      "p1R_mc3",
+      "pdfjs_internal_id_3R",
+      "pdfjs_internal_id_4R",
+    ]);
   });
 
   it("only uses the caption role inside a table or a figure", async function () {

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -193,6 +193,8 @@ class StructTreeLayerBuilder {
 
   #treePromise;
 
+  #annotationIds = new Set();
+
   #elementAttributes = new Map();
 
   #structElementIdPrefix = `pdfjs_internal_struct_${getUuid()}_`;
@@ -230,6 +232,7 @@ class StructTreeLayerBuilder {
     try {
       const tree = await this.#promise;
       this.#collectStructElements(tree);
+      this.#collectAnnotations(tree);
       this.#treeDom = this.#walk(tree);
     } catch (ex) {
       reject(ex);
@@ -249,6 +252,20 @@ class StructTreeLayerBuilder {
     } catch {
       // If the structTree cannot be fetched, parsed, and/or rendered,
       // ensure that e.g. the AnnotationLayer won't break completely.
+    }
+    return null;
+  }
+
+  /**
+   * Get the ids of annotations owned by the structure tree.
+   * @returns {Promise<Set<string>|null>}
+   */
+  async getAnnotationIds() {
+    try {
+      await this.render();
+      return this.#annotationIds;
+    } catch {
+      // See the comment in `getAriaAttributes`.
     }
     return null;
   }
@@ -276,6 +293,19 @@ class StructTreeLayerBuilder {
     }
     for (const child of node.children || []) {
       this.#collectStructElements(child);
+    }
+  }
+
+  #collectAnnotations(node) {
+    if (!node) {
+      return;
+    }
+    if (node.type === "annotation") {
+      this.#annotationIds.add(node.id);
+      return;
+    }
+    for (const child of node.children || []) {
+      this.#collectAnnotations(child);
     }
   }
 


### PR DESCRIPTION
OBJR children used raw object references that do not match annotation-layer element IDs. Type correction also required the structure element to have exactly one child, so links with marked content were missed.

Match OBJR children to annotations by object reference. When available, use nearby marked content in the same structure element as the text-layer anchor instead of deriving its position geometrically.