### PR TITLE
Don't copy applied signatures when extracting pages (issue 21696)

### DIFF
--- a/src/core/editor/pdf_editor.js
+++ b/src/core/editor/pdf_editor.js
@@ -1241,10 +1241,23 @@ class PDFEditor {
         xref.fetchIfRefAsync(annotationRef).then(async annotationDict => {
           if (!isName(annotationDict.get("Subtype"), "Link")) {
             if (isName(annotationDict.get("Subtype"), "Widget")) {
-              hasSignatureAnnotations ||= isName(
-                getInheritableProperty({ dict: annotationDict, key: "FT" }),
-                "Sig"
-              );
+              const fieldType = getInheritableProperty({
+                dict: annotationDict,
+                key: "FT",
+              });
+              if (isName(fieldType, "Sig")) {
+                const sigValue = getInheritableProperty({
+                  dict: annotationDict,
+                  key: "V",
+                });
+                if (sigValue) {
+                  // Applied signatures cannot survive extract/edit: ByteRange
+                  // covers the original file and the CMS payload no longer
+                  // verifies (issue 21696). Keep unsigned Sig widgets.
+                  return;
+                }
+                hasSignatureAnnotations = true;
+              }
               const parentRef = annotationDict.getRaw("Parent") || null;
               // The parent will be omitted from the annotation clone to avoid
               // visiting it, then restored by #mergeAcroForms.

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -8355,6 +8355,83 @@ small scripts as well as for`);
         await loadingTask.destroy();
       });
 
+      it("strips applied signatures when extracting the first page of a signed document", async function () {
+        const pdfData = assemblePdf([
+          "1 0 obj\n<< /Type /Catalog /Pages 2 0 R " +
+            "/AcroForm 7 0 R >>\nendobj\n",
+          "2 0 obj\n<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>\nendobj\n",
+          "3 0 obj\n<< /Type /Page /Parent 2 0 R " +
+            "/MediaBox [0 0 100 100] /Annots [5 0 R] >>\nendobj\n",
+          "4 0 obj\n<< /Type /Page /Parent 2 0 R " +
+            "/MediaBox [0 0 100 100] >>\nendobj\n",
+          "5 0 obj\n<< /Type /Annot /Subtype /Widget /FT /Sig " +
+            "/T (Signature1) /V 6 0 R /F 132 /Rect [0 0 0 0] >>\nendobj\n",
+          "6 0 obj\n<< /Type /Sig /Filter /Adobe.PPKMS " +
+            "/SubFilter /adbe.pkcs7.sha1 /ByteRange [0 10 20 30] " +
+            "/Contents <00> /M (D:20260731191548+02'00') >>\nendobj\n",
+          "7 0 obj\n<< /Fields [5 0 R] /SigFlags 3 >>\nendobj\n",
+        ]);
+
+        let loadingTask = getDocument({ data: pdfData });
+        let pdfDoc = await loadingTask.promise;
+        const data = await pdfDoc.extractPages([
+          { document: null, includePages: [0] },
+        ]);
+        await loadingTask.destroy();
+
+        expect(countMarker(data, "/FT /Sig")).toEqual(0);
+        expect(countMarker(data, "/Type /Sig")).toEqual(0);
+        expect(countMarker(data, "/SigFlags")).toEqual(0);
+        expect(countMarker(data, "/ByteRange")).toEqual(0);
+
+        loadingTask = getDocument({ data });
+        pdfDoc = await loadingTask.promise;
+        expect(pdfDoc.numPages).toEqual(1);
+        expect(await pdfDoc.getSignatures()).toBeNull();
+        expect(await pdfDoc.getFieldObjects()).toBeNull();
+        const annotations = await (await pdfDoc.getPage(1)).getAnnotations();
+        expect(annotations.some(a => a.fieldType === "Sig")).toBeFalse();
+        await loadingTask.destroy();
+      });
+
+      it("strips inherited applied signatures when extracting pages", async function () {
+        const pdfData = assemblePdf([
+          "1 0 obj\n<< /Type /Catalog /Pages 2 0 R " +
+            "/AcroForm 8 0 R >>\nendobj\n",
+          "2 0 obj\n<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>\nendobj\n",
+          "3 0 obj\n<< /Type /Page /Parent 2 0 R " +
+            "/MediaBox [0 0 100 100] /Annots [5 0 R] >>\nendobj\n",
+          "4 0 obj\n<< /Type /Page /Parent 2 0 R " +
+            "/MediaBox [0 0 100 100] >>\nendobj\n",
+          "5 0 obj\n<< /Type /Annot /Subtype /Widget /Rect [0 0 0 0] " +
+            "/Parent 6 0 R >>\nendobj\n",
+          "6 0 obj\n<< /FT /Sig /T (Signature1) /V 7 0 R " +
+            "/Kids [5 0 R] >>\nendobj\n",
+          "7 0 obj\n<< /Type /Sig /Filter /Adobe.PPKMS " +
+            "/SubFilter /adbe.pkcs7.sha1 /ByteRange [0 10 20 30] " +
+            "/Contents <00> >>\nendobj\n",
+          "8 0 obj\n<< /Fields [6 0 R] /SigFlags 3 >>\nendobj\n",
+        ]);
+
+        let loadingTask = getDocument({ data: pdfData });
+        let pdfDoc = await loadingTask.promise;
+        const data = await pdfDoc.extractPages([
+          { document: null, includePages: [0] },
+        ]);
+        await loadingTask.destroy();
+
+        expect(countMarker(data, "/FT /Sig")).toEqual(0);
+        expect(countMarker(data, "/Type /Sig")).toEqual(0);
+        expect(countMarker(data, "/SigFlags")).toEqual(0);
+        expect(countMarker(data, "/ByteRange")).toEqual(0);
+
+        loadingTask = getDocument({ data });
+        pdfDoc = await loadingTask.promise;
+        expect(await pdfDoc.getSignatures()).toBeNull();
+        expect(await pdfDoc.getFieldObjects()).toBeNull();
+        await loadingTask.destroy();
+      });
+
       it("extract page 2 and check AcroForm Fields T entries", async function () {
         let loadingTask = getDocument(
           buildGetDocumentParams("form_two_pages.pdf")


### PR DESCRIPTION
`extractPages` copied signature widgets (and `SigFlags`) into the exported file. After a page extract the original `/ByteRange` no longer matches the new bytes, so tools still report a digital signature that cannot be verified.

Skip widget annotations whose inheritable `FT` is `Sig` and that have a `V` value. Unsigned signature fields are unchanged.

Fixes #21696