### PR TITLE
Get the l10n arguments at once in `PDFDocumentProperties.prototype.#parsePageSize`

### DIFF
--- a/web/pdf_document_properties.js
+++ b/web/pdf_document_properties.js
@@ -326,20 +326,19 @@ class PDFDocumentProperties {
       }
     }
 
-    const [{ width, height }, unit, name, orientation] = await Promise.all([
-      nonMetric ? sizeInches : sizeMillimeters,
-      this.l10n.get(
-        nonMetric
-          ? "pdfjs-document-properties-page-size-unit-inches"
-          : "pdfjs-document-properties-page-size-unit-millimeters"
-      ),
-      nameId && this.l10n.get(nameId),
-      this.l10n.get(
-        isPortrait
-          ? "pdfjs-document-properties-page-size-orientation-portrait"
-          : "pdfjs-document-properties-page-size-orientation-landscape"
-      ),
-    ]);
+    const { width, height } = nonMetric ? sizeInches : sizeMillimeters;
+    const ids = [
+      nonMetric
+        ? "pdfjs-document-properties-page-size-unit-inches"
+        : "pdfjs-document-properties-page-size-unit-millimeters",
+      isPortrait
+        ? "pdfjs-document-properties-page-size-orientation-portrait"
+        : "pdfjs-document-properties-page-size-orientation-landscape",
+    ];
+    if (nameId) {
+      ids.push(nameId);
+    }
+    const [unit, orientation, name] = await this.l10n.get(ids);
 
     return this.l10n.get(
       name


### PR DESCRIPTION
Given that Fluent supports localizing multiple strings "at once", we can replace the current two or three calls (depending on page size) with just a single one.

This also, indirectly, improves test coverage of the `L10n` class since the "multiple ids branch" previously wasn't used anywhere in the code-base.