### PR TITLE
Remove unnecessary `typeof` check in `Field.prototype.currentValueIndices`

### DIFF
--- a/src/scripting_api/field.js
+++ b/src/scripting_api/field.js
@@ -109,13 +109,7 @@ class Field extends PDFObject {
       indices = [indices];
     }
     if (
-      !indices.every(
-        i =>
-          typeof i === "number" &&
-          Number.isInteger(i) &&
-          i >= 0 &&
-          i < this.numItems
-      )
+      !indices.every(i => Number.isInteger(i) && i >= 0 && i < this.numItems)
     ) {
       return;
     }


### PR DESCRIPTION
There's no point in first checking if something is a number, when we *immediately* afterwards have a `Number.isInteger(...)` check.