### PR TITLE
Pass operator list to operationsFilter

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1268,6 +1268,7 @@ class PDFDocumentProxy {
 /**
  * @callback OperationsFilter
  * @param {number} index - The index of the operation.
+ * @param {PDFOperatorList} operatorList - The operator list being rendered.
  * @returns {boolean} If false, the operation is ignored.
  */
 

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -699,7 +699,7 @@ class CanvasGraphics {
         }
       }
 
-      if (!operationsFilter || operationsFilter(i)) {
+      if (!operationsFilter || operationsFilter(i, operatorList)) {
         fnId = fnArray[i];
         // TODO: There is a `undefined` coming from somewhere.
         fnArgs = argsArray[i] ?? null;

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -53,6 +53,7 @@ import {
   RenderTask,
 } from "../../src/display/api.js";
 import { AutoPrintRegExp } from "../../web/ui_utils.js";
+import { CanvasGraphics } from "../../src/display/canvas.js";
 import { GlobalImageCache } from "../../src/core/image_utils.js";
 import { GlobalWorkerOptions } from "../../src/display/worker_options.js";
 import { Metadata } from "../../src/display/metadata.js";
@@ -5330,6 +5331,56 @@ have written that much by now. So, here’s to squashing bugs.`);
       expect(statEntry.end - statEntry.start).toBeGreaterThanOrEqual(0);
 
       await loadingTask.destroy();
+    });
+
+    it("passes the rendered operator list to operationsFilter", async function () {
+      let activeOperatorList = null;
+      const filterCalls = [];
+      const executeOperatorList = CanvasGraphics.prototype.executeOperatorList;
+      spyOn(CanvasGraphics.prototype, "executeOperatorList").and.callFake(
+        function (...args) {
+          const previousOperatorList = activeOperatorList;
+          activeOperatorList = args[0];
+          try {
+            return executeOperatorList.apply(this, args);
+          } finally {
+            activeOperatorList = previousOperatorList;
+          }
+        }
+      );
+
+      const viewport = page.getViewport({ scale: 1 });
+      const { canvasFactory } = pdfDocument;
+      const canvasAndCtx = canvasFactory.create(
+        viewport.width,
+        viewport.height
+      );
+      const renderTask = page.render({
+        canvas: canvasAndCtx.canvas,
+        viewport,
+        operationsFilter(index, operatorList) {
+          filterCalls.push({ index, operatorList, activeOperatorList });
+          return true;
+        },
+      });
+
+      await renderTask.promise;
+
+      expect(filterCalls.length).toBeGreaterThan(0);
+      for (const {
+        index,
+        operatorList,
+        activeOperatorList: activeList,
+      } of filterCalls) {
+        expect(operatorList).toBe(activeList);
+        expect(index).toBeGreaterThanOrEqual(0);
+        expect(index).toBeLessThan(operatorList.fnArray.length);
+        expect(operatorList.argsArray.length).toEqual(
+          operatorList.fnArray.length
+        );
+      }
+
+      canvasFactory.destroy(canvasAndCtx);
     });
 
     it("gets page stats after rendering page, with `pdfBug` set", async function () {


### PR DESCRIPTION
## Summary

- pass the exact render-time operator list as the second `operationsFilter` argument
- document the additive callback parameter in the public JSDoc API
- cover the contract with a render test that checks strict object identity

Existing one-argument callbacks remain compatible because JavaScript ignores additional arguments.

Fixes #20399.

## Testing

- `npx gulp unittest --headless --noFirefox` (1,638 tests passed in Chrome)
- `npx gulp lint`
- `npx gulp typestest`
- `git diff --check upstream/master...HEAD`