### PR TITLE
Remove old `info` logging from the "GetOperatorList"/"GetTextContent" handlers (issue 21836)

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -610,7 +610,7 @@ class Page {
       intent & RenderingIntentFlag.ANNOTATIONS_DISABLE
     ) {
       pageOpList.flush(/* lastChunk = */ true);
-      return { length: pageOpList.totalLength };
+      return;
     }
     const renderForms = !!(intent & RenderingIntentFlag.ANNOTATIONS_FORMS),
       isEditing = !!(intent & RenderingIntentFlag.IS_EDITING),
@@ -661,7 +661,6 @@ class Page {
       /* lastChunk = */ true,
       /* separateAnnots = */ { form, canvas }
     );
-    return { length: pageOpList.totalLength };
   }
 
   async extractTextContent({

--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -667,7 +667,6 @@ class OperatorList {
         ? new QueueOptimizer(this)
         : new NullOptimizer(this);
     this.dependencies = new Set();
-    this._totalLength = 0;
     this.weight = 0;
     this._resolved = streamSink ? null : Promise.resolve();
   }
@@ -682,14 +681,6 @@ class OperatorList {
 
   get ready() {
     return this._resolved || this._streamSink.ready;
-  }
-
-  /**
-   * @type {number} The total length of the entire operator list, since
-   *                `this.length === 0` after flushing.
-   */
-  get totalLength() {
-    return this._totalLength + this.length;
   }
 
   addOp(fn, args) {
@@ -802,8 +793,6 @@ class OperatorList {
 
   flush(lastChunk = false, separateAnnots = null) {
     this.optimizer.flush();
-    const length = this.length;
-    this._totalLength += length;
 
     this._streamSink.enqueue(
       {
@@ -811,7 +800,7 @@ class OperatorList {
         argsArray: this.argsArray,
         lastChunk,
         separateAnnots,
-        length,
+        length: this.length,
       },
       1,
       this._transfers

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -16,12 +16,9 @@
 import {
   AbortException,
   assert,
-  getVerbosityLevel,
-  info,
   isNodeJS,
   PasswordException,
   setVerbosityLevel,
-  VerbosityLevel,
   warn,
 } from "../shared/util.js";
 import {
@@ -115,7 +112,6 @@ class WorkerMessageHandler {
     let terminated = false;
     let cancelXHRs = null;
     const WorkerTasks = new Set();
-    const verbosity = getVerbosityLevel();
 
     const { docId, apiVersion } = docParams;
     const workerVersion =
@@ -897,10 +893,6 @@ class WorkerMessageHandler {
           const task = new WorkerTask(`GetOperatorList: page ${pageIndex}`);
           startWorkerTask(task);
 
-          // NOTE: Keep this condition in sync with the `info` helper function.
-          const start = verbosity >= VerbosityLevel.INFOS ? Date.now() : 0;
-
-          // Pre compile the pdf page and fetch the fonts/images.
           page
             .getOperatorList({
               handler,
@@ -913,12 +905,7 @@ class WorkerMessageHandler {
               pageIndex,
             })
             .then(
-              opListInfo => {
-                if (start) {
-                  info(
-                    `${task.name}; time=${Date.now() - start}ms, len=${opListInfo.length}`
-                  );
-                }
+              () => {
                 sink.close();
               },
               reason => {
@@ -945,9 +932,6 @@ class WorkerMessageHandler {
           const task = new WorkerTask("GetTextContent: page " + pageIndex);
           startWorkerTask(task);
 
-          // NOTE: Keep this condition in sync with the `info` helper function.
-          const start = verbosity >= VerbosityLevel.INFOS ? Date.now() : 0;
-
           page
             .extractTextContent({
               handler,
@@ -958,9 +942,6 @@ class WorkerMessageHandler {
             })
             .then(
               () => {
-                if (start) {
-                  info(`${task.name}; time=${Date.now() - start}ms`);
-                }
                 sink.close();
               },
               reason => {

--- a/test/unit/evaluator_spec.js
+++ b/test/unit/evaluator_spec.js
@@ -513,17 +513,15 @@ describe("evaluator", function () {
       enqueue() {}
     }
 
-    it("should get correct total length after flushing", function () {
+    it("should get correct length after flushing", function () {
       const operatorList = new OperatorList(null, new StreamSinkMock());
       operatorList.addOp(OPS.save, null);
       operatorList.addOp(OPS.restore, null);
 
-      expect(operatorList.totalLength).toEqual(2);
       expect(operatorList.length).toEqual(2);
 
       operatorList.flush();
 
-      expect(operatorList.totalLength).toEqual(2);
       expect(operatorList.length).toEqual(0);
     });
   });


### PR DESCRIPTION
 - **Remove old `info` logging from the "GetOperatorList"/"GetTextContent" handlers (issue 21836)**
 
    Also remove an "ancient" comment, from the "GetOperatorList" handler, which no longer seems helpful.
    Finally, since they're now unused, remove the return-values from the `Page.prototype.getOperatorList` method.

 - **Remove the unused `totalLength` getter from the `OperatorList` class**

   The only actual `totalLength` invocations, outside of the unit-tests, were removed in the previous commit and this is now dead code.