### PR TITLE
Unskip the "should reorder thumbnails after dropping two adjacent pages" integration test

### DIFF
--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -355,8 +355,6 @@ describe("Reorganize Pages View", () => {
     it("should reorder thumbnails after dropping two adjacent pages", async () => {
       await Promise.all(
         pages.map(async ([browserName, page]) => {
-          pending("Fails consistently (issue #20814).");
-
           await waitForThumbnailVisible(page, 1);
           const rect2 = await getRect(page, getThumbnailSelector(2));
           const rect4 = await getRect(page, getThumbnailSelector(4));


### PR DESCRIPTION
It passes consistently now, and most likely got fixed by a combination of #21186, #21789 and other patches.

Fixes #20814.