### PR TITLE
Shorten the handling of /A and /a page labels

### DIFF
--- a/src/core/catalog.js
+++ b/src/core/catalog.js
@@ -918,13 +918,9 @@ class Catalog {
         case "A":
         case "a":
           const LIMIT = 26; // Use only the characters A-Z, or a-z.
-          const A_UPPER_CASE = 0x41,
-            A_LOWER_CASE = 0x61;
-
-          const baseCharCode = style === "a" ? A_LOWER_CASE : A_UPPER_CASE;
           const letterIndex = currentIndex - 1;
           const character = String.fromCharCode(
-            baseCharCode + (letterIndex % LIMIT)
+            style.charCodeAt(0) + (letterIndex % LIMIT)
           );
           currentLabel = character.repeat(Math.floor(letterIndex / LIMIT) + 1);
           break;


### PR DESCRIPTION
I happened to glance at this code, and noticed that using the style-value *itself* to compute the current character would shorten this code a little bit.

Note that this particular page label format seems to be somewhat rarely used in practice, compared to e.g. the roman numerals format, which probably isn't that strange given its definition: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#G11.2096063