### PR TITLE
Implement unit tests for the error cases in `src/core/xml_parser.js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "webpack-stream": "^7.0.0"
       },
       "engines": {
-        "node": ">=22.13.0 || >=24"
+        "node": ">=22.22.3 || >=24.15.0 || >=26.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/core/xml_parser.js
+++ b/src/core/xml_parser.js
@@ -22,7 +22,7 @@ import { shadow } from "../shared/util.js";
 const XMLParserErrorCode = {
   NoError: 0,
   EndOfDocument: -1,
-  UnterminatedCdat: -2,
+  UnterminatedCdata: -2,
   UnterminatedXmlDeclaration: -3,
   UnterminatedDoctypeDeclaration: -4,
   UnterminatedComment: -5,
@@ -213,7 +213,7 @@ class XMLParserBase {
             } else if (s.substring(j + 1, j + 8) === "[CDATA[") {
               q = s.indexOf("]]>", j + 8);
               if (q < 0) {
-                this.onError(XMLParserErrorCode.UnterminatedCdat);
+                this.onError(XMLParserErrorCode.UnterminatedCdata);
                 return;
               }
               this.onCdata(s.substring(j + 8, q));

--- a/test/unit/xml_spec.js
+++ b/test/unit/xml_spec.js
@@ -13,7 +13,11 @@
  * limitations under the License.
  */
 
-import { SimpleXMLParser, XMLParserBase } from "../../src/core/xml_parser.js";
+import {
+  SimpleXMLParser,
+  XMLParserBase,
+  XMLParserErrorCode,
+} from "../../src/core/xml_parser.js";
 import { parseXFAPath } from "../../src/core/core_utils.js";
 
 describe("XML", function () {
@@ -180,6 +184,83 @@ describe("XML", function () {
       const startTime = performance.now();
       expect(parseText(`<a>${text}</a>`)).toEqual(text);
       expect(performance.now() - startTime).toBeLessThan(1000);
+    });
+  });
+
+  describe("errors", function () {
+    class ErrorXMLParser extends SimpleXMLParser {
+      errorCode = XMLParserErrorCode.NoError;
+
+      onError(code) {
+        super.onError(code);
+        this.errorCode = code;
+      }
+    }
+
+    it("should handle unterminated closing elements", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("</a")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(
+        XMLParserErrorCode.UnterminatedElement
+      );
+    });
+
+    it("should handle unterminated XML declarations", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<?xml")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(
+        XMLParserErrorCode.UnterminatedXmlDeclaration
+      );
+    });
+
+    it("should handle unterminated comments", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<!-- Comment")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(
+        XMLParserErrorCode.UnterminatedComment
+      );
+    });
+
+    it("should handle unterminated CDATA sections", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<![CDATA[")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(XMLParserErrorCode.UnterminatedCdata);
+    });
+
+    it("should handle unterminated DOCTYPE declarations without internal DTD", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<!DOCTYPE foo")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(
+        XMLParserErrorCode.UnterminatedDoctypeDeclaration
+      );
+    });
+
+    it("should handle unterminated DOCTYPE declarations with internal DTD", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<!DOCTYPE foo [>")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(
+        XMLParserErrorCode.UnterminatedDoctypeDeclaration
+      );
+    });
+
+    it("should handle malformed elements", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<!foo")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(XMLParserErrorCode.MalformedElement);
+    });
+
+    it("should handle malformed element attributes", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<c a=/>")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(XMLParserErrorCode.MalformedElement);
+    });
+
+    it("should handle unterminated opening elements", function () {
+      const xmlParser = new ErrorXMLParser({});
+      expect(xmlParser.parseFromString("<a")).toEqual(undefined);
+      expect(xmlParser.errorCode).toEqual(
+        XMLParserErrorCode.UnterminatedElement
+      );
     });
   });
 });


### PR DESCRIPTION
This improves coverage of the file because the error cases were previously untested.

_Coverage of `src/core/xml_parser.js` goes from 85.37% on `master` to 93.90% on this branch, which is an increase of 8.53%._