### PR TITLE
Improve the runtime of Chrome tests

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1071,8 +1071,6 @@ async function startBrowser({
       // Disable logging for remote settings and the messaging system.
       "services.settings.loglevel": "off",
       "messaging-system.log": "off",
-      // Prevent remote settings from using the network.
-      "services.settings.server": "data:,#remote-settings-dummy/v1",
       // Disable Nimbus rollouts and studies.
       "nimbus.rollouts.enabled": false,
       "app.shield.optoutstudies.enabled": false,

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1019,7 +1019,7 @@ async function startBrowser({
     // calls can run before events triggered by the previous protocol calls had
     // a chance to be processed (essentially causing events to get lost). This
     // value gives Chrome a more similar execution speed as Firefox.
-    options.slowMo = 3;
+    options.slowMo = 2;
 
     options.args = [
       // Avoid crashing because no sandbox is shipped by default and we only run


### PR DESCRIPTION
The commit messages contain more information about the individual changes.

Before this change:

<img width="312" height="252" alt="afbeelding" src="https://github.com/user-attachments/assets/4eeaf043-2cc0-42a8-95ff-52b65ec55a62" />

After this change:

<img width="306" height="244" alt="afbeelding" src="https://github.com/user-attachments/assets/a8281425-5d36-4119-a856-4faa5f7d48ee" />

The reduction in Chrome test runtime is thus around 2 to 3 minutes on GitHub Actions.