### PR TITLE
Vertically center the text in single-line and comb text fields (bug 2055455)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2586,6 +2586,21 @@ class WidgetAnnotation extends Annotation {
     );
     const alignment = this.data.textAlignment;
 
+    let { ascent: fontAscent, descent: fontDescent } = font;
+    if (
+      isNaN(fontAscent) ||
+      isNaN(fontDescent) ||
+      (!fontAscent && !fontDescent)
+    ) {
+      fontAscent = LINE_FACTOR - LINE_DESCENT_FACTOR;
+      fontDescent = LINE_DESCENT_FACTOR;
+    } else {
+      fontDescent = Math.abs(fontDescent);
+    }
+    const vShift =
+      (totalHeight - (fontAscent + fontDescent) * fontSize) / 2 +
+      fontDescent * fontSize;
+
     if (this.data.multiLine) {
       return this._getMultilineAppearance(
         defaultAppearance,
@@ -2610,14 +2625,14 @@ class WidgetAnnotation extends Annotation {
         encodedLines[0],
         fontSize,
         totalWidth,
-        totalHeight,
+        vShift,
         alignment,
         bidi(lines[0]).dir === "rtl",
         annotationStorage
       );
     }
 
-    const bottomPadding = defaultVPadding + descent;
+    const bottomPadding = vShift;
     if (alignment === 0 || alignment > 2) {
       // Left alignment: nothing to do
       return (
@@ -2971,7 +2986,7 @@ class TextWidgetAnnotation extends WidgetAnnotation {
     text,
     fontSize,
     width,
-    height,
+    vShift,
     alignment,
     isRTL,
     annotationStorage
@@ -3008,12 +3023,6 @@ class TextWidgetAnnotation extends WidgetAnnotation {
       previousWidth = glyphWidth;
     }
     const renderedComb = buf.join(" ");
-
-    // Vertically center the glyphs within the field: comb fields are mostly
-    // filled with uppercase letters and/or digits, hence we use the cap height
-    // (with a fallback on the ascent or the font size) to center them.
-    const vShift =
-      (height - (font.capHeight || font.ascent || 1) * fontSize) / 2;
 
     return (
       `/Tx BMC q ${colors}BT ` +

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -952,3 +952,4 @@
 !function_based_shading_cmyk.pdf
 !large_jpeg_downscale.pdf
 !bug1898053_minimal.pdf
+!bug2055455.pdf

--- a/test/pdfs/bug2055455.pdf
+++ b/test/pdfs/bug2055455.pdf
@@ -1,0 +1,62 @@
+%PDF-1.7
+%«Ïè¢
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /AcroForm 9 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 140 100] /Contents 4 0 R
+   /Resources << >> /Annots [7 0 R 8 0 R] >>
+endobj
+4 0 obj
+<< /Length 59 >>
+stream
+0.5 w 0 G
+20 60 15.307 18.992 re S
+20 20 57.26 18.992 re S
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /TrueType /BaseFont /CourierNew /Name /CourierNew
+   /FirstChar 56 /LastChar 56 /Widths [600] /Encoding /WinAnsiEncoding
+   /FontDescriptor 6 0 R >>
+endobj
+6 0 obj
+<< /Type /FontDescriptor /FontName /CourierNew /Flags 34
+   /FontBBox [-122 -680 623 1021] /ItalicAngle 0
+   /Ascent 1021 /Descent -680 /CapHeight 571 /XHeight 423 /StemV 40 >>
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Tx /F 4 /P 3 0 R
+   /Rect [20 60 35.307 78.992] /T (single) /V (8) /Q 1 /MaxLen 1
+   /Ff 12582912 /DA (/CourierNew 16 Tf 0 g) >>
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Tx /F 4 /P 3 0 R
+   /Rect [20 20 77.26 38.992] /T (comb) /V (8888) /MaxLen 4
+   /Ff 29360128 /DA (/CourierNew 16 Tf 0 g) >>
+endobj
+9 0 obj
+<< /Fields [7 0 R 8 0 R] /NeedAppearances true
+   /DA (/CourierNew 16 Tf 0 g)
+   /DR << /Font << /CourierNew 5 0 R >> >> >>
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000266 00000 n 
+0000000374 00000 n 
+0000000562 00000 n 
+0000000754 00000 n 
+0000000936 00000 n 
+0000001113 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+1252
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -14524,5 +14524,14 @@
     "rounds": 1,
     "lastPage": 1,
     "type": "eq"
+  },
+  {
+    "id": "bug2055455",
+    "file": "pdfs/bug2055455.pdf",
+    "md5": "e9a7d04240532aa4c6849f291f275895",
+    "rounds": 1,
+    "lastPage": 1,
+    "type": "eq",
+    "print": true
   }
 ]

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1764,7 +1764,7 @@ describe("annotation", function () {
       );
       expect(appearance).toEqual(
         "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm" +
-          " 2 3.07 Td (test\\\\print) Tj ET Q EMC"
+          " 2 3.72 Td (test\\\\print) Tj ET Q EMC"
       );
     });
 
@@ -1801,7 +1801,7 @@ describe("annotation", function () {
         "\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
       expect(appearance).toEqual(
         "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm" +
-          ` 2 3.07 Td (${utf16String}) Tj ET Q EMC`
+          ` 2 3.38 Td (${utf16String}) Tj ET Q EMC`
       );
     });
 
@@ -1884,7 +1884,7 @@ describe("annotation", function () {
       );
       expect(appearance).toEqual(
         "/Tx BMC q BT /Helv 5.92 Tf 0 g 1 0 0 1 0 0 Tm" +
-          " 2 3.07 Td (test \\(print\\)) Tj ET Q EMC"
+          " 2 3.49 Td (test \\(print\\)) Tj ET Q EMC"
       );
     });
 
