### PR TITLE
Add an accessible name to the save button

### DIFF
--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -44,6 +44,7 @@ pdfjs-print-button =
 pdfjs-print-button-label = Print
 pdfjs-save-button =
     .title = Save
+    .aria-label = Save
 pdfjs-save-button-label = Save
 
 # Used in Firefox for Android as a tooltip for the download button (“download” is a verb).

--- a/l10n/en-US/viewer.ftl
+++ b/l10n/en-US/viewer.ftl
@@ -44,8 +44,11 @@ pdfjs-print-button =
 pdfjs-print-button-label = Print
 pdfjs-save-button =
     .title = Save
-    .aria-label = Save
 pdfjs-save-button-label = Save
+
+pdfjs-save-button-with-aria-label =
+    .title = Save
+    .aria-label = Save
 
 # Used in Firefox for Android as a tooltip for the download button (“download” is a verb).
 pdfjs-download-button =

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -34,6 +34,30 @@ import { PNG } from "pngjs";
 const __dirname = import.meta.dirname;
 
 describe("PDF viewer", () => {
+  describe("Toolbar accessibility", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait("tracemonkey.pdf", ".textLayer .endOfContent");
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("exposes an accessible name for the save button", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const ariaLabel = await page.$eval(
+            "#downloadButton",
+            button => button.getAttribute("aria-label")
+          );
+          expect(ariaLabel).withContext(`In ${browserName}`).toEqual("Save");
+        })
+      );
+    });
+  });
+
   describe("EFOpen attachments", () => {
     let pages;
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -658,7 +658,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <span data-l10n-id="pdfjs-print-button-label"></span>
                   </button>
 
-                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
+                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button-with-aria-label">
                     <span data-l10n-id="pdfjs-save-button-label"></span>
                   </button>
                 </div>


### PR DESCRIPTION
Fixes #20473

The standard viewer's save button uses the localized `pdfjs-save-button` message, but that message only exposed a tooltip through `.title`. Add a localized `.aria-label` so screen reader users receive an accessible name.

The integration test checks the rendered `#downloadButton` in the viewer and verifies its `aria-label`.

Tests: `node --check test/integration/viewer_spec.mjs` (full PDF.js integration tests require the repository dependencies and browser test setup).