### PR TITLE
Remove unused /FS branch from the `FileSpec` constructor

### DIFF
--- a/src/core/file_spec.js
+++ b/src/core/file_spec.js
@@ -44,9 +44,7 @@ class FileSpec {
       return;
     }
     this.root = root;
-    if (root.has("FS")) {
-      this.fs = root.get("FS");
-    }
+
     if (root.has("RF")) {
       warn("Related file specifications are not supported");
     }


### PR DESCRIPTION
This code goes all the way back to PR #4329, however the `this.fs` property has never actually been used anywhere.
Furthermore, looking at the coverage data this branch also isn't reached by any tests; see https://app.codecov.io/gh/mozilla/pdf.js/commit/a570239153c3af4508c3f06348dff35faa313737/blob/src/core/file_spec.js?dropdown=coverage#L47
