### PR TITLE
Fix the RTL layout of the views manager header (bug 2060033)

### DIFF
--- a/web/menu.css
+++ b/web/menu.css
@@ -159,7 +159,7 @@ button.hasPopupMenu {
       position: absolute;
       inset-inline-start: var(--menuitem-gap);
       top: 50%;
-      transform: translateY(-50%);
+      transform: translateY(-50%) scaleX(var(--dir-factor));
     }
 
     &:disabled {

--- a/web/views_manager.css
+++ b/web/views_manager.css
@@ -334,7 +334,8 @@
       align-self: stretch;
       justify-content: space-between;
       width: auto;
-      padding: 12px 16px 12px 8px;
+      padding-block: 12px;
+      padding-inline: 8px 16px;
 
       &:not(:has(#viewsManagerHeaderLabel ~ button:not([hidden])))::after {
         /* If one of the following buttons is visible, hide the placeholder
@@ -372,7 +373,7 @@
             display: inline-block;
             width: 12px;
             height: 12px;
-            margin-left: 8px;
+            margin-inline-start: 8px;
             mask-repeat: no-repeat;
             mask-position: center;
             mask-image: var(--views-manager-button-arrow-icon);


### PR DESCRIPTION
The chevron and the header padding used physical properties, so they didn't mirror in RTL: the chevron ended up flush against the pages icon and the selector and trailing buttons had their insets swapped.

The menu check mark is a "V" shaped glyph, hence it must be mirrored too, as it's already done for the check mark of the signature properties.