### PR TITLE
test: remove slowMo option for Chrome in tests

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1013,14 +1013,6 @@ async function startBrowser({
   const printFile = path.join(tempDir, "print.pdf");
 
   if (browserName === "chrome") {
-    // Slow down protocol calls by the given number of milliseconds. In Chrome
-    // protocol calls are faster than in Firefox and thus trigger in quicker
-    // succession. This can cause intermittent failures because new protocol
-    // calls can run before events triggered by the previous protocol calls had
-    // a chance to be processed (essentially causing events to get lost). This
-    // value gives Chrome a more similar execution speed as Firefox.
-    options.slowMo = 2;
-
     options.args = [
       // Avoid crashing because no sandbox is shipped by default and we only run
       // our own trusted content in the scope of the tests (for more information


### PR DESCRIPTION
Removed slowMo option for Chrome protocol calls to prevent intermittent failures.

Last time we had non-determinism for CDP messages for websockets was before https://github.com/websockets/ws/issues/2216 and with the pipe transport before https://github.com/puppeteer/puppeteer/pull/14009