### PR TITLE
Use moz-message-bar for the Firefox features notification (bug 2057608)

### DIFF
--- a/external/stylelint/mozcentral-tokens.css
+++ b/external/stylelint/mozcentral-tokens.css
@@ -68,7 +68,10 @@
   --icon-color-information: initial;
   --input-search-border-radius: initial;
   --link-color: initial;
+  --link-color-active: initial;
   --link-color-hover: initial;
+  --link-color-visited: initial;
+  --link-focus-outline-offset: initial;
   --panel-border-radius: initial;
   --panel-menuitem-border-radius: initial;
   --panel-menuitem-margin: initial;

--- a/web/app.js
+++ b/web/app.js
@@ -516,7 +516,7 @@ const PDFViewerApplication = {
       !AppOptions.get("featuresNotificationDismissed")
     ) {
       const { featuresNotification } = appConfig;
-      customElements.whenDefined("pdf-features-notification").then(() => {
+      customElements.whenDefined("moz-message-bar").then(() => {
         if (AppOptions.get("featuresNotificationDismissed")) {
           return;
         }
@@ -524,7 +524,7 @@ const PDFViewerApplication = {
         featuresNotification.addEventListener(
           "click",
           event => {
-            if (!event.target.closest(".cta")) {
+            if (!event.target.closest("a")) {
               return;
             }
             event.preventDefault();
@@ -548,8 +548,12 @@ const PDFViewerApplication = {
           featuresNotification.hidden = true;
         };
         featuresNotification.addEventListener(
-          "pdf-features-notification:dismissed",
+          "message-bar:user-dismissed",
           () => {
+            // Move focus before the bar removes itself.
+            if (featuresNotification.matches(":focus-within")) {
+              container.focus();
+            }
             hideBar();
             this.preferences.set("featuresNotificationDismissed", true);
           },
@@ -564,7 +568,7 @@ const PDFViewerApplication = {
           },
           { signal: abortSignal, ...internalOpt }
         );
-        featuresNotification.show();
+        featuresNotification.hidden = false;
       });
     }
 

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -382,6 +382,40 @@ body {
 }
 /*#endif*/
 
+/* Match the bar styles used by about:pdf. */
+/*#if MOZCENTRAL*/
+#pdfFeaturesNotification {
+  border-radius: 0;
+  border-inline: none;
+  border-block-start: none;
+  font: message-box;
+  font-size: var(--font-size-root);
+
+  a {
+    color: var(--link-color);
+
+    &:visited {
+      color: var(--link-color-visited);
+    }
+
+    &:hover {
+      color: var(--link-color-hover);
+    }
+
+    &:hover:active {
+      color: var(--link-color-active);
+      text-decoration: none;
+    }
+
+    &:focus-visible {
+      outline: var(--focus-outline);
+      outline-offset: var(--link-focus-outline-offset);
+      border-radius: var(--border-radius-small);
+    }
+  }
+}
+/*#endif*/
+
 #sidebarContainer :is(input, button, select) {
   font: message-box;
 }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -33,7 +33,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <!--<link rel="icon" type="image/svg+xml" href="chrome://global/skin/icons/pdf.svg" />-->
     <!--<meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; script-src resource: 'wasm-unsafe-eval'; worker-src resource:; style-src resource: chrome:; img-src resource: blob: data:; media-src blob:; font-src resource:; connect-src resource:; base-uri 'none'; form-action 'none';"
+      content="default-src 'none'; script-src resource: chrome: 'wasm-unsafe-eval'; worker-src resource:; style-src resource: chrome:; img-src resource: blob: data:; media-src blob:; font-src resource:; connect-src resource:; base-uri 'none'; form-action 'none';"
     />-->
     <!--#elif TESTING-->
     <!--<meta
@@ -63,6 +63,9 @@ See https://github.com/adobe-type-tools/cmap-resources
     <!--#if MOZCENTRAL-->
     <!--<link rel="stylesheet" href="resource://pdf.js/web/viewer.css">-->
     <!--<link rel="localization" href="toolkit/pdfviewer/viewer.ftl"/>-->
+    <!--<link rel="localization" href="branding/brand.ftl"/>-->
+    <!--<link rel="localization" href="toolkit/global/mozMessageBar.ftl"/>-->
+    <!--<link rel="localization" href="toolkit/about/pdfFeaturesNotification.ftl"/>-->
     <!--#else-->
     <link rel="stylesheet" href="viewer.css" />
     <!--#endif-->
@@ -70,7 +73,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <!--#if MOZCENTRAL-->
     <!--<script src="resource://pdf.js/web/viewer.mjs" type="module"></script>-->
 
-    <!--<script src="resource://pdf.js/pdfFeaturesNotification.mjs" type="module"></script>-->
+    <!--<script src="chrome://global/content/elements/moz-message-bar.mjs" type="module"></script>-->
     <!--#elif !MOZCENTRAL-->
     <!--<script src="viewer.mjs" type="module"></script>-->
     <!--#elif /* Development mode. */-->
@@ -883,7 +886,9 @@ See https://github.com/adobe-type-tools/cmap-resources
         </div>
 
         <!--#if MOZCENTRAL-->
-        <!--<pdf-features-notification id="pdfFeaturesNotification" data-focus-target="#viewerContainer" hidden></pdf-features-notification>-->
+        <!--<moz-message-bar id="pdfFeaturesNotification" type="info" role="region" aria-live="polite" dismissable hidden data-l10n-id="pdf-features-notification">
+          <span slot="message" data-l10n-id="pdf-features-notification-message"><a href="about:pdf#features" data-l10n-name="features-link"></a></span>
+        </moz-message-bar>-->
         <!--#endif-->
 
         <div id="viewerContainer" tabindex="0">


### PR DESCRIPTION
Bug 2066198 lets the PDF viewer load the moz-message-bar module from a chrome: URL. Add the required CSP and localization entries, and preserve viewer focus on dismissal.