### PR TITLE
Convert the `CmdCache`, `NameCache`, and `RefCache` to use Maps

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -18,14 +18,14 @@ import { assert, makeArr, shadow, unreachable } from "../shared/util.js";
 const CIRCULAR_REF = Symbol("CIRCULAR_REF");
 const EOF = Symbol("EOF");
 
-let CmdCache = Object.create(null);
-let NameCache = Object.create(null);
-let RefCache = Object.create(null);
+const CmdCache = new Map();
+const NameCache = new Map();
+const RefCache = new Map();
 
 function clearPrimitiveCaches() {
-  CmdCache = Object.create(null);
-  NameCache = Object.create(null);
-  RefCache = Object.create(null);
+  CmdCache.clear();
+  NameCache.clear();
+  RefCache.clear();
 }
 
 class Name {
@@ -39,9 +39,18 @@ class Name {
     this.name = name;
   }
 
+  /**
+   * NOTE: This method is invoked a lot, hence `getOrInsertComputed` is
+   *       purposely *not* used to avoid creating unneeded callback functions.
+   */
   static get(name) {
-    // eslint-disable-next-line no-restricted-syntax
-    return (NameCache[name] ||= new Name(name));
+    let n = NameCache.get(name);
+    if (!n) {
+      // eslint-disable-next-line no-restricted-syntax
+      n = new Name(name);
+      NameCache.set(name, n);
+    }
+    return n;
   }
 }
 
@@ -56,9 +65,18 @@ class Cmd {
     this.cmd = cmd;
   }
 
+  /**
+   * NOTE: This method is invoked a lot, hence `getOrInsertComputed` is
+   *       purposely *not* used to avoid creating unneeded callback functions.
+   */
   static get(cmd) {
-    // eslint-disable-next-line no-restricted-syntax
-    return (CmdCache[cmd] ||= new Cmd(cmd));
+    let c = CmdCache.get(cmd);
+    if (!c) {
+      // eslint-disable-next-line no-restricted-syntax
+      c = new Cmd(cmd);
+      CmdCache.set(cmd, c);
+    }
+    return c;
   }
 }
 
@@ -291,8 +309,12 @@ class Ref {
     return this.#str;
   }
 
+  /**
+   * NOTE: This method is invoked a lot, hence `getOrInsertComputed` is
+   *       purposely *not* used to avoid creating unneeded callback functions.
+   */
   static fromString(str) {
-    const ref = RefCache[str];
+    let ref = RefCache.get(str);
     if (ref) {
       return ref;
     }
@@ -303,13 +325,24 @@ class Ref {
     const num = parseInt(m[1], 10),
       gen = !m[2] ? 0 : parseInt(m[2], 10);
     // eslint-disable-next-line no-restricted-syntax
-    return (RefCache[str] = new Ref(str, num, gen));
+    ref = new Ref(str, num, gen);
+    RefCache.set(str, ref);
+    return ref;
   }
 
+  /**
+   * NOTE: This method is invoked a lot, hence `getOrInsertComputed` is
+   *       purposely *not* used to avoid creating unneeded callback functions.
+   */
   static get(num, gen) {
     const str = gen === 0 ? `${num}R` : `${num}R${gen}`;
-    // eslint-disable-next-line no-restricted-syntax
-    return (RefCache[str] ||= new Ref(str, num, gen));
+    let ref = RefCache.get(str);
+    if (!ref) {
+      // eslint-disable-next-line no-restricted-syntax
+      ref = new Ref(str, num, gen);
+      RefCache.set(str, ref);
+    }
+    return ref;
   }
 }
 

