### PR TITLE
Remove unused `BasePdfManager`/`LocalPdfManager` methods

### DIFF
--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -192,10 +192,6 @@ class LocalPdfManager extends BasePdfManager {
     return value;
   }
 
-  requestRange(begin, end) {
-    return Promise.resolve();
-  }
-
   requestLoadedStream(noFetch = false) {
     return this._loadedStreamPromise;
   }

--- a/src/core/pdf_manager.js
+++ b/src/core/pdf_manager.js
@@ -108,10 +108,6 @@ class BasePdfManager {
     return this.ensure(this.pdfDocument, prop, args);
   }
 
-  ensureXRef(prop, args) {
-    return this.ensure(this.pdfDocument.xref, prop, args);
-  }
-
   ensureCatalog(prop, args) {
     return this.ensure(this.pdfDocument.catalog, prop, args);
   }


### PR DESCRIPTION
 - **Remove the unused `LocalPdfManager.prototype.requestRange` method**

   This method is never invoked, since the `LocalPdfManager` is only used when all data is already available.
   More specifically, the `requestRange` method is only called from:
    - https://github.com/mozilla/pdf.js/blob/49ff3dc5af480f6db625fa86abce1d74b0d6c67a/src/core/document.js#L2042-L2045
    - https://github.com/mozilla/pdf.js/blob/49ff3dc5af480f6db625fa86abce1d74b0d6c67a/src/core/pdf_manager.js#L227-L230
    - https://github.com/mozilla/pdf.js/blob/49ff3dc5af480f6db625fa86abce1d74b0d6c67a/src/core/xref.js#L1050-L1053

   Note how in all those cases a `MissingDataException` must have been thrown in order for that method to be called, and that exception is *only* ever thrown from the `src/core/chunked_stream.js` file.
   The classes in that file are only invoked from the `NetworkPdfManager` constructor, hence we know that `LocalPdfManager.prototype.requestRange` is indeed unused.

 - **Remove the unused `BasePdfManager.prototype.ensureXRef` method (PR 20333 follow-up)**

   This method became unused in PR #20333, so let's just remove it now.