### PR TITLE
[Editor] Make HighlightEditor extend DrawingEditor

### DIFF
--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -480,20 +480,11 @@ class AnnotationEditorLayer {
         true,
         /* updateButton = */ true
       );
-      this.#textLayer.div.classList.add("free");
-      this.toggleDrawing();
-      HighlightEditor.startHighlighting(
+      HighlightEditor.startDrawing(
         this,
+        this.#uiManager,
         this.#uiManager.direction === "ltr",
-        { target: this.#textLayer.div, x: event.x, y: event.y }
-      );
-      this.#textLayer.div.addEventListener(
-        "pointerup",
-        () => {
-          this.#textLayer.div.classList.remove("free");
-          this.toggleDrawing(true);
-        },
-        { once: true, signal: this.#uiManager._signal }
+        event
       );
       event.preventDefault();
     }

--- a/src/display/editor/color_picker.js
+++ b/src/display/editor/color_picker.js
@@ -158,7 +158,7 @@ class ColorPicker {
       type: AnnotationEditorParamsType.HIGHLIGHT_COLOR,
       value: color,
     });
-    this.updateColor(color);
+    this.update(color);
   }
 
   _colorSelectFromKeyboard(event) {
@@ -279,7 +279,7 @@ class ColorPicker {
     });
   }
 