--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -314,7 +314,7 @@ class Ref {
    *       purposely *not* used to avoid creating unneeded callback functions.
    */
   static fromString(str) {
-    let ref = RefCache.get(str);
+    const ref = RefCache.get(str);
     if (ref) {
       return ref;
     }
@@ -322,12 +322,10 @@ class Ref {
     if (!m || m[1] === "0") {
       return null;
     }
-    const num = parseInt(m[1], 10),
-      gen = !m[2] ? 0 : parseInt(m[2], 10);
-    // eslint-disable-next-line no-restricted-syntax
-    ref = new Ref(str, num, gen);
-    RefCache.set(str, ref);
-    return ref;
+    return this.get(
+      /* num = */ parseInt(m[1], 10),
+      /* gen = */ !m[2] ? 0 : parseInt(m[2], 10)
+    );
   }
 
   /**

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -476,9 +476,11 @@ describe("primitives", function () {
     });
 
     it("should create reference from string representation", function () {
-      expect(Ref.fromString("4R")).toEqual(Ref.get(4, 0));
-      expect(Ref.fromString("4R0")).toEqual(Ref.get(4, 0));
-      expect(Ref.fromString("4R2")).toEqual(Ref.get(4, 2));
+      expect(Ref.fromString("4R")).toBe(Ref.get(4, 0));
+      expect(Ref.fromString("4R0")).toBe(Ref.get(4, 0));
+      expect(Ref.fromString("4R2")).toBe(Ref.get(4, 2));
+      expect(Ref.fromString("4R8")).toBe(Ref.get(4, 8));
+      expect(Ref.fromString("04R08")).toBe(Ref.get(4, 8));
     });
 
     it("should not create reference from invalid string representation", function () {


### PR DESCRIPTION
This patch was tested with the following manifest file:
```json
[
  {
    "id": "tracemonkey-eq",
    "file": "pdfs/tracemonkey.pdf",
    "md5": "9a192d8b1a7dc652a19835f6f08098bd",
    "rounds": 200,
    "type": "eq"
  },
  {
    "id": "issue2618",
    "file": "pdfs/issue2618.pdf",
    "md5": "2c554a99a52288ca1a44a422eeafb8fb",
    "rounds": 200,
    "type": "eq"
  }
]
```
which gave the following results, indicating no significant regression, when comparing this patch against the `master` branch:
```
-- Grouped By pdf, page, stat --
pdf            | page | stat         | Count | Baseline(ms) | Current(ms) | +/- |     %  | Result(P<.05)
-------------- | ---- | ------------ | ----- | ------------ | ----------- | --- | ------ | -------------
issue2618      | 0    | Overall      |   200 |          479 |         469 | -10 |  -2.01 |        faster
issue2618      | 0    | Page Request |   200 |           13 |          12 |   0 |  -1.19 |
issue2618      | 0    | Rendering    |   200 |          466 |         457 |  -9 |  -2.03 |        faster
tracemonkey-eq | 0    | Overall      |   200 |           13 |          13 |   0 |  -0.90 |
tracemonkey-eq | 0    | Page Request |   200 |            1 |           1 |   0 | -13.79 |
tracemonkey-eq | 0    | Rendering    |   200 |           12 |          12 |   0 |  -0.37 |
tracemonkey-eq | 1    | Overall      |   200 |           28 |          28 |   0 |  -0.20 |
tracemonkey-eq | 1    | Page Request |   200 |            2 |           2 |   0 |  10.13 |
tracemonkey-eq | 1    | Rendering    |   200 |           26 |          26 |   0 |  -0.82 |
tracemonkey-eq | 2    | Overall      |   200 |           20 |          20 |   0 |   1.08 |
tracemonkey-eq | 2    | Page Request |   200 |            1 |           1 |   0 |   7.92 |
tracemonkey-eq | 2    | Rendering    |   200 |           19 |          20 |   0 |   1.03 |
tracemonkey-eq | 3    | Overall      |   200 |           29 |          29 |   0 |  -0.26 |
tracemonkey-eq | 3    | Page Request |   200 |            1 |           1 |   0 | -15.53 |
tracemonkey-eq | 3    | Rendering    |   200 |           28 |          28 |   0 |   0.16 |
tracemonkey-eq | 4    | Overall      |   200 |           20 |          21 |   0 |   1.69 |
tracemonkey-eq | 4    | Page Request |   200 |            1 |           1 |   0 |  24.29 |
tracemonkey-eq | 4    | Rendering    |   200 |           20 |          20 |   0 |   0.81 |
tracemonkey-eq | 5    | Overall      |   200 |           20 |          20 |   0 |   0.28 |
tracemonkey-eq | 5    | Page Request |   200 |            1 |           1 |   0 |   1.68 |
tracemonkey-eq | 5    | Rendering    |   200 |           19 |          19 |   0 |   0.24 |
tracemonkey-eq | 6    | Overall      |   200 |           24 |          24 |   0 |   1.10 |
tracemonkey-eq | 6    | Page Request |   200 |            1 |           1 |   0 |  52.55 |
tracemonkey-eq | 6    | Rendering    |   200 |           23 |          23 |   0 |  -0.41 |
tracemonkey-eq | 7    | Overall      |   200 |           23 |          23 |   0 |   0.04 |
tracemonkey-eq | 7    | Page Request |   200 |            1 |           1 |   0 |  -2.52 |
tracemonkey-eq | 7    | Rendering    |   200 |           23 |          23 |   0 |   0.02 |
tracemonkey-eq | 8    | Overall      |   200 |           24 |          24 |   0 |  -0.02 |
tracemonkey-eq | 8    | Page Request |   200 |            1 |           0 |   0 | -13.27 |
tracemonkey-eq | 8    | Rendering    |   200 |           23 |          23 |   0 |   0.33 |
tracemonkey-eq | 9    | Overall      |   200 |           21 |          21 |   0 |   0.74 |
tracemonkey-eq | 9    | Page Request |   200 |            1 |           1 |   0 |  -4.13 |
tracemonkey-eq | 9    | Rendering    |   200 |           20 |          20 |   0 |   0.94 |
tracemonkey-eq | 10   | Overall      |   200 |          107 |         106 |  -1 |  -1.27 |
tracemonkey-eq | 10   | Page Request |   200 |            1 |           0 |   0 | -44.83 |
tracemonkey-eq | 10   | Rendering    |   200 |          106 |         105 |  -1 |  -0.93 |
tracemonkey-eq | 11   | Overall      |   200 |           21 |          21 |  -1 |  -2.71 |
tracemonkey-eq | 11   | Page Request |   200 |            1 |           1 |   0 | -20.12 |
tracemonkey-eq | 11   | Rendering    |   200 |           21 |          20 |   0 |  -1.99 |
tracemonkey-eq | 12   | Overall      |   200 |           35 |          34 |  -1 |  -1.79 |
tracemonkey-eq | 12   | Page Request |   200 |            1 |           1 |   0 | -18.89 |        faster
tracemonkey-eq | 12   | Rendering    |   200 |           34 |          34 |   0 |  -1.37 |
tracemonkey-eq | 13   | Overall      |   200 |           11 |          11 |  -1 |  -6.44 |
tracemonkey-eq | 13   | Page Request |   200 |            1 |           0 |   0 | -16.67 |
tracemonkey-eq | 13   | Rendering    |   200 |           11 |          10 |  -1 |  -5.99 |
```