### PR TITLE
Tweak the `WorkerTask` class and the `hasJSActions` getter

### DIFF
--- a/src/core/document.js
+++ b/src/core/document.js
@@ -2244,28 +2244,22 @@ class PDFDocument {
   }
 
   get hasJSActions() {
-    const promise = this.pdfManager.ensureDoc("_parseHasJSActions");
-    return shadow(this, "hasJSActions", promise);
-  }
-
-  /**
-   * @private
-   */
-  async _parseHasJSActions() {
-    const [catalogJsActions, fieldObjects] = await Promise.all([
+    const promise = Promise.all([
       this.pdfManager.ensureCatalog("jsActions"),
       this.pdfManager.ensureDoc("fieldObjects"),
-    ]);
+    ]).then(([catalogJsActions, fieldObjects]) => {
+      if (catalogJsActions) {
+        return true;
+      }
+      if (fieldObjects?.allFields) {
+        return fieldObjects.allFields
+          .values()
+          .some(fieldObj => fieldObj.some(obj => obj.actions !== null));
+      }
+      return false;
+    });
 
-    if (catalogJsActions) {
-      return true;
-    }
-    if (fieldObjects?.allFields) {
-      return fieldObjects.allFields
-        .values()
-        .some(fieldObj => fieldObj.some(obj => obj.actions !== null));
-    }
-    return false;
+    return shadow(this, "hasJSActions", promise);
   }
 
   get calculationOrderIds() {

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -41,18 +41,20 @@ import { stringToPDFString } from "./string_utils.js";
 import { StructTreeRoot } from "./struct_tree.js";
 
 class WorkerTask {
+  #capability = Promise.withResolvers();
+
+  terminated = false;
+
   constructor(name) {
     this.name = name;
-    this.terminated = false;
-    this._capability = Promise.withResolvers();
   }
 
   get finished() {
-    return this._capability.promise;
+    return this.#capability.promise;
   }
 
   finish() {
-    this._capability.resolve();
+    this.#capability.resolve();
   }
 
   terminate() {


### PR DESCRIPTION
 - **Move some `WorkerTask` class field definitions out of the constructor**
 
   Also, make use of actually private fields in one case.

 - **Inline the `PDFDocument.prototype._parseHasJSActions` method**

   This code is short and simple enough that it can just be inlined in the `hasJSActions` getter.

---

*Smaller diff with https://github.com/mozilla/pdf.js/pull/21841/changes?w=1*