### PR TITLE
Remove the unused `fallback` parameter from `L10n.prototype.get`

### DIFF
--- a/web/l10n.js
+++ b/web/l10n.js
@@ -50,7 +50,7 @@ class L10n {
   }
 
   /** @inheritdoc */
-  async get(ids, args = null, fallback) {
+  async get(ids, args = null) {
     if (Array.isArray(ids)) {
       ids = ids.map(id => ({ id }));
       const messages = await this.#l10n.formatMessages(ids);
@@ -63,7 +63,7 @@ class L10n {
         args,
       },
     ]);
-    return messages[0]?.value || fallback;
+    return messages[0]?.value;
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
This parameter hasn't been used anywhere in the code-base after the introduction of Fluent, hence it can simply be removed now.
Furthermore, note also that the `L10n.prototype.get` method itself is not used very much nowadays.