@@ -1921,7 +1921,7 @@ describe("annotation", function () {
         "\x30\x53\x30\x93\x30\x6b\x30\x61\x30\x6f\x4e\x16\x75\x4c\x30\x6e";
       expect(appearance).toEqual(
         "/Tx BMC q BT /Goth 3.5 Tf 0 g 1 0 0 1 0 0 Tm" +
-          ` 2 3.07 Td (${utf16String}) Tj ET Q EMC`
+          ` 2 3.86 Td (${utf16String}) Tj ET Q EMC`
       );
     });
 
@@ -2124,7 +2124,7 @@ describe("annotation", function () {
         annotationStorage
       );
       expect(appearance).toEqual(
-        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 3.21 Tm" +
+        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 3.72 Tm" +
           " 2.61 0 Td (a) Tj 8 0 Td (a) Tj 8.56 0 Td (\\() Tj" +
           " 7.44 0 Td (a) Tj 8 0 Td (a) Tj" +
           " 8.56 0 Td (\\)) Tj 7.44 0 Td (a) Tj" +
@@ -2165,7 +2165,7 @@ describe("annotation", function () {
         annotationStorage
       );
       expect(appearance).toEqual(
-        "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 2.5 Tm" +
+        "/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 3.38 Tm" +
           " 1.5 0 Td (\x30\x53) Tj 8 0 Td (\x30\x93) Tj 8 0 Td (\x30\x6b) Tj" +
           " 8 0 Td (\x30\x61) Tj 8 0 Td (\x30\x6f) Tj" +
           " 8 0 Td (\x4e\x16) Tj 8 0 Td (\x75\x4c) Tj" +
@@ -2209,7 +2209,7 @@ describe("annotation", function () {
       expect(newData.data).toEqual(
         "2 0 obj\n<< /Subtype /Form /Resources " +
           "<< /Font << /Helv 314 0 R>>>> /BBox [0 0 32 10] /Length 74>> stream\n" +
-          "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 3.07 Td (hello world) Tj " +
+          "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 3.72 Td (hello world) Tj " +
           "ET Q EMC\nendstream\nendobj\n"
       );
     });
@@ -2327,8 +2327,8 @@ describe("annotation", function () {
       );
       expect(newData.data).toEqual(
         "2 0 obj\n<< /Subtype /Form /Resources " +
-          "<< /Font << /Helv 314 0 R>>>> /BBox [0 0 10 32] /Matrix [0 1 -1 0 32 0] /Length 74>> stream\n" +
-          "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 2.94 Td (hello world) Tj " +
+          "<< /Font << /Helv 314 0 R>>>> /BBox [0 0 10 32] /Matrix [0 1 -1 0 32 0] /Length 75>> stream\n" +
+          "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 14.72 Td (hello world) Tj " +
           "ET Q EMC\nendstream\nendobj\n"
       );
     });
@@ -2388,7 +2388,7 @@ describe("annotation", function () {
       // generated data with the PDF.js library.
       const flateStream = new FlateStream(new StringStream(compressedStream));
       expect(flateStream.getString()).toEqual(
-        `/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 3.07 Td (${value}) Tj ET Q EMC`
+        `/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 3.72 Td (${value}) Tj ET Q EMC`
       );
     });
 
@@ -2513,7 +2513,7 @@ describe("annotation", function () {
       expect(newData.data).toEqual(
         "2 0 obj\n<< /Subtype /Form /Resources " +
           "<< /Font << /Helv 314 0 R /Goth 159 0 R>>>> /BBox [0 0 32 10] /Length 79>> stream\n" +
-          `/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm 2 3.07 Td (${utf16String}) Tj ` +
+          `/Tx BMC q BT /Goth 5 Tf 1 0 0 1 0 0 Tm 2 3.38 Td (${utf16String}) Tj ` +
           "ET Q EMC\nendstream\nendobj\n"
       );
     });


### PR DESCRIPTION
Improve the formula for centering glyphs in text fields and use the same shift for the single-line and the comb paths.