### PR TITLE
[api-minor] Offload canvas drawing operations to a worker 

### DIFF
--- a/external/dist/webpack.mjs
+++ b/external/dist/webpack.mjs
@@ -21,8 +21,10 @@ if (typeof window !== "undefined" && "Worker" in window) {
     new URL("./build/pdf.worker.mjs", import.meta.url),
     { type: "module" }
   );
-  // Worker rendering is not enabled yet, hence
-  // `GlobalWorkerOptions.rendererSrc` is deliberately left unset here.
+  GlobalWorkerOptions.rendererSrc = new URL(
+    "./build/pdf.renderer.mjs",
+    import.meta.url
+  ).href;
 }
 
 export * from "./build/pdf.mjs";

--- a/external/dist/webpack.mjs
+++ b/external/dist/webpack.mjs
@@ -21,10 +21,6 @@ if (typeof window !== "undefined" && "Worker" in window) {
     new URL("./build/pdf.worker.mjs", import.meta.url),
     { type: "module" }
   );
-  GlobalWorkerOptions.rendererSrc = new URL(
-    "./build/pdf.renderer.mjs",
-    import.meta.url
-  ).href;
 }
 
 export * from "./build/pdf.mjs";

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -627,6 +627,24 @@ function createWorkerBundle(defines) {
     .pipe(webpack2Stream(workerFileConfig));
 }
 
