### PR TITLE
Modernize the `MessageHandler` class

### DIFF
--- a/src/shared/message_handler.js
+++ b/src/shared/message_handler.js
@@ -74,26 +74,47 @@ function wrapReason(ex) {
 }
 
 class MessageHandler {
+  #actions = new Map();
+
+  #callbackCapabilities = new Map();
+
+  #callbackId = 1;
+
+  #comObj;
+
   #messageAC = new AbortController();
 
+  #sourceName;
+
+  #streamControllers = new Map();
+
+  #streamId = 1;
+
+  #streamSinks = new Map();
+
+  #targetName;
+
   constructor(sourceName, targetName, comObj) {
-    this.sourceName = sourceName;
-    this.targetName = targetName;
-    this.comObj = comObj;
-    this.callbackId = 1;
-    this.streamId = 1;
-    this.streamSinks = Object.create(null);
-    this.streamControllers = Object.create(null);
-    this.callbackCapabilities = Object.create(null);
-    this.actionHandler = Object.create(null);
+    this.#sourceName = sourceName;
+    this.#targetName = targetName;
+    this.#comObj = comObj;
 
     comObj.addEventListener("message", this.#onMessage.bind(this), {
       signal: this.#messageAC.signal,
     });
+
+    if (typeof PDFJSDev === "undefined" || PDFJSDev.test("TESTING")) {
+      // For testing purposes.
+      Object.defineProperty(this, "_comObj", {
+        get() {
+          return comObj;
+        },
+      });
+    }
   }
 
   #onMessage({ data }) {
