### PR TITLE
Remove the unused `getOutputLength` method from the `ColorSpace` classes (PR 21637 follow-up)

### DIFF
--- a/src/core/colorspace.js
+++ b/src/core/colorspace.js
@@ -199,15 +199,6 @@ class ColorSpace {
   }
 
   /**
-   * Determines the number of bytes required to store the result of the
-   * conversion done by the getRgbBuffer method. As in getRgbBuffer,
-   * |alpha01| is either 0 (RGB output) or 1 (RGBA output).
-   */
-  getOutputLength(inputLength, alpha01) {
-    unreachable("Should not call ColorSpace.getOutputLength");
-  }
-
-  /**
    * Returns true if source data will be equal the result/output data.
    */
   isPassthrough(bits) {
@@ -451,13 +442,6 @@ class AlternateCS extends ColorSpace {
       base.getRgbBuffer(baseBuf, 0, count, dest, destOffset, 8, alpha01);
     }
   }
-
-  getOutputLength(inputLength, alpha01) {
-    return this.base.getOutputLength(
-      (inputLength * this.base.numComps) / this.numComps,
-      alpha01
-    );
-  }
 }
 
 class PatternCS extends ColorSpace {
@@ -542,10 +526,6 @@ class IndexedCS extends ColorSpace {
     }
   }
 
-  getOutputLength(inputLength, alpha01) {
-    return inputLength * (3 + alpha01);
-  }
-
   isDefaultDecode(decode, bpc) {
     if (isDefaultDecodeHelper(decode, 2)) {
       return true;
@@ -595,10 +575,6 @@ class DeviceGrayCS extends ColorSpace {
       q += alpha01;
     }
   }
-
-  getOutputLength(inputLength, alpha01) {
-    return inputLength * (3 + alpha01);
-  }
 }
 
 /**
@@ -643,10 +619,6 @@ class DeviceRgbCS extends ColorSpace {
     }
   }
 
-  getOutputLength(inputLength, alpha01) {
-    return ((inputLength * (3 + alpha01)) / 3) | 0;
-  }
-
   isPassthrough(bits) {
     return bits === 8;
   }
@@ -658,10 +630,6 @@ class DeviceRgbCS extends ColorSpace {
 class DeviceRgbaCS extends ColorSpace {
   constructor() {
     super("DeviceRGBA", 4);
-  }
-
-  getOutputLength(inputLength, _alpha01) {
-    return inputLength * 4;
   }
 
   isPassthrough(bits) {
@@ -798,10 +766,6 @@ class DeviceCmykCS extends ColorSpace {
       destOffset += 3 + alpha01;
     }
   }
-
-  getOutputLength(inputLength, alpha01) {
-    return ((inputLength / 4) * (3 + alpha01)) | 0;
-  }
 }
 
 /**
@@ -891,10 +855,6 @@ class CalGrayCS extends ColorSpace {
       srcOffset += 1;
       destOffset += 3 + alpha01;
     }
-  }
-
-  getOutputLength(inputLength, alpha01) {
-    return inputLength * (3 + alpha01);
   }
 }
 
@@ -1188,10 +1148,6 @@ class CalRGBCS extends ColorSpace {
       destOffset += 3 + alpha01;
     }
   }
-
-  getOutputLength(inputLength, alpha01) {
-    return ((inputLength * (3 + alpha01)) / 3) | 0;
-  }
 }
 
 /**
@@ -1329,10 +1285,6 @@ class LabCS extends ColorSpace {
       srcOffset += 3;
       destOffset += 3 + alpha01;
     }
-  }
-
-  getOutputLength(inputLength, alpha01) {
-    return ((inputLength * (3 + alpha01)) / 3) | 0;
   }
 
   isDefaultDecode(decode, bpc) {

--- a/src/core/icc_colorspace.js
+++ b/src/core/icc_colorspace.js
@@ -148,10 +148,6 @@ class IccColorSpace extends ColorSpace {
     QCMS._destBuffer = null;
   }
 
-  getOutputLength(inputLength, alpha01) {
-    return ((inputLength / this.numComps) * (3 + alpha01)) | 0;
-  }
-
   static setOptions({ useWasm, useWorkerFetch, wasmUrl }) {
     if (!useWorkerFetch) {
       this.#useWasm = false;

--- a/test/unit/colorspace_spec.js
+++ b/test/unit/colorspace_spec.js
@@ -267,7 +267,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb(new Float32Array([0.1]), 0)).toEqual(
         new Uint8ClampedArray([26, 26, 26])
       );
-      expect(colorSpace.getOutputLength(2, 0)).toEqual(6);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
@@ -312,7 +311,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb(new Float32Array([0.2]), 0)).toEqual(
         new Uint8ClampedArray([51, 51, 51])
       );
-      expect(colorSpace.getOutputLength(3, 1)).toEqual(12);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
@@ -383,7 +381,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0)).toEqual(
         new Uint8ClampedArray([26, 51, 77])
       );
-      expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
@@ -434,7 +431,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0)).toEqual(
         new Uint8ClampedArray([26, 51, 77])
       );
-      expect(colorSpace.getOutputLength(4, 1)).toEqual(5);
       expect(colorSpace.isPassthrough(8)).toBeTrue();
       expect(testDest).toEqual(expectedDest);
     });
@@ -505,7 +501,6 @@ describe("colorspace", function () {
       expect(
         colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]), 0)
       ).toEqual(new Uint8ClampedArray([32, 28, 21]));
-      expect(colorSpace.getOutputLength(4, 0)).toEqual(3);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
@@ -556,7 +551,6 @@ describe("colorspace", function () {
       expect(
         colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3, 1]), 0)
       ).toEqual(new Uint8ClampedArray([32, 28, 21]));
-      expect(colorSpace.getOutputLength(4, 1)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
@@ -626,7 +620,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb(new Float32Array([1.0]), 0)).toEqual(
         new Uint8ClampedArray([255, 255, 255])
       );
-      expect(colorSpace.getOutputLength(4, 0)).toEqual(12);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
@@ -696,7 +689,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb(new Float32Array([0.1, 0.2, 0.3]), 0)).toEqual(
         new Uint8ClampedArray([0, 147, 151])
       );
-      expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(testDest).toEqual(expectedDest);
     });
@@ -765,7 +757,6 @@ describe("colorspace", function () {
       expect(colorSpace.getRgb([55, 25, 35], 0)).toEqual(
         new Uint8ClampedArray([188, 100, 61])
       );
-      expect(colorSpace.getOutputLength(4, 0)).toEqual(4);
       expect(colorSpace.isPassthrough(8)).toBeFalse();
       expect(colorSpace.isDefaultDecode([0, 1])).toBeTrue();
       expect(testDest).toEqual(expectedDest);


### PR DESCRIPTION
The only actual `getOutputLength` call-site, outside of the unit-tests, was removed in PR #21637 and these methods are now unused.
This code can always be easily re-instated if needed, thanks to version control, so let's avoid shipping dead code in the builds.