### PR TITLE
Set the direction of the floating toolbar in RTL locales (bug 2060032)

### DIFF
--- a/src/display/editor/toolbar.js
+++ b/src/display/editor/toolbar.js
@@ -277,6 +277,10 @@ class FloatingToolbar {
     const editToolbar = (this.#toolbar = document.createElement("div"));
     editToolbar.className = "editToolbar";
     editToolbar.setAttribute("role", "toolbar");
+    // The toolbar is inserted in the text layer which is always LTR (see
+    // `.pdfViewer .page`), hence the direction must be set here in order to
+    // have `inset-inline-end` (see `show`) resolved against the UI direction.
+    editToolbar.dir = this.#uiManager.direction;
 
     const signal = this.#uiManager._signal;
     if (signal instanceof AbortSignal && !signal.aborted) {

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -1437,6 +1437,48 @@ describe("Highlight Editor", () => {
     });
   });
 
+  describe("Floating highlight button in a RTL locale", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        ".annotationEditorLayer",
+        null,
+        null,
+        { locale: "ar" }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must check that the floating toolbar is next to the selected text", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const { x, y, width, height } = await getSpanRectFromText(
+            page,
+            1,
+            "Abstract"
+          );
+          await page.mouse.click(x + width / 2, y + height / 2, {
+            count: 2,
+            delay: 100,
+          });
+
+          const toolbarRect = await getRect(page, ".textLayer .editToolbar");
+
+          // In RTL, the left edge of the toolbar is aligned on the left edge
+          // of the selection (bug 2060032).
+          expect(toolbarRect.x)
+            .withContext(`In ${browserName}`)
+            .toBeCloseTo(x, 0);
+        })
+      );
+    });
+  });
+
   describe("Text layer must have the focus before highlights", () => {
     let pages;
 


### PR DESCRIPTION
The toolbar is appended to the text layer, which is always LTR (see `.pdfViewer .page`), hence the `inset-inline-end` used to position it always resolved to `right` while in RTL the anchor point is the left edge of the selection: the toolbar ended up on the other side of the page.

The annotation editor layer already sets its own direction, so just do the same here.