### PR TITLE
Schedule render animation frames on the canvas's own window

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3342,6 +3342,25 @@ class InternalRenderTask {
 
   static #canvasInUse = new WeakSet();
 
+  /**
+   * The window that owns the canvas being rendered into, falling back to the
+   * global one.
+   *
+   * These are not always the same window. A canvas can live in another
+   * document -- one opened with `window.open`, or an iframe -- while the code
+   * driving the render runs in the opener. Animation frames have to be
+   * scheduled on the window that owns the canvas: browsers pause
+   * `requestAnimationFrame` for a window that is not visible, so scheduling on
+   * an occluded opener means the callback never runs and the render stalls
+   * partway through, leaving a partially drawn canvas.
+   */
+  get #ownerWindow() {
+    return (
+      (this._canvas ?? this._canvasContext?.canvas)?.ownerDocument
+        ?.defaultView ?? window
+    );
+  }
+
   constructor({
     callback,
     params,
@@ -3464,7 +3483,7 @@ class InternalRenderTask {
     this.cancelled = true;
     this.gfx?.endDrawing();
     if (this.#rAF) {
-      window.cancelAnimationFrame(this.#rAF);
+      this.#ownerWindow.cancelAnimationFrame(this.#rAF);
       this.#rAF = null;
     }
     InternalRenderTask.#canvasInUse.delete(this._canvas);
@@ -3508,7 +3527,7 @@ class InternalRenderTask {
 
   _scheduleNext() {
     if (this._useRequestAnimationFrame) {
-      this.#rAF = window.requestAnimationFrame(() => {
+      this.#rAF = this.#ownerWindow.requestAnimationFrame(() => {
         this.#rAF = null;
         this._nextBound().catch(this._cancelBound);
       });


### PR DESCRIPTION
`InternalRenderTask` schedules each render continuation with the global
`window.requestAnimationFrame` and cancels with `window.cancelAnimationFrame`.
When the canvas belongs to a *different* window than the one running the render,
those calls go to the wrong window.

The case where this matters: a page opened with `window.open` whose content is
rendered by the opener. The canvas lives in the popup's document, but
`_scheduleNext` schedules on the opener. If the opener is not visible — a
full-screen popup covering it is enough — the browser pauses its animation
frames, the continuation never runs, and the render stalls partway through. It is
eventually cancelled, and `cancel()` then calls `cancelAnimationFrame` on that
same wrong window, so the handle is never actually released.

From the outside this looks like a blank or half-drawn canvas with no error:
`RenderingCancelledException` is what callers get, which is normally the benign
result of paging or zooming, so it tends to be ignored. Making the opener visible
again (switching windows) lets a later render complete, which makes it look
intermittent.

Browsers differ in how aggressively they throttle a non-visible window's
`requestAnimationFrame`, so this reproduces in Chrome, Edge and Safari but not in
Firefox.

This patch resolves the window from the canvas's own document, falling back to
the global `window` when there is no canvas (the `canvasContext`-only path) or no
owner document:

```js
get #ownerWindow() {
  return (
    (this._canvas ?? this._canvasContext?.canvas)?.ownerDocument
      ?.defaultView ?? window
  );
}
```

Behaviour is unchanged for the single-window case, which is why the viewer itself
never hit this — it renders into the document that owns the canvas.

Not PDF-specific, so there is no test PDF to attach: it reproduces with any
document rendered into a `window.open`'d page from the opener, with the opener
occluded. Happy to add a test if you can point me at the right harness for a
second window — `test/integration/` drives a single page, and the unit tests do
not have a second document to render into.

`npx eslint src/display/api.js` and `npx prettier --check src/display/api.js` are
clean. I have not been able to finish `npx gulp unittestcli` locally -- it stalls
fetching the test corpus from web.archive.org on my network -- so I am relying on
CI for the unit suite.
