### PR TITLE
Let link annotations own their text

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -4136,12 +4136,19 @@ class AnnotationLayer {
       this.#hasAriaAttributesFromStructTree = true;
       for (const {
         contentElement,
-        data: { id },
+        data: { hidden, id, oc },
       } of this.#elements) {
         const annotationId = (contentElement.id = `${AnnotationPrefix}${id}`);
+        // An unbound link has no <a>, hidden links aren't exposed, and
+        // optional-content visibility can change after this one-time setup.
+        // Keep the structure-tree Link fallback in all three cases; a visible
+        // optional-content link can therefore remain duplicated, matching the
+        // pre-existing behavior.
+        const enableLinkOwnership =
+          contentElement.localName === "a" && !hidden && !oc;
         promises.push(
           this.#structTreeLayer
-            ?.getAriaAttributes(annotationId)
+            ?.getAriaAttributes(annotationId, { enableLinkOwnership })
             .then(ariaAttributes => {
               if (ariaAttributes) {
                 for (const [key, value] of ariaAttributes) {

--- a/test/unit/struct_tree_layer_builder_spec.js
+++ b/test/unit/struct_tree_layer_builder_spec.js
@@ -360,6 +360,49 @@ describe("StructTreeLayerBuilder", function () {
     expect(row.id).toEqual("");
   });
 
+  it("only lets an eligible link annotation own its tagged text", async function () {
+    const annotationId = "pdfjs_internal_id_1R";
+    const builder = build({
+      role: "Root",
+      children: [
+        {
+          role: "Link",
+          children: [
+            { type: "content", id: "p1R_mc1" },
+            {
+              role: "Lbl",
+              // BBox is layout-only.
+              bbox: [0, 0, 10, 10],
+              children: [{ type: "content", id: "p1R_mc2" }],
+            },
+            { type: "annotation", id: annotationId },
+          ],
+        },
+      ],
+    });
+    const tree = await builder.render();
+    const link = tree.firstElementChild;
+    expect(link.getAttribute("role")).toEqual("link");
+    const [text, label, annotation] = link.children;
+    expect(await builder.getAnnotationIds()).toEqual(new Set([annotationId]));
+    expect([text.id, label.id]).not.toContain("");
+    expect(annotation.getAttribute("aria-owns")).toEqual(annotationId);
+
+    // Merely asking for the annotation attributes keeps the fallback.
+    expect(await builder.getAriaAttributes(annotationId)).toBeUndefined();
+    expect(link.getAttribute("role")).toEqual("link");
+
+    const attributes = await builder.getAriaAttributes(annotationId, {
+      enableLinkOwnership: true,
+    });
+
+    expect(attributes).toEqual(
+      new Map([["aria-owns", `${text.id} ${label.id}`]])
+    );
+    expect(link.getAttribute("role")).toBeNull();
+    expect(link.childElementCount).toEqual(3);
+  });
+
   it("keeps structured annotations in the structure tree", async function () {
     const builder = build({
       role: "Root",

--- a/web/struct_tree_layer_builder.js
+++ b/web/struct_tree_layer_builder.js
@@ -197,6 +197,10 @@ class StructTreeLayerBuilder {
 
   #elementAttributes = new Map();
 
+  #pendingLinkOwnership = new Map();
+
+  #linkTextId = 0;
+
   #structElementIdPrefix = `pdfjs_internal_struct_${getUuid()}_`;
 
   #structElementIds = new Map();
@@ -245,9 +249,26 @@ class StructTreeLayerBuilder {
     return promise;
   }
 
-  async getAriaAttributes(annotationId) {
+  /**
+   * @param {string} annotationId
+   * @param {Object} [options]
+   * @param {boolean} [options.enableLinkOwnership]
+   * @returns {Promise<Map<string, string>|null|undefined>}
+   */
+  async getAriaAttributes(annotationId, { enableLinkOwnership = false } = {}) {
     try {
       await this.render();
+      const ownership = this.#pendingLinkOwnership.get(annotationId);
+      if (ownership && enableLinkOwnership) {
+        const { element, ids } = ownership;
+        element.removeAttribute("role");
+        if (ids.length > 0) {
+          this.#elementAttributes
+            .getOrInsertComputed(annotationId, makeMap)
+            .set("aria-owns", ids.join(" "));
+        }
+        this.#pendingLinkOwnership.delete(annotationId);
+      }
       return this.#elementAttributes.get(annotationId);
     } catch {
       // If the structTree cannot be fetched, parsed, and/or rendered,
@@ -637,6 +658,25 @@ class StructTreeLayerBuilder {
           element.append(this.#walk(kid, parentNodes));
         }
         parentNodes.pop();
+      }
+    }
+    if (node.role === "Link") {
+      const annotations = node.children?.filter(
+        child => child.type === "annotation"
+      );
+      if (annotations?.length === 1) {
+        const annotation = annotations[0];
+        const ids = [];
+        for (const child of element.children) {
+          if (child.getAttribute("aria-owns") === annotation.id) {
+            continue;
+          }
+          child.id ||= `${this.#structElementIdPrefix}link_${this.#linkTextId++}`;
+          ids.push(child.id);
+        }
+        // Keep the structure-tree Link as a fallback until a stable, visible
+        // link annotation explicitly takes ownership of these children.
+        this.#pendingLinkOwnership.set(annotation.id, { element, ids });
       }
     }
     return element;


### PR DESCRIPTION
A tagged Link and its annotation otherwise expose duplicate link semantics.

For a Link with one annotation and text-only content, let the annotation own the text spans. Keep the structure-tree fallback until that succeeds.