### PR TITLE
Shorten some `Array.prototype.map()` callbacks

### DIFF
--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -966,7 +966,7 @@ function createNameTable(name, proto) {
     proto[0][8] || "Unknown", // 8.Manufacturer
     proto[0][9] || "Unknown", // 9.Designer
   ];
-  const stringsBytes = strings.map(s => stringToBytes(s));
+  const stringsBytes = strings.map(stringToBytes);
 
   // Mac want 1-byte per character strings while Windows want
   // 2-bytes per character, so duplicate the names table

--- a/src/core/struct_tree.js
+++ b/src/core/struct_tree.js
@@ -728,7 +728,7 @@ class StructElementNode {
         if (Array.isArray(headers)) {
           const ids = headers
             .filter(header => typeof header === "string")
-            .map(header => stringToPDFString(header));
+            .map(stringToPDFString);
           if (ids.length > 0) {
             map.set("headers", ids);
           }

--- a/src/core/xfa/xhtml.js
+++ b/src/core/xfa/xhtml.js
@@ -265,7 +265,7 @@ class XhtmlObject extends XmlObject {
           xfaFont.letterSpacing = getMeasurement(value);
           break;
         case "margin":
-          const values = value.split(/ \t/).map(x => getMeasurement(x));
+          const values = value.split(/ \t/).map(getMeasurement);
           switch (values.length) {
             case 1:
               margin.top =

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -654,8 +654,8 @@ class AnnotationElement {
       return;
     }
 
-    const [rectBlX, rectBlY, rectTrX, rectTrY] = this.data.rect.map(x =>
-      Math.fround(x)
+    const [rectBlX, rectBlY, rectTrX, rectTrY] = this.data.rect.map(
+      Math.fround
     );
 
     if (quadPoints.length === 8) {

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -867,7 +867,7 @@ describe("FreeText Editor", () => {
             }, proprName);
 
           const rects = (await serialize("rect")).map(rect =>
-            rect.slice(0, 2).map(x => Math.floor(x))
+            rect.slice(0, 2).map(Math.floor)
           );
           const expected = [
             [-28, 695],


### PR DESCRIPTION
In a few spots we can directly pass the function, and don't need to create an "intermediate" arrow function.