### PR TITLE
Fix incorrect text stroke width caused by stale pixel-width cache

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -598,7 +598,6 @@ class CanvasGraphics {
     this.pageColors = pageColors;
 
     this._cachedScaleForStroking = [-1, 0];
-    this._cachedGetSinglePixelWidth = null;
     this._cachedBitmapsMap = new Map();
 
     this.dependencyTracker = dependencyTracker ?? null;
@@ -2051,7 +2050,6 @@ class CanvasGraphics {
     this.pendingClip = null;
 
     this._cachedScaleForStroking[0] = -1;
-    this._cachedGetSinglePixelWidth = null;
   }
 
   transform(opIdx, a, b, c, d, e, f) {
@@ -2059,7 +2057,6 @@ class CanvasGraphics {
     this.ctx.transform(a, b, c, d, e, f);
 
     this._cachedScaleForStroking[0] = -1;
-    this._cachedGetSinglePixelWidth = null;
   }
 
   // Path
@@ -2933,7 +2930,6 @@ class CanvasGraphics {
       return;
     }
     this._cachedScaleForStroking[0] = -1;
-    this._cachedGetSinglePixelWidth = null;
 
     ctx.save();
     if (current.textMatrix) {
@@ -4228,20 +4224,15 @@ class CanvasGraphics {
   }
 
   getSinglePixelWidth() {
-    if (!this._cachedGetSinglePixelWidth) {
-      const m = getCurrentTransform(this.ctx);
-      if (m[1] === 0 && m[2] === 0) {
-        // Fast path
-        this._cachedGetSinglePixelWidth =
-          1 / Math.min(Math.abs(m[0]), Math.abs(m[3]));
-      } else {
-        const absDet = Math.abs(m[0] * m[3] - m[2] * m[1]);
-        const normX = Math.hypot(m[0], m[2]);
-        const normY = Math.hypot(m[1], m[3]);
-        this._cachedGetSinglePixelWidth = Math.max(normX, normY) / absDet;
-      }
+    const m = getCurrentTransform(this.ctx);
+    if (m[1] === 0 && m[2] === 0) {
+      // Fast path
+      return 1 / Math.min(Math.abs(m[0]), Math.abs(m[3]));
     }
-    return this._cachedGetSinglePixelWidth;
+    const absDet = Math.abs(m[0] * m[3] - m[2] * m[1]);
+    const normX = Math.hypot(m[0], m[2]);
+    const normY = Math.hypot(m[1], m[3]);
+    return Math.max(normX, normY) / absDet;
   }
 
   getScaleForStroking() {

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -953,3 +953,4 @@
 !large_jpeg_downscale.pdf
 !bug1898053_minimal.pdf
 !bug2055455.pdf
+!issue20294_reduced.pdf

--- a/test/pdfs/issue20294_reduced.pdf
+++ b/test/pdfs/issue20294_reduced.pdf
@@ -1,0 +1,41 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 120] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 80 >>
+stream
+BT
+0 w
+1 Tr
+/F1 1 Tf
+0.1 0 0 0.1 10 110 Tm
+(.) Tj
+36 0 0 36 10 30 Tm
+(Ab) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+446
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -14533,5 +14533,12 @@
     "lastPage": 1,
     "type": "eq",
     "print": true
+  },
+  {
+    "id": "issue20294",
+    "file": "pdfs/issue20294_reduced.pdf",
+    "md5": "29bdb56f4249dc642556c36ecb8de22b",
+    "rounds": 1,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
## 1. Symptom

Issue #20294 reports what appears to be a hidden speech-bubble shape being rendered black on page 5 of a PDF, covering the text underneath.

No hidden shape is actually being rendered. Some text is rendered with an excessively wide stroke, so that the glyph outlines cover an entire column of the document, and that is what reads as a black shape.

## 2. Cause

`getSinglePixelWidth` computes the conversion factor from one screen pixel to the current coordinate system, so its return value depends on the current transform.

However, the result is cached in `_cachedGetSinglePixelWidth`, while `showText` applies the text matrix to the canvas without invalidating that cache.

A ratio computed for one text run can therefore be reused by the next one under a different transform.

In the PDF from #20294, a text run with a text-matrix scale of `0.1` caches `10`.
The following run at scale `36` should recompute approximately `0.03`, but uses the cached `10` instead.

The stroke thus ends up about 334 times wider than expected.

## 3. Why the cache is removed rather than invalidated

The cache itself is removed, instead of adding another invalidation in `showText`.

Keeping the cache would require validating that the stored ratio is still correct for the current transform. Doing that means reading the current transform, which accounts for most of the cost the caching was meant to avoid.

`getSinglePixelWidth` also has a single caller, and is called at most once per text-showing operation. With correct invalidation there would therefore be no opportunity for a cache hit in the first place.

## 4. How often the code is actually reached

The call-site is only reached when rendering stroked text with a line width of `0`.

Rendering the first three pages of each of the 977 PDF files that were already committed in `test/pdfs`, `zerowidthline.pdf` is the only one that reaches `getSinglePixelWidth` at all, and even there the cache is never hit.

The practical benefit of keeping the cache is therefore very limited, and removing it seems like the simpler and safer fix.

## 5. Testing

A reduced test case is added: a 629-byte file with two stroked text runs whose only meaningful difference is the text matrix scale, which is the smallest input that reproduces the bug. Without the patch the glyph outlines of the second run cover half the page.

The unit tests pass, with the same single failure that already occurs on `master`: `bug1820909.pdf` no longer matches the MD5 recorded in the manifest.

- The existing `zerowidthline.pdf` renders identically before and after the change.
- For the PDF from #20294, only page 5 changes, which is the page where the problem occurred.

Fixes #20294
