### PR TITLE
Remove unnecessary `!lzwState` check in `LZWStream.prototype.readBlock`

### DIFF
--- a/src/core/lzw_stream.js
+++ b/src/core/lzw_stream.js
@@ -65,11 +65,7 @@ class LZWStream extends DecodeStream {
     let estimatedDecodedSize = blockSize * 2;
     let i, j, q;
 
-    const lzwState = this.lzwState;
-    if (!lzwState) {
-      return; // eof was found
-    }
-
+    const { lzwState } = this;
     const earlyChange = lzwState.earlyChange;
     let nextCode = lzwState.nextCode;
     const dictionaryValues = lzwState.dictionaryValues;


### PR DESCRIPTION
According to the coverage data this is now dead code; see https://app.codecov.io/gh/mozilla/pdf.js/commit/6694c0eca8c80e3b0aaefa1ad3b76d9317ab2466/blob/src/core/lzw_stream.js?dropdown=coverage#L69

The reason that this check isn't necessary is that the `DecodeStream` class always checks that `!this.eof` holds *before* invoking the `readBlock` method.
Looking at the other `DecodeStream` sub-classes they generally rely on this fact, since there's no other `readBlock` implementation with a similar check.
Finally, note that `this.lzwState` is only removed in a single case where `this.eof = true;` is also being set; see https://github.com/mozilla/pdf.js/blob/6694c0eca8c80e3b0aaefa1ad3b76d9317ab2466/src/core/lzw_stream.js#L108-L112

---

*Edit:* As shown in https://app.codecov.io/gh/mozilla/pdf.js/pull/21788, this brings code coverage for the `src/core/lzw_stream.js` file to 100 percent.