-  updateColor(color) {
+  update(color) {
     if (this.#buttonSwatch) {
       this.#buttonSwatch.style.backgroundColor = color;
     }

--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -13,10 +13,15 @@
  * limitations under the License.
  */
 
+// eslint-disable-next-line max-len
+/** @typedef {import("./annotation_editor_layer.js").AnnotationEditorLayer} AnnotationEditorLayer */
+// eslint-disable-next-line max-len
+/** @typedef {import("./tools.js").AnnotationEditorUIManager} AnnotationEditorUIManager */
+
 import { AnnotationEditorParamsType, unreachable } from "../../shared/util.js";
+import { bindEvents, CurrentPointers } from "./tools.js";
 import { noContextMenu, stopEvent } from "../display_utils.js";
 import { AnnotationEditor } from "./editor.js";
-import { CurrentPointers } from "./tools.js";
 
 class DrawingOptions {
   #svgProperties = Object.create(null);
@@ -64,13 +69,19 @@ class DrawingOptions {
  * Basic draw editor.
  */
 class DrawingEditor extends AnnotationEditor {
-  #drawOutlines = null;
+  #internalDiv = null;
 
   #mustBeCommitted;
+
+  _clipPathId = null;
 
   _colorPicker = null;
 
   _drawId = null;
+
+  _drawOutlines = null;
+
+  _focusDrawId = null;
 
   static _currentDrawId = -1;
 
@@ -81,6 +92,8 @@ class DrawingEditor extends AnnotationEditor {
   static #currentDrawingAC = null;
 
   static #currentDrawingOptions = null;
+
+  static #currentClipPathId = null;
 
   static _INNER_MARGIN = 3;
 
@@ -109,8 +122,8 @@ class DrawingEditor extends AnnotationEditor {
     }
   }
 
-  #createDrawOutlines({ drawOutlines, drawId, drawingOptions }) {
-    this.#drawOutlines = drawOutlines;
+  #createDrawOutlines({ drawOutlines, drawId, drawingOptions, clipPathId }) {
+    this._drawOutlines = drawOutlines;
     this._drawingOptions ||= drawingOptions;
     if (!this.annotationElementId) {
       this._uiManager.a11yAlert(AnnotationEditor._l10nAlert[this.editorType]);
@@ -118,12 +131,14 @@ class DrawingEditor extends AnnotationEditor {
 
     if (drawId >= 0) {
       this._drawId = drawId;
+      this._clipPathId = clipPathId ?? null;
       // We need to redraw the drawing because we changed the coordinates to be
       // in the box coordinate system.
       this.parent.drawLayer.finalizeDraw(
         drawId,
         drawOutlines.defaultProperties
       );
+      this.#createFocusOutline(this.parent);
     } else {
       // We create a new drawing.
       this._drawId = this.#createDrawing(drawOutlines, this.parent);
@@ -133,15 +148,60 @@ class DrawingEditor extends AnnotationEditor {
   }
 
   #createDrawing(drawOutlines, parent) {
-    const { id } = parent.drawLayer.draw(
+    const { id, clipPathId } = parent.drawLayer.draw(
       DrawingEditor._mergeSVGProperties(
         this._drawingOptions.toSVGProperties(),
         drawOutlines.defaultSVGProperties
       ),
       /* isPathUpdatable = */ false,
-      /* hasClip = */ false
+      /* hasClip = */ this.constructor._hasClipPath
     );
+    if (this.constructor._hasClipPath) {
+      this._clipPathId = clipPathId;
+    }
+    this.#createFocusOutline(parent);
+
     return id;
+  }
+
+  #createFocusOutline(parent) {
+    const properties = this._drawOutlines.getFocusSVGProperties(
+      this.#rotationAngle
+    );
+    if (properties) {
+      this._focusDrawId = parent.drawLayer.drawOutline(
+        properties,
+        this._drawOutlines.focusMustRemoveSelfIntersections
+      );
+    }
+  }
+
+  #updateFocusOutline(angle = this.#rotationAngle) {
+    if (this._focusDrawId === null) {
+      return;
+    }
+    this.parent?.drawLayer.updateProperties(
+      this._focusDrawId,
+      this._drawOutlines.getFocusSVGProperties(angle)
+    );
+  }
+
+  #toggleFocusOutlineClass(rootClass) {
+    if (this._focusDrawId !== null) {
+      this.parent?.drawLayer.updateProperties(this._focusDrawId, { rootClass });
+    }
+  }
+
+  #updateVisibility() {
+    const { parent, _drawId, _focusDrawId, _isVisible } = this;
+    if (!parent || _drawId === null) {
+      return;
+    }
+    const rootClass = { hidden: !_isVisible };
+    parent.drawLayer.updateProperties(_drawId, { rootClass });
+    if (_focusDrawId !== null) {
+      parent.drawLayer.updateProperties(_focusDrawId, { rootClass });
+    }
   }
 
   static _mergeSVGProperties(p1, p2) {
@@ -178,12 +238,32 @@ class DrawingEditor extends AnnotationEditor {
     return true;
   }
 
+  static get _hasClipPath() {
+    return false;
+  }
+
+  static get _hasDrawClass() {
+    return true;
+  }
+
   /**
    * @returns {boolean} `true` if several drawings can be added to the
    * annotation.
    */
   static get supportMultipleDrawings() {
     return false;
+  }
+
+  get _drawRotation() {
+    return this.rotation;
+  }
+
+  get _opacityName() {
+    return this.constructor.typesMap.get(this.opacityType);
+  }
+
+  get #rotationAngle() {
+    return (this.parentRotation - this._drawRotation + 360) % 360;
   }
 
   /** @inheritdoc */
@@ -238,7 +318,7 @@ class DrawingEditor extends AnnotationEditor {
     const savedValue = options[name];
     const setter = val => {
       options.updateProperty(name, val);
-      const bbox = this.#drawOutlines.updateProperty(name, val);
+      const bbox = this._drawOutlines.updateProperty(name, val);
       if (bbox) {
         this.#updateBbox(bbox);
       }
@@ -266,17 +346,17 @@ class DrawingEditor extends AnnotationEditor {
   /**
    * Update color and opacity atomically as one undoable command.
    */
-  _updateColorAndOpacity(color, opacity) {
+  _updateColorAndOpacity(color, opacity, type = this.colorAndOpacityType) {
     const colorName = this.constructor.typesMap.get(this.colorType);
-    const opacityName = this.constructor.typesMap.get(this.opacityType);
+    const opacityName = this._opacityName;
     const options = this._drawingOptions;
     const savedColor = options[colorName];
     const savedOpacity = options[opacityName];
     const setter = (c, op) => {
       options.updateProperty(colorName, c);
       options.updateProperty(opacityName, op);
-      this.#drawOutlines.updateProperty(colorName, c);
-      this.#drawOutlines.updateProperty(opacityName, op);
+      this._drawOutlines.updateProperty(colorName, c);
+      this._drawOutlines.updateProperty(opacityName, op);
       this.parent?.drawLayer.updateProperties(
         this._drawId,
         options.toSVGProperties()
@@ -289,7 +369,7 @@ class DrawingEditor extends AnnotationEditor {
       undo: setter.bind(this, savedColor, savedOpacity),
       post: this._uiManager.updateUI.bind(this._uiManager, this),
       mustExec: true,
-      type: AnnotationEditorParamsType.INK_COLOR_AND_OPACITY,
+      type,
       overwriteIfSameType: true,
       keepUndo: true,
     });
@@ -300,7 +380,7 @@ class DrawingEditor extends AnnotationEditor {
     this.parent?.drawLayer.updateProperties(
       this._drawId,
       DrawingEditor._mergeSVGProperties(
-        this.#drawOutlines.getPathResizingSVGProperties(
+        this._drawOutlines.getPathResizingSVGProperties(
           this.#convertToDrawSpace()
         ),
         {
@@ -315,7 +395,7 @@ class DrawingEditor extends AnnotationEditor {
     this.parent?.drawLayer.updateProperties(
       this._drawId,
       DrawingEditor._mergeSVGProperties(
-        this.#drawOutlines.getPathResizedSVGProperties(
+        this._drawOutlines.getPathResizedSVGProperties(
           this.#convertToDrawSpace()
         ),
         {
@@ -323,6 +403,7 @@ class DrawingEditor extends AnnotationEditor {
         }
       )
     );
+    this.#updateFocusOutline();
   }
 
   /** @inheritdoc */
@@ -337,7 +418,7 @@ class DrawingEditor extends AnnotationEditor {
     this.parent?.drawLayer.updateProperties(
       this._drawId,
       DrawingEditor._mergeSVGProperties(
-        this.#drawOutlines.getPathTranslatedSVGProperties(
+        this._drawOutlines.getPathTranslatedSVGProperties(
           this.#convertToDrawSpace(),
           this.parentDimensions
         ),
@@ -364,12 +445,18 @@ class DrawingEditor extends AnnotationEditor {
     });
   }
 
+  get _mustBeDisabledOnCommit() {
+    return true;
+  }
+
   /** @inheritdoc */
   commit() {
     super.commit();
 
-    this.disableEditMode();
-    this.disableEditing();
+    if (this._mustBeDisabledOnCommit) {
+      this.disableEditMode();
+      this.disableEditing();
+    }
   }
 
   /** @inheritdoc */
@@ -414,6 +501,7 @@ class DrawingEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   remove() {
+    this._uiManager.removeShouldRescale(this);
     this.#cleanDrawLayer();
     super.remove();
   }
@@ -429,7 +517,7 @@ class DrawingEditor extends AnnotationEditor {
     }
 
     this.#addToDrawLayer();
-    this.#updateBbox(this.#drawOutlines.box);
+    this.#updateBbox(this._drawOutlines.box);
 
     if (!this.isAttachedToDOM) {
       // At some point this editor was removed and we're rebuilding it,
@@ -452,6 +540,7 @@ class DrawingEditor extends AnnotationEditor {
         !this.parent && this.div?.classList.contains("selectedEditor");
     }
     super.setParent(parent);
+    this.#updateVisibility();
     if (mustBeSelected) {
       // We select it after the parent has been set.
       this.select();
@@ -462,8 +551,13 @@ class DrawingEditor extends AnnotationEditor {
     if (this._drawId === null || !this.parent) {
       return;
     }
-    this.parent.drawLayer.remove(this._drawId);
+    const { drawLayer } = this.parent;
+    drawLayer.remove(this._drawId);
     this._drawId = null;
+    if (this._focusDrawId !== null) {
+      drawLayer.remove(this._focusDrawId);
+      this._focusDrawId = null;
+    }
 
     // All the SVG properties must be reset in order to make it possible to
     // undo.
@@ -476,17 +570,24 @@ class DrawingEditor extends AnnotationEditor {
     }
     if (this._drawId !== null) {
       // The parent has changed, we need to move the drawing to the new parent.
-      this.parent.drawLayer.updateParent(this._drawId, parent.drawLayer);
+      const { drawLayer } = this.parent;
+      drawLayer.updateParent(this._drawId, parent.drawLayer);
+      if (this._focusDrawId !== null) {
+        drawLayer.updateParent(this._focusDrawId, parent.drawLayer);
+      }
       return;
     }
     this._drawingOptions.updateAll();
-    this._drawId = this.#createDrawing(this.#drawOutlines, parent);
+    this._drawId = this.#createDrawing(this._drawOutlines, parent);
+    if (this._clipPathId && this.#internalDiv) {
+      this.#internalDiv.style.clipPath = this._clipPathId;
+    }
   }
 
   #convertToParentSpace([x, y, width, height]) {
     const {
       parentDimensions: [pW, pH],
-      rotation,
+      _drawRotation: rotation,
     } = this;
     switch (rotation) {
       case 90:
@@ -507,7 +608,7 @@ class DrawingEditor extends AnnotationEditor {
       width,
       height,
       parentDimensions: [pW, pH],
-      rotation,
+      _drawRotation: rotation,
     } = this;
     switch (rotation) {
       case 90:
@@ -531,7 +632,7 @@ class DrawingEditor extends AnnotationEditor {
     this._onResized();
   }
 
-  #rotateBox() {
+  #rotateBox(parentRotation = this.parentRotation) {
     // We've to deal with two rotations: the rotation of the annotation and the
     // rotation of the parent page.
     // When the page is rotated, all the layers are just rotated thanks to CSS
@@ -549,8 +650,7 @@ class DrawingEditor extends AnnotationEditor {
       y,
       width,
       height,
-      rotation,
-      parentRotation,
+      _drawRotation: rotation,
       parentDimensions: [pW, pH],
     } = this;
     switch ((rotation * 4 + parentRotation) / 90) {
@@ -635,34 +735,68 @@ class DrawingEditor extends AnnotationEditor {
     }
   }
 
-  /** @inheritdoc */
-  rotate() {
-    if (!this.parent) {
+  /**
+   * @inheritdoc
+   * @param {number} [parentRotation] - The parent rotation to apply.
+   */
+  rotate(parentRotation = this.parentRotation) {
+    if (!this.parent || this._drawId === null) {
       return;
     }
+    const angle = (parentRotation - this._drawRotation + 360) % 360;
     this.parent.drawLayer.updateProperties(
       this._drawId,
       DrawingEditor._mergeSVGProperties(
         {
-          bbox: this.#rotateBox(),
+          bbox: this.#rotateBox(parentRotation),
         },
-        this.#drawOutlines.updateRotation(
-          (this.parentRotation - this.rotation + 360) % 360
-        )
+        this._drawOutlines.updateRotation(angle)
       )
     );
+    this.#updateFocusOutline(angle);
+  }
+
+  /** @inheritdoc */
+  show(visible = this._isVisible) {
+    super.show(visible);
+    this.#updateVisibility();
+  }
+
+  /** @inheritdoc */
+  select() {
+    super.select();
+    this.#toggleFocusOutlineClass({ hovered: false, selected: true });
+  }
+
+  /** @inheritdoc */
+  unselect() {
+    super.unselect();
+    this.#toggleFocusOutlineClass({ selected: false });
+  }
+
+  pointerover() {
+    if (!this.isSelected) {
+      this.#toggleFocusOutlineClass({ hovered: true });
+    }
+  }
+
+  pointerleave() {
+    if (!this.isSelected) {
+      this.#toggleFocusOutlineClass({ hovered: false });
+    }
   }
 
   onScaleChanging() {
     if (!this.parent) {
       return;
     }
-    this.#updateBbox(
-      this.#drawOutlines.updateParentDimensions(
-        this.parentDimensions,
-        this.parent.scale
-      )
+    const bbox = this._drawOutlines.updateParentDimensions(
+      this.parentDimensions,
+      this.parent.scale
     );
+    if (bbox) {
+      this.#updateBbox(bbox);
+    }
   }
 
   static onScaleChangingWhenDrawing() {}
@@ -680,12 +814,18 @@ class DrawingEditor extends AnnotationEditor {
     }
 
     const div = super.render();
-    div.classList.add("draw");
+    if (this.constructor._hasDrawClass) {
+      div.classList.add("draw");
+    }
 
-    const drawDiv = document.createElement("div");
+    const drawDiv = (this.#internalDiv = document.createElement("div"));
     div.append(drawDiv);
     drawDiv.setAttribute("aria-hidden", "true");
     drawDiv.className = "internal";
+    if (this._clipPathId) {
+      drawDiv.style.clipPath = this._clipPathId;
+    }
+    bindEvents(this, drawDiv, ["pointerover", "pointerleave"]);
     this.setDims();
     this._uiManager.addShouldRescale(this);
     this.disableEditing();
@@ -698,18 +838,68 @@ class DrawingEditor extends AnnotationEditor {
   }
 
   /**
-   * Create a new drawer instance.
-   * @param {number} x - The x coordinate of the event.
-   * @param {number} y - The y coordinate of the event.
-   * @param {number} parentWidth - The parent width.
-   * @param {number} parentHeight - The parent height.
-   * @param {number} rotation - The parent rotation.
+   * @param {Object} params
+   * @param {number} params.x - The x coordinate of the event.
+   * @param {number} params.y - The y coordinate of the event.
+   * @param {Array<number>} params.box - The target's client bounding box.
+   * @param {number} params.rotation - The viewport rotation.
+   * @param {AnnotationEditorLayer} params.parent - The parent layer.
+   * @param {boolean} params.isLTR - Whether the direction is left-to-right.
    */
-  static createDrawerInstance(_x, _y, _parentWidth, _parentHeight, _rotation) {
+  static createDrawerInstance(_params) {
     unreachable("Not implemented");
   }
 
-  static startDrawing(parent, uiManager, _isLTR, event) {
+  /**
+   * @param {AnnotationEditorLayer} _parent
+   * @param {PointerEvent} event
+   * @returns {HTMLElement}
+   */
+  static _getDrawingTarget(_parent, { target }) {
+    return target;
+  }
+
+  /**
+   * @param {PointerEvent} event
+   * @param {PointerEvent} [referenceEvent]
+   * @returns {Array<number>}
+   */
+  static _getPointerCoords(
+    { offsetX, offsetY, clientX, clientY },
+    referenceEvent = null
+  ) {
+    if (!referenceEvent) {
+      return [offsetX, offsetY];
+    }
+
+    let deltaX = clientX - referenceEvent.clientX;
+    let deltaY = clientY - referenceEvent.clientY;
+    switch (this._currentParent.viewport.rotation) {
+      case 90:
+        [deltaX, deltaY] = [deltaY, -deltaX];
+        break;
+      case 180:
+        [deltaX, deltaY] = [-deltaX, -deltaY];
+        break;
+      case 270:
+        [deltaX, deltaY] = [-deltaY, deltaX];
+        break;
+    }
+    return [referenceEvent.offsetX + deltaX, referenceEvent.offsetY + deltaY];
+  }
+
+  /**
+   * @param {HTMLElement} _target
+   * @param {AbortSignal} _signal
+   */
+  static _addDrawingListeners(_target, _signal) {}
+
+  /** @param {boolean} isAborted */
+  static _endDrawingSession(isAborted = false) {
+    return this._currentParent.endDrawingSession(isAborted);
+  }
+
+  static startDrawing(parent, uiManager, isLTR, event) {
     // The pointerType of CurrentPointer is set when the user starts an empty
     // drawing session. If, in the same drawing session, the user starts using a
     // different type of pointer (e.g. a pen and then a finger), we just return.
@@ -717,16 +907,22 @@ class DrawingEditor extends AnnotationEditor {
     // If the user starts to draw with a finger and then uses a second finger,
     // we just stop the current drawing and let the user zoom the document.
 
-    const { target, offsetX: x, offsetY: y, pointerId, pointerType } = event;
+    const { pointerId, pointerType } = event;
     if (CurrentPointers.isInitializedAndDifferentPointerType(pointerType)) {
       return;
     }
 
+    const target = this._getDrawingTarget(parent, event);
+    const [x, y] = this._getPointerCoords(event);
     const {
       viewport: { rotation },
     } = parent;
-    const { width: parentWidth, height: parentHeight } =
-      target.getBoundingClientRect();
+    const {
+      x: boxX,
+      y: boxY,
+      width: parentWidth,
+      height: parentHeight,
+    } = target.getBoundingClientRect();
 
     const ac = (DrawingEditor.#currentDrawingAC = new AbortController());
     const signal = parent.combinedSignal(ac);
@@ -746,7 +942,7 @@ class DrawingEditor extends AnnotationEditor {
       "pointercancel",
       e => {
         if (CurrentPointers.isSamePointerIdOrRemove(e.pointerId)) {
-          this._currentParent.endDrawingSession();
+          this._endDrawingSession();
         }
       },
       { signal }
@@ -768,7 +964,7 @@ class DrawingEditor extends AnnotationEditor {
         if (DrawingEditor.#currentDraw.isCancellable()) {
           DrawingEditor.#currentDraw.removeLastElement();
           if (DrawingEditor.#currentDraw.isEmpty()) {
-            this._currentParent.endDrawingSession(/* isAborted = */ true);
+            this._endDrawingSession(/* isAborted = */ true);
           } else {
             this._endDraw(null);
           }
@@ -794,6 +990,7 @@ class DrawingEditor extends AnnotationEditor {
       },
       { signal }
     );
+    this._addDrawingListeners(target, signal);
     parent.toggleDrawing();
     uiManager._editorUndoBar?.hide();
 
@@ -813,24 +1010,27 @@ class DrawingEditor extends AnnotationEditor {
 
     uiManager.updateUIForDefaultProperties(this);
 
-    DrawingEditor.#currentDraw = this.createDrawerInstance(
+    DrawingEditor.#currentDraw = this.createDrawerInstance({
       x,
       y,
-      parentWidth,
-      parentHeight,
-      rotation
-    );
+      box: [boxX, boxY, parentWidth, parentHeight],
+      rotation,
+      parent,
+      isLTR,
+    });
     DrawingEditor.#currentDrawingOptions = this.getDefaultDrawingOptions();
     this._currentParent = parent;
 
-    ({ id: this._currentDrawId } = parent.drawLayer.draw(
+    const { id, clipPathId } = parent.drawLayer.draw(
       this._mergeSVGProperties(
         DrawingEditor.#currentDrawingOptions.toSVGProperties(),
         DrawingEditor.#currentDraw.defaultSVGProperties
       ),
       /* isPathUpdatable = */ true,
-      /* hasClip = */ false
-    ));
+      /* hasClip = */ this._hasClipPath
+    );
+    this._currentDrawId = id;
+    DrawingEditor.#currentClipPathId = this._hasClipPath ? clipPathId : null;
   }
 
   static _drawMove(event) {
@@ -838,9 +1038,7 @@ class DrawingEditor extends AnnotationEditor {
     if (!DrawingEditor.#currentDraw) {
       return;
     }
-    const { offsetX, offsetY, clientX, clientY, pointerId } = event;
-
-    if (!CurrentPointers.isSamePointerId(pointerId)) {
+    if (!CurrentPointers.isSamePointerId(event.pointerId)) {
       return;
     }
     if (CurrentPointers.isUsingMultiplePointers()) {
@@ -852,34 +1050,18 @@ class DrawingEditor extends AnnotationEditor {
     // A pointermove can represent multiple coalesced pointer updates. When
     // available, feed each sample to the outliner so it receives the
     // intermediate positions.
-    // offsetX/offsetY are computed in the target's untransformed coordinate
-    // system, whereas clientX/clientY are viewport coordinates. Since
-    // [data-main-rotation] transforms the layer, rotate each client-space delta
-    // back before adding it to the dispatched event's offsets.
     let properties;
     const coalesced = event.getCoalescedEvents?.();
     if (coalesced?.length) {
-      const { rotation } = this._currentParent.viewport;
       const points = [];
-      for (const { clientX: x, clientY: y } of coalesced) {
-        let deltaX = x - clientX;
-        let deltaY = y - clientY;
-        switch (rotation) {
-          case 90:
-            [deltaX, deltaY] = [deltaY, -deltaX];
-            break;
-          case 180:
-            [deltaX, deltaY] = [-deltaX, -deltaY];
-            break;
-          case 270:
-            [deltaX, deltaY] = [-deltaY, deltaX];
-            break;
-        }
-        points.push(offsetX + deltaX, offsetY + deltaY);
+      for (const sample of coalesced) {
+        points.push(...this._getPointerCoords(sample, event));
       }
       properties = DrawingEditor.#currentDraw.addPoints(points);
     } else {
-      properties = DrawingEditor.#currentDraw.add(offsetX, offsetY);
+      properties = DrawingEditor.#currentDraw.add(
+        ...this._getPointerCoords(event)
+      );
     }
     this._currentParent.drawLayer.updateProperties(
       this._currentDrawId,
@@ -896,6 +1078,7 @@ class DrawingEditor extends AnnotationEditor {
       this._currentParent = null;
       DrawingEditor.#currentDraw = null;
       DrawingEditor.#currentDrawingOptions = null;
+      DrawingEditor.#currentClipPathId = null;
       CurrentPointers.clearTimeStamp();
     }
 
@@ -920,7 +1103,7 @@ class DrawingEditor extends AnnotationEditor {
     parent.drawLayer.updateProperties(
       this._currentDrawId,
       event?.target === parent.div
-        ? DrawingEditor.#currentDraw.end(event.offsetX, event.offsetY)
+        ? DrawingEditor.#currentDraw.end(...this._getPointerCoords(event))
         : DrawingEditor.#currentDraw.end()
     );
     if (this.supportMultipleDrawings) {
@@ -966,6 +1149,7 @@ class DrawingEditor extends AnnotationEditor {
         false,
         {
           drawId: this._currentDrawId,
+          clipPathId: DrawingEditor.#currentClipPathId,
           drawOutlines: DrawingEditor.#currentDraw.getOutlines(
             pageWidth * scale,
             pageHeight * scale,
@@ -997,8 +1181,9 @@ class DrawingEditor extends AnnotationEditor {
    * @param {number} pageY - The y coordinate of the page.
    * @param {number} pageWidth - The width of the page.
    * @param {number} pageHeight - The height of the page.
-   * @param {number} innerWidth - The inner width.
+   * @param {number} innerMargin - The outline's inner margin.
    * @param {Object} data - The data to deserialize.
+   * @param {AnnotationEditorUIManager} uiManager
    * @returns {Object} The deserialized outlines.
    */
   static deserializeDraw(
@@ -1006,8 +1191,9 @@ class DrawingEditor extends AnnotationEditor {
     _pageY,
     _pageWidth,
     _pageHeight,
-    _innerWidth,
-    _data
+    _innerMargin,
+    _data,
+    _uiManager
   ) {
     unreachable("Not implemented");
   }
@@ -1023,7 +1209,8 @@ class DrawingEditor extends AnnotationEditor {
       pageWidth,
       pageHeight,
       this._INNER_MARGIN,
-      data
+      data,
+      uiManager
     );
     const editor = await super.deserialize(data, parent, uiManager);
     editor.createDrawingOptions(data);
@@ -1038,7 +1225,7 @@ class DrawingEditor extends AnnotationEditor {
   serializeDraw(isForCopying) {
     const [pageX, pageY] = this.pageTranslation;
     const [pageWidth, pageHeight] = this.pageDimensions;
-    return this.#drawOutlines.serialize(
+    return this._drawOutlines.serialize(
       [pageX, pageY, pageWidth, pageHeight],
       isForCopying
     );

--- a/src/display/editor/drawers/freedraw.js
+++ b/src/display/editor/drawers/freedraw.js
@@ -56,7 +56,7 @@ class FreeDrawOutliner {
 
   static #MIN = FreeDrawOutliner.#MIN_DIST + FreeDrawOutliner.#MIN_DIFF;
 
-  constructor({ x, y }, box, scaleFactor, thickness, isLTR, innerMargin = 0) {
+  constructor(x, y, box, scaleFactor, thickness, isLTR, innerMargin = 0) {
     this.#box = box;
     this.#thickness = thickness * scaleFactor;
     this.#isLTR = isLTR;
@@ -75,6 +75,19 @@ class FreeDrawOutliner {
     return isNaN(this.#last[8]);
   }
 
+  isCancellable() {
+    // Treat strokes of at most five points as cancellable.
+    return this.#points.length <= 10;
+  }
+
+  /** @returns {Object} The SVG properties to apply. */
+  removeLastElement() {
+    this.#last.fill(NaN);
+    this.#top.length = this.#bottom.length = this.#points.length = 0;
+
+    return { path: { d: "" } };
+  }
+
   #getLastCoords() {
     const lastTop = this.#last.subarray(4, 6);
     const lastBottom = this.#last.subarray(16, 18);
@@ -88,7 +101,7 @@ class FreeDrawOutliner {
     ];
   }
 
-  add({ x, y }) {
+  add(x, y) {
     this.#lastX = x;
     this.#lastY = y;
     const [layerX, layerY, layerWidth, layerHeight] = this.#box;
@@ -627,15 +640,31 @@ class FreeDrawOutline extends Outline {
     return this.#bbox;
   }
 
-  newOutliner(point, box, scaleFactor, thickness, isLTR, innerMargin = 0) {
+  newOutliner(x, y, box, scaleFactor, thickness, isLTR, innerMargin = 0) {
     return new FreeDrawOutliner(
-      point,
+      x,
+      y,
       box,
       scaleFactor,
       thickness,
       isLTR,
       innerMargin
     );
+  }
+
+  /**
+   * @param {number} thickness
+   * @returns {Float32Array} The new bounding box.
+   */
+  updateThickness(thickness) {
+    const outline = this.getNewOutline(thickness);
+    this.#outline = outline.#outline;
+    this.#points = outline.#points;
+    this.#bbox.set(outline.#bbox);
+    this.firstPoint = outline.firstPoint;
+    this.lastPoint = outline.lastPoint;
+
+    return this.#bbox;
   }
 
   getNewOutline(thickness, innerMargin) {
@@ -646,22 +675,18 @@ class FreeDrawOutline extends Outline {
     const sy = height * layerHeight;
     const tx = x * layerWidth + layerX;
     const ty = y * layerHeight + layerY;
+    const points = this.#points;
     const outliner = this.newOutliner(
-      {
-        x: this.#points[0] * sx + tx,
-        y: this.#points[1] * sy + ty,
-      },
+      points[0] * sx + tx,
+      points[1] * sy + ty,
       this.#box,
       this.#scaleFactor,
       thickness,
       this.#isLTR,
       innerMargin ?? this.#innerMargin
     );
-    for (let i = 2; i < this.#points.length; i += 2) {
-      outliner.add({
-        x: this.#points[i] * sx + tx,
-        y: this.#points[i + 1] * sy + ty,
-      });
+    for (let i = 2, ii = points.length; i < ii; i += 2) {
+      outliner.add(points[i] * sx + tx, points[i + 1] * sy + ty);
     }
     return outliner.getOutlines();
   }

--- a/src/display/editor/drawers/highlight.js
+++ b/src/display/editor/drawers/highlight.js
@@ -17,6 +17,48 @@ import { BBOX_INIT, Util } from "../../../shared/util.js";
 import { FreeDrawOutline, FreeDrawOutliner } from "./freedraw.js";
 import { Outline } from "./outline.js";
 
+/**
+ * @param {Outline} outline
+ * @returns {Object}
+ */
+function getHighlightSVGProperties(outline) {
+  return {
+    bbox: outline.box,
+    root: {
+      viewBox: "0 0 1 1",
+    },
+    rootClass: {
+      highlight: true,
+      free: outline.isFree,
+    },
+    path: {
+      d: outline.toSVGPath(),
+    },
+  };
+}
+
+/**
+ * @param {Outline} outline
+ * @param {number} rotation
+ * @returns {Object}
+ */
+function getHighlightFocusSVGProperties(outline, rotation) {
+  const { focusOutline } = outline;
+  return {
+    bbox: Outline._rotateBox(focusOutline.box, rotation),
+    root: {
+      "data-main-rotation": rotation,
+    },
+    rootClass: {
+      highlightOutline: true,
+      free: outline.isFree,
+    },
+    path: {
+      d: focusOutline.toSVGPath(),
+    },
+  };
+}
+
 class HighlightOutliner {
   #box;
 
@@ -288,6 +330,8 @@ class HighlightOutliner {
 class HighlightOutline extends Outline {
   #box;
 
+  #boxes = null;
+
   #outlines;
 
   constructor(outlines, box, firstPoint, lastPoint) {
@@ -296,6 +340,69 @@ class HighlightOutline extends Outline {
     this.#box = box;
     this.firstPoint = firstPoint;
     this.lastPoint = lastPoint;
+  }
+
+  /**
+   * Build a text selection and its hover/selection outline.
+   * @param {Array<Object>} boxes - the boxes of the selected text.
+   * @param {boolean} isLTR
+   * @returns {HighlightOutline}
+   */
+  static build(boxes, isLTR) {
+    // The boxes come from the text layer, hence two contiguous ones can be
+    // separated by a tiny gap: expanding them makes them overlap and the
+    // sweep line merges them into a single gapless outline.
+    const outline = new HighlightOutliner(
+      boxes,
+      /* borderWidth = */ 0.001
+    ).getOutlines();
+    outline.#boxes = boxes;
+    // Expand the focus outline and leave room for its stroke.
+    outline.focusOutline = new HighlightOutliner(
+      boxes,
+      /* borderWidth = */ 0.0025,
+      /* innerMargin = */ 0.001,
+      isLTR
+    ).getOutlines();
+
+    return outline;
+  }
+
+  get isFree() {
+    return false;
+  }
+
+  /** @inheritdoc */
+  get defaultSVGProperties() {
+    return getHighlightSVGProperties(this);
+  }
+
+  /** @inheritdoc */
+  getFocusSVGProperties(rotation) {
+    return getHighlightFocusSVGProperties(this, rotation);
+  }
+
+  /** @inheritdoc */
+  updateRotation(rotation) {
+    return { root: { "data-main-rotation": rotation } };
+  }
+
+  /** @inheritdoc */
+  serializeQuadPoints([pageX, pageY], [pageWidth, pageHeight]) {
+    const boxes = this.#boxes;
+    const quadPoints = new Float32Array(boxes.length * 8);
+    let i = 0;
+    for (const { x, y, width, height } of boxes) {
+      const sx = x * pageWidth + pageX;
+      const sy = (1 - y) * pageHeight + pageY;
+      // QuadPoints order: top-left, top-right, bottom-left, bottom-right.
+      quadPoints[i] = quadPoints[i + 4] = sx;
+      quadPoints[i + 1] = quadPoints[i + 3] = sy;
+      quadPoints[i + 2] = quadPoints[i + 6] = sx + width * pageWidth;
+      quadPoints[i + 5] = quadPoints[i + 7] = sy - height * pageHeight;
+      i += 8;
+    }
+    return quadPoints;
   }
 
   toSVGPath() {
@@ -358,10 +465,91 @@ class FreeHighlightOutliner extends FreeDrawOutliner {
   }
 }
 
+class FreeHighlightDrawer {
+  #outliner;
+
+  #thickness;
+
+  constructor(x, y, box, scaleFactor, thickness, isLTR, innerMargin) {
+    this.#outliner = new FreeHighlightOutliner(
+      x,
+      y,
+      box,
+      scaleFactor,
+      thickness,
+      isLTR,
+      innerMargin
+    );
+    this.#thickness = thickness;
+  }
+
+  add(x, y) {
+    return this.#outliner.add(x, y)
+      ? { path: { d: this.#outliner.toSVGPath() } }
+      : null;
+  }
+
+  addPoints(points) {
+    let hasChanged = false;
+    for (let i = 0, ii = points.length; i < ii; i += 2) {
+      hasChanged = this.#outliner.add(points[i], points[i + 1]) || hasChanged;
+    }
+    return hasChanged ? { path: { d: this.#outliner.toSVGPath() } } : null;
+  }
+
+  end(x, y) {
+    return x === undefined ? null : this.add(x, y);
+  }
+
+  isEmpty() {
+    return this.#outliner.isEmpty();
+  }
+
+  isCancellable() {
+    return this.#outliner.isCancellable();
+  }
+
+  removeLastElement() {
+    return this.#outliner.removeLastElement();
+  }
+
+  updateProperty(_name, _value) {
+    // Drawing options update the SVG, but this stroke's geometry stays fixed.
+    return null;
+  }
+
+  getOutlines() {
+    const outlines = this.#outliner.getOutlines();
+    outlines.buildFocusOutline(2 * this.#thickness);
+
+    return outlines;
+  }
+
+  get defaultSVGProperties() {
+    return {
+      bbox: [0, 0, 1, 1],
+      root: {
+        viewBox: "0 0 1 1",
+      },
+      rootClass: {
+        highlight: true,
+        free: true,
+      },
+      path: {
+        d: this.#outliner.toSVGPath(),
+      },
+    };
+  }
+}
+
 class FreeHighlightOutline extends FreeDrawOutline {
-  newOutliner(point, box, scaleFactor, thickness, isLTR, innerMargin = 0) {
+  // Extra radius around the highlight.
+  static #EXTRA_THICKNESS = 1.5;
+
+  newOutliner(x, y, box, scaleFactor, thickness, isLTR, innerMargin = 0) {
     return new FreeHighlightOutliner(
-      point,
+      x,
+      y,
       box,
       scaleFactor,
       thickness,
@@ -369,6 +557,61 @@ class FreeHighlightOutline extends FreeDrawOutline {
       innerMargin
     );
   }
+
+  get isFree() {
+    return true;
+  }
+
+  /** @param {number} thickness */
+  buildFocusOutline(thickness) {
+    this.focusOutline = this.getNewOutline(
+      thickness / 2 + FreeHighlightOutline.#EXTRA_THICKNESS,
+      /* innerMargin = */ 0.0025
+    );
+  }
+
+  /** @inheritdoc */
+  get defaultSVGProperties() {
+    return getHighlightSVGProperties(this);
+  }
+
+  /** @inheritdoc */
+  getFocusSVGProperties(rotation) {
+    return getHighlightFocusSVGProperties(this, rotation);
+  }
+
+  /** @inheritdoc */
+  get focusMustRemoveSelfIntersections() {
+    // Mask out the part of the stroke inside the shape.
+    return true;
+  }
+
+  /** @inheritdoc */
+  updateRotation(rotation) {
+    return { root: { "data-main-rotation": rotation } };
+  }
+
+  /** @inheritdoc */
+  updateProperty(name, value) {
+    if (name !== "thickness") {
+      return null;
+    }
+    const bbox = this.updateThickness(value / 2);
+    this.buildFocusOutline(value);
+
+    return bbox;
+  }
+
+  /** @inheritdoc */
+  getPathResizedSVGProperties() {
+    // Thickness changes rebuild the path.
+    return { path: { d: this.toSVGPath() } };
+  }
 }
 
-export { FreeHighlightOutliner, HighlightOutliner };
+export {
+  FreeHighlightDrawer,
+  FreeHighlightOutliner,
+  HighlightOutline,
+  HighlightOutliner,
+};

--- a/src/display/editor/drawers/outline.js
+++ b/src/display/editor/drawers/outline.js
@@ -18,6 +18,9 @@ import { unreachable } from "../../../shared/util.js";
 class Outline {
   static PRECISION = 1e-4;
 
+  /** @type {Outline|null} Optional hover/selection outline drawn separately. */
+  focusOutline = null;
+
   /**
    * @returns {string} The SVG path of the outline.
    */
@@ -35,6 +38,111 @@ class Outline {
 
   serialize(_bbox, _rotation) {
     unreachable("Abstract method `serialize` must be implemented.");
+  }
+
+  /** @type {Object} */
+  // eslint-disable-next-line getter-return
+  get defaultSVGProperties() {
+    unreachable("Abstract getter `defaultSVGProperties` must be implemented.");
+  }
+
+  /** @type {Object} SVG properties used to finalize a drawing session. */
+  get defaultProperties() {
+    return this.defaultSVGProperties;
+  }
+
+  /**
+   * @param {number} _rotation - the rotation to apply to the outline.
+   * @returns {Object|null}
+   */
+  getFocusSVGProperties(_rotation) {
+    return null;
+  }
+
+  /** @type {boolean} Whether `DrawLayer.drawOutline` applies its mask. */
+  get focusMustRemoveSelfIntersections() {
+    return false;
+  }
+
+  /**
+   * @param {string} _name
+   * @param {*} _value
+   * @returns {Array<number>|Float32Array|null} The new bounding box, if any.
+   */
+  updateProperty(_name, _value) {
+    return null;
+  }
+
+  /**
+   * @param {Array<number>} _dimensions
+   * @param {number} _scale
+   * @returns {Array<number>|Float32Array|null} The new bounding box, if any.
+   */
+  updateParentDimensions(_dimensions, _scale) {
+    return null;
+  }
+
+  /**
+   * @param {Array<number>} _pageTranslation
+   * @param {Array<number>} _pageDimensions
+   * @returns {Float32Array|null}
+   */
+  serializeQuadPoints(_pageTranslation, _pageDimensions) {
+    return null;
+  }
+
+  /**
+   * @param {number} _rotation
+   * @returns {Object} the SVG properties to apply to the rotated shape.
+   */
+  updateRotation(_rotation) {
+    return {};
+  }
+
+  /**
+   * Called on each resizing step, hence the outline itself is unchanged.
+   * @param {Array<number>} _bbox - the bounding box being resized to.
+   * @returns {Object} the SVG properties to apply to the resizing shape.
+   */
+  getPathResizingSVGProperties(_bbox) {
+    return {};
+  }
+
+  /**
+   * Called once the resizing is done, hence the outline can be updated.
+   * @param {Array<number>} _bbox - the new bounding box.
+   * @returns {Object} the SVG properties to apply to the resized shape.
+   */
+  getPathResizedSVGProperties(_bbox) {
+    return {};
+  }
+
+  /**
+   * Called once the translation is done, hence the outline can be updated.
+   * @param {Array<number>} _bbox - the new bounding box.
+   * @param {Array<number>} _parentDimensions
+   * @returns {Object} the SVG properties to apply to the translated shape.
+   */
+  getPathTranslatedSVGProperties(_bbox, _parentDimensions) {
+    return {};
+  }
+
+  /**
+   * Rotate a bounding box which lives in the unit square.
+   * @param {Array<number>} bbox
+   * @param {number} angle
+   * @returns {Array<number>}
+   */
+  static _rotateBox([x, y, width, height], angle) {
+    switch (angle) {
+      case 90:
+        return [1 - y - height, x, height, width];
+      case 180:
+        return [1 - x - width, 1 - y - height, width, height];
+      case 270:
+        return [y, 1 - x - width, height, width];
+    }
+    return [x, y, width, height];
   }
 
   static _rescale(src, tx, ty, sx, sy, dest) {

--- a/src/display/editor/editor.js
+++ b/src/display/editor/editor.js
@@ -1977,6 +1977,9 @@ class AnnotationEditor {
     }
   }
 
+  /**
+   * @returns {Array<number>|null}
+   */
   get toolbarPosition() {
     return null;
   }

--- a/src/display/editor/highlight.js
+++ b/src/display/editor/highlight.js
@@ -19,74 +19,69 @@ import {
   shadow,
   Util,
 } from "../../shared/util.js";
-import { bindEvents, KeyboardManager } from "./tools.js";
+import { DrawingEditor, DrawingOptions } from "./draw.js";
 import {
+  FreeHighlightDrawer,
   FreeHighlightOutliner,
-  HighlightOutliner,
+  HighlightOutline,
 } from "./drawers/highlight.js";
 import {
   HighlightAnnotationElement,
   InkAnnotationElement,
 } from "../annotation_layer.js";
-import { noContextMenu, stopEvent } from "../display_utils.js";
 import { AnnotationEditor } from "./editor.js";
 import { ColorPicker } from "./color_picker.js";
+import { KeyboardManager } from "./tools.js";
+import { stopEvent } from "../display_utils.js";
+
+class HighlightDrawingOptions extends DrawingOptions {
+  constructor(properties = null) {
+    super();
+    super.updateProperties(properties);
+  }
+
+  /** @inheritdoc */
+  updateSVGProperty(name, value) {
+    if (name !== "thickness") {
+      // Thickness changes free-highlight geometry, not SVG attributes.
+      super.updateSVGProperty(name, value);
+    }
+  }
+
+  /** @inheritdoc */
+  clone() {
+    const clone = new HighlightDrawingOptions();
+    clone.updateAll(this);
+    return clone;
+  }
+}
 
 /**
- * Basic draw editor in order to generate an Highlight annotation.
+ * Editor for text-selection and freehand highlights.
+ * Their geometry comes from separate outline implementations.
  */
-class HighlightEditor extends AnnotationEditor {
+class HighlightEditor extends DrawingEditor {
   #anchorNode = null;
 
   #anchorOffset = 0;
-
-  #boxes;
-
-  #clipPathId = null;
-
-  #colorPicker = null;
-
-  #focusOutlines = null;
 
   #focusNode = null;
 
   #focusOffset = 0;
 
-  #highlightDiv = null;
-
-  #highlightOutlines = null;
-
-  #id = null;
-
-  #isFreeHighlight = false;
-
-  #firstPoint = null;
-
-  #lastPoint = null;
-
-  #outlineId = null;
+  #methodOfCreation = "";
 
   #text = "";
 
-  #thickness;
+  static _DEFAULT_OPACITY = 1;
 
-  #methodOfCreation = "";
+  static _DEFAULT_THICKNESS = 12;
 
-  static _defaultColor = null;
-
-  static _defaultOpacity = 1;
-
-  static _defaultThickness = 12;
+  static _defaultDrawingOptions = null;
 
   static _type = "highlight";
 
   static _editorType = AnnotationEditorType.HIGHLIGHT;
-
-  static _freeHighlightId = -1;
-
-  static _freeHighlight = null;
-
-  static _freeHighlightClipId = "";
 
   static get _keyboardManager() {
     const proto = HighlightEditor.prototype;
@@ -104,41 +99,132 @@ class HighlightEditor extends AnnotationEditor {
 
   constructor(params) {
     super({ ...params, name: "highlightEditor" });
-    this.color = params.color || HighlightEditor._defaultColor;
-    this.#thickness = params.thickness || HighlightEditor._defaultThickness;
-    this.opacity = params.opacity || HighlightEditor._defaultOpacity;
-    this.#boxes = params.boxes || null;
-    this.#methodOfCreation = params.methodOfCreation || "";
+    this.#anchorNode = params.anchorNode || null;
+    this.#anchorOffset = params.anchorOffset || 0;
+    this.#focusNode = params.focusNode || null;
+    this.#focusOffset = params.focusOffset || 0;
+    this.#methodOfCreation =
+      params.methodOfCreation ||
+      (this._drawOutlines?.isFree ? "main_toolbar" : "");
     this.#text = params.text || "";
     this._isDraggable = false;
     this.defaultL10nId = "pdfjs-editor-highlight-editor";
+    this.rotate();
+  }
 
-    if (params.highlightId > -1) {
-      this.#isFreeHighlight = true;
-      this.#createFreeOutlines(params);
-      this.#addToDrawLayer();
-    } else if (this.#boxes) {
-      this.#anchorNode = params.anchorNode;
-      this.#anchorOffset = params.anchorOffset;
-      this.#focusNode = params.focusNode;
-      this.#focusOffset = params.focusOffset;
-      this.#createOutlines();
-      this.#addToDrawLayer();
-      this.rotate(this.rotation);
-    }
+  /** @inheritdoc */
+  static initialize(l10n, uiManager) {
+    AnnotationEditor.initialize(l10n, uiManager);
+    // Preserve user-selected defaults across initialize calls.
+    this._defaultDrawingOptions ||= new HighlightDrawingOptions({
+      fill: uiManager.highlightColors?.values().next().value || "#fff066",
+      "fill-opacity": HighlightEditor._DEFAULT_OPACITY,
+      thickness: HighlightEditor._DEFAULT_THICKNESS,
+    });
+  }
 
-    if (!this.annotationElementId) {
-      this._uiManager.a11yAlert(AnnotationEditor._l10nAlert.highlight);
+  /** @inheritdoc */
+  static getDefaultDrawingOptions(options) {
+    const clone = this._defaultDrawingOptions.clone();
+    clone.updateProperties(options);
+    return clone;
+  }
+
+  /** @inheritdoc */
+  static get typesMap() {
+    return shadow(
+      this,
+      "typesMap",
+      new Map([
+        [AnnotationEditorParamsType.HIGHLIGHT_COLOR, "fill"],
+        [AnnotationEditorParamsType.HIGHLIGHT_THICKNESS, "thickness"],
+      ])
+    );
+  }
+
+  /** @inheritdoc */
+  static get isDrawer() {
+    // Free highlights start on the text layer.
+    return false;
+  }
+
+  /** @inheritdoc */
+  static get _hasClipPath() {
+    // Clip the interactive div to the highlight shape.
+    return true;
+  }
+
+  /** @inheritdoc */
+  static get _hasDrawClass() {
+    return false;
+  }
+
+  /** @inheritdoc */
+  _addOutlines(params) {
+    const { boxes, drawOutlines } = params;
+    if (!boxes && !drawOutlines) {
+      return;
     }
+    this._drawingOptions ||=
+      params.drawingOptions || HighlightEditor.getDefaultDrawingOptions();
+    if (boxes) {
+      params = {
+        ...params,
+        drawOutlines: HighlightOutline.build(
+          boxes,
+          this._uiManager.direction === "ltr"
+        ),
+      };
+    }
+    super._addOutlines(params);
+  }
+
+  get colorType() {
+    return AnnotationEditorParamsType.HIGHLIGHT_COLOR;
+  }
+
+  get color() {
+    return this._drawingOptions.fill;
+  }
+
+  get opacity() {
+    return this._drawingOptions["fill-opacity"];
+  }
+
+  /** @inheritdoc */
+  get _opacityName() {
+    // Preserve imported opacity, which the UI doesn't expose.
+    return "fill-opacity";
+  }
+
+  /** @inheritdoc */
+  get _drawRotation() {
+    // Text uses page coordinates; freehand uses editor rotation.
+    return this._drawOutlines?.isFree ? this.rotation : 0;
+  }
+
+  /** @inheritdoc */
+  get isResizable() {
+    return false;
+  }
+
+  /** @inheritdoc */
+  get _mustBeDisabledOnCommit() {
+    return false;
+  }
+
+  /** @inheritdoc */
+  get _mustFixPosition() {
+    return !this._drawOutlines?.isFree;
   }
 
   /** @inheritdoc */
   get telemetryInitialData() {
     return {
       action: "added",
-      type: this.#isFreeHighlight ? "free_highlight" : "highlight",
+      type: this._drawOutlines.isFree ? "free_highlight" : "highlight",
       color: this._uiManager.getNonHCMColorName(this.color),
-      thickness: this.#thickness,
+      thickness: this._drawingOptions.thickness,
       methodOfCreation: this.#methodOfCreation,
     };
   }
@@ -156,310 +242,81 @@ class HighlightEditor extends AnnotationEditor {
     return { numberOfColors: data.get("color").size };
   }
 
-  #createOutlines() {
-    const outliner = new HighlightOutliner(
-      this.#boxes,
-      /* borderWidth = */ 0.001
-    );
-    this.#highlightOutlines = outliner.getOutlines();
-    [this.x, this.y, this.width, this.height] = this.#highlightOutlines.box;
-
-    const outlinerForOutline = new HighlightOutliner(
-      this.#boxes,
-      /* borderWidth = */ 0.0025,
-      /* innerMargin = */ 0.001,
-      this._uiManager.direction === "ltr"
-    );
-    this.#focusOutlines = outlinerForOutline.getOutlines();
-
-    const { firstPoint } = this.#highlightOutlines;
-    this.#firstPoint = [
-      (firstPoint[0] - this.x) / this.width,
-      (firstPoint[1] - this.y) / this.height,
-    ];
-    // The last point is in the pages coordinate system.
-    const { lastPoint } = this.#focusOutlines;
-    this.#lastPoint = [
-      (lastPoint[0] - this.x) / this.width,
-      (lastPoint[1] - this.y) / this.height,
-    ];
-  }
-
-  #createFreeOutlines({ highlightOutlines, highlightId, clipPathId }) {
-    this.#highlightOutlines = highlightOutlines;
-    const extraThickness = 1.5;
-    this.#focusOutlines = highlightOutlines.getNewOutline(
-      /* Slightly bigger than the highlight in order to have a little
-         space between the highlight and the outline. */
-      this.#thickness / 2 + extraThickness,
-      /* innerMargin = */ 0.0025
-    );
-
-    if (highlightId >= 0) {
-      this.#id = highlightId;
-      this.#clipPathId = clipPathId;
-      // We need to redraw the highlight because we change the coordinates to be
-      // in the box coordinate system.
-      this.parent.drawLayer.finalizeDraw(highlightId, {
-        bbox: highlightOutlines.box,
-        path: {
-          d: highlightOutlines.toSVGPath(),
-        },
-      });
-      this.#outlineId = this.parent.drawLayer.drawOutline(
-        {
-          rootClass: {
-            highlightOutline: true,
-            free: true,
-          },
-          bbox: this.#focusOutlines.box,
-          path: {
-            d: this.#focusOutlines.toSVGPath(),
-          },
-        },
-        /* mustRemoveSelfIntersections = */ true
-      );
-    } else if (this.parent) {
-      const angle = this.parent.viewport.rotation;
-      this.parent.drawLayer.updateProperties(this.#id, {
-        bbox: HighlightEditor.#rotateBbox(
-          this.#highlightOutlines.box,
-          (angle - this.rotation + 360) % 360
-        ),
-        path: {
-          d: highlightOutlines.toSVGPath(),
-        },
-      });
-      this.parent.drawLayer.updateProperties(this.#outlineId, {
-        bbox: HighlightEditor.#rotateBbox(this.#focusOutlines.box, angle),
-        path: {
-          d: this.#focusOutlines.toSVGPath(),
-        },
-      });
-    }
-    const [x, y, width, height] = highlightOutlines.box;
-    switch (this.rotation) {
-      case 0:
-        this.x = x;
-        this.y = y;
-        this.width = width;
-        this.height = height;
-        break;
-      case 90: {
-        const [pageWidth, pageHeight] = this.parentDimensions;
-        this.x = y;
-        this.y = 1 - x;
-        this.width = (width * pageHeight) / pageWidth;
-        this.height = (height * pageWidth) / pageHeight;
-        break;
-      }
-      case 180:
-        this.x = 1 - x;
-        this.y = 1 - y;
-        this.width = width;
-        this.height = height;
-        break;
-      case 270: {
-        const [pageWidth, pageHeight] = this.parentDimensions;
-        this.x = 1 - y;
-        this.y = x;
-        this.width = (width * pageHeight) / pageWidth;
-        this.height = (height * pageWidth) / pageHeight;
-        break;
-      }
-    }
-
-    const { firstPoint } = highlightOutlines;
-    this.#firstPoint = [
-      (firstPoint[0] - x) / width,
-      (firstPoint[1] - y) / height,
-    ];
-    const { lastPoint } = this.#focusOutlines;
-    this.#lastPoint = [(lastPoint[0] - x) / width, (lastPoint[1] - y) / height];
-  }
-
-  /** @inheritdoc */
-  static initialize(l10n, uiManager) {
-    AnnotationEditor.initialize(l10n, uiManager);
-    HighlightEditor._defaultColor ||=
-      uiManager.highlightColors?.values().next().value || "#fff066";
-  }
-
-  /** @inheritdoc */
-  static updateDefaultParams(type, value) {
-    switch (type) {
-      case AnnotationEditorParamsType.HIGHLIGHT_COLOR:
-        HighlightEditor._defaultColor = value;
-        break;
-      case AnnotationEditorParamsType.HIGHLIGHT_THICKNESS:
-        HighlightEditor._defaultThickness = value;
-        break;
-    }
-  }
-
   /** @inheritdoc */
   translateInPage(x, y) {}
 
   /** @inheritdoc */
   get toolbarPosition() {
-    return this.#lastPoint;
+    return this.#relativeToBox(this._drawOutlines.focusOutline.lastPoint);
   }
 
   /** @inheritdoc */
   get commentButtonPosition() {
-    return this.#firstPoint;
+    return this.#relativeToBox(this._drawOutlines.firstPoint);
+  }
+
+  #relativeToBox([pointX, pointY]) {
+    // The point and box use page coordinates.
+    const [x, y, width, height] = this._drawOutlines.box;
+    return [(pointX - x) / width, (pointY - y) / height];
   }
 
   /** @inheritdoc */
   updateParams(type, value) {
     switch (type) {
       case AnnotationEditorParamsType.HIGHLIGHT_COLOR:
-        this.#updateColor(value);
+        // User-selected colors use the default opacity.
+        this._updateColorAndOpacity(
+          value,
+          HighlightEditor._DEFAULT_OPACITY,
+          type
+        );
+        this._reportTelemetry(
+          {
+            action: "color_changed",
+            color: this._uiManager.getNonHCMColorName(value),
+          },
+          /* mustWait = */ true
+        );
         break;
       case AnnotationEditorParamsType.HIGHLIGHT_THICKNESS:
-        this.#updateThickness(value);
+        super.updateParams(type, value);
+        this._reportTelemetry(
+          { action: "thickness_changed", thickness: value },
+          /* mustWait = */ true
+        );
         break;
     }
   }
 
-  static get defaultPropertiesToUpdate() {
-    return [
-      [
-        AnnotationEditorParamsType.HIGHLIGHT_COLOR,
-        HighlightEditor._defaultColor,
-      ],
-      [
-        AnnotationEditorParamsType.HIGHLIGHT_THICKNESS,
-        HighlightEditor._defaultThickness,
-      ],
-    ];
-  }
-
   /** @inheritdoc */
   get propertiesToUpdate() {
-    return [
-      [
-        AnnotationEditorParamsType.HIGHLIGHT_COLOR,
-        this.color || HighlightEditor._defaultColor,
-      ],
-      [
-        AnnotationEditorParamsType.HIGHLIGHT_THICKNESS,
-        this.#thickness || HighlightEditor._defaultThickness,
-      ],
-      [AnnotationEditorParamsType.HIGHLIGHT_FREE, this.#isFreeHighlight],
-    ];
-  }
-
-  /** @inheritdoc */
-  onUpdatedColor() {
-    this.parent?.drawLayer.updateProperties(this.#id, {
-      root: {
-        fill: this.color,
-        "fill-opacity": this.opacity,
-      },
-    });
-    this.#colorPicker?.updateColor(this.color);
-    super.onUpdatedColor();
-  }
-
-  /**
-   * Update the color and make this action undoable.
-   * @param {string} color
-   */
-  #updateColor(color) {
-    const setColorAndOpacity = (col, opa) => {
-      this.color = col;
-      this.opacity = opa;
-      this.onUpdatedColor();
-    };
-    const savedColor = this.color;
-    const savedOpacity = this.opacity;
-    this.addCommands({
-      cmd: setColorAndOpacity.bind(
-        this,
-        color,
-        HighlightEditor._defaultOpacity
-      ),
-      undo: setColorAndOpacity.bind(this, savedColor, savedOpacity),
-      post: this._uiManager.updateUI.bind(this._uiManager, this),
-      mustExec: true,
-      type: AnnotationEditorParamsType.HIGHLIGHT_COLOR,
-      overwriteIfSameType: true,
-      keepUndo: true,
-    });
-
-    this._reportTelemetry(
-      {
-        action: "color_changed",
-        color: this._uiManager.getNonHCMColorName(color),
-      },
-      /* mustWait = */ true
-    );
-  }
-
-  /**
-   * Update the thickness and make this action undoable.
-   * @param {number} thickness
-   */
-  #updateThickness(thickness) {
-    const savedThickness = this.#thickness;
-    const setThickness = th => {
-      this.#thickness = th;
-      this.#changeThickness(th);
-    };
-    this.addCommands({
-      cmd: setThickness.bind(this, thickness),
-      undo: setThickness.bind(this, savedThickness),
-      post: this._uiManager.updateUI.bind(this._uiManager, this),
-      mustExec: true,
-      type: AnnotationEditorParamsType.INK_THICKNESS,
-      overwriteIfSameType: true,
-      keepUndo: true,
-    });
-    this._reportTelemetry(
-      { action: "thickness_changed", thickness },
-      /* mustWait = */ true
-    );
+    const properties = super.propertiesToUpdate;
+    properties.push([
+      AnnotationEditorParamsType.HIGHLIGHT_FREE,
+      this._drawOutlines.isFree,
+    ]);
+    return properties;
   }
 
   /** @inheritdoc */
   get toolbarButtons() {
     if (this._uiManager.highlightColors) {
-      const colorPicker = (this.#colorPicker = new ColorPicker({
-        editor: this,
-      }));
-      return [["colorPicker", colorPicker]];
+      // The toolbar destroys its picker, so rebuild it with the toolbar.
+      this._colorPicker = new ColorPicker({ editor: this });
+      return [["colorPicker", this._colorPicker]];
     }
     return super.toolbarButtons;
   }
 
   /** @inheritdoc */
-  disableEditing() {
-    super.disableEditing();
-    this.div.classList.toggle("disabled", true);
-  }
-
-  /** @inheritdoc */
-  enableEditing() {
-    super.enableEditing();
-    this.div.classList.toggle("disabled", false);
-  }
-
-  /** @inheritdoc */
   fixAndSetPosition() {
-    return super.fixAndSetPosition(this.#getRotation());
-  }
-
-  /** @inheritdoc */
-  getBaseTranslation() {
-    // The editor itself doesn't have any CSS border (we're drawing one
-    // ourselves in using SVG).
-    return [0, 0];
+    return super.fixAndSetPosition(this._drawRotation);
   }
 
   /** @inheritdoc */
   getRect(tx, ty) {
-    return super.getRect(tx, ty, this.#getRotation());
+    return super.getRect(tx, ty, this._drawRotation);
   }
 
   /** @inheritdoc */
@@ -474,153 +331,10 @@ class HighlightEditor extends AnnotationEditor {
 
   /** @inheritdoc */
   remove() {
-    this.#cleanDrawLayer();
     this._reportTelemetry({
       action: "deleted",
     });
     super.remove();
-  }
-
-  /** @inheritdoc */
-  rebuild() {
-    if (!this.parent) {
-      return;
-    }
-    super.rebuild();
-    if (this.div === null) {
-      return;
-    }
-
-    this.#addToDrawLayer();
-
-    if (!this.isAttachedToDOM) {
-      // At some point this editor was removed and we're rebuilding it,
-      // hence we must add it to its parent.
-      this.parent.add(this);
-    }
-  }
-
-  setParent(parent) {
-    let mustBeSelected = false;
-    if (this.parent && !parent) {
-      this.#cleanDrawLayer();
-    } else if (parent) {
-      this.#addToDrawLayer(parent);
-      // If mustBeSelected is true it means that this editor was selected
-      // when its parent has been destroyed, hence we must select it again.
-      mustBeSelected =
-        !this.parent && this.div?.classList.contains("selectedEditor");
-    }
-    super.setParent(parent);
-    this.show(this._isVisible);
-    if (mustBeSelected) {
-      // We select it after the parent has been set.
-      this.select();
-    }
-  }
-
-  #changeThickness(thickness) {
-    if (!this.#isFreeHighlight) {
-      return;
-    }
-    this.#createFreeOutlines({
-      highlightOutlines: this.#highlightOutlines.getNewOutline(thickness / 2),
-    });
-    this.fixAndSetPosition();
-    this.setDims();
-  }
-
-  #cleanDrawLayer() {
-    if (this.#id === null || !this.parent) {
-      return;
-    }
-    this.parent.drawLayer.remove(this.#id);
-    this.#id = null;
-    this.parent.drawLayer.remove(this.#outlineId);
-    this.#outlineId = null;
-  }
-
-  #addToDrawLayer(parent = this.parent) {
-    if (this.#id !== null) {
-      return;
-    }
-    ({ id: this.#id, clipPathId: this.#clipPathId } = parent.drawLayer.draw(
-      {
-        bbox: this.#highlightOutlines.box,
-        root: {
-          viewBox: "0 0 1 1",
-          fill: this.color,
-          "fill-opacity": this.opacity,
-        },
-        rootClass: {
-          highlight: true,
-          free: this.#isFreeHighlight,
-        },
-        path: {
-          d: this.#highlightOutlines.toSVGPath(),
-        },
-      },
-      /* isPathUpdatable = */ false,
-      /* hasClip = */ true
-    ));
-    this.#outlineId = parent.drawLayer.drawOutline(
-      {
-        rootClass: {
-          highlightOutline: true,
-          free: this.#isFreeHighlight,
-        },
-        bbox: this.#focusOutlines.box,
-        path: {
-          d: this.#focusOutlines.toSVGPath(),
-        },
-      },
-      /* mustRemoveSelfIntersections = */ this.#isFreeHighlight
-    );
-
-    if (this.#highlightDiv) {
-      this.#highlightDiv.style.clipPath = this.#clipPathId;
-    }
-  }
-
-  static #rotateBbox([x, y, width, height], angle) {
-    switch (angle) {
-      case 90:
-        return [1 - y - height, x, height, width];
-      case 180:
-        return [1 - x - width, 1 - y - height, width, height];
-      case 270:
-        return [y, 1 - x - width, height, width];
-    }
-    return [x, y, width, height];
-  }
-
-  /** @inheritdoc */
-  rotate(angle) {
-    // We need to rotate the svgs because of the coordinates system.
-    const { drawLayer } = this.parent;
-    let box;
-    if (this.#isFreeHighlight) {
-      angle = (angle - this.rotation + 360) % 360;
-      box = HighlightEditor.#rotateBbox(this.#highlightOutlines.box, angle);
-    } else {
-      // An highlight annotation is always drawn horizontally.
-      box = HighlightEditor.#rotateBbox(
-        [this.x, this.y, this.width, this.height],
-        angle
-      );
-    }
-    drawLayer.updateProperties(this.#id, {
-      bbox: box,
-      root: {
-        "data-main-rotation": angle,
-      },
-    });
-    drawLayer.updateProperties(this.#outlineId, {
-      bbox: HighlightEditor.#rotateBbox(this.#focusOutlines.box, angle),
-      root: {
-        "data-main-rotation": angle,
-      },
-    });
   }
 
   /** @inheritdoc */
@@ -634,44 +348,16 @@ class HighlightEditor extends AnnotationEditor {
       div.setAttribute("aria-label", this.#text);
       div.setAttribute("role", "mark");
     }
-    if (this.#isFreeHighlight) {
+    if (this._drawOutlines.isFree) {
       div.classList.add("free");
     } else {
-      this.div.addEventListener("keydown", this.#keydown.bind(this), {
+      div.addEventListener("keydown", this.#keydown.bind(this), {
         signal: this._uiManager._signal,
       });
     }
-    const highlightDiv = (this.#highlightDiv = document.createElement("div"));
-    div.append(highlightDiv);
-    highlightDiv.setAttribute("aria-hidden", "true");
-    highlightDiv.className = "internal";
-    highlightDiv.style.clipPath = this.#clipPathId;
-    this.setDims();
-
-    bindEvents(this, this.#highlightDiv, ["pointerover", "pointerleave"]);
     this.enableEditing();
 
     return div;
-  }
-
-  pointerover() {
-    if (!this.isSelected) {
-      this.parent?.drawLayer.updateProperties(this.#outlineId, {
-        rootClass: {
-          hovered: true,
-        },
-      });
-    }
-  }
-
-  pointerleave() {
-    if (!this.isSelected) {
-      this.parent?.drawLayer.updateProperties(this.#outlineId, {
-        rootClass: {
-          hovered: false,
-        },
-      });
-    }
   }
 
   #keydown(event) {
@@ -705,179 +391,120 @@ class HighlightEditor extends AnnotationEditor {
   }
 
   /** @inheritdoc */
-  select() {
-    super.select();
-    if (!this.#outlineId) {
-      return;
-    }
-    this.parent?.drawLayer.updateProperties(this.#outlineId, {
-      rootClass: {
-        hovered: false,
-        selected: true,
-      },
-    });
-  }
-
-  /** @inheritdoc */
   unselect() {
     super.unselect();
-    if (!this.#outlineId) {
-      return;
-    }
-    this.parent?.drawLayer.updateProperties(this.#outlineId, {
-      rootClass: {
-        selected: false,
-      },
-    });
-    if (!this.#isFreeHighlight) {
+    if (!this._drawOutlines.isFree) {
       this.#setCaret(/* start = */ false);
     }
   }
 
   /** @inheritdoc */
-  get _mustFixPosition() {
-    return !this.#isFreeHighlight;
+  static createDrawerInstance({ x, y, box, parent, isLTR }) {
+    // The outliner spreads the stroke on both sides of the pointer path, hence
+    // it takes the half-thickness. The inner margin slightly inflates the
+    // bounding box, else the shape would be clipped by its own SVG viewport.
+    return new FreeHighlightDrawer(
+      x,
+      y,
+      box,
+      parent.scale,
+      this._defaultDrawingOptions.thickness / 2,
+      isLTR,
+      /* innerMargin = */ 0.001
+    );
   }
 
   /** @inheritdoc */
-  show(visible = this._isVisible) {
-    super.show(visible);
-    if (this.parent) {
-      this.parent.drawLayer.updateProperties(this.#id, {
-        rootClass: {
-          hidden: !visible,
-        },
-      });
-      this.parent.drawLayer.updateProperties(this.#outlineId, {
-        rootClass: {
-          hidden: !visible,
-        },
-      });
-    }
+  static _getDrawingTarget(parent, { target }) {
+    // The event target can be a child of the text layer.
+    return target.closest(".textLayer");
   }
 
-  #getRotation() {
-    // Highlight annotations are always drawn horizontally but if
-    // a free highlight annotation can be rotated.
-    return this.#isFreeHighlight ? this.rotation : 0;
+  /** @inheritdoc */
+  static _getPointerCoords({ x, y }) {
+    // Child-relative offsets don't match the text layer's client box.
+    return [x, y];
   }
 
-  #serializeBoxes() {
-    if (this.#isFreeHighlight) {
-      return null;
-    }
-    const [pageWidth, pageHeight] = this.pageDimensions;
-    const [pageX, pageY] = this.pageTranslation;
-    const boxes = this.#boxes;
-    const quadPoints = new Float32Array(boxes.length * 8);
-    let i = 0;
-    for (const { x, y, width, height } of boxes) {
-      const sx = x * pageWidth + pageX;
-      const sy = (1 - y) * pageHeight + pageY;
-      // Serializes the rectangle in the Adobe Acrobat format.
-      // The rectangle's coordinates (b = bottom, t = top, L = left, R = right)
-      // are ordered as follows: tL, tR, bL, bR (bL origin).
-      quadPoints[i] = quadPoints[i + 4] = sx;
-      quadPoints[i + 1] = quadPoints[i + 3] = sy;
-      quadPoints[i + 2] = quadPoints[i + 6] = sx + width * pageWidth;
-      quadPoints[i + 5] = quadPoints[i + 7] = sy - height * pageHeight;
-      i += 8;
-    }
-    return quadPoints;
-  }
-
-  #serializeOutlines(rect) {
-    return this.#highlightOutlines.serialize(rect, this.#getRotation());
-  }
-
-  static startHighlighting(parent, isLTR, { target: textLayer, x, y }) {
-    const {
-      x: layerX,
-      y: layerY,
-      width: parentWidth,
-      height: parentHeight,
-    } = textLayer.getBoundingClientRect();
-
-    const ac = new AbortController();
-    const signal = parent.combinedSignal(ac);
-
-    const pointerUpCallback = e => {
-      ac.abort();
-      this.#endHighlight(parent, e);
-    };
-    window.addEventListener("blur", pointerUpCallback, { signal });
-    window.addEventListener("pointerup", pointerUpCallback, { signal });
+  /** @inheritdoc */
+  static _addDrawingListeners(target, signal) {
+    // Highlights bypass AnnotationEditorLayer.startDrawingSession.
+    target.classList.add("free");
+    signal.addEventListener("abort", () => target.classList.remove("free"), {
+      once: true,
+    });
+    window.addEventListener("blur", () => this._endDraw(null), { signal });
     window.addEventListener(
       "pointerdown",
-      stopEvent /* Avoid to have undesired clicks during the drawing. */,
+      stopEvent /* Prevent pointerdown from reaching page content. */,
       {
         capture: true,
         passive: false,
         signal,
       }
     );
-    window.addEventListener("contextmenu", noContextMenu, { signal });
+  }
 
-    textLayer.addEventListener(
-      "pointermove",
-      this.#highlightMove.bind(this, parent),
-      { signal }
-    );
-    this._freeHighlight = new FreeHighlightOutliner(
-      { x, y },
-      [layerX, layerY, parentWidth, parentHeight],
-      parent.scale,
-      this._defaultThickness / 2,
-      isLTR,
+  /** @inheritdoc */
+  static _endDrawingSession(isAborted = false) {
+    return this.endDrawing(isAborted);
+  }
+
+  /** @inheritdoc */
+  createDrawingOptions({ color, opacity, thickness }) {
+    const { _defaultDrawingOptions: defaults, _DEFAULT_OPACITY } =
+      HighlightEditor;
+    this._drawingOptions = HighlightEditor.getDefaultDrawingOptions({
+      fill: Util.makeHexColor(...color),
+      "fill-opacity": opacity || _DEFAULT_OPACITY,
+      thickness: thickness || defaults.thickness,
+    });
+  }
+
+  /** @inheritdoc */
+  static deserializeDraw(
+    pageX,
+    pageY,
+    pageWidth,
+    pageHeight,
+    _innerMargin,
+    data,
+    uiManager
+  ) {
+    const { quadPoints } = data;
+    if (quadPoints) {
+      const boxes = [];
+      for (let i = 0, ii = quadPoints.length; i < ii; i += 8) {
+        boxes.push({
+          x: (quadPoints[i] - pageX) / pageWidth,
+          y: 1 - (quadPoints[i + 1] - pageY) / pageHeight,
+          width: (quadPoints[i + 2] - quadPoints[i]) / pageWidth,
+          height: (quadPoints[i + 1] - quadPoints[i + 5]) / pageHeight,
+        });
+      }
+      return HighlightOutline.build(boxes, uiManager.direction === "ltr");
+    }
+
+    const thickness = data.thickness || this._defaultDrawingOptions.thickness;
+    const points = (data.inkLists || data.outlines.points)[0];
+    // As in `createDrawerInstance`, the outliner takes the half-thickness and a
+    // non-null inner margin.
+    const outliner = new FreeHighlightOutliner(
+      points[0] - pageX,
+      pageHeight - (points[1] - pageY),
+      [0, 0, pageWidth, pageHeight],
+      1,
+      thickness / 2,
+      true,
       /* innerMargin = */ 0.001
     );
-    ({ id: this._freeHighlightId, clipPathId: this._freeHighlightClipId } =
-      parent.drawLayer.draw(
-        {
-          bbox: [0, 0, 1, 1],
-          root: {
-            viewBox: "0 0 1 1",
-            fill: this._defaultColor,
-            "fill-opacity": this._defaultOpacity,
-          },
-          rootClass: {
-            highlight: true,
-            free: true,
-          },
-          path: {
-            d: this._freeHighlight.toSVGPath(),
-          },
-        },
-        /* isPathUpdatable = */ true,
-        /* hasClip = */ true
-      ));
-  }
-
-  static #highlightMove(parent, event) {
-    if (this._freeHighlight.add(event)) {
-      // Redraw only if the point has been added.
-      parent.drawLayer.updateProperties(this._freeHighlightId, {
-        path: {
-          d: this._freeHighlight.toSVGPath(),
-        },
-      });
+    for (let i = 0, ii = points.length; i < ii; i += 2) {
+      outliner.add(points[i] - pageX, pageHeight - (points[i + 1] - pageY));
     }
-  }
+    const outlines = outliner.getOutlines();
+    outlines.buildFocusOutline(thickness);
 
-  static #endHighlight(parent, event) {
-    if (!this._freeHighlight.isEmpty()) {
-      parent.createAndAddNewEditor(event, false, {
-        highlightId: this._freeHighlightId,
-        highlightOutlines: this._freeHighlight.getOutlines(),
-        clipPathId: this._freeHighlightClipId,
-        methodOfCreation: "main_toolbar",
-      });
-    } else {
-      parent.drawLayer.remove(this._freeHighlightId);
-    }
-    this._freeHighlightId = -1;
-    this._freeHighlight = null;
-    this._freeHighlightClipId = "";
+    return outlines;
   }
 
   /** @inheritdoc */
@@ -907,7 +534,6 @@ class HighlightEditor extends AnnotationEditor {
         color: Array.from(color),
         opacity,
         quadPoints,
-        boxes: null,
         pageIndex: pageNumber - 1,
         rect: rect.slice(0),
         rotation,
@@ -944,7 +570,6 @@ class HighlightEditor extends AnnotationEditor {
         color: Array.from(color),
         thickness,
         inkLists,
-        boxes: null,
         pageIndex: pageNumber - 1,
         rect: rect.slice(0),
         rotation,
@@ -959,81 +584,10 @@ class HighlightEditor extends AnnotationEditor {
       };
     }
 
-    const { color, quadPoints, inkLists, outlines, opacity } = data;
     const editor = await super.deserialize(data, parent, uiManager);
-
-    editor.color = Util.makeHexColor(...color);
-    editor.opacity = opacity || 1;
-    if (inkLists) {
-      editor.#thickness = data.thickness;
-    }
     editor._initialData = initialData;
     if (data.comment) {
       editor.setCommentData(data);
-    }
-
-    const [pageWidth, pageHeight] = editor.pageDimensions;
-    const [pageX, pageY] = editor.pageTranslation;
-
-    if (quadPoints) {
-      const boxes = (editor.#boxes = []);
-      for (let i = 0; i < quadPoints.length; i += 8) {
-        boxes.push({
-          x: (quadPoints[i] - pageX) / pageWidth,
-          y: 1 - (quadPoints[i + 1] - pageY) / pageHeight,
-          width: (quadPoints[i + 2] - quadPoints[i]) / pageWidth,
-          height: (quadPoints[i + 1] - quadPoints[i + 5]) / pageHeight,
-        });
-      }
-      editor.#createOutlines();
-      editor.#addToDrawLayer();
-      editor.rotate(editor.rotation);
-    } else if (inkLists || outlines) {
-      editor.#isFreeHighlight = true;
-      const points = (inkLists || outlines.points)[0];
-      const point = {
-        x: points[0] - pageX,
-        y: pageHeight - (points[1] - pageY),
-      };
-      const outliner = new FreeHighlightOutliner(
-        point,
-        [0, 0, pageWidth, pageHeight],
-        1,
-        editor.#thickness / 2,
-        true,
-        0.001
-      );
-      for (let i = 0, ii = points.length; i < ii; i += 2) {
-        point.x = points[i] - pageX;
-        point.y = pageHeight - (points[i + 1] - pageY);
-        outliner.add(point);
-      }
-      const { id, clipPathId } = parent.drawLayer.draw(
-        {
-          bbox: [0, 0, 1, 1],
-          root: {
-            viewBox: "0 0 1 1",
-            fill: editor.color,
-            "fill-opacity": editor._defaultOpacity,
-          },
-          rootClass: {
-            highlight: true,
-            free: true,
-          },
-          path: {
-            d: outliner.toSVGPath(),
-          },
-        },
-        /* isPathUpdatable = */ true,
-        /* hasClip = */ true
-      );
-      editor.#createFreeOutlines({
-        highlightOutlines: outliner.getOutlines(),
-        highlightId: id,
-        clipPathId,
-      });
-      editor.#addToDrawLayer();
-      editor.rotate(editor.parentRotation);
     }
 
     return editor;
@@ -1050,16 +604,21 @@ class HighlightEditor extends AnnotationEditor {
       return this.serializeDeleted();
     }
 
-    const color = AnnotationEditor._colorManager.convert(
-      this._uiManager.getNonHCMColor(this.color)
-    );
     const serialized = super.serialize(isForCopying);
     Object.assign(serialized, {
-      color,
+      color: AnnotationEditor._colorManager.convert(
+        this._uiManager.getNonHCMColor(this.color)
+      ),
       opacity: this.opacity,
-      thickness: this.#thickness,
-      quadPoints: this.#serializeBoxes(),
-      outlines: this.#serializeOutlines(serialized.rect),
+      thickness: this._drawingOptions.thickness,
+      quadPoints: this._drawOutlines.serializeQuadPoints(
+        this.pageTranslation,
+        this.pageDimensions
+      ),
+      outlines: this._drawOutlines.serialize(
+        serialized.rect,
+        this._drawRotation
+      ),
     });
     this.addComment(serialized);
 
@@ -1090,10 +649,6 @@ class HighlightEditor extends AnnotationEditor {
     });
 
     return null;
-  }
-
-  static canCreateNewEmptyEditor() {
-    return false;
   }
 }
 

--- a/src/display/editor/ink.js
+++ b/src/display/editor/ink.js
@@ -106,12 +106,12 @@ class InkEditor extends DrawingEditor {
   }
 
   /** @inheritdoc */
-  static createDrawerInstance(x, y, parentWidth, parentHeight, rotation) {
+  static createDrawerInstance({ x, y, box: [, , width, height], rotation }) {
     return new InkDrawOutliner(
       x,
       y,
-      parentWidth,
-      parentHeight,
+      width,
+      height,
       rotation,
       this._defaultDrawingOptions["stroke-width"]
     );

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -613,6 +613,47 @@ describe("Highlight Editor", () => {
     });
   });
 
+  describe("Free highlight drawing state", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must be cleared when the pointer is released outside the text layer", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await switchToHighlight(page);
+
+          const rect = await getRect(page, ".textLayer");
+          const x = rect.x + 40;
+          const y = rect.y + 40;
+          const clickHandle = await waitForPointerUp(page);
+
+          await page.mouse.move(x, y);
+          await page.mouse.down();
+          await page.waitForSelector(".textLayer.highlighting.free");
+          await page.mouse.move(x + 40, y + 40);
+          await page.mouse.move(rect.x - 10, y);
+          await page.mouse.up();
+          await awaitPromise(clickHandle);
+
+          await page.waitForSelector(".textLayer.highlighting:not(.free)", {
+            visible: true,
+          });
+          const isFree = await page.$eval(".textLayer", element =>
+            element.classList.contains("free")
+          );
+          expect(isFree).withContext(`In ${browserName}`).toEqual(false);
+        })
+      );
+    });
+  });
+
   describe("Highlight with the keyboard", () => {
     let pages;
 

--- a/web/annotation_editor_layer_builder.js
+++ b/web/annotation_editor_layer_builder.js
@@ -137,6 +137,15 @@ class AnnotationEditorLayerBuilder {
     this.show();
   }
 
+  /** @param {PageViewport} viewport */
+  update(viewport) {
+    if (this.div) {
+      this.annotationEditorLayer.update({
+        viewport: viewport.clone({ dontFlip: true }),
+      });
+    }
+  }
+
   cancel() {
     this._cancelled = true;
 

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -860,6 +860,9 @@ class PDFPageView extends BasePDFPageView {
       }
     }
     this.cssTransform({});
+    // Drawings stay visible in the unrotated canvas wrapper while the other
+    // kept layers are hidden, so reposition them before reset().
+    this.annotationEditorLayer?.update(this.viewport);
     this.reset({
       keepAnnotationLayer: true,
       keepAnnotationEditorLayer: true,

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -309,7 +309,7 @@ class Toolbar {
       eventBus.on(
         "mainhighlightcolorpickerupdatecolor",
         ({ value }) => {
-          this.#colorPicker?.updateColor(value);
+          this.#colorPicker?.update(value);
         },
         internalOpt
       );


### PR DESCRIPTION
Reuse DrawingEditor drawing lifecycle and outline handling for text and free highlights. This also fixes highlight rotation, pointer handling, and serialization.