### PR TITLE
Convert the font `seacMap` and `seacs` structures into Maps

### DIFF
--- a/src/core/cff_parser.js
+++ b/src/core/cff_parser.js
@@ -740,7 +740,7 @@ class CFFParser {
     fdArray,
     privateDict,
   }) {
-    const seacs = [];
+    const seacs = new Map();
     const widths = [];
     const count = charStrings.count;
     for (let i = 0; i < count; i++) {
@@ -789,7 +789,7 @@ class CFFParser {
         widths[i] = defaultWidth;
       }
       if (state.seac !== null) {
-        seacs[i] = state.seac;
+        seacs.set(i, state.seac);
       }
       if (!valid) {
         // resetting invalid charstring to single 'endchar'

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -3313,7 +3313,7 @@ class Font {
       newCharCodeToGlyphId = newMapping.charCodeToGlyphId;
       toUnicodeExtraMap = newMapping.toUnicodeExtraMap;
     }
-    const numGlyphs = font.numGlyphs;
+    const { numGlyphs, seacs } = font;
 
     function getCharCodes(charCodeToGlyphId, glyphId) {
       let charCodes = null;
@@ -3336,14 +3336,11 @@ class Font {
       return newMapping.nextAvailableFontCharCode++;
     }
 
-    const seacs = font.seacs;
-    if (newMapping && SEAC_ANALYSIS_ENABLED && seacs?.length) {
+    if (newMapping && SEAC_ANALYSIS_ENABLED && seacs?.size) {
       const matrix = properties.fontMatrix || FONT_IDENTITY_MATRIX;
       const charset = font.getCharset();
-      const seacMap = Object.create(null);
-      for (let glyphId in seacs) {
-        glyphId |= 0;
-        const seac = seacs[glyphId];
+      const seacMap = new Map();
+      for (const [glyphId, seac] of seacs) {
         const baseGlyphName = StandardEncoding[seac[2]];
         const accentGlyphName = StandardEncoding[seac[3]];
         const baseGlyphId = charset.indexOf(baseGlyphName);
@@ -3374,11 +3371,11 @@ class Font {
             charCodeToGlyphId,
             accentGlyphId
           );
-          seacMap[charCode] = {
+          seacMap.set(charCode, {
             baseFontCharCode,
             accentFontCharCode,
             accentOffset,
-          };
+          });
         }
       }
       properties.seacMap = seacMap;
@@ -3608,9 +3605,9 @@ class Font {
     }
 
     let accent = null;
-    if (this.seacMap?.[charcode]) {
+    const seac = this.seacMap?.get(charcode);
+    if (seac) {
       isInFont = true;
-      const seac = this.seacMap[charcode];
       fontCharCode = seac.baseFontCharCode;
       accent = {
         fontChar: String.fromCodePoint(seac.accentFontCharCode),

--- a/src/core/type1_font.js
+++ b/src/core/type1_font.js
@@ -315,15 +315,15 @@ class Type1Font {
   }
 
   getSeacs(charstrings) {
-    const seacMap = [];
+    const seacs = new Map();
     for (let i = 0, ii = charstrings.length; i < ii; i++) {
-      const charstring = charstrings[i];
-      if (charstring.seac) {
+      const { seac } = charstrings[i];
+      if (seac) {
         // Offset by 1 for .notdef
-        seacMap[i + 1] = charstring.seac;
+        seacs.set(i + 1, seac);
       }
     }
-    return seacMap;
+    return seacs;
   }
 
   getType2Charstrings(type1Charstrings) {

--- a/test/unit/cff_parser_spec.js
+++ b/test/unit/cff_parser_spec.js
@@ -486,12 +486,8 @@ describe("CFFParser", function () {
     });
     expect(result.charStrings.count).toEqual(1);
     expect(result.charStrings.get(0).length).toEqual(1);
-    expect(result.seacs.length).toEqual(1);
-    expect(result.seacs[0].length).toEqual(4);
-    expect(result.seacs[0][0]).toEqual(130);
-    expect(result.seacs[0][1]).toEqual(180);
-    expect(result.seacs[0][2]).toEqual(65);
-    expect(result.seacs[0][3]).toEqual(194);
+    expect(result.seacs.size).toEqual(1);
+    expect(result.seacs.get(0)).toEqual([130, 180, 65, 194]);
   });
 
   it("parses a CharString endchar with 4 args w/seac disabled", function () {
@@ -516,7 +512,7 @@ describe("CFFParser", function () {
     });
     expect(result.charStrings.count).toEqual(1);
     expect(result.charStrings.get(0).length).toEqual(9);
-    expect(result.seacs.length).toEqual(0);
+    expect(result.seacs.size).toEqual(0);
   });
 
   it("parses a CharString endchar no args", function () {
@@ -533,7 +529,7 @@ describe("CFFParser", function () {
     });
     expect(result.charStrings.count).toEqual(1);
     expect(result.charStrings.get(0)[0]).toEqual(14);
-    expect(result.seacs.length).toEqual(0);
+    expect(result.seacs.size).toEqual(0);
   });
 
   it("parses predefined charsets", function () {


### PR DESCRIPTION
This changes `seacMap` from a regular Object into a Map, and the Type1/CFF `seacs` from (potentially very) sparse Arrays into Maps.

*Note:* These changes are covered by existing ref-tests such as: `issue818.pdf`, `issue4801`, `issue4573.pdf`, `bug1308536.pdf`, and `glyph_accent.pdf`.