### PR TITLE
Fix the [Object] param entry in createAndAddNewEditor and three similar slips

### DIFF
--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -1028,7 +1028,6 @@ class CanvasNestedDependencyTracker {
 
   /**
    * @param {number} idx
-   * @param {SimpleDependency[]} dependencyNames
    */
   recordOperation(idx) {
     this.#dependencyTracker.recordOperation(this.#opIdx, true);

--- a/src/display/editor/annotation_editor_layer.js
+++ b/src/display/editor/annotation_editor_layer.js
@@ -728,7 +728,7 @@ class AnnotationEditorLayer {
    * Create and add a new editor.
    * @param {PointerEvent} event
    * @param {boolean} isCentered
-   * @param [Object] data
+   * @param {Object} [data]
    * @returns {AnnotationEditor}
    */
   createAndAddNewEditor(event, isCentered, data = {}) {

--- a/src/display/editor/draw.js
+++ b/src/display/editor/draw.js
@@ -311,7 +311,9 @@ class DrawingEditor extends AnnotationEditor {
 
   /**
    * Update a property and make this action undoable.
-   * @param {string} color
+   * @param {number} type
+   * @param {string} name
+   * @param {*} value
    */
   _updateProperty(type, name, value) {
     const options = this._drawingOptions;

--- a/src/display/editor/tools.js
+++ b/src/display/editor/tools.js
@@ -2254,7 +2254,7 @@ class AnnotationEditorUIManager {
   /**
    * Update the toolbar if it's required to reflect the tool currently used.
    * @param {Object} options
-   * @param {number} mode
+   * @param {number} options.mode
    * @returns {undefined}
    */
   updateToolbar(options) {


### PR DESCRIPTION
The one in `annotation_editor_layer` is the interesting one: the brackets sit around the type rather than the name, so jsdoc reads a parameter literally called `Object` and `data` ends up undocumented. `recordOperation` looks like it picked up the second entry from `recordNamedDependency` right above it. I left the underscore-prefixed unused args and the `workerPort` setters alone.
