### PR TITLE
Improve the filename extension detection in `MediaAnnotation.prototype._getContentType`

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -5506,7 +5506,8 @@ class MediaAnnotation extends Annotation {
       return subtype.name;
     }
 
-    const ext = filename.split(".").at(-1)?.toLowerCase();
+    const extPos = filename.lastIndexOf(".") + 1,
+      ext = extPos > 0 && filename.substring(extPos).toLowerCase();
     switch (ext) {
       case "mp4":
       case "m4v":


### PR DESCRIPTION
Rather than splitting the filename into an Array, and then take its last element, we can directly search for the *last* dot instead.

Doing this also fixes what appears to be a small oversight, since the current code may find a "valid" extension when one doesn't actually exist in the filename. For example, try running the following code in the console:
```js
var filename = "mp4";
filename.split(".").at(-1)?.toLowerCase();
```