### PR TITLE
[api-minor] Convert `documentInfo` to return any "Custom" data in a Map

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -1593,16 +1593,12 @@ class PDFDocument {
             default:
               if (value instanceof Name) {
                 customValue = value;
+                break;
               }
-              break;
+              warn(`Bad value, for custom key "${key}", in Info: ${value}.`);
+              continue;
           }
-
-          if (customValue === undefined) {
-            warn(`Bad value, for custom key "${key}", in Info: ${value}.`);
-            continue;
-          }
-          docInfo.Custom ??= Object.create(null);
-          docInfo.Custom[key] = customValue;
+          (docInfo.Custom ??= new Map()).set(key, customValue);
           continue;
       }
       warn(`Bad value, for key "${key}", in Info: ${value}.`);

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -2742,12 +2742,13 @@ describe("api", function () {
       expect(info.Producer).toEqual("pdfeTeX-1.21a");
       expect(info.CreationDate).toEqual("D:20090401163925-07'00'");
       // Custom, non-standard, information dictionary entries.
-      const custom = info.Custom;
-      expect(typeof custom === "object" && custom !== null).toBeTrue();
-
-      expect(custom["PTEX.Fullbanner"]).toEqual(
-        "This is pdfeTeX, " +
-          "Version 3.141592-1.21a-2.2 (Web2C 7.5.4) kpathsea version 3.5.6"
+      expect(info.Custom).toEqual(
+        new Map([
+          [
+            "PTEX.Fullbanner",
+            "This is pdfeTeX, Version 3.141592-1.21a-2.2 (Web2C 7.5.4) kpathsea version 3.5.6",
+          ],
+        ])
       );
       // The following are PDF.js specific, non-standard, properties.
       expect(info.PDFFormatVersion).toEqual("1.4");


### PR DESCRIPTION
The "Custom" entry is a feature that, outside of a single unit-test, isn't used anywhere in the PDF.js code-base.
Besides changing this data to use a Map, rather than a regular Object, the validation can be moved since it's not necessary when a white-listed type has been encountered.