### PR TITLE
Address the high-severity zizmor findings

### DIFF
--- a/.github/workflows/notify-pdf-sync.yml
+++ b/.github/workflows/notify-pdf-sync.yml
@@ -52,6 +52,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: mozilla
           repositories: pdf.js.pdfs
+          permission-contents: write
 
       - name: Trigger sync
         if: steps.check.outputs.has_added == 'true'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,14 +2,15 @@ name: Publish release
 on:
   release:
     types: [published]
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     strategy:
       matrix:
@@ -23,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
 - Scope the GitHub App tokens in `notify-pdf-sync.yml` and
   `update_locales.yml` using `permission-*` inputs.
 - Move the `publish_release.yml` permissions to the job level.
 - Ignore the (low-confidence) `cache-poisoning` finding in
   `publish_release.yml` and keep the npm cache enabled.