+function createRendererWorkerBundle(defines) {
+  const rendererWorkerDefines = {
+    ...defines,
+    WORKER_THREAD: true,
+  };
+  const rendererWorkerFileConfig = createWebpackConfig(rendererWorkerDefines, {
+    filename: rendererWorkerDefines.MINIFIED
+      ? "pdf.renderer.min.mjs"
+      : "pdf.renderer.mjs",
+    library: {
+      type: "module",
+    },
+  });
+  return gulp
+    .src("./src/pdf.renderer.js", { encoding: false })
+    .pipe(webpack2Stream(rendererWorkerFileConfig));
+}
+
 function createWebBundle(defines, options) {
   const viewerFileConfig = createWebpackConfig(defines, {
     filename: "viewer.mjs",
@@ -1438,6 +1456,7 @@ function buildGeneric(defines, dir) {
   return ordered([
     createMainBundle(defines).pipe(gulp.dest(dir + "build")),
     createWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
+    createRendererWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
     createSandboxBundle(defines).pipe(gulp.dest(dir + "build")),
     createWebBundle(defines).pipe(gulp.dest(dir + "web")),
     gulp
@@ -1582,6 +1601,7 @@ function buildMinified(defines, dir) {
   return ordered([
     createMainBundle(defines).pipe(gulp.dest(dir + "build")),
     createWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
+    createRendererWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
     createSandboxBundle(defines).pipe(gulp.dest(dir + "build")),
     createImageDecodersBundle({ ...defines, IMAGE_DECODERS: true }).pipe(
       gulp.dest(dir + "image_decoders")
@@ -1712,6 +1732,10 @@ async function buildMozcentral(changedFiles = null) {
       create: () => createScriptingBundle(defines),
     },
     { bundle: "pdf.worker.mjs", create: () => createWorkerBundle(defines) },
+    {
+      bundle: "pdf.renderer.mjs",
+      create: () => createRendererWorkerBundle(defines),
+    },
     {
       files: /^src\/pdf\.sandbox\.external\.js$/,
       create: () => createSandboxExternal(defines),
@@ -2150,6 +2174,9 @@ gulp.task(
         createWorkerBundle(defines).pipe(
           gulp.dest(CHROME_BUILD_CONTENT_DIR + "build")
         ),
+        createRendererWorkerBundle(defines).pipe(
+          gulp.dest(CHROME_BUILD_CONTENT_DIR + "build")
+        ),
         createSandboxBundle(defines).pipe(
           gulp.dest(CHROME_BUILD_CONTENT_DIR + "build")
         ),
@@ -2343,7 +2370,7 @@ function buildLib(defines, dir) {
     gulp.src(
       [
         "src/{core,display,shared}/**/*.js",
-        "src/{pdf,pdf.image_decoders,pdf.worker}.js",
+        "src/{pdf,pdf.image_decoders,pdf.worker,pdf.renderer}.js",
       ],
       { base: "src/", encoding: false, sourcemaps: enableSourceMaps }
     ),
@@ -3202,6 +3229,7 @@ function buildInternalViewer(defines, dir) {
   return ordered([
     createMainBundle(defines).pipe(gulp.dest(dir + "build")),
     createWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
+    createRendererWorkerBundle(defines).pipe(gulp.dest(dir + "build")),
     createInternalViewerBundle(defines).pipe(gulp.dest(dir + "web")),
     preprocessHTML("web/internal/debugger.html", defines).pipe(
       gulp.dest(dir + "web")
@@ -3420,8 +3448,10 @@ gulp.task(
         gulp
           .src(
             [
-              GENERIC_DIR + "build/{pdf,pdf.worker,pdf.sandbox}.mjs",
-              GENERIC_DIR + "build/{pdf,pdf.worker,pdf.sandbox}.mjs.map",
+              GENERIC_DIR +
+                "build/{pdf,pdf.worker,pdf.sandbox,pdf.renderer}.mjs",
+              GENERIC_DIR +
+                "build/{pdf,pdf.worker,pdf.sandbox,pdf.renderer}.mjs.map",
             ],
             { encoding: false }
           )
@@ -3429,16 +3459,22 @@ gulp.task(
         gulp
           .src(
             [
-              GENERIC_LEGACY_DIR + "build/{pdf,pdf.worker,pdf.sandbox}.mjs",
-              GENERIC_LEGACY_DIR + "build/{pdf,pdf.worker,pdf.sandbox}.mjs.map",
+              GENERIC_LEGACY_DIR +
+                "build/{pdf,pdf.worker,pdf.sandbox,pdf.renderer}.mjs",
+              GENERIC_LEGACY_DIR +
+                "build/{pdf,pdf.worker,pdf.sandbox,pdf.renderer}.mjs.map",
             ],
             { encoding: false }
           )
           .pipe(gulp.dest(DIST_DIR + "legacy/build/")),
         gulp
-          .src(MINIFIED_DIR + "build/{pdf,pdf.worker,pdf.sandbox}.min.mjs", {
-            encoding: false,
-          })
+          .src(
+            MINIFIED_DIR +
+              "build/{pdf,pdf.worker,pdf.sandbox,pdf.renderer}.min.mjs",
+            {
+              encoding: false,
+            }
+          )
           .pipe(gulp.dest(DIST_DIR + "build/")),
         gulp
           .src(MINIFIED_DIR + "image_decoders/pdf.image_decoders.min.mjs", {
@@ -3447,7 +3483,8 @@ gulp.task(
           .pipe(gulp.dest(DIST_DIR + "image_decoders/")),
         gulp
           .src(
-            MINIFIED_LEGACY_DIR + "build/{pdf,pdf.worker,pdf.sandbox}.min.mjs",
+            MINIFIED_LEGACY_DIR +
+              "build/{pdf,pdf.worker,pdf.sandbox,pdf.renderer}.min.mjs",
             { encoding: false }
           )
           .pipe(gulp.dest(DIST_DIR + "legacy/build/")),

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -42,6 +42,7 @@ import {
   CanvasDependencyTracker,
   CanvasImagesTracker,
 } from "./canvas_dependency_tracker.js";
+import { CanvasGraphics, setAnnotationCanvasName } from "./canvas.js";
 import {
   getDataProp,
   getFactoryUrlProp,
@@ -61,7 +62,6 @@ import {
   NodeCanvasFactory,
   NodeFilterFactory,
 } from "display-node_utils";
-import { CanvasGraphics } from "./canvas.js";
 import { DOMBinaryDataFactory } from "display-binary_data_factory";
 import { DOMCanvasFactory } from "./canvas_factory.js";
 import { DOMFilterFactory } from "./filter_factory.js";
@@ -3611,15 +3611,52 @@ class InternalRenderTask {
     return this._rendererWorker?.messageHandler ?? null;
   }
 
-  #drawFrame({ bitmap }) {
+  // Rebuild the worker's annotation canvases as DOM canvases for the
+  // annotation layer. The first tuple for an id replaces any previous entry,
+  // later ones (checkbox/radio states) append.
+  #drawAnnotationFrames(annotationBitmaps) {
+    const { ownerDocument } = this._canvas;
+    if (typeof ownerDocument?.createElement !== "function") {
+      return;
+    }
+    const seen = new Set();
+    for (const [id, canvasName, bitmap] of annotationBitmaps) {
+      const canvas = ownerDocument.createElement("canvas");
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+      canvas.getContext("2d").drawImage(bitmap, 0, 0);
+
+      if (!canvasName) {
+        this.annotationCanvasMap.set(id, canvas);
+        continue;
+      }
+      setAnnotationCanvasName(canvas, canvasName);
+      if (seen.has(id)) {
+        this.annotationCanvasMap.get(id).push(canvas);
+      } else {
+        seen.add(id);
+        this.annotationCanvasMap.set(id, [canvas]);
+      }
+    }
+  }
+
+  #drawFrame({ bitmap, annotationBitmaps }) {
     try {
       if (this.cancelled) {
         return;
       }
       const ctx = this._canvas.getContext("2d", { alpha: false });
       ctx.drawImage(bitmap, 0, 0);
+      if (annotationBitmaps) {
+        this.#drawAnnotationFrames(annotationBitmaps);
+      }
     } finally {
       bitmap.close();
+      if (annotationBitmaps) {
+        for (const [, , annotationBitmap] of annotationBitmaps) {
+          annotationBitmap.close();
+        }
+      }
     }
   }
 
@@ -3653,13 +3690,12 @@ class InternalRenderTask {
 
     // The stepper needs `gfx` on the main thread, so we have to fall back to
     // local rendering when it's enabled; the same holds for `pageColors`,
-    // which needs DOM-based SVG filters. Annotation canvases and operation
-    // recording move into the worker in follow-up commits.
+    // which needs DOM-based SVG filters. Operation recording moves into the
+    // worker in a follow-up commit.
     let useWorkerRendering =
       this.rendererHandler &&
       !this.params.canvasContext &&
       (!background || typeof background === "string") &&
-      !this.annotationCanvasMap &&
       !dependencyTracker &&
       !imagesTracker &&
       !this.pageColors &&
@@ -3676,6 +3712,7 @@ class InternalRenderTask {
           pageId: this._pageId,
           renderTaskId: this._renderTaskId,
           enableHWA: this._enableHWA,
+          hasAnnotationCanvasMap: !!this.annotationCanvasMap,
           optionalContentConfig: optionalContentConfig.serializable,
           transform,
           viewport,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1667,6 +1667,7 @@ class PDFPageProxy {
       annotationCanvasMap,
       operatorList: intentState.operatorList,
       pageIndex: this._pageIndex,
+      pageId: this.#pageId,
       canvasFactory: this._transport.canvasFactory,
       filterFactory: this._transport.filterFactory,
       useRequestAnimationFrame: !intentPrint,
@@ -1674,6 +1675,7 @@ class PDFPageProxy {
       pageColors,
       enableHWA: this._transport.enableHWA,
       operationsFilter,
+      rendererWorker: this._transport.rendererWorker,
     });
 
     (intentState.renderTasks ||= new Set()).add(internalRenderTask);
@@ -1683,7 +1685,7 @@ class PDFPageProxy {
       intentState.displayReadyCapability.promise,
       optionalContentConfigPromise,
     ])
-      .then(([transparency, optionalContentConfig]) => {
+      .then(async ([transparency, optionalContentConfig]) => {
         if (this.destroyed) {
           complete();
           return;
@@ -1696,7 +1698,7 @@ class PDFPageProxy {
               "and `PDFDocumentProxy.getOptionalContentConfig` methods."
           );
         }
-        internalRenderTask.initializeGraphics({
+        await internalRenderTask.initializeGraphics({
           transparency,
           optionalContentConfig,
         });
@@ -2207,6 +2209,10 @@ class RendererWorker {
         } catch (reason) {
           terminateEarly(reason);
         }
+      });
+
+      messageHandler.on("RenderFrame", frame => {
+        InternalRenderTask.handleRenderFrame(frame);
       });
 
       const sendTest = () => {
@@ -3517,6 +3523,27 @@ class InternalRenderTask {
 
   static #canvasInUse = new WeakSet();
 
+  // Render tasks drawing in a renderer worker, keyed by id, so that frames
+  // arriving from it can be routed to the right one.
+  static #activeRenderTasks = new Map();
+
+  static #renderTaskId = 0;
+
+  static handleRenderFrame(frame) {
+    const internalTask = InternalRenderTask.#activeRenderTasks.get(
+      frame.renderTaskId
+    );
+    if (!internalTask) {
+      frame.bitmap.close();
+      return;
+    }
+    try {
+      internalTask.#drawFrame(frame);
+    } catch (ex) {
+      internalTask.cancel(ex);
+    }
+  }
+
   constructor({
     callback,
     params,
@@ -3525,6 +3552,7 @@ class InternalRenderTask {
     annotationCanvasMap,
     operatorList,
     pageIndex,
+    pageId,
     canvasFactory,
     filterFactory,
     useRequestAnimationFrame = false,
@@ -3532,6 +3560,7 @@ class InternalRenderTask {
     pageColors = null,
     enableHWA = false,
     operationsFilter = null,
+    rendererWorker = null,
   }) {
     this.callback = callback;
     this.params = params;
@@ -3541,6 +3570,7 @@ class InternalRenderTask {
     this.operatorListIdx = null;
     this.operatorList = operatorList;
     this._pageIndex = pageIndex;
+    this._pageId = pageId;
     this.canvasFactory = canvasFactory;
     this.filterFactory = filterFactory;
     this._pdfBug = pdfBug;
@@ -3565,6 +3595,9 @@ class InternalRenderTask {
     this._dependencyTracker = params.dependencyTracker;
     this._imagesTracker = params.imagesTracker;
     this._operationsFilter = operationsFilter;
+    this._rendererWorker = rendererWorker;
+    this._renderTaskId = InternalRenderTask.#renderTaskId++;
+    this._sentOperatorListLength = 0;
   }
 
   get completed() {
@@ -3574,7 +3607,23 @@ class InternalRenderTask {
     });
   }
 
-  initializeGraphics({ transparency = false, optionalContentConfig }) {
+  get rendererHandler() {
+    return this._rendererWorker?.messageHandler ?? null;
+  }
+
+  #drawFrame({ bitmap }) {
+    try {
+      if (this.cancelled) {
+        return;
+      }
+      const ctx = this._canvas.getContext("2d", { alpha: false });
+      ctx.drawImage(bitmap, 0, 0);
+    } finally {
+      bitmap.close();
+    }
+  }
+
+  async initializeGraphics({ transparency = false, optionalContentConfig }) {
     if (this.cancelled) {
       return;
     }
@@ -3602,33 +3651,85 @@ class InternalRenderTask {
       imagesTracker,
     } = this.params;
 
-    // When printing in Firefox, we get a specific context in mozPrintCallback
-    // which cannot be created from the canvas itself.
-    const canvasContext =
-      this._canvasContext ||
-      this._canvas.getContext("2d", {
-        alpha: false,
-        willReadFrequently: !this._enableHWA,
-      });
+    // The stepper needs `gfx` on the main thread, so we have to fall back to
+    // local rendering when it's enabled; the same holds for `pageColors`,
+    // which needs DOM-based SVG filters. Annotation canvases and operation
+    // recording move into the worker in follow-up commits.
+    let useWorkerRendering =
+      this.rendererHandler &&
+      !this.params.canvasContext &&
+      (!background || typeof background === "string") &&
+      !this.annotationCanvasMap &&
+      !dependencyTracker &&
+      !imagesTracker &&
+      !this.pageColors &&
+      !this.stepper;
 
-    this.gfx = new CanvasGraphics(
-      canvasContext,
-      this.commonObjs,
-      this.objs,
-      this.canvasFactory,
-      this.filterFactory,
-      { optionalContentConfig },
-      this.annotationCanvasMap,
-      this.pageColors,
-      dependencyTracker,
-      imagesTracker
-    );
-    this.gfx.beginDrawing({
-      transform,
-      viewport,
-      transparency,
-      background,
-    });
+    if (!useWorkerRendering && this._rendererWorker) {
+      this._rendererWorker = null;
+    }
+    if (useWorkerRendering) {
+      try {
+        const initParams = {
+          width: this._canvas.width,
+          height: this._canvas.height,
+          pageId: this._pageId,
+          renderTaskId: this._renderTaskId,
+          enableHWA: this._enableHWA,
+          optionalContentConfig: optionalContentConfig.serializable,
+          transform,
+          viewport,
+          transparency,
+          background,
+        };
+        // Wait for the renderer worker to finish setup, so that a failure can
+        // still fall back to main-thread rendering below.
+        await this.rendererHandler.sendWithPromise(
+          "InitializeGraphics",
+          initParams
+        );
+        if (this.cancelled) {
+          return;
+        }
+        InternalRenderTask.#activeRenderTasks.set(this._renderTaskId, this);
+      } catch (ex) {
+        warn(
+          `Failed to initialize graphics in renderer worker: ${ex.message}. ` +
+            "Falling back to main-thread rendering."
+        );
+        this._rendererWorker = null;
+        useWorkerRendering = false;
+      }
+    }
+    if (!useWorkerRendering) {
+      // When printing in Firefox, we get a specific context in mozPrintCallback
+      // which cannot be created from the canvas itself.
+      const canvasContext =
+        this._canvasContext ||
+        this._canvas.getContext("2d", {
+          alpha: false,
+          willReadFrequently: !this._enableHWA,
+        });
+
+      this.gfx = new CanvasGraphics(
+        canvasContext,
+        this.commonObjs,
+        this.objs,
+        this.canvasFactory,
+        this.filterFactory,
+        { optionalContentConfig },
+        this.annotationCanvasMap,
+        this.pageColors,
+        dependencyTracker,
+        imagesTracker
+      );
+      this.gfx.beginDrawing({
+        transform,
+        viewport,
+        transparency,
+        background,
+      });
+    }
     this.operatorListIdx = 0;
     this.graphicsReady = true;
     this.graphicsReadyCallback?.();
@@ -3637,6 +3738,10 @@ class InternalRenderTask {
   cancel(error = null, extraDelay = 0) {
     this.running = false;
     this.cancelled = true;
+    this.rendererHandler?.send("CleanupRenderTask", {
+      renderTaskId: this._renderTaskId,
+    });
+    InternalRenderTask.#activeRenderTasks.delete(this._renderTaskId);
     this.gfx?.endDrawing();
     if (this.#rAF) {
       window.cancelAnimationFrame(this.#rAF);
@@ -3658,10 +3763,14 @@ class InternalRenderTask {
       this.graphicsReadyCallback ||= this._continueBound;
       return;
     }
-    this.gfx.dependencyTracker?.growOperationsCount(
-      this.operatorList.fnArray.length
-    );
-    this.stepper?.updateOperatorList(this.operatorList);
+    // The stepper is main-thread only and mutually exclusive with worker
+    // rendering, so there's nothing to update here in that case.
+    if (!this._rendererWorker) {
+      this.gfx.dependencyTracker?.growOperationsCount(
+        this.operatorList.fnArray.length
+      );
+      this.stepper?.updateOperatorList(this.operatorList);
+    }
 
     if (this.running) {
       return;
@@ -3696,10 +3805,74 @@ class InternalRenderTask {
     if (this.cancelled) {
       return;
     }
+    const { operatorList, operatorListIdx } = this;
+    if (this._rendererWorker) {
+      const { rendererHandler } = this;
+      if (!rendererHandler) {
+        throw new Error("Renderer worker was destroyed during rendering.");
+      }
+      const operatorListArgsArrayLen = operatorList.argsArray.length;
+      const sentLength = this._sentOperatorListLength;
+      const hasNewOps = sentLength < operatorListArgsArrayLen;
+      const fnArray = hasNewOps
+        ? operatorList.fnArray.slice(sentLength, operatorListArgsArrayLen)
+        : null;
+      const argsArray = hasNewOps
+        ? operatorList.argsArray.slice(sentLength, operatorListArgsArrayLen)
+        : null;
+      // Since operationsFilter is a function and cannot be structured-cloned,
+      // precomputing the results for the ops being sent as a mask that the
+      // worker can index into.
+      let operationsFilterMask = null;
+      if (fnArray && this._operationsFilter) {
+        operationsFilterMask = new Uint8Array(fnArray.length);
+        for (let i = 0, ii = fnArray.length; i < ii; i++) {
+          operationsFilterMask[i] = this._operationsFilter(
+            sentLength + i,
+            operatorList
+          )
+            ? 1
+            : 0;
+        }
+      }
+      const sentLastChunk = operatorList.lastChunk;
+      const response = await rendererHandler.sendWithPromise(
+        "ExecuteOperatorList",
+        {
+          renderTaskId: this._renderTaskId,
+          fnArray,
+          argsArray,
+          operatorListIdx,
+          operationsFilterMask,
+          lastChunk: sentLastChunk,
+        }
+      );
+      this.operatorListIdx = response.operatorListIdx;
+      this._sentOperatorListLength = operatorListArgsArrayLen;
+      if (this.cancelled) {
+        return;
+      }
+
+      if (this.operatorListIdx === operatorList.argsArray.length) {
+        this.running = false;
+        if (sentLastChunk) {
+          InternalRenderTask.#activeRenderTasks.delete(this._renderTaskId);
+          InternalRenderTask.#canvasInUse.delete(this._canvas);
+          this.callback();
+        } else if (this.operatorList.lastChunk) {
+          this._continue();
+        }
+      } else {
+        this._continue();
+      }
+      return;
+    }
     this.operatorListIdx = this.gfx.executeOperatorList(
       this.operatorList,
       this.operatorListIdx,
       this._continueBound,
+      // main-thread doesn't reject objects
+      null,
       this.stepper,
       this._operationsFilter
     );

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -2221,10 +2221,6 @@ class RendererWorker {
         }
       });
 
-      messageHandler.on("RenderFrame", frame => {
-        InternalRenderTask.handleRenderFrame(frame);
-      });
-
       const sendTest = () => {
         const testObj = new Uint8Array();
         // Ensure that we can use `postMessage` transfers.
@@ -3043,6 +3039,10 @@ class WorkerTransport {
       }
       return messageHandler.sendWithPromise("FontFallback", data);
     });
+    this.rendererHandler?.on(
+      "RenderFrame",
+      InternalRenderTask.handleRenderFrame
+    );
 
     const forwardToRenderer = (action, data) => {
       const { rendererHandler } = this;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3910,78 +3910,8 @@ class InternalRenderTask {
     if (this.cancelled) {
       return;
     }
-    const { operatorList, operatorListIdx } = this;
     if (this._rendererWorker) {
-      const { rendererHandler } = this;
-      if (!rendererHandler) {
-        throw new Error("Renderer worker was destroyed during rendering.");
-      }
-      const operatorListArgsArrayLen = operatorList.argsArray.length;
-      const sentLength = this._sentOperatorListLength;
-      const hasNewOps = sentLength < operatorListArgsArrayLen;
-      const fnArray = hasNewOps
-        ? operatorList.fnArray.slice(sentLength, operatorListArgsArrayLen)
-        : null;
-      const argsArray = hasNewOps
-        ? operatorList.argsArray.slice(sentLength, operatorListArgsArrayLen)
-        : null;
-      // Since operationsFilter is a function and cannot be structured-cloned,
-      // precomputing the results for the ops being sent as a mask that the
-      // worker can index into.
-      let operationsFilterMask = null;
-      if (fnArray && this._operationsFilter) {
-        operationsFilterMask = new Uint8Array(fnArray.length);
-        for (let i = 0, ii = fnArray.length; i < ii; i++) {
-          operationsFilterMask[i] = this._operationsFilter(
-            sentLength + i,
-            operatorList
-          )
-            ? 1
-            : 0;
-        }
-      }
-      const sentLastChunk = operatorList.lastChunk;
-      const response = await rendererHandler.sendWithPromise(
-        "ExecuteOperatorList",
-        {
-          renderTaskId: this._renderTaskId,
-          fnArray,
-          argsArray,
-          operatorListIdx,
-          operationsFilterMask,
-          lastChunk: sentLastChunk,
-        }
-      );
-      this.operatorListIdx = response.operatorListIdx;
-      // Only the final chunk carries `recordedBBoxes` / `imageCoordinates`.
-      if (response.recordedBBoxesBuffer) {
-        this.recordedBBoxes = BBoxReader.fromBuffer(
-          response.recordedBBoxesBuffer
-        );
-      }
-      if (response.imageCoordinates) {
-        this.imageCoordinates = response.imageCoordinates;
-      }
-      this._sentOperatorListLength = operatorListArgsArrayLen;
-      if (this.cancelled) {
-        return;
-      }
-      if (response.aborted) {
-        throw new Error("Render task was aborted in the renderer worker.");
-      }
-
-      if (this.operatorListIdx === operatorList.argsArray.length) {
-        this.running = false;
-        if (sentLastChunk) {
-          InternalRenderTask.#activeRenderTasks.delete(this._renderTaskId);
-          InternalRenderTask.#canvasInUse.delete(this._canvas);
-          this.callback();
-        } else if (this.operatorList.lastChunk) {
-          this._continue();
-        }
-      } else {
-        this._continue();
-      }
+      await this.#executeOperatorListInWorker();
       return;
     }
     this.operatorListIdx = this.gfx.executeOperatorList(
@@ -4000,6 +3930,79 @@ class InternalRenderTask {
         InternalRenderTask.#canvasInUse.delete(this._canvas);
         this.callback();
       }
+    }
+  }
+
+  async #executeOperatorListInWorker() {
+    const { rendererHandler, operatorList, operatorListIdx } = this;
+    if (!rendererHandler) {
+      throw new Error("Renderer worker was destroyed during rendering.");
+    }
+    const operatorListArgsArrayLen = operatorList.argsArray.length;
+    const sentLength = this._sentOperatorListLength;
+    const hasNewOps = sentLength < operatorListArgsArrayLen;
+    const fnArray = hasNewOps
+      ? operatorList.fnArray.slice(sentLength, operatorListArgsArrayLen)
+      : null;
+    const argsArray = hasNewOps
+      ? operatorList.argsArray.slice(sentLength, operatorListArgsArrayLen)
+      : null;
+    // Since operationsFilter is a function and cannot be structured-cloned,
+    // precomputing the results for the ops being sent as a mask that the
+    // worker can index into.
+    let operationsFilterMask = null;
+    if (fnArray && this._operationsFilter) {
+      operationsFilterMask = new Uint8Array(fnArray.length);
+      for (let i = 0, ii = fnArray.length; i < ii; i++) {
+        operationsFilterMask[i] = this._operationsFilter(
+          sentLength + i,
+          operatorList
+        )
+          ? 1
+          : 0;
+      }
+    }
+    const sentLastChunk = operatorList.lastChunk;
+    const response = await rendererHandler.sendWithPromise(
+      "ExecuteOperatorList",
+      {
+        renderTaskId: this._renderTaskId,
+        fnArray,
+        argsArray,
+        operatorListIdx,
+        operationsFilterMask,
+        lastChunk: sentLastChunk,
+      }
+    );
+    this.operatorListIdx = response.operatorListIdx;
+    // Only the final chunk carries `recordedBBoxes` / `imageCoordinates`.
+    if (response.recordedBBoxesBuffer) {
+      this.recordedBBoxes = BBoxReader.fromBuffer(
+        response.recordedBBoxesBuffer
+      );
+    }
+    if (response.imageCoordinates) {
+      this.imageCoordinates = response.imageCoordinates;
+    }
+    this._sentOperatorListLength = operatorListArgsArrayLen;
+    if (this.cancelled) {
+      return;
+    }
+    if (response.aborted) {
+      throw new Error("Render task was aborted in the renderer worker.");
+    }
+
+    if (this.operatorListIdx === operatorList.argsArray.length) {
+      this.running = false;
+      if (sentLastChunk) {
+        InternalRenderTask.#activeRenderTasks.delete(this._renderTaskId);
+        InternalRenderTask.#canvasInUse.delete(this._canvas);
+        this.callback();
+      } else if (operatorList.lastChunk) {
+        this._continue();
+      }
+    } else {
+      this._continue();
     }
   }
 }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -186,7 +186,8 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
  *   The default value is `false`.
  * @property {HTMLDocument} [ownerDocument] - Specify an explicit document
  *   context to create elements with and to load resources, such as fonts,
- *   into. Defaults to the current document.
+ *   into. Defaults to the current document. Renderer-worker rendering is
+ *   disabled when this is set to a custom document.
  * @property {boolean} [disableRange] - Disable range request loading of PDF
  *   files. When enabled, and if the server supports partial content requests,
  *   then the PDF will be fetched in chunks. The default value is `false`.
@@ -309,6 +310,12 @@ function getDocument(src = {}) {
   const useWasm = src.useWasm !== false;
   const pagesMapper = src.pagesMapper || new PagesMapper();
 
+  // Parameters only intended for development/testing purposes.
+  const styleElement =
+    typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")
+      ? src.styleElement
+      : null;
+
   // Parameters whose default values depend on other parameters.
   const useSystemFonts =
     typeof src.useSystemFonts === "boolean"
@@ -329,11 +336,6 @@ function getDocument(src = {}) {
           isValidFetchUrl(wasmUrl, document.baseURI)
         );
 
-  // Parameters only intended for development/testing purposes.
-  const styleElement =
-    typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")
-      ? src.styleElement
-      : null;
   const disableWorkerRendering =
     src.disableWorkerRendering === true ||
     !GlobalWorkerOptions.rendererSrc ||
@@ -1681,7 +1683,7 @@ class PDFPageProxy {
       intentState.displayReadyCapability.promise,
       optionalContentConfigPromise,
     ])
-      .then(async ([transparency, optionalContentConfig]) => {
+      .then(async ([renderPageData, optionalContentConfig]) => {
         if (this.destroyed) {
           complete();
           return;
@@ -1694,8 +1696,10 @@ class PDFPageProxy {
               "and `PDFDocumentProxy.getOptionalContentConfig` methods."
           );
         }
+        const { transparency, hasCanvasFilters } = renderPageData;
         await internalRenderTask.initializeGraphics({
           transparency,
+          hasCanvasFilters,
           optionalContentConfig,
         });
         internalRenderTask.operatorListChanged();
@@ -1900,7 +1904,7 @@ class PDFPageProxy {
   /**
    * @private
    */
-  _startRenderPage(transparency, cacheKey) {
+  _startRenderPage(transparency, cacheKey, hasCanvasFilters = false) {
     const intentState = this._intentStates.get(cacheKey);
     if (!intentState) {
       return; // Rendering was cancelled.
@@ -1909,7 +1913,10 @@ class PDFPageProxy {
 
     // TODO Refactor RenderPageRequest to separate rendering
     // and operator list logic
-    intentState.displayReadyCapability?.resolve(transparency);
+    intentState.displayReadyCapability?.resolve({
+      transparency,
+      hasCanvasFilters,
+    });
   }
 
   /**
@@ -3005,7 +3012,11 @@ class WorkerTransport {
       }
 
       const page = this.#pageCache.get(data.pageIndex);
-      page._startRenderPage(data.transparency, data.cacheKey);
+      page._startRenderPage(
+        data.transparency,
+        data.cacheKey,
+        data.hasCanvasFilters
+      );
     });
 
     const objectHandler = new ObjectHandler({
@@ -3663,7 +3674,11 @@ class InternalRenderTask {
     }
   }
 
-  async initializeGraphics({ transparency = false, optionalContentConfig }) {
+  async initializeGraphics({
+    transparency = false,
+    hasCanvasFilters = false,
+    optionalContentConfig,
+  }) {
     if (this.cancelled) {
       return;
     }
@@ -3686,13 +3701,16 @@ class InternalRenderTask {
     const { viewport, transform, background } = this.params;
 
     // The stepper-driven debug recording path needs `gfx` on the main thread,
-    // so we have to fall back to local rendering when it's enabled; the same
-    // holds for `pageColors`, which needs DOM-based SVG filters. Plain
-    // `recordOperations`/`recordImages` are handled inside the worker.
+    // so we have to fall back to local rendering when it's enabled. Plain
+    // `recordOperations`/`recordImages` are now handled inside the worker.
+    // Worker rendering is also disabled when canvas filters (TR) are present
+    // because OffscreenCanvas's OffscreenCanvasRenderingContext2D ignores
+    // `.filter` values set from a data URL. See bug 2011237.
     let useWorkerRendering =
       this.rendererHandler &&
       !this.params.canvasContext &&
       (!background || typeof background === "string") &&
+      !hasCanvasFilters &&
       !this.pageColors &&
       !this._recordForDebugger;
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -21,6 +21,7 @@ import {
   AbortException,
   AnnotationMode,
   assert,
+  FeatureTest,
   getVerbosityLevel,
   info,
   isNodeJS,
@@ -214,6 +215,11 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
  * @property {object} [pagesMapper] - The pages mapper that will be used to map
  *   page ids and page numbers. It's used when the page order is changed or some
  *   pages are removed, cloned, etc.
+ * @property {boolean} [disableWorkerRendering] - Disables rendering of pages in
+ *   a worker thread. Note that worker rendering also requires
+ *   `GlobalWorkerOptions.rendererSrc` to be set; when it's unset, or the
+ *   renderer worker fails to start, rendering falls back to the main-thread.
+ *   The default value is `false`.
  */
 
 /**
@@ -327,6 +333,13 @@ function getDocument(src = {}) {
     typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")
       ? src.styleElement
       : null;
+  const disableWorkerRendering =
+    src.disableWorkerRendering === true ||
+    !GlobalWorkerOptions.rendererSrc ||
+    typeof Worker === "undefined" ||
+    !FeatureTest.isOffscreenCanvasSupported ||
+    ownerDocument !== globalThis.document ||
+    !!styleElement;
 
   // Set the main-thread verbosity level.
   setVerbosityLevel(verbosity);
@@ -351,6 +364,9 @@ function getDocument(src = {}) {
       port: GlobalWorkerOptions.workerPort,
     });
     task._worker = worker;
+  }
+  if (!disableWorkerRendering) {
+    task._rendererWorker = new RendererWorker({ verbosity });
   }
 
   const docParams = {
@@ -395,7 +411,18 @@ function getDocument(src = {}) {
     },
   };
 
-  Promise.all([worker.promise, gpuPromise])
+  const workerPromises = [worker.promise, gpuPromise];
+  if (task._rendererWorker) {
+    workerPromises.push(
+      task._rendererWorker.promise.catch(reason => {
+        warn(`Renderer worker disabled: ${reason.message}`);
+        task._rendererWorker.destroy();
+        task._rendererWorker = null;
+      })
+    );
+  }
+
+  Promise.all(workerPromises)
     .then(function ([, hasGPU]) {
       if (worker.destroyed) {
         throw new Error("Worker was destroyed");
@@ -509,6 +536,11 @@ class PDFDocumentLoadingTask {
   _worker = null;
 
   /**
+   * @private
+   */
+  _rendererWorker = null;
+
+  /**
    * Unique identifier for the document loading task.
    * @type {string}
    */
@@ -581,6 +613,9 @@ class PDFDocumentLoadingTask {
 
     this._worker?.destroy();
     this._worker = null;
+
+    this._rendererWorker?.destroy();
+    this._rendererWorker = null;
   }
 
   /**
@@ -2032,6 +2067,163 @@ class PDFPageProxy {
    */
   get stats() {
     return this._stats;
+  }
+}
+
+/**
+ * @typedef {object} RendererWorkerParameters
+ * @property {number} [verbosity] - Controls the logging level;
+ *   the constants from {@link VerbosityLevel} should be used.
+ */
+
+/**
+ * Renderer worker abstraction that controls the instantiation of a dedicated
+ * worker that can host canvas rendering.
+ * @param {RendererWorkerParameters} params - The worker initialization
+ *   parameters.
+ */
+class RendererWorker {
+  #capability = Promise.withResolvers();
+
+  #messageHandler = null;
+
+  #webWorker = null;
+
+  destroyed = false;
+
+  constructor({ verbosity = getVerbosityLevel() } = {}) {
+    this.verbosity = verbosity;
+    this.#initialize();
+  }
+
+  /**
+   * Promise for worker initialization completion.
+   * @type {Promise<void>}
+   */
+  get promise() {
+    return this.#capability.promise;
+  }
+
+  /**
+   * The current MessageHandler-instance.
+   * @type {MessageHandler | null}
+   */
+  get messageHandler() {
+    return this.#messageHandler;
+  }
+
+  #resolve() {
+    this.#capability.resolve();
+    // Send global setting, e.g. verbosity level.
+    this.#messageHandler.send("configure", {
+      verbosity: this.verbosity,
+    });
+  }
+
+  #initialize() {
+    try {
+      let { rendererSrc } = RendererWorker;
+
+      // Wraps rendererSrc path into blob URL, if the former does not belong
+      // to the same origin.
+      if (
+        typeof PDFJSDev !== "undefined" &&
+        PDFJSDev.test("GENERIC") &&
+        !PDFWorker._isSameOrigin(window.location, rendererSrc)
+      ) {
+        rendererSrc = PDFWorker._createCDNWrapper(
+          new URL(rendererSrc, window.location).href
+        );
+      }
+      const worker = new Worker(rendererSrc, { type: "module" });
+      const messageHandler = new MessageHandler("main", "renderer", worker);
+      const terminateEarly = reason => {
+        ac.abort();
+        messageHandler.destroy();
+        worker.terminate();
+
+        this.#capability.reject(
+          new Error(
+            `Renderer worker failed to initialize: "${reason?.message ?? reason}".`
+          )
+        );
+      };
+
+      const ac = new AbortController();
+      worker.addEventListener(
+        "error",
+        event => {
+          if (!this.#webWorker) {
+            // Worker failed to initialize due to an error.
+            terminateEarly(event.error || event.message);
+          }
+        },
+        { signal: ac.signal }
+      );
+
+      messageHandler.on("test", data => {
+        ac.abort();
+        if (this.destroyed || !data) {
+          terminateEarly("TypedArray transfer test failed.");
+          return;
+        }
+        this.#messageHandler = messageHandler;
+        this.#webWorker = worker;
+
+        this.#resolve();
+      });
+
+      messageHandler.on("ready", data => {
+        ac.abort();
+        if (this.destroyed) {
+          terminateEarly("Worker was destroyed.");
+          return;
+        }
+        try {
+          sendTest();
+        } catch (reason) {
+          terminateEarly(reason);
+        }
+      });
+
+      const sendTest = () => {
+        const testObj = new Uint8Array();
+        // Ensure that we can use `postMessage` transfers.
+        messageHandler.send("test", testObj, [testObj.buffer]);
+      };
+
+      // It might take time for the worker to initialize. We will try to send
+      // the "test" message immediately, and once the "ready" message arrives.
+      // The worker shall process only the first received "test" message.
+      sendTest();
+    } catch (reason) {
+      this.#capability.reject(reason);
+    }
+  }
+
+  /**
+   * Destroys the worker instance.
+   */
+  destroy() {
+    this.destroyed = true;
+
+    // We need to terminate only web worker created resource.
+    this.#webWorker?.terminate();
+    this.#webWorker = null;
+
+    this.#messageHandler?.destroy();
+    this.#messageHandler = null;
+  }
+
+  /**
+   * The current `rendererSrc`, when it exists.
+   * @type {string}
+   */
+  static get rendererSrc() {
+    if (GlobalWorkerOptions.rendererSrc) {
+      return GlobalWorkerOptions.rendererSrc;
+    }
+    throw new Error('No "GlobalWorkerOptions.rendererSrc" specified.');
   }
 }
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -38,6 +38,7 @@ import {
   SerializableEmpty,
 } from "./annotation_storage.js";
 import {
+  BBoxReader,
   CanvasBBoxTracker,
   CanvasDependencyTracker,
   CanvasImagesTracker,
@@ -1587,14 +1588,25 @@ class PDFPageProxy {
     const complete = error => {
       intentState.renderTasks.delete(internalRenderTask);
 
+      // Get the trackers from `gfx` into the task's. The worker path populates
+      // them from the final `ExecuteOperatorList` response, so we don't need
+      // this in that case.
+      if (internalRenderTask.gfx) {
+        const { dependencyTracker, imagesTracker } = internalRenderTask.gfx;
+        internalRenderTask.recordedBBoxes = dependencyTracker?.take() ?? null;
+        internalRenderTask.debugMetadata = recordForDebugger
+          ? (dependencyTracker?.takeDebugMetadata() ?? null)
+          : null;
+        internalRenderTask.imageCoordinates = imagesTracker?.take() ?? null;
+      }
+
       if (shouldRecordOperations) {
-        const recordedBBoxes = internalRenderTask.gfx?.dependencyTracker.take();
+        const { recordedBBoxes, debugMetadata } = internalRenderTask;
         if (recordedBBoxes) {
           internalRenderTask.stepper?.setOperatorBBoxes(
             recordedBBoxes,
-            internalRenderTask.gfx.dependencyTracker.takeDebugMetadata()
+            debugMetadata
           );
-
           if (recordOperations) {
             this.recordedBBoxes = recordedBBoxes;
           }
@@ -1602,7 +1614,7 @@ class PDFPageProxy {
       }
 
       if (shouldRecordImages && !error) {
-        this.imageCoordinates = internalRenderTask.gfx?.imagesTracker.take();
+        this.imageCoordinates = internalRenderTask.imageCoordinates;
       }
 
       // Attempt to reduce memory usage during *printing*, by always running
@@ -1633,34 +1645,18 @@ class PDFPageProxy {
       }
     };
 
-    let dependencyTracker = null;
-    let bboxTracker = null;
-    if (shouldRecordOperations || shouldRecordImages) {
-      bboxTracker = new CanvasBBoxTracker(
-        canvas,
-        intentState.operatorList.length
-      );
-    }
-    if (shouldRecordOperations) {
-      dependencyTracker = new CanvasDependencyTracker(
-        bboxTracker,
-        recordForDebugger
-      );
-    }
-
     const internalRenderTask = new InternalRenderTask({
       callback: complete,
       // Only include the required properties, and *not* the entire object.
       params: {
         canvas,
         canvasContext,
-        dependencyTracker: dependencyTracker ?? bboxTracker,
-        imagesTracker: shouldRecordImages
-          ? new CanvasImagesTracker(canvas)
-          : null,
         viewport,
         transform,
         background,
+        recordOperations: shouldRecordOperations,
+        recordImages: shouldRecordImages,
+        recordForDebugger,
       },
       objs: this.objs,
       commonObjs: this.commonObjs,
@@ -3592,12 +3588,19 @@ class InternalRenderTask {
     this._canvas = params.canvas;
     this._canvasContext = params.canvas ? null : params.canvasContext;
     this._enableHWA = enableHWA;
-    this._dependencyTracker = params.dependencyTracker;
-    this._imagesTracker = params.imagesTracker;
+    this._recordOperations = !!params.recordOperations;
+    this._recordImages = !!params.recordImages;
+    this._recordForDebugger = !!params.recordForDebugger;
     this._operationsFilter = operationsFilter;
     this._rendererWorker = rendererWorker;
     this._renderTaskId = InternalRenderTask.#renderTaskId++;
     this._sentOperatorListLength = 0;
+    // The worker path populates `recordedBBoxes`/`imageCoordinates` from the
+    // final `ExecuteOperatorList` response; `debugMetadata` is main-thread
+    // only, since the stepper disables worker rendering.
+    this.recordedBBoxes = null;
+    this.debugMetadata = null;
+    this.imageCoordinates = null;
   }
 
   get completed() {
@@ -3680,26 +3683,18 @@ class InternalRenderTask {
       this.stepper.init(this.operatorList);
       this.stepper.nextBreakPoint = this.stepper.getNextBreakPoint();
     }
-    const {
-      viewport,
-      transform,
-      background,
-      dependencyTracker,
-      imagesTracker,
-    } = this.params;
+    const { viewport, transform, background } = this.params;
 
-    // The stepper needs `gfx` on the main thread, so we have to fall back to
-    // local rendering when it's enabled; the same holds for `pageColors`,
-    // which needs DOM-based SVG filters. Operation recording moves into the
-    // worker in a follow-up commit.
+    // The stepper-driven debug recording path needs `gfx` on the main thread,
+    // so we have to fall back to local rendering when it's enabled; the same
+    // holds for `pageColors`, which needs DOM-based SVG filters. Plain
+    // `recordOperations`/`recordImages` are handled inside the worker.
     let useWorkerRendering =
       this.rendererHandler &&
       !this.params.canvasContext &&
       (!background || typeof background === "string") &&
-      !dependencyTracker &&
-      !imagesTracker &&
       !this.pageColors &&
-      !this.stepper;
+      !this._recordForDebugger;
 
     if (!useWorkerRendering && this._rendererWorker) {
       this._rendererWorker = null;
@@ -3713,6 +3708,8 @@ class InternalRenderTask {
           renderTaskId: this._renderTaskId,
           enableHWA: this._enableHWA,
           hasAnnotationCanvasMap: !!this.annotationCanvasMap,
+          recordOperations: this._recordOperations,
+          recordImages: this._recordImages,
           optionalContentConfig: optionalContentConfig.serializable,
           transform,
           viewport,
@@ -3748,6 +3745,25 @@ class InternalRenderTask {
           willReadFrequently: !this._enableHWA,
         });
 
+      let bboxTracker = null;
+      let dependencyTracker = null;
+      let imagesTracker = null;
+      if (this._recordOperations || this._recordImages) {
+        bboxTracker = new CanvasBBoxTracker(
+          this._canvas,
+          this.operatorList.fnArray.length
+        );
+      }
+      if (this._recordOperations) {
+        dependencyTracker = new CanvasDependencyTracker(
+          bboxTracker,
+          this._recordForDebugger
+        );
+      }
+      if (this._recordImages) {
+        imagesTracker = new CanvasImagesTracker(this._canvas);
+      }
+
       this.gfx = new CanvasGraphics(
         canvasContext,
         this.commonObjs,
@@ -3757,7 +3773,7 @@ class InternalRenderTask {
         { optionalContentConfig },
         this.annotationCanvasMap,
         this.pageColors,
-        dependencyTracker,
+        dependencyTracker ?? bboxTracker,
         imagesTracker
       );
       this.gfx.beginDrawing({
@@ -3885,6 +3901,15 @@ class InternalRenderTask {
         }
       );
       this.operatorListIdx = response.operatorListIdx;
+      // Only the final chunk carries `recordedBBoxes` / `imageCoordinates`.
+      if (response.recordedBBoxesBuffer) {
+        this.recordedBBoxes = BBoxReader.fromBuffer(
+          response.recordedBBoxesBuffer
+        );
+      }
+      if (response.imageCoordinates) {
+        this.imageCoordinates = response.imageCoordinates;
+      }
       this._sentOperatorListLength = operatorListArgsArrayLen;
       if (this.cancelled) {
         return;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -475,7 +475,10 @@ function getDocument(src = {}) {
           messageHandler,
           task,
           networkStream,
-          transportParams,
+          {
+            ...transportParams,
+            rendererWorker: task._rendererWorker,
+          },
           transportFactory,
           pagesMapper
         );
@@ -1403,6 +1406,14 @@ class PDFPageProxy {
   }
 
   /**
+   * @type {number} The index of the page in the original document, stable
+   *   across page moves/copies, matching the `p<pageId>_<n>` object ids.
+   */
+  get #pageId() {
+    return this.#pagesMapper.getPageId(this._pageIndex + 1) - 1;
+  }
+
+  /**
    * @type {number} The number of degrees the page is rotated clockwise.
    */
   get rotate() {
@@ -1842,6 +1853,9 @@ class PDFPageProxy {
       }
     }
     this.objs.clear();
+    this._transport.rendererHandler?.send("cleanupPage", {
+      pageId: this.#pageId,
+    });
     this.#pendingCleanup = false;
 
     return Promise.all(waitOn);
@@ -1878,6 +1892,9 @@ class PDFPageProxy {
     }
     this._intentStates.clear();
     this.objs.clear();
+    this._transport.rendererHandler?.send("cleanupPage", {
+      pageId: this.#pageId,
+    });
     this.#pendingCleanup = false;
     return true;
   }
@@ -1935,11 +1952,17 @@ class PDFPageProxy {
       );
     }
     const { map, transfer } = annotationStorageSerializable;
+    const pageId = this.#pageId;
+
+    // Restore the page in the renderer worker before any `obj` message can
+    // be forwarded, since the core worker emits each object only once and a
+    // dropped one would hang `ExecuteOperatorList` on its dependency.
+    this._transport.rendererHandler?.send("restorePage", { pageId });
 
     const readableStream = this._transport.messageHandler.sendWithStream(
       "GetOperatorList",
       {
-        pageId: this.#pagesMapper.getPageId(this._pageIndex + 1) - 1,
+        pageId,
         pageIndex: this._pageIndex,
         intent: renderingIntent,
         cacheKey,
@@ -2616,6 +2639,7 @@ class WorkerTransport {
       styleElement: params.styleElement,
     });
     this.enableHWA = params.enableHWA;
+    this.rendererWorker = params.rendererWorker || null;
     this.loadingParams = params.loadingParams;
     this._params = params;
 
@@ -2688,6 +2712,13 @@ class WorkerTransport {
 
   get annotationStorage() {
     return shadow(this, "annotationStorage", new AnnotationStorage());
+  }
+
+  /**
+   * @type {MessageHandler | null} The renderer worker's message handler.
+   */
+  get rendererHandler() {
+    return this.rendererWorker?.messageHandler ?? null;
   }
 
   getRenderingIntent(
@@ -2803,6 +2834,7 @@ class WorkerTransport {
 
       this.messageHandler?.destroy();
       this.messageHandler = null;
+      this.rendererWorker = null;
 
       this.destroyCapability.resolve();
     }, this.destroyCapability.reject);
@@ -2982,10 +3014,63 @@ class WorkerTransport {
       pdfBug: this._params.pdfBug,
     });
 
+    // TODO: add a direct channel between the renderer worker and the core
+    // worker so these main-thread forwarders can be removed.
+    this.rendererHandler?.on("FontFallback", data => {
+      if (this.destroyed) {
+        return null;
+      }
+      return messageHandler.sendWithPromise("FontFallback", data);
+    });
+
+    const forwardToRenderer = (action, data) => {
+      const { rendererHandler } = this;
+      if (!rendererHandler) {
+        return;
+      }
+      try {
+        rendererHandler.send(action, data);
+      } catch (reason) {
+        warn(`forwardToRenderer("${action}") failed: ${reason}`);
+        rendererHandler.send("objFailed", {
+          id: data[0],
+          pageIndex: action === "obj" ? data[1] : null,
+          reason: reason.message,
+        });
+      }
+    };
+
     messageHandler.on("commonobj", ([id, type, exportedData]) => {
       if (this.destroyed) {
         return null; // Ignore any pending requests if the worker was terminated.
       }
+
+      if (type === "CopyLocalImage") {
+        const dataLen = this.commonObjs.has(id)
+          ? null
+          : objectHandler.resolveCommonObject(id, type, exportedData);
+        const { rendererHandler } = this;
+        if (!dataLen || !rendererHandler) {
+          return dataLen;
+        }
+        // If the core worker doesn't re-send the image data, ensure that
+        // the renderer worker has a copy too
+        return rendererHandler
+          .sendWithPromise("commonobj", [id, type, exportedData])
+          .catch(() => null)
+          .then(rendererDataLen => {
+            if (!rendererDataLen) {
+              forwardToRenderer("commonobj", [
+                id,
+                "Image",
+                this.commonObjs.get(id),
+              ]);
+            }
+            return dataLen;
+          });
+      }
+
+      forwardToRenderer("commonobj", [id, type, exportedData]);
 
       if (this.commonObjs.has(id)) {
         return null;
@@ -3000,6 +3085,7 @@ class WorkerTransport {
         return;
       }
 
+      forwardToRenderer("obj", [id, pageIndex, type, imageData]);
       objectHandler.resolveObject(id, pageIndex, type, imageData);
     });
 
@@ -3325,6 +3411,9 @@ class WorkerTransport {
     if (!keepLoadedFonts) {
       this.fontLoader.clear();
     }
+    // Keep the renderer worker's document-level state in sync with the main
+    // thread.
+    this.rendererHandler?.send("Cleanup", { keepLoadedFonts });
     this.#methodPromises.clear();
     this.filterFactory.destroy(/* keepHCM = */ true);
     TextLayer.cleanup();

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3482,7 +3482,7 @@ class RenderTask {
   /**
    * Callback invoked after a frame from the renderer worker has been drawn
    * onto the canvas, including the final one.
-   * @type {function}
+   * @type {Function}
    */
   onFrame = null;
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -343,6 +343,7 @@ function getDocument(src = {}) {
     !isOffscreenCanvasSupported ||
     !FeatureTest.isOffscreenCanvasSupported ||
     ownerDocument !== globalThis.document ||
+    !ownerDocument?.fonts ||
     !!styleElement;
 
   // Set the main-thread verbosity level.

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -41,12 +41,6 @@ import {
   CanvasDependencyTracker,
   CanvasImagesTracker,
 } from "./canvas_dependency_tracker.js";
-import { FontFaceObject, FontLoader } from "./font_loader.js";
-import {
-  FontInfo,
-  FontPathInfo,
-  PatternInfo,
-} from "./obj_bin_transform_display.js";
 import {
   getDataProp,
   getFactoryUrlProp,
@@ -70,11 +64,13 @@ import { CanvasGraphics } from "./canvas.js";
 import { DOMBinaryDataFactory } from "display-binary_data_factory";
 import { DOMCanvasFactory } from "./canvas_factory.js";
 import { DOMFilterFactory } from "./filter_factory.js";
+import { FontLoader } from "./font_loader.js";
 import { getNetworkStream } from "display-network_stream";
 import { GlobalWorkerOptions } from "./worker_options.js";
 import { initGPU } from "./webgpu.js";
 import { MathClamp } from "../shared/math_clamp.js";
 import { Metadata } from "./metadata.js";
+import { ObjectHandler } from "./object_handler.js";
 import { OptionalContentConfig } from "./optional_content_config.js";
 import { PagesMapper } from "./pages_mapper.js";
 import { PageViewport } from "./page_viewport.js";
@@ -2786,6 +2782,14 @@ class WorkerTransport {
       page._startRenderPage(data.transparency, data.cacheKey);
     });
 
+    const objectHandler = new ObjectHandler({
+      messageHandler,
+      commonObjs: this.commonObjs,
+      fontLoader: this.fontLoader,
+      pageCache: this.#pageCache,
+      pdfBug: this._params.pdfBug,
+    });
+
     messageHandler.on("commonobj", ([id, type, exportedData]) => {
       if (this.destroyed) {
         return null; // Ignore any pending requests if the worker was terminated.
@@ -2795,78 +2799,7 @@ class WorkerTransport {
         return null;
       }
 
-      switch (type) {
-        case "Font":
-          if ("error" in exportedData) {
-            const exportedError = exportedData.error;
-            warn(`Error during font loading: ${exportedError}`);
-            this.commonObjs.resolve(id, exportedError);
-            break;
-          }
-
-          const fontData = new FontInfo(exportedData);
-          const inspectFont =
-            this._params.pdfBug && globalThis.FontInspector?.enabled
-              ? (font, url) => globalThis.FontInspector.fontAdded(font, url)
-              : null;
-          const font = new FontFaceObject(
-            fontData,
-            inspectFont,
-            exportedData.charProcOperatorList,
-            exportedData.extra
-          );
-
-          this.fontLoader
-            .bind(font)
-            .catch(() => messageHandler.sendWithPromise("FontFallback", { id }))
-            .finally(() => {
-              if (!font.fontExtraProperties) {
-                // Immediately release the `font.data` property once the font
-                // has been attached to the DOM, since it's no longer needed,
-                // rather than waiting for a `PDFDocumentProxy.cleanup` call.
-                // Since `font.data` could be very large, e.g. in some cases
-                // multiple megabytes, this will help reduce memory usage.
-                font.clearData();
-              }
-              this.commonObjs.resolve(id, font);
-            });
-          break;
-        case "CopyLocalImage":
-          const { imageRef } = exportedData;
-          assert(imageRef, "The imageRef must be defined.");
-
-          for (const pageProxy of this.#pageCache.values()) {
-            for (const [, data] of pageProxy.objs) {
-              if (data?.ref !== imageRef) {
-                continue;
-              }
-              if (!data.dataLen) {
-                return null;
-              }
-              const copy = structuredClone(data);
-              if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
-                copy.CopyLocalImage = true;
-              }
-              this.commonObjs.resolve(id, copy);
-              return data.dataLen;
-            }
-          }
-          break;
-        case "FontPath":
-          this.commonObjs.resolve(id, new FontPathInfo(exportedData));
-          break;
-        case "Image":
-          this.commonObjs.resolve(id, exportedData);
-          break;
-        case "Pattern":
-          const pattern = new PatternInfo(exportedData);
-          this.commonObjs.resolve(id, pattern.getIR());
-          break;
-        default:
-          throw new Error(`Got unknown common object type ${type}`);
-      }
-
-      return null;
+      return objectHandler.resolveCommonObject(id, type, exportedData);
     });
 
     messageHandler.on("obj", ([id, pageIndex, type, imageData]) => {
@@ -2875,24 +2808,7 @@ class WorkerTransport {
         return;
       }
 
-      const pageProxy = this.#pageCache.get(pageIndex);
-      if (pageProxy.objs.has(id)) {
-        return;
-      }
-      // Don't store data *after* cleanup has successfully run, see bug 1854145.
-      if (pageProxy._intentStates.size === 0) {
-        imageData?.bitmap?.close(); // Release any `ImageBitmap` data.
-        return;
-      }
-
-      switch (type) {
-        case "Image":
-        case "Pattern":
-          pageProxy.objs.resolve(id, imageData);
-          break;
-        default:
-          throw new Error(`Got unknown object type ${type}`);
-      }
+      objectHandler.resolveObject(id, pageIndex, type, imageData);
     });
 
     messageHandler.on("DocProgress", data => {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1286,6 +1286,9 @@ class PDFDocumentProxy {
  * @property {boolean} [recordImages] - Record the location of images in the PDF
  * @property {boolean} [recordOperations] - Record the dependencies and bounding
  *   boxes of all PDF operations that render onto the canvas.
+ * @property {boolean} [partialFrames] - Emit partial renderings of the page
+ *   through `RenderTask.onFrame` while it is being drawn. Only has an effect
+ *   when the page is rendered in a renderer worker.
  * @property {OperationsFilter} [operationsFilter] - If provided, only
  *   run for which this function returns `true`.
  */
@@ -1532,6 +1535,7 @@ class PDFPageProxy {
     isEditing = false,
     recordImages = false,
     recordOperations = false,
+    partialFrames = false,
     operationsFilter = null,
   }) {
     this._stats?.time("Overall");
@@ -1658,6 +1662,7 @@ class PDFPageProxy {
         background,
         recordOperations: shouldRecordOperations,
         recordImages: shouldRecordImages,
+        partialFrames,
         recordForDebugger,
       },
       objs: this.objs,
@@ -3471,6 +3476,13 @@ class RenderTask {
    */
   onError = null;
 
+  /**
+   * Callback invoked after a frame from the renderer worker has been drawn
+   * onto the canvas, including the final one.
+   * @type {function}
+   */
+  onFrame = null;
+
   constructor(internalRenderTask) {
     this._internalRenderTask = internalRenderTask;
 
@@ -3519,6 +3531,13 @@ class RenderTask {
   get imageCoordinates() {
     return this._internalRenderTask.imageCoordinates || null;
   }
+
+  /**
+   * @type {boolean} Whether this render task draws in a renderer worker.
+   */
+  get isWorkerRendering() {
+    return !!this._internalRenderTask.rendererHandler;
+  }
 }
 
 /**
@@ -3548,7 +3567,9 @@ class InternalRenderTask {
       internalTask.#drawFrame(frame);
     } catch (ex) {
       internalTask.cancel(ex);
+      return;
     }
+    internalTask.task.onFrame?.();
   }
 
   constructor({
@@ -3602,6 +3623,7 @@ class InternalRenderTask {
     this._recordOperations = !!params.recordOperations;
     this._recordImages = !!params.recordImages;
     this._recordForDebugger = !!params.recordForDebugger;
+    this._partialFrames = !!params.partialFrames;
     this._operationsFilter = operationsFilter;
     this._rendererWorker = rendererWorker;
     this._renderTaskId = InternalRenderTask.#renderTaskId++;
@@ -3728,6 +3750,7 @@ class InternalRenderTask {
           hasAnnotationCanvasMap: !!this.annotationCanvasMap,
           recordOperations: this._recordOperations,
           recordImages: this._recordImages,
+          partialFrames: this._partialFrames,
           optionalContentConfig: optionalContentConfig.serializable,
           transform,
           viewport,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -186,8 +186,8 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
  *   The default value is `false`.
  * @property {HTMLDocument} [ownerDocument] - Specify an explicit document
  *   context to create elements with and to load resources, such as fonts,
- *   into. Defaults to the current document. Renderer-worker rendering is
- *   disabled when this is set to a custom document.
+ *   into. Defaults to the current document.
+ *   NOTE: Worker rendering is disabled when this is set to a custom document.
  * @property {boolean} [disableRange] - Disable range request loading of PDF
  *   files. When enabled, and if the server supports partial content requests,
  *   then the PDF will be fetched in chunks. The default value is `false`.
@@ -1690,7 +1690,7 @@ class PDFPageProxy {
       intentState.displayReadyCapability.promise,
       optionalContentConfigPromise,
     ])
-      .then(async ([renderPageData, optionalContentConfig]) => {
+      .then(async ([transparency, optionalContentConfig]) => {
         if (this.destroyed) {
           complete();
           return;
@@ -1703,10 +1703,8 @@ class PDFPageProxy {
               "and `PDFDocumentProxy.getOptionalContentConfig` methods."
           );
         }
-        const { transparency, hasCanvasFilters } = renderPageData;
         await internalRenderTask.initializeGraphics({
           transparency,
-          hasCanvasFilters,
           optionalContentConfig,
         });
         internalRenderTask.operatorListChanged();
@@ -1911,7 +1909,7 @@ class PDFPageProxy {
   /**
    * @private
    */
-  _startRenderPage(transparency, cacheKey, hasCanvasFilters = false) {
+  _startRenderPage(transparency, cacheKey) {
     const intentState = this._intentStates.get(cacheKey);
     if (!intentState) {
       return; // Rendering was cancelled.
@@ -1920,10 +1918,7 @@ class PDFPageProxy {
 
     // TODO Refactor RenderPageRequest to separate rendering
     // and operator list logic
-    intentState.displayReadyCapability?.resolve({
-      transparency,
-      hasCanvasFilters,
-    });
+    intentState.displayReadyCapability?.resolve(transparency);
   }
 
   /**
@@ -3016,11 +3011,7 @@ class WorkerTransport {
       }
 
       const page = this.#pageCache.get(data.pageIndex);
-      page._startRenderPage(
-        data.transparency,
-        data.cacheKey,
-        data.hasCanvasFilters
-      );
+      page._startRenderPage(data.transparency, data.cacheKey);
     });
 
     const objectHandler = new ObjectHandler({
@@ -3706,11 +3697,7 @@ class InternalRenderTask {
     }
   }
 
-  async initializeGraphics({
-    transparency = false,
-    hasCanvasFilters = false,
-    optionalContentConfig,
-  }) {
+  async initializeGraphics({ transparency = false, optionalContentConfig }) {
     if (this.cancelled) {
       return;
     }
@@ -3735,14 +3722,10 @@ class InternalRenderTask {
     // The stepper-driven debug recording path needs `gfx` on the main thread,
     // so we have to fall back to local rendering when it's enabled. Plain
     // `recordOperations`/`recordImages` are now handled inside the worker.
-    // Worker rendering is also disabled when canvas filters (TR) are present
-    // because OffscreenCanvas's OffscreenCanvasRenderingContext2D ignores
-    // `.filter` values set from a data URL. See bug 2011237.
     let useWorkerRendering =
       this.rendererHandler &&
       !this.params.canvasContext &&
       (!background || typeof background === "string") &&
-      !hasCanvasFilters &&
       !this.pageColors &&
       !this._recordForDebugger;
 

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3564,6 +3564,11 @@ class InternalRenderTask {
     );
     if (!internalTask) {
       frame.bitmap.close();
+      if (frame.annotationBitmaps) {
+        for (const [, , annotationBitmap] of frame.annotationBitmaps) {
+          annotationBitmap.close();
+        }
+      }
       return;
     }
     try {

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -218,7 +218,7 @@ const RENDERING_CANCELLED_TIMEOUT = 100; // ms
  *   page ids and page numbers. It's used when the page order is changed or some
  *   pages are removed, cloned, etc.
  * @property {boolean} [disableWorkerRendering] - Disables rendering of pages in
- *   a worker thread. Note that worker rendering also requires
+ *   a worker-thread. Note that worker rendering also requires
  *   `GlobalWorkerOptions.rendererSrc` to be set; when it's unset, or the
  *   renderer worker fails to start, rendering falls back to the main-thread.
  *   The default value is `false`.
@@ -340,6 +340,7 @@ function getDocument(src = {}) {
     src.disableWorkerRendering === true ||
     !GlobalWorkerOptions.rendererSrc ||
     typeof Worker === "undefined" ||
+    !isOffscreenCanvasSupported ||
     !FeatureTest.isOffscreenCanvasSupported ||
     ownerDocument !== globalThis.document ||
     !!styleElement;

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -408,6 +408,7 @@ function getDocument(src = {}) {
     pdfBug,
     styleElement,
     enableHWA,
+    enableWebGPU,
     loadingParams: {
       disableAutoFetch,
       enableXfa,
@@ -1677,6 +1678,7 @@ class PDFPageProxy {
       pdfBug: this._pdfBug,
       pageColors,
       enableHWA: this._transport.enableHWA,
+      enableWebGPU: this._transport.enableWebGPU,
       operationsFilter,
       rendererWorker: this._transport.rendererWorker,
     });
@@ -2653,6 +2655,7 @@ class WorkerTransport {
       styleElement: params.styleElement,
     });
     this.enableHWA = params.enableHWA;
+    this.enableWebGPU = params.enableWebGPU === true;
     this.rendererWorker = params.rendererWorker || null;
     this.loadingParams = params.loadingParams;
     this._params = params;
@@ -3587,6 +3590,7 @@ class InternalRenderTask {
     pdfBug = false,
     pageColors = null,
     enableHWA = false,
+    enableWebGPU = false,
     operationsFilter = null,
     rendererWorker = null,
   }) {
@@ -3620,6 +3624,7 @@ class InternalRenderTask {
     this._canvas = params.canvas;
     this._canvasContext = params.canvas ? null : params.canvasContext;
     this._enableHWA = enableHWA;
+    this._enableWebGPU = enableWebGPU;
     this._recordOperations = !!params.recordOperations;
     this._recordImages = !!params.recordImages;
     this._recordForDebugger = !!params.recordForDebugger;
@@ -3747,6 +3752,7 @@ class InternalRenderTask {
           pageId: this._pageId,
           renderTaskId: this._renderTaskId,
           enableHWA: this._enableHWA,
+          enableWebGPU: this._enableWebGPU,
           hasAnnotationCanvasMap: !!this.annotationCanvasMap,
           recordOperations: this._recordOperations,
           recordImages: this._recordImages,

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -3966,6 +3966,9 @@ class InternalRenderTask {
       if (this.cancelled) {
         return;
       }
+      if (response.aborted) {
+        throw new Error("Render task was aborted in the renderer worker.");
+      }
 
       if (this.operatorListIdx === operatorList.argsArray.length) {
         this.running = false;

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -449,6 +449,15 @@ function copyCtxState(sourceCtx, destCtx) {
   }
 }
 
+function setAnnotationCanvasName(canvas, canvasName) {
+  canvas.setAttribute?.("data-canvas-name", canvasName);
+  canvas._pdfjsCanvasName = canvasName;
+}
+
+function getAnnotationCanvasName(canvas) {
+  return canvas._pdfjsCanvasName ?? null;
+}
+
 function resetCtxToDefault(ctx) {
   ctx.strokeStyle = ctx.fillStyle = "#000000";
   ctx.fillRule = "nonzero";
@@ -3825,11 +3834,11 @@ class CanvasGraphics {
             id,
             makeArr
           );
-          canvas.setAttribute("data-canvas-name", canvasName);
+          setAnnotationCanvasName(canvas, canvasName);
           // Replace any same-named canvas from a previous render so stale
           // low-resolution canvases don't pile up across zooms.
           const index = canvases.findIndex(
-            c => c.getAttribute("data-canvas-name") === canvasName
+            c => getAnnotationCanvasName(c) === canvasName
           );
           if (index === -1) {
             canvases.push(canvas);
@@ -4471,4 +4480,4 @@ for (const op in OPS) {
   }
 }
 
-export { CanvasGraphics };
+export { CanvasGraphics, getAnnotationCanvasName, setAnnotationCanvasName };

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -727,83 +727,92 @@ class CanvasGraphics {
   ) {
     const argsArray = operatorList.argsArray;
     const fnArray = operatorList.fnArray;
-    let i = executionStartIdx || 0;
-    const argsArrayLen = argsArray.length;
+    // Cache materialized Path2D objects on the operator list itself rather
+    // than by mutating `argsArray[i][0]`, so that the arguments stay
+    // structured-cloneable.
+    const prevPathCache = this._pathCache;
+    this._pathCache = operatorList.pathCache ||= new Map();
+    try {
+      let i = executionStartIdx || 0;
+      const argsArrayLen = argsArray.length;
 
-    // Sometimes the OperatorList to execute is empty.
-    if (argsArrayLen === i) {
-      return i;
-    }
-
-    const chunkOperations =
-      argsArrayLen - i > EXECUTION_STEPS &&
-      typeof continueCallback === "function";
-    const endTime = chunkOperations ? Date.now() + EXECUTION_TIME : 0;
-    let steps = 0;
-
-    const commonObjs = this.commonObjs;
-    const objs = this.objs;
-    let fnId, fnArgs;
-
-    while (true) {
-      if (stepper !== undefined) {
-        if (i === stepper.nextBreakPoint) {
-          stepper.breakIt(i, continueCallback);
-          return i;
-        }
-        if (stepper.shouldSkip(i)) {
-          if (++i === argsArrayLen) {
-            return i;
-          }
-          continue;
-        }
-      }
-
-      if (!operationsFilter || operationsFilter(i, operatorList)) {
-        fnId = fnArray[i];
-        // TODO: There is a `undefined` coming from somewhere.
-        fnArgs = argsArray[i] ?? null;
-
-        if (fnId !== OPS.dependency) {
-          if (fnArgs === null) {
-            this[fnId](i);
-          } else {
-            this[fnId](i, ...fnArgs);
-          }
-        } else {
-          for (const depObjId of fnArgs) {
-            this.dependencyTracker?.recordNamedData(depObjId, i);
-            const objsPool = depObjId.startsWith("g_") ? commonObjs : objs;
-
-            // If the promise isn't resolved yet, add the continueCallback
-            // to the promise and bail out.
-            if (!objsPool.has(depObjId)) {
-              objsPool.get(depObjId, continueCallback);
-              return i;
-            }
-          }
-        }
-      }
-
-      i++;
-
-      // If the entire operatorList was executed, stop as were done.
-      if (i === argsArrayLen) {
+      // Sometimes the OperatorList to execute is empty.
+      if (argsArrayLen === i) {
         return i;
       }
 
-      // If the execution took longer then a certain amount of time and
-      // `continueCallback` is specified, interrupt the execution.
-      if (chunkOperations && ++steps > EXECUTION_STEPS) {
-        if (Date.now() > endTime) {
-          continueCallback();
+      const chunkOperations =
+        argsArrayLen - i > EXECUTION_STEPS &&
+        typeof continueCallback === "function";
+      const endTime = chunkOperations ? Date.now() + EXECUTION_TIME : 0;
+      let steps = 0;
+
+      const commonObjs = this.commonObjs;
+      const objs = this.objs;
+      let fnId, fnArgs;
+
+      while (true) {
+        if (stepper !== undefined) {
+          if (i === stepper.nextBreakPoint) {
+            stepper.breakIt(i, continueCallback);
+            return i;
+          }
+          if (stepper.shouldSkip(i)) {
+            if (++i === argsArrayLen) {
+              return i;
+            }
+            continue;
+          }
+        }
+
+        if (!operationsFilter || operationsFilter(i, operatorList)) {
+          fnId = fnArray[i];
+          // TODO: There is a `undefined` coming from somewhere.
+          fnArgs = argsArray[i] ?? null;
+
+          if (fnId !== OPS.dependency) {
+            if (fnArgs === null) {
+              this[fnId](i);
+            } else {
+              this[fnId](i, ...fnArgs);
+            }
+          } else {
+            for (const depObjId of fnArgs) {
+              this.dependencyTracker?.recordNamedData(depObjId, i);
+              const objsPool = depObjId.startsWith("g_") ? commonObjs : objs;
+
+              // If the promise isn't resolved yet, add the continueCallback
+              // to the promise and bail out.
+              if (!objsPool.has(depObjId)) {
+                objsPool.get(depObjId, continueCallback);
+                return i;
+              }
+            }
+          }
+        }
+
+        i++;
+
+        // If the entire operatorList was executed, stop as were done.
+        if (i === argsArrayLen) {
           return i;
         }
-        steps = 0;
-      }
 
-      // If the operatorList isn't executed completely yet OR the execution
-      // time was short enough, do another execution round.
+        // If the execution took longer then a certain amount of time and
+        // `continueCallback` is specified, interrupt the execution.
+        if (chunkOperations && ++steps > EXECUTION_STEPS) {
+          if (Date.now() > endTime) {
+            continueCallback();
+            return i;
+          }
+          steps = 0;
+        }
+
+        // If the operatorList isn't executed completely yet OR the execution
+        // time was short enough, do another execution round.
+      }
+    } finally {
+      this._pathCache = prevPathCache;
     }
   }
 
@@ -2147,10 +2156,12 @@ class CanvasGraphics {
 
   // Path
   constructPath(opIdx, op, data, minMax) {
-    let [path] = data;
+    let path = this._pathCache.get(opIdx);
     if (!minMax) {
-      // The path is empty, so no need to update the current minMax.
-      path ||= data[0] = new Path2D();
+      if (!path) {
+        path = new Path2D();
+        this._pathCache.set(opIdx, path);
+      }
       if (op !== OPS.stroke && op !== OPS.closeStroke) {
         this.current.tilingPatternDims = null;
       }
@@ -2173,8 +2184,9 @@ class CanvasGraphics {
         .recordDependencies(opIdx, ["transform"]);
     }
 
-    if (!(path instanceof Path2D)) {
-      path = data[0] = makePathFromDrawOPS(path);
+    if (!path) {
+      path = makePathFromDrawOPS(data[0]);
+      this._pathCache.set(opIdx, path);
     }
     Util.axialAlignedBoundingBox(
       minMax,

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -722,6 +722,7 @@ class CanvasGraphics {
     operatorList,
     executionStartIdx,
     continueCallback,
+    errorCallback,
     stepper,
     operationsFilter
   ) {
@@ -784,7 +785,7 @@ class CanvasGraphics {
               // If the promise isn't resolved yet, add the continueCallback
               // to the promise and bail out.
               if (!objsPool.has(depObjId)) {
-                objsPool.get(depObjId, continueCallback);
+                objsPool.get(depObjId, continueCallback, errorCallback);
                 return i;
               }
             }

--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -70,6 +70,17 @@ class BBoxReader {
     this.#coords = coords;
   }
 
+  static fromBuffer(buffer) {
+    return new BBoxReader(
+      new Uint32Array(buffer),
+      new Uint8ClampedArray(buffer)
+    );
+  }
+
+  get buffer() {
+    return this.#bboxes.buffer;
+  }
+
   get length() {
     return this.#bboxes.length;
   }
@@ -1259,6 +1270,7 @@ class CanvasImagesTracker {
 }
 
 export {
+  BBoxReader,
   CanvasBBoxTracker,
   CanvasDependencyTracker,
   CanvasImagesTracker,

--- a/src/display/canvas_factory.js
+++ b/src/display/canvas_factory.js
@@ -89,4 +89,13 @@ class DOMCanvasFactory extends BaseCanvasFactory {
   }
 }
 
-export { BaseCanvasFactory, DOMCanvasFactory };
+class OffscreenCanvasFactory extends BaseCanvasFactory {
+  /**
+   * @ignore
+   */
+  _createCanvas(width, height) {
+    return new OffscreenCanvas(width, height);
+  }
+}
+
+export { BaseCanvasFactory, DOMCanvasFactory, OffscreenCanvasFactory };

--- a/src/display/filter_factory.js
+++ b/src/display/filter_factory.js
@@ -93,6 +93,8 @@ class BaseFilterFactory {
   destroy(keepHCM = false) {}
 }
 
+class WorkerFilterFactory extends BaseFilterFactory {}
+
 /**
  * FilterFactory aims to create some SVG filters we can use when drawing an
  * image (or whatever) on a canvas.
@@ -698,4 +700,4 @@ function blend(fg, bg, alpha) {
   return Math.round(alpha * fg + (1 - alpha) * bg);
 }
 
-export { BaseFilterFactory, DOMFilterFactory };
+export { BaseFilterFactory, DOMFilterFactory, WorkerFilterFactory };

--- a/src/display/filter_factory.js
+++ b/src/display/filter_factory.js
@@ -93,8 +93,6 @@ class BaseFilterFactory {
   destroy(keepHCM = false) {}
 }
 
-class WorkerFilterFactory extends BaseFilterFactory {}
-
 /**
  * FilterFactory aims to create some SVG filters we can use when drawing an
  * image (or whatever) on a canvas.
@@ -684,6 +682,8 @@ class DOMFilterFactory extends BaseFilterFactory {
     ];
   }
 }
+
+class WorkerFilterFactory extends BaseFilterFactory {}
 
 /**
  * Blend a foreground color with a background color using the alpha value.

--- a/src/display/object_handler.js
+++ b/src/display/object_handler.js
@@ -21,6 +21,7 @@ import {
 } from "./obj_bin_transform_display.js";
 
 import { FontFaceObject } from "./font_loader.js";
+import { PDFObjects } from "./pdf_objects.js";
 
 class ObjectHandler {
   constructor({
@@ -29,12 +30,14 @@ class ObjectHandler {
     fontLoader,
     pageCache,
     pdfBug = null,
+    shouldCreatePageObjs = false,
   }) {
     this.messageHandler = messageHandler;
     this.commonObjs = commonObjs;
     this.fontLoader = fontLoader;
     this.pageCache = pageCache;
     this.pdfBug = pdfBug;
+    this.shouldCreatePageObjs = shouldCreatePageObjs;
   }
 
   resolveCommonObject(id, type, exportedData) {
@@ -62,7 +65,11 @@ class ObjectHandler {
         this.fontLoader
           .bind(font)
           .catch(() =>
-            this.messageHandler.sendWithPromise("FontFallback", { id })
+            this.messageHandler
+              .sendWithPromise("FontFallback", { id })
+              .catch(reason => {
+                warn(`FontFallback failed for "${id}": ${reason}`);
+              })
           )
           .finally(() => {
             if (!font.fontExtraProperties) {
@@ -80,8 +87,10 @@ class ObjectHandler {
         const { imageRef } = exportedData;
         assert(imageRef, "The imageRef must be defined.");
 
-        for (const pageProxy of this.pageCache.values()) {
-          for (const [, data] of pageProxy.objs) {
+        for (const pageOrObjs of this.pageCache.values()) {
+          const objs = pageOrObjs.objs || pageOrObjs;
+
+          for (const [, data] of objs) {
             if (data?.ref !== imageRef) {
               continue;
             }
@@ -113,13 +122,25 @@ class ObjectHandler {
     return null;
   }
 
-  resolveObject(id, pageIndex, type, exportedData) {
-    const pageProxy = this.pageCache.get(pageIndex);
-    if (pageProxy.objs.has(id)) {
+  // `pageKey` is the key into `pageCache` - each realm supplies its own
+  // keying (the display index on the main thread, the stable page id in the
+  // renderer worker).
+  resolveObject(id, pageKey, type, exportedData) {
+    let pageOrObjs = this.pageCache.get(pageKey);
+    if (!pageOrObjs) {
+      if (!this.shouldCreatePageObjs) {
+        return;
+      }
+      pageOrObjs = new PDFObjects();
+      this.pageCache.set(pageKey, pageOrObjs);
+    }
+
+    const objs = pageOrObjs.objs || pageOrObjs;
+    if (objs.has(id)) {
       return;
     }
     // Don't store data *after* cleanup has successfully run, see bug 1854145.
-    if (pageProxy._intentStates.size === 0) {
+    if (pageOrObjs._intentStates?.size === 0) {
       exportedData?.bitmap?.close(); // Release any `ImageBitmap` data.
       return;
     }
@@ -127,7 +148,7 @@ class ObjectHandler {
     switch (type) {
       case "Image":
       case "Pattern":
-        pageProxy.objs.resolve(id, exportedData);
+        objs.resolve(id, exportedData);
         break;
       default:
         throw new Error(`Got unknown object type ${type}`);

--- a/src/display/object_handler.js
+++ b/src/display/object_handler.js
@@ -1,0 +1,138 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert, warn } from "../shared/util.js";
+import {
+  FontInfo,
+  FontPathInfo,
+  PatternInfo,
+} from "./obj_bin_transform_display.js";
+
+import { FontFaceObject } from "./font_loader.js";
+
+class ObjectHandler {
+  constructor({
+    messageHandler,
+    commonObjs,
+    fontLoader,
+    pageCache,
+    pdfBug = null,
+  }) {
+    this.messageHandler = messageHandler;
+    this.commonObjs = commonObjs;
+    this.fontLoader = fontLoader;
+    this.pageCache = pageCache;
+    this.pdfBug = pdfBug;
+  }
+
+  resolveCommonObject(id, type, exportedData) {
+    switch (type) {
+      case "Font":
+        if ("error" in exportedData) {
+          const exportedError = exportedData.error;
+          warn(`Error during font loading: ${exportedError}`);
+          this.commonObjs.resolve(id, exportedError);
+          break;
+        }
+
+        const fontData = new FontInfo(exportedData);
+        const inspectFont =
+          this.pdfBug && globalThis.FontInspector?.enabled
+            ? (font, url) => globalThis.FontInspector.fontAdded(font, url)
+            : null;
+        const font = new FontFaceObject(
+          fontData,
+          inspectFont,
+          exportedData.charProcOperatorList,
+          exportedData.extra
+        );
+
+        this.fontLoader
+          .bind(font)
+          .catch(() =>
+            this.messageHandler.sendWithPromise("FontFallback", { id })
+          )
+          .finally(() => {
+            if (!font.fontExtraProperties) {
+              // Immediately release the `font.data` property once the font
+              // has been attached to the DOM, since it's no longer needed,
+              // rather than waiting for a `PDFDocumentProxy.cleanup` call.
+              // Since `font.data` could be very large, e.g. in some cases
+              // multiple megabytes, this will help reduce memory usage.
+              font.clearData();
+            }
+            this.commonObjs.resolve(id, font);
+          });
+        break;
+      case "CopyLocalImage":
+        const { imageRef } = exportedData;
+        assert(imageRef, "The imageRef must be defined.");
+
+        for (const pageProxy of this.pageCache.values()) {
+          for (const [, data] of pageProxy.objs) {
+            if (data?.ref !== imageRef) {
+              continue;
+            }
+            if (!data.dataLen) {
+              return null;
+            }
+            const copy = structuredClone(data);
+            if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+              copy.CopyLocalImage = true;
+            }
+            this.commonObjs.resolve(id, copy);
+            return data.dataLen;
+          }
+        }
+        break;
+      case "FontPath":
+        this.commonObjs.resolve(id, new FontPathInfo(exportedData));
+        break;
+      case "Image":
+        this.commonObjs.resolve(id, exportedData);
+        break;
+      case "Pattern":
+        const pattern = new PatternInfo(exportedData);
+        this.commonObjs.resolve(id, pattern.getIR());
+        break;
+      default:
+        throw new Error(`Got unknown common object type ${type}`);
+    }
+    return null;
+  }
+
+  resolveObject(id, pageIndex, type, exportedData) {
+    const pageProxy = this.pageCache.get(pageIndex);
+    if (pageProxy.objs.has(id)) {
+      return;
+    }
+    // Don't store data *after* cleanup has successfully run, see bug 1854145.
+    if (pageProxy._intentStates.size === 0) {
+      exportedData?.bitmap?.close(); // Release any `ImageBitmap` data.
+      return;
+    }
+
+    switch (type) {
+      case "Image":
+      case "Pattern":
+        pageProxy.objs.resolve(id, exportedData);
+        break;
+      default:
+        throw new Error(`Got unknown object type ${type}`);
+    }
+  }
+}
+
+export { ObjectHandler };

--- a/src/display/pdf_objects.js
+++ b/src/display/pdf_objects.js
@@ -100,7 +100,6 @@ class PDFObjects {
 
   /**
    * Rejects the object `objId`, signalling that it will never be resolved.
-   *
    * @param {string} objId
    * @param {Error} reason
    */

--- a/src/display/pdf_objects.js
+++ b/src/display/pdf_objects.js
@@ -37,14 +37,17 @@ class PDFObjects {
    * and the object is already resolved, the callback gets called right away.
    * @param {string} objId
    * @param {Function} [callback]
+   * @param {Function} [errorCallback] - Called with the rejection reason if the
+   *   object fails to resolve (e.g. it could never be delivered). Only used
+   *   together with `callback`.
    * @returns {any}
    */
-  get(objId, callback = null) {
+  get(objId, callback = null, errorCallback = null) {
     // If there is a callback, then the get can be async and the object is
     // not required to be resolved right now.
     if (callback) {
       const obj = this.#objs.getOrInsertComputed(objId, dataObj);
-      obj.promise.then(() => callback(obj.data));
+      obj.promise.then(() => callback(obj.data), errorCallback);
       return null;
     }
     // If there isn't a callback, the user expects to get the resolved data

--- a/src/display/pdf_objects.js
+++ b/src/display/pdf_objects.js
@@ -95,6 +95,23 @@ class PDFObjects {
     obj.resolve();
   }
 
+  /**
+   * Rejects the object `objId`, signalling that it will never be resolved.
+   *
+   * @param {string} objId
+   * @param {Error} reason
+   */
+  reject(objId, reason) {
+    const obj = this.#objs.getOrInsertComputed(objId, dataObj);
+    if (obj.data !== INITIAL_DATA) {
+      return;
+    }
+    // Make sure a rejection that lands before a consumer calls
+    // `get` doesn't surface as an unhandled rejection
+    obj.promise.catch(() => {});
+    obj.reject(reason);
+  }
+
   clear() {
     for (const { data } of this.#objs.values()) {
       data?.bitmap?.close(); // Release any `ImageBitmap` data.

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -14,10 +14,14 @@
  */
 
 import { isNodeJS, setVerbosityLevel } from "../shared/util.js";
+import { CanvasGraphics } from "./canvas.js";
 import { FontLoader } from "./font_loader.js";
 import { MessageHandler } from "../shared/message_handler.js";
 import { ObjectHandler } from "./object_handler.js";
+import { OffscreenCanvasFactory } from "./canvas_factory.js";
+import { OptionalContentConfig } from "./optional_content_config.js";
 import { PDFObjects } from "./pdf_objects.js";
+import { WorkerFilterFactory } from "./filter_factory.js";
 
 class RendererMessageHandler {
   static #cleanedPages = new Set();
@@ -29,6 +33,8 @@ class RendererMessageHandler {
   });
 
   static #objsMap = new Map();
+
+  static #renderTaskStates = new Map();
 
   static {
     // Worker thread (and not Node.js)?
@@ -53,6 +59,12 @@ class RendererMessageHandler {
     return objs;
   }
 
+  static #sendFrame(handler, renderTaskState) {
+    const { canvas, renderTaskId } = renderTaskState;
+    const bitmap = canvas.transferToImageBitmap();
+    handler.send("RenderFrame", { renderTaskId, bitmap }, [bitmap]);
+  }
+
   // Object ids contain the id of the page they were parsed from
   // (`createObjId` in src/core/document.js), which are always stable unlike
   // the page index, when pages are moved or copied.
@@ -66,6 +78,75 @@ class RendererMessageHandler {
     this.#cleanedPages.add(pageId);
     this.#objsMap.get(pageId)?.clear();
     this.#objsMap.delete(pageId);
+    for (const [renderTaskId, renderTaskState] of this.#renderTaskStates) {
+      if (renderTaskState.pageId === pageId) {
+        this.#cleanupRenderTask(renderTaskId);
+      }
+    }
+  }
+
+  static #cleanupRenderTask(renderTaskId) {
+    const renderTaskState = this.#renderTaskStates.get(renderTaskId);
+    if (!renderTaskState) {
+      return;
+    }
+    renderTaskState.aborted = true;
+    renderTaskState.continueResolve?.();
+
+    renderTaskState.gfx?.endDrawing();
+    this.#renderTaskStates.delete(renderTaskId);
+  }
+
+  static #appendOperatorList(
+    renderTaskState,
+    fnArray,
+    argsArray,
+    operationsFilterMask,
+    lastChunk
+  ) {
+    const { operatorList } = renderTaskState;
+    if (fnArray) {
+      for (let i = 0, ii = fnArray.length; i < ii; i++) {
+        operatorList.fnArray.push(fnArray[i]);
+        operatorList.argsArray.push(argsArray[i]);
+      }
+      if (operationsFilterMask) {
+        const mask = (renderTaskState.operationsFilterMask ||= []);
+        for (let i = 0, ii = operationsFilterMask.length; i < ii; i++) {
+          mask.push(operationsFilterMask[i]);
+        }
+      }
+    }
+    operatorList.lastChunk = lastChunk;
+  }
+
+  // `renderTaskState.gfx` is always non-null here: the main thread awaits the
+  // `InitializeGraphics` reply, which assigns it, before sending
+  // `ExecuteOperatorList`.
+  static async #executeOperatorList(renderTaskState) {
+    const { operatorList, gfx, operationsFilterMask } = renderTaskState;
+    const operationsFilter = operationsFilterMask
+      ? i => operationsFilterMask[i]
+      : null;
+    while (!renderTaskState.aborted) {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      renderTaskState.continueResolve = resolve;
+
+      renderTaskState.operatorListIdx = gfx.executeOperatorList(
+        operatorList,
+        renderTaskState.operatorListIdx,
+        resolve,
+        reject,
+        undefined, // Renderer does not support stepper yet.
+        operationsFilter
+      );
+
+      if (renderTaskState.operatorListIdx === operatorList.argsArray.length) {
+        return renderTaskState.operatorListIdx;
+      }
+      await promise;
+    }
+    return renderTaskState.operatorListIdx;
   }
 
   static #setupObjectHandler(handler) {
@@ -144,6 +225,128 @@ class RendererMessageHandler {
       if (!keepLoadedFonts) {
         this.#fontLoader.clear();
       }
+    });
+
+    handler.on("CleanupRenderTask", ({ renderTaskId }) => {
+      this.#cleanupRenderTask(renderTaskId);
+    });
+
+    handler.on("InitializeGraphics", async data => {
+      const {
+        width,
+        height,
+        pageId,
+        renderTaskId,
+        enableHWA = false,
+        transform,
+        viewport,
+        transparency,
+        background,
+      } = data;
+      const canvas = new OffscreenCanvas(width, height);
+      const renderTaskState = {
+        pageId,
+        renderTaskId,
+        canvas,
+        gfx: null,
+        operatorList: {
+          fnArray: [],
+          argsArray: [],
+          lastChunk: false,
+          pathCache: null,
+        },
+        operatorListIdx: 0,
+        operationsFilterMask: null,
+        continueResolve: null,
+        aborted: false,
+      };
+      this.#renderTaskStates.set(renderTaskId, renderTaskState);
+
+      try {
+        const objs = this.#getPageObjs(pageId);
+        const optionalContentConfig = OptionalContentConfig.fromSerializable(
+          data.optionalContentConfig
+        );
+
+        const ctx = canvas.getContext("2d", {
+          alpha: false,
+          willReadFrequently: !enableHWA,
+        });
+        const canvasFactory = new OffscreenCanvasFactory({ enableHWA });
+        const filterFactory = new WorkerFilterFactory();
+
+        // Annotation canvases and operation recording are not supported yet;
+        // `pageColors` requires DOM-based SVG filters, so pages that need it
+        // never render in the worker.
+        const gfx = new CanvasGraphics(
+          ctx,
+          this.#commonObjs,
+          objs,
+          canvasFactory,
+          filterFactory,
+          { optionalContentConfig },
+          /* annotationCanvasMap = */ null,
+          /* pageColors = */ null,
+          /* dependencyTracker = */ null,
+          /* imagesTracker = */ null
+        );
+
+        gfx.beginDrawing({
+          transform,
+          viewport,
+          transparency,
+          background,
+        });
+
+        renderTaskState.gfx = gfx;
+      } catch (ex) {
+        this.#cleanupRenderTask(renderTaskId);
+        throw ex;
+      }
+    });
+
+    handler.on("ExecuteOperatorList", async data => {
+      const {
+        renderTaskId,
+        fnArray,
+        argsArray,
+        operatorListIdx,
+        operationsFilterMask,
+        lastChunk,
+      } = data;
+      const renderTaskState = this.#renderTaskStates.get(renderTaskId);
+      if (!renderTaskState) {
+        // A render task can be cleaned up before queued
+        // ExecuteOperatorList messages for that task are processed.
+        return { operatorListIdx };
+      }
+
+      renderTaskState.operatorListIdx = operatorListIdx;
+      this.#appendOperatorList(
+        renderTaskState,
+        fnArray,
+        argsArray,
+        operationsFilterMask,
+        lastChunk
+      );
+
+      const currentOperatorListIdx =
+        await this.#executeOperatorList(renderTaskState);
+
+      if (
+        renderTaskState.operatorList.lastChunk &&
+        currentOperatorListIdx === renderTaskState.operatorList.argsArray.length
+      ) {
+        const aborted = renderTaskState.aborted;
+        // `endDrawing` applies the final filter, so snapshot after it. The
+        // frame is sent before this reply, so the main thread has drawn the
+        // canvas by the time the render task reports completion.
+        this.#cleanupRenderTask(renderTaskId);
+        if (!aborted) {
+          this.#sendFrame(handler, renderTaskState);
+        }
+      }
+      return { operatorListIdx: currentOperatorListIdx };
     });
   }
 

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -21,6 +21,7 @@ import {
 import { CanvasGraphics, getAnnotationCanvasName } from "./canvas.js";
 import { isNodeJS, setVerbosityLevel } from "../shared/util.js";
 import { FontLoader } from "./font_loader.js";
+import { initGPU } from "./webgpu.js";
 import { MessageHandler } from "../shared/message_handler.js";
 import { ObjectHandler } from "./object_handler.js";
 import { OffscreenCanvasFactory } from "./canvas_factory.js";
@@ -303,6 +304,7 @@ class RendererMessageHandler {
         pageId,
         renderTaskId,
         enableHWA = false,
+        enableWebGPU = false,
         hasAnnotationCanvasMap = false,
         transform,
         viewport,
@@ -335,6 +337,12 @@ class RendererMessageHandler {
       this.#renderTaskStates.set(renderTaskId, renderTaskState);
 
       try {
+        if (enableWebGPU) {
+          await initGPU();
+          if (renderTaskState.aborted) {
+            return;
+          }
+        }
         const objs = this.#getPageObjs(pageId);
         const optionalContentConfig = OptionalContentConfig.fromSerializable(
           data.optionalContentConfig

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -14,9 +14,22 @@
  */
 
 import { isNodeJS, setVerbosityLevel } from "../shared/util.js";
+import { FontLoader } from "./font_loader.js";
 import { MessageHandler } from "../shared/message_handler.js";
+import { ObjectHandler } from "./object_handler.js";
+import { PDFObjects } from "./pdf_objects.js";
 
 class RendererMessageHandler {
+  static #cleanedPages = new Set();
+
+  static #commonObjs = new PDFObjects();
+
+  static #fontLoader = new FontLoader({
+    ownerDocument: globalThis,
+  });
+
+  static #objsMap = new Map();
+
   static {
     // Worker thread (and not Node.js)?
     if (
@@ -29,6 +42,72 @@ class RendererMessageHandler {
     ) {
       this.#initializeFromPort(self);
     }
+  }
+
+  static #getPageObjs(pageId) {
+    let objs = this.#objsMap.get(pageId);
+    if (!objs) {
+      objs = new PDFObjects();
+      this.#objsMap.set(pageId, objs);
+    }
+    return objs;
+  }
+
+  // Object ids contain the id of the page they were parsed from
+  // (`createObjId` in src/core/document.js), which are always stable unlike
+  // the page index, when pages are moved or copied.
+  static #getObjPageId(id, fallbackPageId) {
+    const objIdPattern = /^(?:img|mask|pattern)_p(\d+)_\d+$/;
+    const match = objIdPattern.exec(id);
+    return match ? parseInt(match[1], 10) : fallbackPageId;
+  }
+
+  static #cleanupPage(pageId) {
+    this.#cleanedPages.add(pageId);
+    this.#objsMap.get(pageId)?.clear();
+    this.#objsMap.delete(pageId);
+  }
+
+  static #setupObjectHandler(handler) {
+    const objectHandler = new ObjectHandler({
+      messageHandler: handler,
+      commonObjs: this.#commonObjs,
+      fontLoader: this.#fontLoader,
+      pageCache: this.#objsMap,
+      shouldCreatePageObjs: true,
+    });
+
+    handler.on("commonobj", ([id, type, exportedData]) => {
+      if (this.#commonObjs.has(id)) {
+        return null;
+      }
+      return objectHandler.resolveCommonObject(id, type, exportedData);
+    });
+
+    handler.on("obj", ([id, pageIndex, type, imageData]) => {
+      const pageId = this.#getObjPageId(id, pageIndex);
+      // The page may have been cleaned up before this message was processed;
+      // drop the data and release any `ImageBitmap` instead of resurrecting
+      // an empty object bag for a dead page.
+      if (this.#cleanedPages.has(pageId)) {
+        imageData?.bitmap?.close();
+        return;
+      }
+      objectHandler.resolveObject(id, pageId, type, imageData);
+    });
+
+    handler.on("objFailed", ({ id, pageIndex, reason }) => {
+      const error = new Error(reason);
+      if (pageIndex === null) {
+        this.#commonObjs.reject(id, error);
+        return;
+      }
+      const pageId = this.#getObjPageId(id, pageIndex);
+      if (this.#cleanedPages.has(pageId)) {
+        return;
+      }
+      this.#getPageObjs(pageId).reject(id, error);
+    });
   }
 
   static #setup(handler) {
@@ -45,6 +124,26 @@ class RendererMessageHandler {
 
     handler.on("configure", data => {
       setVerbosityLevel(data.verbosity);
+    });
+
+    this.#setupObjectHandler(handler);
+
+    handler.on("cleanupPage", ({ pageId }) => {
+      this.#cleanupPage(pageId);
+    });
+
+    handler.on("restorePage", ({ pageId }) => {
+      this.#cleanedPages.delete(pageId);
+    });
+
+    // Mirrors the document-level cleanup the main thread performs in
+    // `WorkerTransport.startCleanup`; without this the worker's copies of
+    // `commonObjs`/`fontLoader` would outlive their main-thread counterparts.
+    handler.on("Cleanup", ({ keepLoadedFonts }) => {
+      this.#commonObjs.clear();
+      if (!keepLoadedFonts) {
+        this.#fontLoader.clear();
+      }
     });
   }
 

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -1,0 +1,58 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isNodeJS, setVerbosityLevel } from "../shared/util.js";
+import { MessageHandler } from "../shared/message_handler.js";
+
+class RendererMessageHandler {
+  static {
+    // Worker thread (and not Node.js)?
+    if (
+      typeof window === "undefined" &&
+      !isNodeJS &&
+      typeof self !== "undefined" &&
+      /* isMessagePort = */
+      typeof self.postMessage === "function" &&
+      "onmessage" in self
+    ) {
+      this.#initializeFromPort(self);
+    }
+  }
+
+  static #setup(handler) {
+    let testMessageProcessed = false;
+    handler.on("test", data => {
+      if (testMessageProcessed) {
+        return;
+      }
+      testMessageProcessed = true;
+
+      // Ensure that `TypedArray`s can be sent to the worker.
+      handler.send("test", data instanceof Uint8Array);
+    });
+
+    handler.on("configure", data => {
+      setVerbosityLevel(data.verbosity);
+    });
+  }
+
+  static #initializeFromPort(port) {
+    const handler = new MessageHandler("renderer", "main", port);
+    this.#setup(handler);
+    handler.send("ready", null);
+  }
+}
+
+export { RendererMessageHandler };

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -413,7 +413,7 @@ class RendererMessageHandler {
       if (!renderTaskState) {
         // A render task can be cleaned up before queued
         // ExecuteOperatorList messages for that task are processed.
-        return { operatorListIdx };
+        return { operatorListIdx, aborted: true };
       }
 
       renderTaskState.operatorListIdx = operatorListIdx;

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -87,12 +87,24 @@ class RendererMessageHandler {
 
   static async #sendFrame(handler, renderTaskState, isFinal) {
     const { canvas, renderTaskId } = renderTaskState;
-    // We need to use createImageBitmap for interim frames because
-    // `transferToImageBitmap` would clear the canvas that is still
-    // being drawn into
-    const bitmap = isFinal
-      ? canvas.transferToImageBitmap()
-      : await createImageBitmap(canvas);
+    let bitmap;
+    if (isFinal) {
+      bitmap = canvas.transferToImageBitmap();
+    } else {
+      // We need to use createImageBitmap for interim frames because
+      // `transferToImageBitmap` would clear the canvas that is still
+      // being drawn into
+      const { transparentCanvas } = renderTaskState.gfx;
+      if (transparentCanvas) {
+        const composite = new OffscreenCanvas(canvas.width, canvas.height);
+        const ctx = composite.getContext("2d");
+        ctx.drawImage(canvas, 0, 0);
+        ctx.drawImage(transparentCanvas, 0, 0);
+        bitmap = composite.transferToImageBitmap();
+      } else {
+        bitmap = await createImageBitmap(canvas);
+      }
+    }
     const transfers = [bitmap];
     const annotationBitmaps = isFinal
       ? this.#collectAnnotationBitmaps(renderTaskState, transfers)

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -59,12 +59,7 @@ class RendererMessageHandler {
   }
 
   static #getPageObjs(pageId) {
-    let objs = this.#objsMap.get(pageId);
-    if (!objs) {
-      objs = new PDFObjects();
-      this.#objsMap.set(pageId, objs);
-    }
-    return objs;
+    return this.#objsMap.getOrInsertComputed(pageId, () => new PDFObjects());
   }
 
   // Flatten the annotation canvases into `[id, canvasName, bitmap]` tuples so

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -13,6 +13,11 @@
  * limitations under the License.
  */
 
+import {
+  CanvasBBoxTracker,
+  CanvasDependencyTracker,
+  CanvasImagesTracker,
+} from "./canvas_dependency_tracker.js";
 import { CanvasGraphics, getAnnotationCanvasName } from "./canvas.js";
 import { isNodeJS, setVerbosityLevel } from "../shared/util.js";
 import { FontLoader } from "./font_loader.js";
@@ -145,6 +150,9 @@ class RendererMessageHandler {
       }
     }
     operatorList.lastChunk = lastChunk;
+    renderTaskState.gfx.dependencyTracker?.growOperationsCount(
+      operatorList.fnArray.length
+    );
   }
 
   // `renderTaskState.gfx` is always non-null here: the main thread awaits the
@@ -270,6 +278,8 @@ class RendererMessageHandler {
         viewport,
         transparency,
         background,
+        recordOperations = false,
+        recordImages = false,
       } = data;
       const canvas = new OffscreenCanvas(width, height);
       const renderTaskState = {
@@ -303,10 +313,24 @@ class RendererMessageHandler {
         const canvasFactory = new OffscreenCanvasFactory({ enableHWA });
         const filterFactory = new WorkerFilterFactory();
         const annotationCanvases = hasAnnotationCanvasMap ? new Map() : null;
+        let bboxTracker = null;
+        let dependencyTracker = null;
+        let imagesTracker = null;
+        if (recordOperations || recordImages) {
+          bboxTracker = new CanvasBBoxTracker(canvas, 0);
+        }
+        if (recordOperations) {
+          dependencyTracker = new CanvasDependencyTracker(
+            bboxTracker,
+            /* recordDebugMetadata = */ false
+          );
+        }
+        if (recordImages) {
+          imagesTracker = new CanvasImagesTracker(canvas);
+        }
 
-        // Operation recording is not supported yet; `pageColors` requires
-        // DOM-based SVG filters, so pages that need it never render in the
-        // worker.
+        // `pageColors` requires DOM-based SVG filters, so pages that need it
+        // never render in the worker.
         const gfx = new CanvasGraphics(
           ctx,
           this.#commonObjs,
@@ -316,8 +340,8 @@ class RendererMessageHandler {
           { optionalContentConfig },
           annotationCanvases,
           /* pageColors = */ null,
-          /* dependencyTracker = */ null,
-          /* imagesTracker = */ null
+          dependencyTracker ?? bboxTracker,
+          imagesTracker
         );
 
         gfx.beginDrawing({
@@ -362,11 +386,18 @@ class RendererMessageHandler {
       const currentOperatorListIdx =
         await this.#executeOperatorList(renderTaskState);
 
+      let recordedBBoxesBuffer = null;
+      let imageCoordinates = null;
       if (
         renderTaskState.operatorList.lastChunk &&
         currentOperatorListIdx === renderTaskState.operatorList.argsArray.length
       ) {
+        const reader = renderTaskState.gfx.dependencyTracker?.take();
+        recordedBBoxesBuffer = reader?.buffer;
+        const images = renderTaskState.gfx.imagesTracker?.take();
+        imageCoordinates = images || null;
         const aborted = renderTaskState.aborted;
+
         // `endDrawing` applies the final filter, so snapshot after it. The
         // frame is sent before this reply, so the main thread has drawn the
         // canvas by the time the render task reports completion.
@@ -375,7 +406,11 @@ class RendererMessageHandler {
           this.#sendFrame(handler, renderTaskState);
         }
       }
-      return { operatorListIdx: currentOperatorListIdx };
+      return {
+        operatorListIdx: currentOperatorListIdx,
+        recordedBBoxesBuffer,
+        imageCoordinates,
+      };
     });
   }
 

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
+import { CanvasGraphics, getAnnotationCanvasName } from "./canvas.js";
 import { isNodeJS, setVerbosityLevel } from "../shared/util.js";
-import { CanvasGraphics } from "./canvas.js";
 import { FontLoader } from "./font_loader.js";
 import { MessageHandler } from "../shared/message_handler.js";
 import { ObjectHandler } from "./object_handler.js";
@@ -59,10 +59,37 @@ class RendererMessageHandler {
     return objs;
   }
 
+  // Flatten the annotation canvases into `[id, canvasName, bitmap]` tuples so
+  // the main thread can rebuild the map with DOM canvases of its own.
+  static #collectAnnotationBitmaps(renderTaskState, transfers) {
+    const map = renderTaskState.gfx?.annotationCanvasMap;
+    if (!map?.size) {
+      return null;
+    }
+    const tuples = [];
+    for (const [id, value] of map) {
+      for (const canvas of Array.isArray(value) ? value : [value]) {
+        const bitmap = canvas.transferToImageBitmap();
+        tuples.push([id, getAnnotationCanvasName(canvas), bitmap]);
+        transfers.push(bitmap);
+      }
+    }
+    return tuples;
+  }
+
   static #sendFrame(handler, renderTaskState) {
     const { canvas, renderTaskId } = renderTaskState;
     const bitmap = canvas.transferToImageBitmap();
-    handler.send("RenderFrame", { renderTaskId, bitmap }, [bitmap]);
+    const transfers = [bitmap];
+    const annotationBitmaps = this.#collectAnnotationBitmaps(
+      renderTaskState,
+      transfers
+    );
+    handler.send(
+      "RenderFrame",
+      { renderTaskId, bitmap, annotationBitmaps },
+      transfers
+    );
   }
 
   // Object ids contain the id of the page they were parsed from
@@ -238,6 +265,7 @@ class RendererMessageHandler {
         pageId,
         renderTaskId,
         enableHWA = false,
+        hasAnnotationCanvasMap = false,
         transform,
         viewport,
         transparency,
@@ -274,10 +302,11 @@ class RendererMessageHandler {
         });
         const canvasFactory = new OffscreenCanvasFactory({ enableHWA });
         const filterFactory = new WorkerFilterFactory();
+        const annotationCanvases = hasAnnotationCanvasMap ? new Map() : null;
 
-        // Annotation canvases and operation recording are not supported yet;
-        // `pageColors` requires DOM-based SVG filters, so pages that need it
-        // never render in the worker.
+        // Operation recording is not supported yet; `pageColors` requires
+        // DOM-based SVG filters, so pages that need it never render in the
+        // worker.
         const gfx = new CanvasGraphics(
           ctx,
           this.#commonObjs,
@@ -285,7 +314,7 @@ class RendererMessageHandler {
           canvasFactory,
           filterFactory,
           { optionalContentConfig },
-          /* annotationCanvasMap = */ null,
+          annotationCanvases,
           /* pageColors = */ null,
           /* dependencyTracker = */ null,
           /* imagesTracker = */ null

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -28,6 +28,8 @@ import { OptionalContentConfig } from "./optional_content_config.js";
 import { PDFObjects } from "./pdf_objects.js";
 import { WorkerFilterFactory } from "./filter_factory.js";
 
+const PARTIAL_FRAME_TIME = 500; // ms
+
 class RendererMessageHandler {
   static #cleanedPages = new Set();
 
@@ -82,19 +84,40 @@ class RendererMessageHandler {
     return tuples;
   }
 
-  static #sendFrame(handler, renderTaskState) {
+  static async #sendFrame(handler, renderTaskState, isFinal) {
     const { canvas, renderTaskId } = renderTaskState;
-    const bitmap = canvas.transferToImageBitmap();
+    // We need to use createImageBitmap for interim frames because
+    // `transferToImageBitmap` would clear the canvas that is still
+    // being drawn into
+    const bitmap = isFinal
+      ? canvas.transferToImageBitmap()
+      : await createImageBitmap(canvas);
     const transfers = [bitmap];
-    const annotationBitmaps = this.#collectAnnotationBitmaps(
-      renderTaskState,
-      transfers
-    );
+    const annotationBitmaps = isFinal
+      ? this.#collectAnnotationBitmaps(renderTaskState, transfers)
+      : null;
     handler.send(
       "RenderFrame",
       { renderTaskId, bitmap, annotationBitmaps },
       transfers
     );
+  }
+
+  // We try sending the interim frame at pauses: at each operator list chunk
+  // and when a chunk is paused mid-way.
+  static async #maybeSendInterimFrame(handler, renderTaskState) {
+    if (!renderTaskState.partialFrames || renderTaskState.aborted) {
+      return;
+    }
+    if (Date.now() - renderTaskState.lastFrameTime < PARTIAL_FRAME_TIME) {
+      return;
+    }
+    if (renderTaskState.operatorListIdx === renderTaskState.lastFrameIdx) {
+      return;
+    }
+    await this.#sendFrame(handler, renderTaskState, /* isFinal = */ false);
+    renderTaskState.lastFrameTime = Date.now();
+    renderTaskState.lastFrameIdx = renderTaskState.operatorListIdx;
   }
 
   // Object ids contain the id of the page they were parsed from
@@ -158,7 +181,7 @@ class RendererMessageHandler {
   // `renderTaskState.gfx` is always non-null here: the main thread awaits the
   // `InitializeGraphics` reply, which assigns it, before sending
   // `ExecuteOperatorList`.
-  static async #executeOperatorList(renderTaskState) {
+  static async #executeOperatorList(handler, renderTaskState) {
     const { operatorList, gfx, operationsFilterMask } = renderTaskState;
     const operationsFilter = operationsFilterMask
       ? i => operationsFilterMask[i]
@@ -179,7 +202,14 @@ class RendererMessageHandler {
       if (renderTaskState.operatorListIdx === operatorList.argsArray.length) {
         return renderTaskState.operatorListIdx;
       }
+      // Flush painted content both before the wait, since it may be a long
+      // stall on a dependency, e.g. a font or an image that has not been
+      // forwarded yet and after it. The lastFrameIdx check in
+      // #maybeSendInterimFrame ensures that at most one frame is sent
+      // when nothing was painted in between.
+      await this.#maybeSendInterimFrame(handler, renderTaskState);
       await promise;
+      await this.#maybeSendInterimFrame(handler, renderTaskState);
     }
     return renderTaskState.operatorListIdx;
   }
@@ -280,12 +310,15 @@ class RendererMessageHandler {
         background,
         recordOperations = false,
         recordImages = false,
+        partialFrames = false,
       } = data;
       const canvas = new OffscreenCanvas(width, height);
       const renderTaskState = {
         pageId,
         renderTaskId,
         canvas,
+        partialFrames,
+        lastFrameTime: Date.now(),
         gfx: null,
         operatorList: {
           fnArray: [],
@@ -294,6 +327,7 @@ class RendererMessageHandler {
           pathCache: null,
         },
         operatorListIdx: 0,
+        lastFrameIdx: 0,
         operationsFilterMask: null,
         continueResolve: null,
         aborted: false,
@@ -383,8 +417,10 @@ class RendererMessageHandler {
         lastChunk
       );
 
-      const currentOperatorListIdx =
-        await this.#executeOperatorList(renderTaskState);
+      const currentOperatorListIdx = await this.#executeOperatorList(
+        handler,
+        renderTaskState
+      );
 
       let recordedBBoxesBuffer = null;
       let imageCoordinates = null;
@@ -403,8 +439,10 @@ class RendererMessageHandler {
         // canvas by the time the render task reports completion.
         this.#cleanupRenderTask(renderTaskId);
         if (!aborted) {
-          this.#sendFrame(handler, renderTaskState);
+          await this.#sendFrame(handler, renderTaskState, /* isFinal = */ true);
         }
+      } else {
+        await this.#maybeSendInterimFrame(handler, renderTaskState);
       }
       return {
         operatorListIdx: currentOperatorListIdx,

--- a/src/display/renderer_worker.js
+++ b/src/display/renderer_worker.js
@@ -210,14 +210,18 @@ class RendererMessageHandler {
       if (renderTaskState.operatorListIdx === operatorList.argsArray.length) {
         return renderTaskState.operatorListIdx;
       }
-      // Flush painted content both before the wait, since it may be a long
-      // stall on a dependency, e.g. a font or an image that has not been
-      // forwarded yet and after it. The lastFrameIdx check in
-      // #maybeSendInterimFrame ensures that at most one frame is sent
-      // when nothing was painted in between.
+      // Send pending painted content, if eligible, before waiting for a
+      // dependency such as a font or image that has not been forwarded yet.
       await this.#maybeSendInterimFrame(handler, renderTaskState);
       await promise;
-      await this.#maybeSendInterimFrame(handler, renderTaskState);
+      if (renderTaskState.aborted) {
+        break;
+      }
+      // The continuation may have resolved synchronously. Yield to the event
+      // loop so cancellation messages can be processed before the next slice.
+      await new Promise(resolveYield => {
+        setTimeout(resolveYield, 0);
+      });
     }
     return renderTaskState.operatorListIdx;
   }

--- a/src/display/worker_options.js
+++ b/src/display/worker_options.js
@@ -16,7 +16,31 @@
 class GlobalWorkerOptions {
   static #port = null;
 
+  static #rendererSrc = "";
+
   static #src = "";
+
+  /**
+   * @type {string}
+   */
+  static get rendererSrc() {
+    return this.#rendererSrc;
+  }
+
+  /**
+   * @param {string} val - A string containing the path and
+   *   filename of the renderer worker file.
+   *
+   *   NOTE: The `rendererSrc` option must be set in order to render pages in a
+   *         worker thread; when it's unset, rendering falls back to the
+   *         main-thread.
+   */
+  static set rendererSrc(val) {
+    if (typeof val !== "string") {
+      throw new Error("Invalid `rendererSrc` type.");
+    }
+    this.#rendererSrc = val;
+  }
 
   /**
    * @type {Worker | null}

--- a/src/pdf.renderer.js
+++ b/src/pdf.renderer.js
@@ -1,4 +1,4 @@
-/* Copyright 2022 Mozilla Foundation
+/* Copyright 2026 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,17 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable import/no-unresolved */
 
-import { GlobalWorkerOptions } from "./build/pdf.mjs";
-
-if (typeof window !== "undefined" && "Worker" in window) {
-  GlobalWorkerOptions.workerPort = new Worker(
-    new URL("./build/pdf.worker.mjs", import.meta.url),
-    { type: "module" }
-  );
-  // Worker rendering is not enabled yet, hence
-  // `GlobalWorkerOptions.rendererSrc` is deliberately left unset here.
-}
-
-export * from "./build/pdf.mjs";
+import "./display/renderer_worker.js";

--- a/test/driver.js
+++ b/test/driver.js
@@ -41,6 +41,7 @@ const IMAGE_RESOURCES_PATH = "/web/images/";
 const VIEWER_CSS = "../build/components/pdf_viewer.css";
 const VIEWER_LOCALE = "en-US";
 const WORKER_SRC = "../build/generic/build/pdf.worker.mjs";
+const RENDERER_SRC = "../build/generic/build/pdf.renderer.mjs";
 const RENDER_TASK_ON_CONTINUE_DELAY = 5; // ms
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -534,6 +535,7 @@ class Driver {
   constructor(options) {
     // Configure the global worker options.
     GlobalWorkerOptions.workerSrc = WORKER_SRC;
+    GlobalWorkerOptions.rendererSrc = RENDERER_SRC;
 
     // We only need to initialize the `L10n`-instance here, since translation is
     // triggered by a `MutationObserver`; see e.g. `Rasterize.annotationLayer`.

--- a/test/integration/reorganize_pages_spec.mjs
+++ b/test/integration/reorganize_pages_spec.mjs
@@ -3890,4 +3890,81 @@ describe("Reorganize Pages View", () => {
       );
     });
   });
+
+  describe("Rendering a moved page", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        `.page[data-page-number = "1"] .endOfContent`,
+        "page-fit",
+        null,
+        { enableSplitMerge: true }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must re-render a moved page that was rendered before the move", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          // The page that will be moved must have been rendered before the
+          // pages are renumbered, so that its operator list and its image
+          // objects are cached. It may already have been pre-rendered as the
+          // neighbour of the first page, hence don't wait for a `pagerendered`
+          // event but for its rendering state.
+          await page.evaluate(() => {
+            window.PDFViewerApplication.pdfViewer.currentPageNumber = 2;
+          });
+          await page.waitForFunction(
+            () =>
+              // RenderingStates.FINISHED
+              window.PDFViewerApplication.pdfViewer.getPageView(1)
+                .renderingState === 3
+          );
+
+          const handlePagesEdited = await waitForPagesEdited(page, "move");
+          await page.evaluate(() => {
+            const { eventBus, pdfDocument } = window.PDFViewerApplication;
+            const { pagesMapper } = pdfDocument;
+            pagesMapper.movePages(new Set([1]), [1], 2);
+            eventBus.dispatch("pagesedited", {
+              source: null,
+              pagesMapper,
+              type: "move",
+            });
+          });
+          const pagesMapping = await awaitPromise(handlePagesEdited);
+          expect(pagesMapping.slice(0, 3))
+            .withContext(`In ${browserName}`)
+            .toEqual([2, 1, 3]);
+
+          // Zoom and go to the moved page: it must be re-rendered, at the new
+          // scale, with the operator list and the image objects cached before
+          // the move.
+          const prevCanvasWidth = await page.evaluate(() => {
+            const { pdfViewer } = window.PDFViewerApplication;
+            const width = pdfViewer.getPageView(0).canvas.width;
+            pdfViewer.increaseScale({ drawingDelay: 0, scaleFactor: 2 });
+            pdfViewer.currentPageNumber = 1;
+            return width;
+          });
+          await page.waitForFunction(
+            prevWidth => {
+              const view = window.PDFViewerApplication.pdfViewer.getPageView(0);
+              return (
+                // RenderingStates.FINISHED
+                view.renderingState === 3 && view.canvas?.width > prevWidth
+              );
+            },
+            {},
+            prevCanvasWidth
+          );
+        })
+      );
+    });
+  });
 });

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -129,6 +129,8 @@ async function initializePDFJS(callback) {
   }
   // Configure the worker.
   GlobalWorkerOptions.workerSrc = "../../build/generic/build/pdf.worker.mjs";
+  GlobalWorkerOptions.rendererSrc =
+    "../../build/generic/build/pdf.renderer.mjs";
 
   callback();
 }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -777,6 +777,14 @@ const defaultOptions = new Map([
     },
   ],
   [
+    "disableWorkerRendering",
+    {
+      /** @type {boolean} */
+      value: typeof PDFJSDev !== "undefined" && !PDFJSDev.test("TESTING"),
+      kind: OptionKind.API + OptionKind.PREFERENCE,
+    },
+  ],
+  [
     "docBaseUrl",
     {
       /** @type {string} */
@@ -913,6 +921,20 @@ const defaultOptions = new Map([
   // End OptionKind.API
 
   // Begin OptionKind.WORKER
+  [
+    "rendererSrc",
+    {
+      /** @type {string} */
+      value:
+        // eslint-disable-next-line no-nested-ternary
+        typeof PDFJSDev === "undefined"
+          ? "../src/pdf.renderer.js"
+          : PDFJSDev.test("MOZCENTRAL")
+            ? "resource://pdf.js/build/pdf.renderer.mjs"
+            : "../build/pdf.renderer.mjs",
+      kind: OptionKind.WORKER,
+    },
+  ],
   [
     "workerPort",
     {

--- a/web/base_pdf_page_view.js
+++ b/web/base_pdf_page_view.js
@@ -124,13 +124,19 @@ class BasePDFPageView extends RenderableView {
     this.#showCanvas = isLastShow => {
       if (updateOnFirstShow) {
         let tempCanvas = this.#tempCanvas;
-        if (!isLastShow && this.minDurationToUpdateCanvas > 0) {
+        // When rendering in the worker, each frame handed back is already
+        // a complete snapshot, throttled worker-side, so double-buffering
+        // through a temporary canvas would only add a copy.
+        if (
+          !isLastShow &&
+          this.minDurationToUpdateCanvas > 0 &&
+          !this.renderTask?.isWorkerRendering
+        ) {
           // We draw on the canvas at 60fps (in using `requestAnimationFrame`),
           // so if the canvas is large, updating it at 60fps can be a way too
           // much and can cause some serious performance issues.
           // To avoid that we only update the canvas every
           // `this.#minDurationToUpdateCanvas` ms.
-
           if (Date.now() - this.#startTime < this.minDurationToUpdateCanvas) {
             return;
           }
@@ -210,6 +216,7 @@ class BasePDFPageView extends RenderableView {
   async _drawCanvas(options, onCancel, onFinish) {
     const renderTask = (this.renderTask = this.pdfPage.render(options));
     renderTask.onContinue = this.#renderContinueCallback;
+    renderTask.onFrame = () => this.#showCanvas?.(false);
     renderTask.onError = error => {
       if (error instanceof RenderingCancelledException) {
         onCancel();

--- a/web/base_pdf_page_view.js
+++ b/web/base_pdf_page_view.js
@@ -183,7 +183,10 @@ class BasePDFPageView extends RenderableView {
   }
 
   #renderContinueCallback = cont => {
-    this.#showCanvas?.(false);
+    // In the worker path the canvas only gains pixels in `onFrame`.
+    if (!this.renderTask?.isWorkerRendering) {
+      this.#showCanvas?.(false);
+    }
     if (this.renderingQueue && !this.renderingQueue.isHighestPriority(this)) {
       this.renderingState = RenderingStates.PAUSED;
       this.resume = () => {

--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -1054,6 +1054,7 @@ class PDFPageView extends BasePDFPageView {
       isEditing: this.#isEditing,
       recordOperations,
       recordImages,
+      partialFrames: true,
     };
   }
 


### PR DESCRIPTION
This follow-up aims to achieve the same goal as PR #20729 but with a slight change in the approach, as suggested by @calixteman, instead of transferring the page's canvas to the renderer worker with transferControlToOffscreen, the worker now draws into an OffscreenCanvas of its own and returns the result to the main thread as an ImageBitmap, so the main thread keeps ownership of the destination canvas.

For long-running pages the worker emits partial frames, while the operator list is executing, the canvas is snapshotted at most every 500ms (at chunk boundaries and dependency pauses), so pages paint progressively. 
Returning bitmaps instead of taking over the canvas simplifies things quite a lot compared to the transferred-canvas approach. `transferControlToOffscreen` was irreversible and detached the canvas from the main thread, so every re-render needed a fresh canvas and a new transfer, the viewer had to track worker-owned canvases specially (thumbnails, detail views, print), falling back to main-thread rendering mid-document meant the original canvas was no longer usable, and the test harness needed workarounds for canvases it could no longer read back. With the bitmap approach the visible canvas stays an ordinary main-thread canvas at all times: the viewer, thumbnails, and fallback paths work unchanged, either rendering path can draw to the same canvas, the harness reverts to reading canvases directly etc. 

Worker rendering falls back to the main thread when the render can't be handled there: a non-string background (gradients/patterns don't structured-clone), pages using TR-based canvas filters (OffscreenCanvasRenderingContext2D ignores .filter values set from a data URL, bug 2011237), pageColors (needs DOM-based SVG filters), and the pdfBug stepper (needs the graphics on the main thread). Worker rendering is disabled by default in built targets via the new `disableWorkerRendering` preference and enabled for local development; the test suites opt in explicitly. 

_Also, rendering is disabled by default in the production viewer builds: the disableWorkerRendering preference defaults to true everywhere except the local dev viewer and the TESTING builds, so Firefox and the generic viewer keep rendering on the main thread until we explicitly flip the pref. The test suites opt in through GlobalWorkerOptions.rendererSrc directly, so all of this is still covered by CI, and API consumers can opt in the same way._