### PR TITLE
Remove a few unnecessary checks after calling `BaseStream.prototype.getBytes`

### DIFF
--- a/src/core/decrypt_stream.js
+++ b/src/core/decrypt_stream.js
@@ -30,12 +30,12 @@ class DecryptStream extends DecodeStream {
 
   readBlock() {
     let chunk = this.#nextChunk ?? this.stream.getBytes(chunkSize);
-    if (!chunk?.length) {
+    if (!chunk.length) {
       this.eof = true;
       return;
     }
     this.#nextChunk = this.stream.getBytes(chunkSize);
-    const hasMoreData = this.#nextChunk?.length > 0;
+    const hasMoreData = this.#nextChunk.length > 0;
 
     const decrypt = this.decrypt;
     chunk = decrypt(chunk, !hasMoreData);

--- a/src/core/run_length_stream.js
+++ b/src/core/run_length_stream.js
@@ -29,7 +29,7 @@ class RunLengthStream extends DecodeStream {
     // (in addition to the second byte from the header), n = 129 through 255 -
     // duplicate the second byte from the header (257 - n) times, n = 128 - end.
     const repeatHeader = this.stream.getBytes(2);
-    if (!repeatHeader || repeatHeader.length < 2 || repeatHeader[0] === 128) {
+    if (repeatHeader.length < 2 || repeatHeader[0] === 128) {
       this.eof = true;
       return;
     }


### PR DESCRIPTION
The `getBytes` methods will *always* return a Uint8Array[1], and remember that even an empty TypedArray is truthy (i.e. `!!new Uint8Array(0) === true`).
Hence we can remove a few pointless checks from the `DecryptStream` and `RunLengthStream` classes, which should improve code readability a tiny bit.

---

[1] See [stream.js](https://github.com/mozilla/pdf.js/blob/e051279385c5cf141935037b340e757081052990/src/core/stream.js#L45-L51), [chunked_stream.js](https://github.com/mozilla/pdf.js/blob/e051279385c5cf141935037b340e757081052990/src/core/chunked_stream.js#L184-L193), and [decode_stream.js](https://github.com/mozilla/pdf.js/blob/e051279385c5cf141935037b340e757081052990/src/core/decode_stream.js#L86-L110).