### PR TITLE
Modernize the Node.js `getinfo.mjs` example

### DIFF
--- a/examples/node/getinfo.mjs
+++ b/examples/node/getinfo.mjs
@@ -15,62 +15,44 @@ const pdfPath =
 // Will be using promises to load document, pages and misc data instead of
 // callback.
 const loadingTask = getDocument({ url: pdfPath });
-loadingTask.promise
-  .then(function (doc) {
-    const numPages = doc.numPages;
-    console.log("# Document Loaded");
-    console.log("Number of Pages: " + numPages);
+try {
+  const pdfDoc = await loadingTask.promise;
+
+  const { numPages } = pdfDoc;
+  console.log("# Document Loaded");
+  console.log(`Number of Pages: ${numPages}`);
+  console.log();
+
+  const { info, metadata } = await pdfDoc.getMetadata();
+  console.log("# Metadata is Loaded");
+  console.log("## Info");
+  console.log(JSON.stringify(info, null, 2));
+  console.log();
+  if (metadata) {
+    console.log("## Metadata");
+    console.log(JSON.stringify(Object.fromEntries(metadata), null, 2));
+    console.log();
+  }
+
+  for (let i = 1; i <= numPages; i++) {
+    const pdfPage = await pdfDoc.getPage(i);
+    console.log(`# Page ${i}`);
+    const viewport = pdfPage.getViewport({ scale: 1.0 });
+    console.log(`Size: ${viewport.width}x${viewport.height}`);
     console.log();
 
-    let lastPromise; // will be used to chain promises
-    lastPromise = doc.getMetadata().then(function (data) {
-      console.log("# Metadata Is Loaded");
-      console.log("## Info");
-      console.log(JSON.stringify(data.info, null, 2));
-      console.log();
-      if (data.metadata) {
-        console.log("## Metadata");
-        console.log(JSON.stringify(data.metadata.getAll(), null, 2));
-        console.log();
-      }
-    });
+    const { items } = await pdfPage.getTextContent();
+    // Content contains lots of information about the text layout and
+    // styles, but we need only strings at the moment
+    console.log("## Text Content");
+    console.log(items.map(item => item.str).join(" "));
+    console.log();
+    // Release page resources.
+    pdfPage.cleanup();
+  }
 
-    const loadPage = function (pageNum) {
-      return doc.getPage(pageNum).then(function (page) {
-        console.log("# Page " + pageNum);
-        const viewport = page.getViewport({ scale: 1.0 });
-        console.log("Size: " + viewport.width + "x" + viewport.height);
-        console.log();
-        return page
-          .getTextContent()
-          .then(function (content) {
-            // Content contains lots of information about the text layout and
-            // styles, but we need only strings at the moment
-            const strings = content.items.map(function (item) {
-              return item.str;
-            });
-            console.log("## Text Content");
-            console.log(strings.join(" "));
-            // Release page resources.
-            page.cleanup();
-          })
-          .then(function () {
-            console.log();
-          });
-      });
-    };
-    // Loading of the first page will wait on metadata and subsequent loadings
-    // will wait on the previous pages.
-    for (let i = 1; i <= numPages; i++) {
-      lastPromise = lastPromise.then(loadPage.bind(null, i));
-    }
-    return lastPromise;
-  })
-  .then(
-    function () {
-      console.log("# End of Document");
-    },
-    function (err) {
-      console.error("Error: " + err);
-    }
-  );
+  await loadingTask.destroy();
+  console.log("# End of Document");
+} catch (ex) {
+  console.error(`Error: ${ex}`);
+}


### PR DESCRIPTION
 - Fix metadata logging, since it's accidentally broken by PR #19778 (over a year ago).
 - Modernize, and simplify, the example by using `await` to remove the promise chains.