### PR TITLE
Set `deployment: false` on the `code-coverage` environment jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    environment: code-coverage
+    environment:
+      name: code-coverage
+      deployment: false
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage_browser_tests.yml
+++ b/.github/workflows/coverage_browser_tests.yml
@@ -51,7 +51,9 @@ jobs:
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
-    environment: code-coverage
+    environment:
+      name: code-coverage
+      deployment: false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/font_tests.yml
+++ b/.github/workflows/font_tests.yml
@@ -45,7 +45,9 @@ jobs:
             skip: --noFirefox
 
     runs-on: ${{ matrix.os }}
-    environment: code-coverage
+    environment:
+      name: code-coverage
+      deployment: false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -45,7 +45,9 @@ jobs:
             skip: --noFirefox
 
     runs-on: ${{ matrix.os }}
-    environment: code-coverage
+    environment:
+      name: code-coverage
+      deployment: false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,9 @@ jobs:
             skip: --noFirefox
 
     runs-on: ${{ matrix.os }}
-    environment: code-coverage
+    environment:
+      name: code-coverage
+      deployment: false
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This avoids creating deployment objects, and the associated pull request timeline entries, for jobs that only need the environment secrets.