### PR TITLE
Change `Word64.prototype.shiftRight` to only support `places < 32` (PR 4938 follow-up)

### DIFF
--- a/src/core/calculate_sha_other.js
+++ b/src/core/calculate_sha_other.js
@@ -31,14 +31,13 @@ class Word64 {
     this.low ^= word.low;
   }
 
+  /**
+   * @param {number} places - An integer, must satisfy `places < 32`.
+   * @returns {undefined}
+   */
   shiftRight(places) {
-    if (places >= 32) {
-      this.low = (this.high >>> (places - 32)) | 0;
-      this.high = 0;
-    } else {
-      this.low = (this.low >>> places) | (this.high << (32 - places));
-      this.high = (this.high >>> places) | 0;
-    }
+    this.low = (this.low >>> places) | (this.high << (32 - places));
+    this.high = (this.high >>> places) | 0;
   }
 
   rotateRight(places) {


### PR DESCRIPTION
Looking at the code in the `src/core/calculate_sha_other.js` file there's only two `shiftRight` call-sites, and none of them pass a `places >= 32` argument.

Originally this method was introduced in *the first* commit of PR #4938, where it's called via a `rotr` helper function that's invoked with `places >= 32` arguments.
However, that `rotr` helper function was removed in *the second* commit of that PR and the `places >= 32` branch of the `shiftRight` method thus became unused.
Hence it seems that we've been accidentally shipping, a small amount of, unused code for over a decade.

Finally, looking at the coverage data confirms that the code is never reached: https://app.codecov.io/gh/mozilla/pdf.js/commit/c1951c846ae7e405a18c87da09345946f324c544/blob/src/core/calculate_sha_other.js?dropdown=coverage#L35