### PR TITLE
Fix a Safari crash in the selectionchange handler

### DIFF
--- a/web/text_layer_builder.js
+++ b/web/text_layer_builder.js
@@ -351,14 +351,14 @@ class TextLayerBuilder {
         }
         if (!modifyStart && range.endOffset === 0) {
           do {
-            while (!anchor.previousSibling) {
+            while (anchor && !anchor.previousSibling) {
               anchor = anchor.parentNode;
             }
-            anchor = anchor.previousSibling;
-          } while (!anchor.childNodes.length);
+            anchor = anchor?.previousSibling;
+          } while (anchor && !anchor.childNodes.length);
         }
 
-        const parentTextLayer = anchor.parentElement?.closest(".textLayer");
+        const parentTextLayer = anchor?.parentElement?.closest(".textLayer");
         const endDiv = this.#textLayers.get(parentTextLayer);
         if (endDiv) {
           endDiv.style.width = parentTextLayer.style.width;


### PR DESCRIPTION
## The problem

Safari throws an unhandled `TypeError` in the global `selectionchange` listener of `TextLayerBuilder`:

```
TypeError: null is not an object (evaluating 'anchor.previousSibling')
```

The listener searches for the node that comes before the end of the selection
(`web/text_layer_builder.js`, in `#enableGlobalSelectionListener`).
The search moves the `anchor` variable up with `parentNode` and back with `previousSibling`.
The search has no null check.

Only Safari comes to this code:

- Firefox returns early, because of the `isFirefox` check.
- Chromium 148 and later versions return early, because of #21514.
- Chrome and Firefox do not report these boundary shapes for user selections.

The crash is frequent. The error telemetry of our application shows more than 1500 events
from 143 users in four months, across Safari 16 through Safari 26. All events come from
Safari on macOS. Our session data shows a common sequence: the user closes a modal PDF
preview, continues to use the page, and the next `selectionchange` event throws.

## The solution

Add a null guard to the three expressions that read `anchor`:

```diff
       if (!modifyStart && range.endOffset === 0) {
         do {
-          while (!anchor.previousSibling) {
+          while (anchor && !anchor.previousSibling) {
             anchor = anchor.parentNode;
           }
-          anchor = anchor.previousSibling;
-        } while (!anchor.childNodes.length);
+          anchor = anchor?.previousSibling;
+        } while (anchor && !anchor.childNodes.length);
       }

-      const parentTextLayer = anchor.parentElement?.closest(".textLayer");
+      const parentTextLayer = anchor?.parentElement?.closest(".textLayer");
```


## Tests

To see the crash, make the boundary shape directly. In Safari on macOS:

1. Open https://mozilla.github.io/pdf.js/web/viewer.html (or any PDF in the viewer).
2. Open the Web Inspector console.
3. Run this code:

```js
const r = document.createRange();
r.setStart(document.querySelector(".textLayer"), 0);
r.setEnd(document.documentElement, 0);
getSelection().removeAllRanges();
getSelection().addRange(r);
```

Without this change, the console shows the `TypeError`. This reproduces on the live demo
viewer (pdf.js 6.3.175 at the time of this report) in Safari.
With this change, no error occurs.

Note: the exact user gesture that makes Safari report this boundary shape is version
dependent. Our telemetry shows the events on Safari 16 through Safari 26 in normal use,
but recent Safari versions report the shape less often. The code above makes the same
boundary shape that Safari makes, and gives a stable reproduction on all versions.
