### PR TITLE
Fix stale TextLayer font cache after canvas resize in #getAscent

### DIFF
--- a/src/display/text_layer.js
+++ b/src/display/text_layer.js
@@ -535,6 +535,11 @@ class TextLayer {
     const descent = Math.abs(metrics.fontBoundingBoxDescent);
 
     ctx.canvas.width = ctx.canvas.height = 0;
+    // Canvas resize resets the 2d context state, including `font` (spec).
+    // Invalidate the manual font cache so the next `#ensureCtxFont` with the
+    // same size/family still re-applies `ctx.font` instead of hitting a stale
+    // entry (cold `fontSize*scale === DEFAULT_FONT_SIZE` → ~3× `--scale-x`).
+    this.#canvasCtxFonts.set(ctx, { size: 0, family: "" });
     let ratio = 0.8; // DEFAULT_FONT_ASCENT
 
     if (ascent) {


### PR DESCRIPTION
Hi — I ran into this while debugging TextLayer scaling on a cold layer.

At `8801a6a64` `TextLayer.#getAscent` resizes the shared measuring canvas to 30, caches `{30, family}`, then resets the canvas to `0×0` at `src/display/text_layer.js:537`. Per spec that also clears `ctx.font` back to `10px sans-serif`, but `static #canvasCtxFonts` at `:96` (checked at `:492`) stays stale. So the next `#layout:432` with `fontSize*scale === 30` (e.g. 24pt × 1.25) hits the cache, skips `ctx.font=`, and `measureText` runs at 10px → `width≈1/3` → `--scale-x≈3×` at `:437` on the first paint only. Second paint is fine because the font gets re-applied then.

I mocked the spec behavior (`canvas.width=` resets `font`) locally and saw `measureText("XXXXX")` go `30 → 90` / scale `3.0 → 1.0` after the fix. The fix is one `WeakMap` reset right after `ctx.canvas.width = ctx.canvas.height = 0`:

```js
this.#canvasCtxFonts.set(ctx, { size: 0, family: "" });
```

It's the only place that resizes the shared canvas (`530`/`537`), so one reset covers it.

![P0 before/after — --scale-x 3× → 1×](https://cdn.vectojs.org/pdfjs-p1/2026-08-29-p0-only.png)

Fixes #21578.

<details><summary>P1 measurement-context matrix (all canvases vs DOM — honest null result on this host)</summary>

Kept as record that `display:none` (PDF.js current at `src/display/text_layer.js:476`) vs `opacity:0` (Vecto) is a candidate, not a fact here — headed `DPR 1.6 refreshHz ~240` runs showed `B ≈ C ≈ D` on both engines. Headless table still honest; headed signal that survived was Firefox `OffscreenCanvas == DOM` while attached sat ~0.4–0.8px short (grid-fit), Chromium all equal.

![P1 measurement-context — candidate, not fact](https://cdn.vectojs.org/pdfjs-p1/2026-08-29-p1-full.png)

</details>
