### PR TITLE
Enable the `unicorn/no-multiple-promise-resolver-calls` linting rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -164,6 +164,7 @@ export default [
       "unicorn/no-incorrect-query-selector": "error",
       "unicorn/no-instanceof-builtins": "error",
       "unicorn/no-invalid-remove-event-listener": "error",
+      "unicorn/no-multiple-promise-resolver-calls": "error",
       "unicorn/no-new-buffer": "error",
       "unicorn/no-single-promise-in-promise-methods": "error",
       "unicorn/no-typeof-undefined": ["error", { checkGlobalVariables: false }],

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -883,6 +883,7 @@ function runTests(testsName, { bot = false } = {}) {
     testProcess.on("close", function (code) {
       if (code !== 0) {
         reject(new Error(`Running ${testsName} tests failed.`));
+        return;
       }
       resolve();
     });


### PR DESCRIPTION
More information about this rule can be found in the documentation at https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-multiple-promise-resolver-calls.md.