-    if (data.targetName !== this.sourceName) {
+    if (data.targetName !== this.#sourceName) {
       return;
     }
     if (data.stream) {
@@ -101,33 +122,33 @@ class MessageHandler {
       return;
     }
     if (data.callback) {
-      const callbackId = data.callbackId;
-      const capability = this.callbackCapabilities[callbackId];
+      const { callbackId, callback } = data;
+      const capability = this.#callbackCapabilities.get(callbackId);
       if (!capability) {
         throw new Error(`Cannot resolve callback ${callbackId}`);
       }
-      delete this.callbackCapabilities[callbackId];
+      this.#callbackCapabilities.delete(callbackId);
 
-      if (data.callback === CallbackKind.DATA) {
+      if (callback === CallbackKind.DATA) {
         capability.resolve(data.data);
-      } else if (data.callback === CallbackKind.ERROR) {
+      } else if (callback === CallbackKind.ERROR) {
         capability.reject(wrapReason(data.reason));
       } else {
         throw new Error("Unexpected callback case");
       }
       return;
     }
-    const action = this.actionHandler[data.action];
+    const action = this.#actions.get(data.action);
     if (!action) {
       throw new Error(`Unknown action from worker: ${data.action}`);
     }
     if (data.callbackId) {
-      const sourceName = this.sourceName,
+      const sourceName = this.#sourceName,
         targetName = data.sourceName,
-        comObj = this.comObj;
+        comObj = this.#comObj;
 
       Promise.try(action, data.data).then(
-        function (result) {
+        result => {
           comObj.postMessage({
             sourceName,
             targetName,
@@ -136,7 +157,7 @@ class MessageHandler {
             data: result,
           });
         },
-        function (reason) {
+        reason => {
           comObj.postMessage({
             sourceName,
             targetName,
@@ -162,11 +183,11 @@ class MessageHandler {
         'MessageHandler.on: Expected "handler" to be a function.'
       );
     }
-    const ah = this.actionHandler;
-    if (ah[actionName]) {
-      throw new Error(`There is already an actionName called "${actionName}"`);
+    const ah = this.#actions;
+    if (ah.has(actionName)) {
+      throw new Error(`There is already a "${actionName}" handler.`);
     }
-    ah[actionName] = handler;
+    ah.set(actionName, handler);
   }
 
   /**
@@ -176,10 +197,10 @@ class MessageHandler {
    * @param {Array} [transfers] - List of transfers/ArrayBuffers.
    */
   send(actionName, data, transfers) {
-    this.comObj.postMessage(
+    this.#comObj.postMessage(
       {
-        sourceName: this.sourceName,
-        targetName: this.targetName,
+        sourceName: this.#sourceName,
+        targetName: this.#targetName,
         action: actionName,
         data,
       },
@@ -196,14 +217,14 @@ class MessageHandler {
    * @returns {Promise} Promise to be resolved with response data.
    */
   sendWithPromise(actionName, data, transfers) {
-    const callbackId = this.callbackId++;
-    const capability = Promise.withResolvers();
-    this.callbackCapabilities[callbackId] = capability;
+    const callbackId = this.#callbackId++,
+      capability = Promise.withResolvers();
+    this.#callbackCapabilities.set(callbackId, capability);
     try {
-      this.comObj.postMessage(
+      this.#comObj.postMessage(
         {
-          sourceName: this.sourceName,
-          targetName: this.targetName,
+          sourceName: this.#sourceName,
+          targetName: this.#targetName,
           action: actionName,
           callbackId,
           data,
@@ -227,22 +248,22 @@ class MessageHandler {
    * @returns {ReadableStream} ReadableStream to read data in chunks.
    */
   sendWithStream(actionName, data, queueingStrategy, transfers) {
-    const streamId = this.streamId++,
-      sourceName = this.sourceName,
-      targetName = this.targetName,
-      comObj = this.comObj;
+    const streamId = this.#streamId++,
+      sourceName = this.#sourceName,
+      targetName = this.#targetName,
+      comObj = this.#comObj;
 
     return new ReadableStream(
       {
         start: controller => {
           const startCapability = Promise.withResolvers();
-          this.streamControllers[streamId] = {
+          this.#streamControllers.set(streamId, {
             controller,
             startCall: startCapability,
             pullCall: null,
             cancelCall: null,
             isClosed: false,
-          };
+          });
           comObj.postMessage(
             {
               sourceName,
@@ -260,7 +281,7 @@ class MessageHandler {
 
         pull: controller => {
           const pullCapability = Promise.withResolvers();
-          this.streamControllers[streamId].pullCall = pullCapability;
+          this.#streamControllers.get(streamId).pullCall = pullCapability;
           comObj.postMessage({
             sourceName,
             targetName,
@@ -276,8 +297,8 @@ class MessageHandler {
         cancel: reason => {
           assert(reason instanceof Error, "cancel must have a valid reason");
           const cancelCapability = Promise.withResolvers();
-          this.streamControllers[streamId].cancelCall = cancelCapability;
-          this.streamControllers[streamId].isClosed = true;
+          this.#streamControllers.get(streamId).cancelCall = cancelCapability;
+          this.#streamControllers.get(streamId).isClosed = true;
           comObj.postMessage({
             sourceName,
             targetName,
@@ -295,11 +316,11 @@ class MessageHandler {
 
   #createStreamSink(data) {
     const streamId = data.streamId,
-      sourceName = this.sourceName,
+      sourceName = this.#sourceName,
       targetName = data.sourceName,
-      comObj = this.comObj;
-    const self = this,
-      action = this.actionHandler[data.action];
+      comObj = this.#comObj;
+    const streamSinks = this.#streamSinks,
+      action = this.#actions.get(data.action);
 
     const streamSink = {
       enqueue(chunk, size = 1, transfers) {
@@ -338,7 +359,7 @@ class MessageHandler {
           stream: StreamKind.CLOSE,
           streamId,
         });
-        delete self.streamSinks[streamId];
+        streamSinks.delete(streamId);
       },
 
       error(reason) {
@@ -366,10 +387,10 @@ class MessageHandler {
 
     streamSink.sinkCapability.resolve();
     streamSink.ready = streamSink.sinkCapability.promise;
-    this.streamSinks[streamId] = streamSink;
+    streamSinks.set(streamId, streamSink);
 
     Promise.try(action, data.data, streamSink).then(
-      function () {
+      () => {
         comObj.postMessage({
           sourceName,
           targetName,
@@ -378,7 +399,7 @@ class MessageHandler {
           success: true,
         });
       },
-      function (reason) {
+      reason => {
         comObj.postMessage({
           sourceName,
           targetName,
@@ -392,11 +413,11 @@ class MessageHandler {
 
   #processStreamMessage(data) {
     const streamId = data.streamId,
-      sourceName = this.sourceName,
+      sourceName = this.#sourceName,
       targetName = data.sourceName,
-      comObj = this.comObj;
-    const streamController = this.streamControllers[streamId],
-      streamSink = this.streamSinks[streamId];
+      comObj = this.#comObj;
+    const streamController = this.#streamControllers.get(streamId),
+      streamSink = this.#streamSinks.get(streamId);
 
     switch (data.stream) {
       case StreamKind.START_COMPLETE:
@@ -434,7 +455,7 @@ class MessageHandler {
         streamSink.desiredSize = data.desiredSize;
 
         Promise.try(streamSink.onPull || onFn).then(
-          function () {
+          () => {
             comObj.postMessage({
               sourceName,
               targetName,
@@ -443,7 +464,7 @@ class MessageHandler {
               success: true,
             });
           },
-          function (reason) {
+          reason => {
             comObj.postMessage({
               sourceName,
               targetName,
@@ -490,7 +511,7 @@ class MessageHandler {
         const dataReason = wrapReason(data.reason);
 
         Promise.try(streamSink.onCancel || onFn, dataReason).then(
-          function () {
+          () => {
             comObj.postMessage({
               sourceName,
               targetName,
@@ -499,7 +520,7 @@ class MessageHandler {
               success: true,
             });
           },
-          function (reason) {
+          reason => {
             comObj.postMessage({
               sourceName,
               targetName,
@@ -511,7 +532,7 @@ class MessageHandler {
         );
         streamSink.sinkCapability.reject(dataReason);
         streamSink.isCancelled = true;
-        delete this.streamSinks[streamId];
+        this.#streamSinks.delete(streamId);
         break;
       default:
         throw new Error("Unexpected stream case");
@@ -526,7 +547,7 @@ class MessageHandler {
       streamController.pullCall?.promise,
       streamController.cancelCall?.promise,
     ]);
-    delete this.streamControllers[streamId];
+    this.#streamControllers.delete(streamId);
   }
 
   destroy() {

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1109,7 +1109,8 @@ describe("api", function () {
         const docWorker = loadingTask._worker;
         expect(!!docWorker).toBeFalse();
         // checking is the same port is used in the MessageHandler
-        const messageHandlerPort = loadingTask._transport.messageHandler.comObj;
+        const messageHandlerPort =
+          loadingTask._transport.messageHandler._comObj;
         expect(messageHandlerPort === worker.port).toBeTrue();
       });
 


### PR DESCRIPTION
Convert the code to use Maps instead of regular Objects, and utilize private class fields.