### PR TITLE
Improve `JpegImage.canUseImageDecoder` return value consistency

### DIFF
--- a/src/core/jpeg_stream.js
+++ b/src/core/jpeg_stream.js
@@ -179,7 +179,7 @@ class JpegStream extends DecodeStream {
         // the height is only known from a DNL marker or because the scan simply
         // ends early (issue15492.pdf). `ImageDecoder` reports and scales the
         // frame according to the SOF, so let our own decoder, which honours the
-        // dictionary, handle the image instead.
+        // actual JPEG image data, handle the image instead.
         return null;
       }
       if (useImageDecoder.exifStart) {

--- a/src/core/jpg.js
+++ b/src/core/jpg.js
@@ -811,11 +811,14 @@ class JpegImage {
 
   static canUseImageDecoder(data, colorTransform = -1) {
     const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-    let exifOffsets = null;
+    const info = {
+      width: 0,
+      height: 0,
+      exifStart: 0,
+      exifEnd: 0,
+    };
     let offset = 0;
     let numComponents = null;
-    let scanLines = 0,
-      samplesPerLine = 0;
     let fileMarker = view.getUint16(offset);
     offset += 2;
     if (fileMarker !== /* SOI (Start of Image) = */ 0xffd8) {
@@ -845,12 +848,13 @@ class JpegImage {
             appData[4] === 0 &&
             appData[5] === 0
           ) {
-            if (exifOffsets) {
+            if (info.exifStart) {
               throw new JpegError("Duplicate EXIF-blocks found.");
             }
             // Don't do the EXIF-block replacement here, see `JpegStream`,
             // since that can modify the original PDF document.
-            exifOffsets = { exifStart: oldOffset + 6, exifEnd: newOffset };
+            info.exifStart = oldOffset + 6;
+            info.exifEnd = newOffset;
           }
           fileMarker = view.getUint16(offset);
           offset += 2;
@@ -860,8 +864,8 @@ class JpegImage {
         case 0xffc2: // SOF2 (Start of Frame, Progressive DCT)
           // Skip marker length.
           // Skip precision.
-          scanLines = view.getUint16(offset + (2 + 1));
-          samplesPerLine = view.getUint16(offset + (2 + 1 + 2));
+          info.height = view.getUint16(offset + (2 + 1)); // scanLines
+          info.width = view.getUint16(offset + (2 + 1 + 2)); // samplesPerLine
           numComponents = data[offset + (2 + 1 + 2 + 2)];
           break markerLoop;
         case 0xffff: // Fill bytes
@@ -882,7 +886,7 @@ class JpegImage {
       return null;
     }
     // A zero SOF height means that a later DNL marker defines it.
-    return { width: samplesPerLine, height: scanLines, ...exifOffsets };
+    return info;
   }
 
   parse(data, { dnlScanLines = null } = {}) {

--- a/test/unit/jpeg_stream_spec.js
+++ b/test/unit/jpeg_stream_spec.js
@@ -18,6 +18,7 @@ import { ImageResizer } from "../../src/core/image_resizer.js";
 import { JpegImage } from "../../src/core/jpg.js";
 import { JpegStream } from "../../src/core/jpeg_stream.js";
 import { Stream } from "../../src/core/stream.js";
+import { stringToBytes } from "../../src/shared/util.js";
 
 // Only a JPEG header is needed: `canUseImageDecoder` stops at the SOF marker.
 function createJpeg({
@@ -57,13 +58,13 @@ describe("jpeg_stream", function () {
     it("should report the frame dimensions", function () {
       expect(
         JpegImage.canUseImageDecoder(createJpeg({ width: 40000, height: 4000 }))
-      ).toEqual({ width: 40000, height: 4000 });
+      ).toEqual({ width: 40000, height: 4000, exifStart: 0, exifEnd: 0 });
 
       expect(
         JpegImage.canUseImageDecoder(
           createJpeg({ width: 123, height: 45, numComponents: 1 })
         )
-      ).toEqual({ width: 123, height: 45 });
+      ).toEqual({ width: 123, height: 45, exifStart: 0, exifEnd: 0 });
     });
 
     it("should report dimensions for each supported SOF marker", function () {
@@ -78,19 +79,19 @@ describe("jpeg_stream", function () {
           )
         )
           .withContext(sofMarker.toString(16))
-          .toEqual({ width: 40000, height: 4000 });
+          .toEqual({ width: 40000, height: 4000, exifStart: 0, exifEnd: 0 });
       }
     });
 
     it("should report a zero SOF height", function () {
       expect(
         JpegImage.canUseImageDecoder(createJpeg({ width: 40000, height: 0 }))
-      ).toEqual({ width: 40000, height: 0 });
+      ).toEqual({ width: 40000, height: 0, exifStart: 0, exifEnd: 0 });
     });
 
     it("should report the frame dimensions together with the EXIF-offsets", function () {
       const payload = [1, 2, 3, 4];
-      const appData = [...new TextEncoder().encode("Exif\x00\x00"), ...payload];
+      const appData = [...stringToBytes("Exif\x00\x00"), ...payload];
 
       // SOI (2) + APP1-marker (2) + length (2) + "Exif\x00\x00" (6) = 12.
       expect(


### PR DESCRIPTION
For JPEG images that can be decoded natively, always return an Object with a consistent shape regardless of the marker data.

Also, tweak a comment in `JpegImage.getTransferableImage` to avoid ambiguity.