### PR TITLE
Use platform print-to-PDF for FreeText appearances (bug 1794809)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -367,6 +367,26 @@ class AnnotationFactory {
     return imagePromises;
   }
 
+  /**
+   * Get platform-rendering data for a serialized editor annotation.
+   * @param {object} annotation - Serialized annotation data.
+   * @returns {object | null}
+   */
+  static getPrintData(annotation) {
+    if (
+      typeof PDFJSDev !== "undefined" &&
+      !PDFJSDev.test("TESTING || MOZCENTRAL")
+    ) {
+      throw new Error("Not implemented: getPrintData");
+    }
+    switch (annotation?.annotationType) {
+      case AnnotationEditorType.FREETEXT:
+        return FreeTextAnnotation.getPrintData(annotation);
+      default:
+        return null;
+    }
+  }
+
   static async saveNewAnnotations(
     evaluator,
     xref,
@@ -385,7 +405,7 @@ class AnnotationFactory {
       }
       switch (annotation.annotationType) {
         case AnnotationEditorType.FREETEXT:
-          if (!baseFontRef) {
+          if (!annotation.appearanceRef && !baseFontRef) {
             const baseFont = new Dict(xref);
             baseFont.setIfName("BaseFont", "Helvetica");
             baseFont.setIfName("Type", "Font");
@@ -1871,19 +1891,11 @@ class MarkupAnnotation extends Annotation {
     const annotationRef = (annotation.ref ||= xref.getNewTemporaryRef());
 
     const ap = await this.createNewAppearanceStream(annotation, xref, params);
-    let annotationDict;
-
+    let apRef = annotation.appearanceRef ?? null;
     if (ap) {
-      const apRef = xref.getNewTemporaryRef();
-      annotationDict = this.createNewDict(annotation, xref, {
-        apRef,
-      });
-      changes.put(apRef, {
-        data: ap,
-      });
-    } else {
-      annotationDict = this.createNewDict(annotation, xref, {});
+      changes.put((apRef = xref.getNewTemporaryRef()), { data: ap });
     }
+    const annotationDict = this.createNewDict(annotation, xref, { apRef });
     if (Number.isInteger(annotation.parentTreeId)) {
       annotationDict.set("StructParent", annotation.parentTreeId);
     }
@@ -4406,7 +4418,43 @@ class FreeTextAnnotation extends MarkupAnnotation {
     return freetext;
   }
 
+  static getPrintData({ color, fontSize, rect, rotation, value }) {
+    if (
+      typeof PDFJSDev !== "undefined" &&
+      !PDFJSDev.test("TESTING || MOZCENTRAL")
+    ) {
+      throw new Error("Not implemented: getPrintData");
+    }
+    if (!color || !value) {
+      return null;
+    }
+    const width = rect[2] - rect[0];
+    const height = rect[3] - rect[1];
+    const isSideways = rotation === 90 || rotation === 270;
+
+    return {
+      matrix: rotation ? getRotationMatrix(rotation, width, height) : null,
+      data: {
+        width: isSideways ? height : width,
+        height: isSideways ? width : height,
+        text: value,
+        color: Util.makeHexColor(...color),
+        fontSize,
+        verticalAlign: "top",
+      },
+    };
+  }
+
   static async createNewAppearanceStream(annotation, xref, params) {
+    if (
+      (typeof PDFJSDev === "undefined" ||
+        PDFJSDev.test("TESTING || MOZCENTRAL")) &&
+      annotation.appearanceRef
+    ) {
+      // Use the platform-rendered appearance.
+      return null;
+    }
+
     const { baseFontRef, evaluator, task } = params;
     const { color, fontSize, rect, rotation, value } = annotation;
     if (!color) {

--- a/src/core/editor/print_appearances.js
+++ b/src/core/editor/print_appearances.js
@@ -1,0 +1,241 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Cmd, Dict, EOF, Ref, RefMap } from "../primitives.js";
+import { stringToBytes, warn } from "../../shared/util.js";
+import { BaseStream } from "../base_stream.js";
+import { EvaluatorPreprocessor } from "../evaluator.js";
+import { Lexer } from "../parser.js";
+import { LocalPdfManager } from "../pdf_manager.js";
+import { Stream } from "../stream.js";
+
+// Drop marked-content operators; their metadata belongs to the generated PDF.
+const MARKED_CONTENT_OPS = new Set(["BDC", "BMC", "DP", "EMC", "MP"]);
+
+/** Resolve copied temporary references from `changes`. */
+class ChangesXRefWrapper {
+  #changes;
+
+  #xref;
+
+  constructor(changes, xref) {
+    this.#changes = changes;
+    this.#xref = xref;
+  }
+
+  getNewTemporaryRef() {
+    return this.#xref.getNewTemporaryRef();
+  }
+
+  fetch(ref) {
+    return this.#changes.has(ref)
+      ? this.#changes.get(ref).data
+      : this.#xref.fetch(ref);
+  }
+
+  fetchIfRef(obj) {
+    return obj instanceof Ref ? this.fetch(obj) : obj;
+  }
+
+  async fetchAsync(ref) {
+    return this.fetch(ref);
+  }
+
+  async fetchIfRefAsync(obj) {
+    return this.fetchIfRef(obj);
+  }
+}
+
+/**
+ * Copy `obj` and its indirect dependencies into the target document.
+ * @param {*} obj
+ * @param {XRef} sourceXref
+ * @param {object} target - `{ changes, refs, xref, xrefWrapper }`.
+ * @returns {Promise<*>} the copy of `obj`.
+ */
+async function copyObject(obj, sourceXref, target) {
+  const { changes, refs, xref, xrefWrapper } = target;
+  if (obj instanceof Ref) {
+    let newRef = refs.get(obj);
+    if (!newRef) {
+      // Register before recursing to handle cycles and preserve sharing.
+      refs.put(obj, (newRef = xref.getNewTemporaryRef()));
+      const value = await sourceXref.fetchAsync(obj);
+      changes.put(newRef, {
+        data: await copyObject(value, sourceXref, target),
+      });
+    }
+    return newRef;
+  }
+  if (Array.isArray(obj)) {
+    return Promise.all(obj.map(value => copyObject(value, sourceXref, target)));
+  }
+  let dict, stream;
+  if (obj instanceof BaseStream) {
+    // Keep the encoded bytes expected by `writeStream`.
+    ({ dict } = stream = obj.getOriginalStream().clone());
+  } else if (obj instanceof Dict) {
+    dict = obj.clone();
+  } else {
+    return obj;
+  }
+  dict.xref = xrefWrapper;
+  const promises = [];
+  for (const [key, value] of dict.getRawEntries()) {
+    promises.push(
+      copyObject(value, sourceXref, target).then(newValue =>
+        dict.set(key, newValue)
+      )
+    );
+  }
+  await Promise.all(promises);
+
+  return stream ?? dict;
+}
+
+/**
+ * Remove marked-content operators while preserving the remaining source
+ * bytes. Optionally wrap widget content in `/Tx BMC ... EMC`.
+ * @param {Uint8Array} bytes
+ * @param {boolean} isWidget
+ * @returns {Uint8Array | null}
+ */
+function filterContentStream(bytes, isWidget) {
+  const lexer = new Lexer(new Stream(bytes), EvaluatorPreprocessor.opMap);
+  const parts = isWidget ? [stringToBytes("/Tx BMC\n")] : [];
+  // `start` begins retained bytes; `end` follows the previous operator.
+  let start = 0;
+  let end = 0;
+
+  try {
+    while (true) {
+      const obj = lexer.getObj();
+      if (obj === EOF) {
+        break;
+      }
+      // Array and dictionary delimiters are Cmd objects, but not operators.
+      if (!(obj instanceof Cmd) || !EvaluatorPreprocessor.opMap[obj.cmd]) {
+        continue;
+      }
+      if (obj.cmd === "BI") {
+        // A bare Lexer cannot safely skip inline-image data.
+        warn("filterContentStream: inline images aren't supported.");
+        return null;
+      }
+      const cmdEnd =
+        lexer.currentChar < 0 ? bytes.length : lexer.stream.pos - 1;
+      if (MARKED_CONTENT_OPS.has(obj.cmd)) {
+        parts.push(bytes.subarray(start, end));
+        start = cmdEnd;
+      }
+      end = cmdEnd;
+    }
+  } catch (reason) {
+    warn(`filterContentStream: "${reason}".`);
+    return null;
+  }
+  parts.push(bytes.subarray(start));
+  if (isWidget) {
+    parts.push(stringToBytes("\nEMC"));
+  }
+
+  const data = new Uint8Array(
+    parts.reduce((length, part) => length + part.length, 0)
+  );
+  let offset = 0;
+  for (const part of parts) {
+    data.set(part, offset);
+    offset += part.length;
+  }
+
+  return data;
+}
+
+/**
+ * Import each generated PDF page as an appearance stream.
+ *
+ * The platform places each appearance in `[0, 0, width, height]`. Its content
+ * and resources are copied into a Form XObject with that /BBox.
+ * @param {object} params
+ * @param {Uint8Array} params.buffer - The generated PDF.
+ * @param {RefMap} params.changes - Where the new objects are added.
+ * @param {string} params.docId
+ * @param {Array<object>} params.entries - `{ key, isWidget, matrix, data }`
+ *   entries, in the same order as the pages of the generated PDF.
+ * @param {object} params.evaluatorOptions
+ * @param {MessageHandler} params.handler
+ * @param {XRef} params.xref - The target document's xref.
+ * @returns {Promise<Map<string, Ref>>} the appearance reference for each entry
+ *   key; the appearance streams themselves are added to `changes`.
+ */
+async function importPrintedAppearances({
+  buffer,
+  changes,
+  docId,
+  entries,
+  evaluatorOptions,
+  handler,
+  xref,
+}) {
+  const pdfManager = new LocalPdfManager({
+    source: buffer,
+    docId: `${docId}_printToPDF`,
+    handler,
+    evaluatorOptions,
+  });
+  await pdfManager.initDocument(/* recoveryMode = */ false);
+  const { pdfDocument } = pdfManager;
+  if (pdfDocument.numPages !== entries.length) {
+    throw new Error("The generated PDF must have one page per appearance.");
+  }
+
+  const appearances = new Map();
+  const target = {
+    changes,
+    refs: new RefMap(),
+    xref,
+    xrefWrapper: new ChangesXRefWrapper(changes, xref),
+  };
+
+  for (let i = 0, ii = entries.length; i < ii; i++) {
+    const { key, isWidget, matrix, data } = entries[i];
+    const page = await pdfDocument.getPage(i);
+    const contentStream = await page.getContentStream();
+    contentStream.reset();
+    const bytes = filterContentStream(contentStream.getBytes(), isWidget);
+    if (!bytes) {
+      continue;
+    }
+
+    const dict = new Dict(xref);
+    dict.setIfName("Type", "XObject");
+    dict.setIfName("Subtype", "Form");
+    dict.set("FormType", 1);
+    dict.set("BBox", [0, 0, data.width, data.height]);
+    dict.setIfArray("Matrix", matrix);
+    dict.set(
+      "Resources",
+      await copyObject(page.resources, pdfDocument.xref, target)
+    );
+
+    const ref = xref.getNewTemporaryRef();
+    changes.put(ref, { data: new Stream(bytes, 0, bytes.length, dict) });
+    appearances.set(key, ref);
+  }
+
+  return appearances;
+}
+
+export { importPrintedAppearances };

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -681,9 +681,61 @@ class WorkerMessageHandler {
       }
     );
 
+    // Import platform-rendered appearances before saving annotations.
+    async function generateAppearances({ annotationStorage, changes, xref }) {
+      const entries = [];
+      for (const [key, value] of annotationStorage) {
+        const entry = AnnotationFactory.getPrintData(value);
+        if (entry) {
+          entries.push({ key, ...entry });
+        }
+      }
+      if (entries.length === 0) {
+        return;
+      }
+
+      try {
+        // One PDF permits resources to be shared across pages.
+        // Only the print data crosses to the main thread: `key` and `matrix`
+        // are consumed here when the generated appearances are imported.
+        const buffer = await handler.sendWithPromise(
+          "PrintToPDF",
+          entries.map(({ data }) => ({ data }))
+        );
+        if (!buffer) {
+          return;
+        }
+        const { importPrintedAppearances } =
+          typeof PDFJSDev === "undefined"
+            ? await import("./editor/print_appearances.js")
+            : await __eager_import__("./editor/print_appearances.js");
+        const appearances = await importPrintedAppearances({
+          buffer,
+          changes,
+          docId,
+          entries,
+          // BasePdfManager mutates and freezes these options.
+          evaluatorOptions: { ...pdfManager.evaluatorOptions },
+          handler,
+          xref,
+        });
+        for (const [key, ref] of appearances) {
+          annotationStorage.get(key).appearanceRef = ref;
+        }
+      } catch (reason) {
+        warn(`generateAppearances: "${reason}".`);
+      }
+    }
+
     handler.on(
       "SaveDocument",
-      async function ({ isPureXfa, numPages, annotationStorage, filename }) {
+      async function ({
+        isPureXfa,
+        numPages,
+        annotationStorage,
+        supportsPrintToPDF,
+        filename,
+      }) {
         const globalPromises = [
           pdfManager.requestLoadedStream(),
           pdfManager.ensureCatalog("acroForm"),
@@ -706,6 +758,17 @@ class WorkerMessageHandler {
           xref,
           _structTreeRoot,
         ] = await Promise.all(globalPromises);
+
+        if (
+          (typeof PDFJSDev === "undefined" ||
+            PDFJSDev.test("TESTING || MOZCENTRAL")) &&
+          !isPureXfa &&
+          supportsPrintToPDF &&
+          annotationStorage
+        ) {
+          await generateAppearances({ annotationStorage, changes, xref });
+        }
+
         const catalogRef = xref.trailer.getRaw("Root") || null;
         let structTreeRoot;
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -975,12 +975,17 @@ class PDFDocumentProxy {
   }
 
   /**
+   * @param {function(Array<object>): Promise<Uint8Array | null>} [printToPDF] -
+   *   Firefox-only platform appearance renderer. It receives ordered
+   *   `{ data }` entries and returns a PDF with one page per entry, or `null`.
+   *   Each page must place its appearance in
+   *   `[0, 0, data.width, data.height]`, with dimensions in points.
    * @returns {Promise<Uint8Array<ArrayBuffer>>} A promise that is
    *   resolved with a {Uint8Array<ArrayBuffer>} containing the
    *   full data of the saved document.
    */
-  saveDocument() {
-    return this._transport.saveDocument();
+  saveDocument(printToPDF) {
+    return this._transport.saveDocument(printToPDF);
   }
 
   /**
@@ -2410,6 +2415,8 @@ class WorkerTransport {
 
   #passwordCapability = null;
 
+  #printToPDF = null;
+
   constructor(
     messageHandler,
     loadingTask,
@@ -2915,13 +2922,20 @@ class WorkerTransport {
         return this.binaryDataFactory.fetch(data);
       });
     }
+
+    if (
+      typeof PDFJSDev === "undefined" ||
+      PDFJSDev.test("TESTING || MOZCENTRAL")
+    ) {
+      messageHandler.on("PrintToPDF", data => this.#printToPDF?.(data) ?? null);
+    }
   }
 
   getData() {
     return this.messageHandler.sendWithPromise("GetData", null);
   }
 
-  saveDocument() {
+  saveDocument(printToPDF = null) {
     if (this.annotationStorage.size <= 0) {
       warn(
         "saveDocument called while `annotationStorage` is empty, " +
@@ -2929,6 +2943,12 @@ class WorkerTransport {
       );
     }
     const { map, transfer } = this.annotationStorage.serializable;
+    if (
+      typeof PDFJSDev === "undefined" ||
+      PDFJSDev.test("TESTING || MOZCENTRAL")
+    ) {
+      this.#printToPDF = printToPDF;
+    }
 
     return this.messageHandler
       .sendWithPromise(
@@ -2937,11 +2957,13 @@ class WorkerTransport {
           isPureXfa: !!this._htmlForXfa,
           numPages: this._numPages,
           annotationStorage: map,
+          supportsPrintToPDF: this.#printToPDF !== null,
           filename: this.#fullReader?.filename ?? null,
         },
         transfer
       )
       .finally(() => {
+        this.#printToPDF = null;
         this.annotationStorage.resetModified();
       });
   }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -143,6 +143,51 @@ describe("api", function () {
     ]);
   }
 
+  function buildGeneratedAppearancePdf(pageContents = null) {
+    pageContents ??= [
+      [
+        "/NonStruct <</MCID 0>> BDC",
+        "/Artifact BMC",
+        "/Span MP",
+        "/Span <</ActualText (source)>> DP",
+        "q",
+        "1 0 0 -1 0 44 cm",
+        "0 4 40 20 re W n",
+        "BT /F1 10 Tf 1 0 0 -1 2 22 Tm (Generated appearance) Tj ET",
+        "BT /F1 10 Tf [(Array) 0.123456789012345 (operand)] TJ ET",
+        "Q",
+        "EMC",
+        "EMC",
+      ].join("\n"),
+    ];
+    const kids = pageContents.map((_, i) => `${2 * i + 4} 0 R`).join(" ");
+    const objects = [
+      "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+      `2 0 obj\n<< /Type /Pages /Kids [${kids}] ` +
+        `/Count ${pageContents.length} >>\nendobj\n`,
+      // Share one font object across all pages.
+      "3 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    ];
+    for (const [i, content] of pageContents.entries()) {
+      objects.push(
+        `${2 * i + 4} 0 obj\n<< /Type /Page /Parent 2 0 R ` +
+          "/MediaBox [0 0 72 72] /Resources << /Font << /F1 3 0 R >> >> " +
+          `/Contents ${2 * i + 5} 0 R >>\nendobj\n`,
+        `${2 * i + 5} 0 obj\n<< /Length ${content.length} >>\n` +
+          `stream\n${content}\nendstream\nendobj\n`
+      );
+    }
+    return assemblePdf(objects);
+  }
+
+  function buildEmptyPagePdf() {
+    return assemblePdf([
+      "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+      "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+      "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>\nendobj\n",
+    ]);
+  }
+
   function getNamedNodeInXML(node, path) {
     for (const component of path.split(".")) {
       if (!node.childNodes) {
@@ -2974,6 +3019,153 @@ describe("api", function () {
       expect(!!field).toBeTrue();
       expect(field.fieldValue).toEqual(value);
 
+      await loadingTask.destroy();
+    });
+
+    it("embeds an externally generated FreeText appearance", async function () {
+      let loadingTask = getDocument(buildGetDocumentParams("empty.pdf"));
+      let pdfDoc = await loadingTask.promise;
+      const rect = [12, 34, 56, 78];
+      const value = "Hello from Firefox";
+      pdfDoc.annotationStorage.setValue("pdfjs_internal_editor_0", {
+        annotationType: AnnotationEditorType.FREETEXT,
+        rect,
+        rotation: 0,
+        fontSize: 10,
+        color: [0, 0, 0],
+        value,
+        pageIndex: 0,
+      });
+
+      let generatedEntries;
+      const data = await pdfDoc.saveDocument(entries => {
+        generatedEntries = entries;
+        return buildGeneratedAppearancePdf();
+      });
+      expect(generatedEntries).toEqual([
+        {
+          data: {
+            width: 44,
+            height: 44,
+            text: value,
+            color: "#000000",
+            fontSize: 10,
+            verticalAlign: "top",
+          },
+        },
+      ]);
+      const savedString = bytesToString(data);
+      // Preserve drawing operators, but drop marked-content operators.
+      expect(savedString).not.toContain(`(${value}) Tj`);
+      expect(savedString).toContain("/BBox [0 0 44 44]");
+      expect(savedString).toContain("1 0 0 -1 0 44 cm");
+      expect(savedString).toContain("0 4 40 20 re");
+      expect(savedString).toContain("1 0 0 -1 2 22 Tm");
+      expect(savedString).toContain("[(Array) 0.123456789012345 (operand)] TJ");
+      expect(savedString).not.toContain("/NonStruct");
+      expect(savedString).not.toContain("/Artifact");
+      expect(savedString).not.toContain("/ActualText");
+      expect(savedString).not.toContain("/MCID");
+      await loadingTask.destroy();
+
+      loadingTask = getDocument({ data });
+      pdfDoc = await loadingTask.promise;
+      const page = await pdfDoc.getPage(1);
+      const annotations = await page.getAnnotations();
+      expect(annotations[0].contentsObj.str).toEqual(value);
+
+      const operatorList = await page.getOperatorList({
+        annotationMode: AnnotationMode.ENABLE,
+      });
+      expect(operatorList.fnArray).toContain(OPS.showText);
+
+      await loadingTask.destroy();
+    });
+
+    it("copies an appearance image stream having an indirect filter", async function () {
+      const hexData = "0123456789abcdef".repeat(18) + ">";
+      const content = "q 44 0 0 44 0 0 cm /Im0 Do Q";
+      const generated = assemblePdf([
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 72 72] " +
+          "/Resources << /XObject << /Im0 4 0 R >> >> /Contents 6 0 R >>\nendobj\n",
+        "4 0 obj\n<< /Type /XObject /Subtype /Image /Width 12 /Height 12 " +
+          "/ColorSpace /DeviceGray /BitsPerComponent 8 /Filter 5 0 R " +
+          `/Length ${hexData.length} >>\nstream\n${hexData}\nendstream\nendobj\n`,
+        "5 0 obj\n/ASCIIHexDecode\nendobj\n",
+        `6 0 obj\n<< /Length ${content.length} >>\n` +
+          `stream\n${content}\nendstream\nendobj\n`,
+      ]);
+
+      let loadingTask = getDocument({ data: buildEmptyPagePdf() });
+      let pdfDoc = await loadingTask.promise;
+      pdfDoc.annotationStorage.setValue("pdfjs_internal_editor_0", {
+        annotationType: AnnotationEditorType.FREETEXT,
+        rect: [12, 34, 56, 78],
+        rotation: 0,
+        fontSize: 10,
+        color: [0, 0, 0],
+        value: "Hello",
+        pageIndex: 0,
+      });
+
+      const data = await pdfDoc.saveDocument(() => generated);
+      const savedString = bytesToString(data);
+      expect(savedString).toContain("/Filter [/FlateDecode /ASCIIHexDecode]");
+      await loadingTask.destroy();
+
+      loadingTask = getDocument({ data });
+      pdfDoc = await loadingTask.promise;
+      const page = await pdfDoc.getPage(1);
+      const operatorList = await page.getOperatorList({
+        annotationMode: AnnotationMode.ENABLE,
+      });
+      expect(operatorList.fnArray).toContain(OPS.paintImageXObject);
+      await loadingTask.destroy();
+    });
+
+    it("embeds externally generated FreeText appearances sharing their font", async function () {
+      let loadingTask = getDocument({ data: buildEmptyPagePdf() });
+      let pdfDoc = await loadingTask.promise;
+      for (let i = 0; i < 2; i++) {
+        pdfDoc.annotationStorage.setValue(`pdfjs_internal_editor_${i}`, {
+          annotationType: AnnotationEditorType.FREETEXT,
+          rect: [12 + 50 * i, 34, 56 + 50 * i, 78],
+          rotation: 0,
+          fontSize: 10,
+          color: [0, 0, 0],
+          value: `Hello n°${i}`,
+          pageIndex: 0,
+        });
+      }
+
+      let generatedEntries;
+      const data = await pdfDoc.saveDocument(entries => {
+        generatedEntries = entries;
+        return buildGeneratedAppearancePdf([
+          "BT /F1 10 Tf (App0) Tj ET",
+          "BT /F1 10 Tf (App1) Tj ET",
+        ]);
+      });
+      expect(generatedEntries.map(entry => entry.data.text)).toEqual([
+        "Hello n°0",
+        "Hello n°1",
+      ]);
+      const savedString = bytesToString(data);
+      expect(savedString).toContain("(App0) Tj");
+      expect(savedString).toContain("(App1) Tj");
+      expect(savedString.match(/\/Subtype \/Form/g).length).toEqual(2);
+      expect(savedString.match(/\/BaseFont \/Helvetica/g).length).toEqual(1);
+      await loadingTask.destroy();
+
+      loadingTask = getDocument({ data });
+      pdfDoc = await loadingTask.promise;
+      const page = await pdfDoc.getPage(1);
+      const annotations = await page.getAnnotations();
+      expect(annotations.map(annotation => annotation.contentsObj.str)).toEqual(
+        ["Hello n°0", "Hello n°1"]
+      );
       await loadingTask.destroy();
     });
 

--- a/web/app.js
+++ b/web/app.js
@@ -1440,7 +1440,9 @@ const PDFViewerApplication = {
     await this.pdfScriptingManager.dispatchWillSave();
 
     try {
-      const data = await this.pdfDocument.saveDocument();
+      const data = await this.pdfDocument.saveDocument(
+        this.externalServices.printToPDF
+      );
       this.downloadManager.download(data, this._downloadUrl, this._docFilename);
     } catch (reason) {
       // When the PDF document isn't ready, fallback to a "regular" download.

--- a/web/external_services.js
+++ b/web/external_services.js
@@ -68,6 +68,12 @@ class BaseExternalServices {
     return null;
   }
 
+  /**
+   * Platform appearance renderer; see `PDFDocumentProxy.saveDocument`.
+   * @type {?function(Array<object>): Promise<Uint8Array | null>}
+   */
+  printToPDF = null;
+
   updateEditorStates(data) {
     throw new Error("Not implemented: updateEditorStates");
   }

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -33,17 +33,37 @@ function initCom(app) {
   viewerApp = app;
 }
 
+// nsPagePrintTimer waits ~4.5s over the first ten sheets, then 50ms per sheet.
+const PRINT_TO_PDF_BASE_DELAY = 4_500;
+const PRINT_TO_PDF_PER_ENTRY_DELAY = 50;
+const PRINT_TO_PDF_MIN_TIMEOUT = 10_000;
+
+function getPrintToPDFTimeout(entries) {
+  return Math.max(
+    PRINT_TO_PDF_MIN_TIMEOUT,
+    2 * (PRINT_TO_PDF_BASE_DELAY + PRINT_TO_PDF_PER_ENTRY_DELAY * entries)
+  );
+}
+
 class FirefoxCom {
   /**
    * Creates an event that the extension is listening for and will
    * asynchronously respond to.
    * @param {string} action - The action to trigger.
    * @param {object | string} [data] - The data to send.
+   * @param {number} [timeout] - Reject after this many milliseconds without a
+   *   response; `0` waits forever.
    * @returns {Promise<any>} A promise that is resolved with the response data.
    */
-  static requestAsync(action, data) {
-    return new Promise(resolve => {
-      this.request(action, data, resolve);
+  static requestAsync(action, data, timeout = 0) {
+    return new Promise((resolve, reject) => {
+      const timeoutId = timeout
+        ? setTimeout(reject, timeout, new Error(`"${action}" timed out.`))
+        : 0;
+      this.request(action, data, response => {
+        clearTimeout(timeoutId);
+        resolve(response);
+      });
     });
   }
 
@@ -672,6 +692,15 @@ class SignatureVerifier {
 }
 
 class ExternalServices extends BaseExternalServices {
+  printToPDF = async data => {
+    const buffer = await FirefoxCom.requestAsync(
+      "printToPDF",
+      data,
+      getPrintToPDFTimeout(data.length)
+    );
+    return buffer ? new Uint8Array(buffer) : null;
+  };
+
   updateFindControlState(data) {
     FirefoxCom.request("updateFindControlState", data);
   }


### PR DESCRIPTION
PDF.js creates FreeText appearances with Helvetica and WinAnsiEncoding. It cannot generate a matching appearance when Helvetica cannot encode the text.

Add a Firefox-only `printToPDF` callback to `saveDocument`. The worker batches serialized FreeText entries and imports one generated PDF page per appearance. The single-PDF batch preserves resources shared across pages.

Copy each page's resources and content without reserializing retained operators. Drop marked-content operators because their metadata belongs to the generated PDF.