### PR TITLE
Use `Array.prototype.filter(Boolean)` more, when filtering out truthy values

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1980,7 +1980,7 @@ class PDFDocument {
         for (const [name, promises] of fieldPromises) {
           allPromises.push(
             Promise.all(promises).then(fields => {
-              fields = fields.filter(field => !!field);
+              fields = fields.filter(Boolean);
               if (fields.length > 0) {
                 allFields.set(name, fields);
               }

--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -1291,7 +1291,7 @@ class PDFEditor {
     }
 
     await Promise.all(promises);
-    newAnnotations = newAnnotations.filter(annot => !!annot);
+    newAnnotations = newAnnotations.filter(Boolean);
     pageData.annotations = newAnnotations.length > 0 ? newAnnotations : null;
     pageData.documentData.hasSignatureAnnotations ||= hasSignatureAnnotations;
   }
@@ -2377,7 +2377,7 @@ class PDFEditor {
     const numPages = document.numPages;
     const labelsByPageIndex = new Map();
     const oldPageIndices = new Set(
-      this.oldPages.filter(p => !!p).map(({ page: { pageIndex } }) => pageIndex)
+      this.oldPages.filter(Boolean).map(({ page: { pageIndex } }) => pageIndex)
     );
     let currentLabel = null;
     let stFirstIndex = -1;

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -515,7 +515,7 @@ class WorkerMessageHandler {
           }
           await Promise.all(pagePromises);
           const annotations = await Promise.all(annotationPromises);
-          return annotations.filter(a => !!a);
+          return annotations.filter(Boolean);
         } finally {
           if (task) {
             finishWorkerTask(task);

--- a/src/core/xfa/config.js
+++ b/src/core/xfa/config.js
@@ -426,7 +426,7 @@ class EquateRange extends XFAObject {
     for (let range of unicodeRange
       .split(",")
       .map(x => x.trim())
-      .filter(x => !!x)) {
+      .filter(Boolean)) {
       range = range.split("-", 2).map(x => {
         const found = x.match(unicodeRegex);
         if (!found) {

--- a/src/core/xfa/template.js
+++ b/src/core/xfa/template.js
@@ -5703,7 +5703,7 @@ class Text extends ContentObject {
     if (typeof this[$content] === "string") {
       return this[$content]
         .split(/[\u2029\u2028\n]/)
-        .filter(line => !!line)
+        .filter(Boolean)
         .join("\n");
     }
     return this[$content][$text]();

--- a/test/unit/display_utils_spec.js
+++ b/test/unit/display_utils_spec.js
@@ -407,7 +407,7 @@ describe("display_utils", function () {
     // Unlike other tests we cannot simply compare the HTML-strings since
     // Chrome and Firefox produce different results. Instead we compare sets
     // containing the individual parts of the HTML-strings.
-    const splitParts = s => new Set(s.split(/[<>/ ]+/).filter(x => x));
+    const splitParts = s => new Set(s.split(/[<>/ ]+/).filter(Boolean));
 
     it("should render plain text", function () {
       if (isNodeJS) {

--- a/web/new_alt_text_manager.js
+++ b/web/new_alt_text_manager.js
@@ -498,7 +498,7 @@ class NewAltTextManager {
       text
         .toLowerCase()
         .split(/[^\p{L}\p{N}]+/gu)
-        .filter(x => !!x)
+        .filter(Boolean)
     );
   }
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -629,7 +629,7 @@ class PDFFindController {
     }
     // We don't bother caching the normalized search query in the Array-case,
     // since this code-path is *essentially* unused in the default viewer.
-    return (query || []).filter(q => !!q).map(q => normalize(q)[0]);
+    return (query || []).filter(Boolean).map(q => normalize(q)[0]);
   }
 
   #shouldDirtyMatch(state) {


### PR DESCRIPTION
There are some spots where we want to filter out any truthy values, where that's currently done with an arrow function. Those cases can instead use `Boolean` as the callback function, which is a pattern that newer parts of the code-base is already using.