### PR TITLE
Fix TextWidgetAnnotation not inheriting text alignment from AcroForm

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2856,7 +2856,7 @@ class TextWidgetAnnotation extends WidgetAnnotation {
   constructor(params) {
     super(params);
 
-    const { dict } = params;
+    const { annotationGlobals, dict } = params;
 
     if (dict.has("PMD")) {
       // It's used to display a barcode but it isn't specified so we just hide
@@ -2875,11 +2875,12 @@ class TextWidgetAnnotation extends WidgetAnnotation {
     }
 
     // Determine the alignment of text in the field.
-    let alignment = getInheritableProperty({ dict, key: "Q" });
-    if (!Number.isInteger(alignment) || alignment < 0 || alignment > 2) {
-      alignment = null;
-    }
-    this.data.textAlignment = alignment;
+    const getAlignment = q =>
+      Number.isInteger(q) && q >= 0 && q <= 2 ? q : null;
+    this.data.textAlignment =
+      getAlignment(getInheritableProperty({ dict, key: "Q" })) ??
+      getAlignment(annotationGlobals.acroForm.get("Q")) ??
+      null;
 
     // Determine the maximum length of text in the field.
     let maximumLength = getInheritableProperty({ dict, key: "MaxLen" });

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1658,6 +1658,46 @@ describe("annotation", function () {
       expect(data.multiLine).toBeTrue();
     });
 
+    it("should inherit text alignment from acroform", async function () {
+      const annotationGlobals =
+        await AnnotationFactory.createGlobals(pdfManagerMock);
+      annotationGlobals.acroForm = new Dict();
+      annotationGlobals.acroForm.set("Q", 2);
+
+      const textWidgetRef = Ref.get(84, 0);
+      const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
+
+      const { data } = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobals,
+        idFactoryMock
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.textAlignment).toEqual(2);
+    });
+
+    it("should not inherit text alignment from acroform if field has its own", async function () {
+      const annotationGlobals =
+        await AnnotationFactory.createGlobals(pdfManagerMock);
+      annotationGlobals.acroForm = new Dict();
+      annotationGlobals.acroForm.set("Q", 2);
+
+      textWidgetDict.set("Q", 0);
+
+      const textWidgetRef = Ref.get(84, 0);
+      const xref = new XRefMock([{ ref: textWidgetRef, data: textWidgetDict }]);
+
+      const { data } = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobals,
+        idFactoryMock
+      );
+      expect(data.annotationType).toEqual(AnnotationType.WIDGET);
+      expect(data.textAlignment).toEqual(0);
+    });
+
     it("should reject comb fields without a maximum length", async function () {
       textWidgetDict.set("Ff", AnnotationFieldFlag.COMB);
 


### PR DESCRIPTION
The "Q" (quadding) text alignment property can be present in the AcroForm dictionary, which sets the default value for Q for all variable text fields in the document, as per the PDF 2.0 spec, Table 224.