### PR TITLE
Avoid a CPU DoS when auto-sizing text fields (bug 2069428)

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -2150,6 +2150,15 @@ class WidgetAnnotation extends Annotation {
       return super.getOperatorList(evaluator, task, intent, annotationStorage);
     }
 
+    const isUsingOwnCanvas = !!(
+      this.data.hasOwnCanvas && intent & RenderingIntentFlag.DISPLAY
+    );
+    if (isUsingOwnCanvas && (this.width === 0 || this.height === 0)) {
+      // Don't request a separate zero-sized canvas (see bug 2069428).
+      this.data.hasOwnCanvas = false;
+      return this._getOperatorListNoAppearance();
+    }
+
     const content = await this._getAppearance(
       evaluator,
       task,
@@ -2167,10 +2176,6 @@ class WidgetAnnotation extends Annotation {
     if (!this._defaultAppearance || content === null) {
       return { opList, separateForm: false, separateCanvas: false };
     }
-
-    const isUsingOwnCanvas = !!(
-      this.data.hasOwnCanvas && intent & RenderingIntentFlag.DISPLAY
-    );
 
     const matrix = [1, 0, 0, 1, 0, 0];
     const bbox = [0, 0, this.width, this.height];
@@ -2470,6 +2475,14 @@ class WidgetAnnotation extends Annotation {
       );
     }
 
+    if (
+      !this.data.defaultAppearanceData.fontSize &&
+      (totalWidth <= 2 * defaultHPadding || totalHeight <= 2 * defaultPadding)
+    ) {
+      // No space remains for auto-sized text after padding (see bug 2069428).
+      return `/Tx BMC q ${colors}Q EMC`;
+    }
+
     let font = await WidgetAnnotation._getFontData(
       evaluator,
       task,
@@ -2688,8 +2701,8 @@ class WidgetAnnotation extends Annotation {
 
   _computeFontSize(height, width, text, font, lineCount) {
     let { fontSize } = this.data.defaultAppearanceData;
-    let lineHeight = (fontSize || 12) * LINE_FACTOR,
-      numberOfLines = Math.round(height / lineHeight);
+    const lineHeight = (fontSize || 12) * LINE_FACTOR;
+    let numberOfLines = Math.round(height / lineHeight);
 
     if (!fontSize) {
       // A zero value for size means that the font shall be auto-sized:
@@ -2745,17 +2758,30 @@ class WidgetAnnotation extends Annotation {
         // Then we'll adjust font size to what we have really.
         numberOfLines = Math.max(numberOfLines, lineCount);
 
-        while (true) {
-          lineHeight = height / numberOfLines;
-          fontSize = roundWithTwoDigits(lineHeight / LINE_FACTOR);
+        const getFontSize = n => roundWithTwoDigits(height / n / LINE_FACTOR);
 
-          if (isTooBig(fontSize)) {
-            numberOfLines++;
-            continue;
+        if (height > 0 && isTooBig(getFontSize(numberOfLines))) {
+          // Smaller font sizes cannot increase the wrapped text height. Find
+          // the first fitting line count with exponential and binary searches,
+          // reducing `isTooBig` calls from linear to logarithmic (bug 2069428).
+          let low = numberOfLines,
+            high = 2 * numberOfLines;
+          while (isTooBig(getFontSize(high))) {
+            low = high;
+            high *= 2;
           }
-
-          break;
+          while (high - low > 1) {
+            const mid = Math.floor((low + high) / 2);
+            if (isTooBig(getFontSize(mid))) {
+              low = mid;
+            } else {
+              high = mid;
+            }
+          }
+          numberOfLines = high;
         }
+
+        fontSize = getFontSize(numberOfLines);
       }
 
       const { fontName, fontColor } = this.data.defaultAppearanceData;

--- a/test/unit/annotation_spec.js
+++ b/test/unit/annotation_spec.js
@@ -1768,6 +1768,37 @@ describe("annotation", function () {
       );
     });
 
+    it("should render fixed-size text in a narrow field for printing", async function () {
+      textWidgetDict.set("Rect", [0, 0, 4, 10]);
+
+      const textWidgetRef = Ref.get(271, 0);
+      const xref = new XRefMock([
+        { ref: textWidgetRef, data: textWidgetDict },
+        helvRefObj,
+      ]);
+      const task = new WorkerTask("test print");
+      partialEvaluator.xref = xref;
+
+      const annotation = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobalsMock,
+        idFactoryMock
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "i" });
+
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        RenderingIntentFlag.PRINT,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 5 Tf 1 0 0 1 0 0 Tm 2 3.72 Td (i) Tj ET Q EMC"
+      );
+    });
+
     it("should render regular text in Japanese for printing", async function () {
       textWidgetDict.get("DR").get("Font").set("Goth", gothRefObj.ref);
       textWidgetDict.set("DA", "/Goth 5 Tf");
@@ -2094,6 +2125,193 @@ describe("annotation", function () {
       );
 
       expect(appearance).toEqual(expectedAppearance);
+    });
+
+    it("should render multiline auto-sized text in a narrow field for printing", async function () {
+      textWidgetDict.set("Ff", AnnotationFieldFlag.MULTILINE);
+      textWidgetDict.set("DA", "/Helv 0 Tf");
+      textWidgetDict.set("Rect", [0, 0, 5, 20]);
+
+      const textWidgetRef = Ref.get(271, 0);
+      const xref = new XRefMock([
+        { ref: textWidgetRef, data: textWidgetDict },
+        helvRefObj,
+      ]);
+      const task = new WorkerTask("test print");
+      partialEvaluator.xref = xref;
+
+      const annotation = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobalsMock,
+        idFactoryMock
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "AAAAAAAAAA" });
+
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        RenderingIntentFlag.PRINT,
+        annotationStorage
+      );
+      expect(appearance).toEqual(
+        "/Tx BMC q BT /Helv 1.48 Tf 0 g 1 0 0 1 0 20 Tm " +
+          "2 -2.48 Td (A) Tj\n" +
+          "0 -2 Td (A) Tj\n".repeat(8) +
+          "0 -2 Td (A) Tj ET Q EMC"
+      );
+    });
+
+    it("should render long multiline auto-sized text in a narrow field (bug 2069428)", async function () {
+      textWidgetDict.set("Ff", AnnotationFieldFlag.MULTILINE);
+      textWidgetDict.set("DA", "/Helv 0 Tf");
+      textWidgetDict.set("Rect", [0, 0, 5, 75000]);
+
+      const textWidgetRef = Ref.get(271, 0);
+      const xref = new XRefMock([
+        { ref: textWidgetRef, data: textWidgetDict },
+        helvRefObj,
+      ]);
+      const task = new WorkerTask("test print");
+      partialEvaluator.xref = xref;
+
+      const annotation = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobalsMock,
+        idFactoryMock
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "A".repeat(50000) });
+
+      const appearance = await annotation._getAppearance(
+        partialEvaluator,
+        task,
+        RenderingIntentFlag.PRINT,
+        annotationStorage
+      );
+      const lines = appearance.split("\n");
+      expect(lines.length).toEqual(50000);
+      expect(lines[0]).toEqual(
+        "/Tx BMC q BT /Helv 1.49 Tf 0 g 1 0 0 1 0 75000 Tm 2 -2.5 Td (A) Tj"
+      );
+      expect(lines[1]).toEqual("0 -2.02 Td (A) Tj");
+      expect(lines.at(-1)).toEqual("0 -2.02 Td (A) Tj ET Q EMC");
+    });
+
+    it("should not render text in a field which is too small (bug 2069428)", async function () {
+      textWidgetDict.set("Ff", AnnotationFieldFlag.MULTILINE);
+      textWidgetDict.set("DA", "/Helv 0 Tf");
+
+      for (const rect of [
+        [0, 0, 0, 75000],
+        [0, 0, 4, 100],
+        [0, 0, 200, 1],
+      ]) {
+        textWidgetDict.set("Rect", rect);
+
+        const textWidgetRef = Ref.get(271, 0);
+        const xref = new XRefMock([
+          { ref: textWidgetRef, data: textWidgetDict },
+          helvRefObj,
+        ]);
+        const task = new WorkerTask("test print");
+        partialEvaluator.xref = xref;
+
+        const annotation = await AnnotationFactory.create(
+          xref,
+          textWidgetRef,
+          annotationGlobalsMock,
+          idFactoryMock
+        );
+        const annotationStorage = new Map();
+        annotationStorage.set(annotation.data.id, {
+          value: "A".repeat(50000),
+        });
+
+        const appearance = await annotation._getAppearance(
+          partialEvaluator,
+          task,
+          RenderingIntentFlag.PRINT,
+          annotationStorage
+        );
+        expect(appearance).toEqual("/Tx BMC q Q EMC");
+      }
+    });
+
+    it("should render the background of a small field without a default appearance", async function () {
+      textWidgetDict.delete("DA");
+      textWidgetDict.set("Rect", [0, 0, 4, 10]);
+      const mk = new Dict();
+      mk.set("BG", [1, 0, 0]);
+      textWidgetDict.set("MK", mk);
+
+      const textWidgetRef = Ref.get(271, 0);
+      const xref = new XRefMock([
+        { ref: textWidgetRef, data: textWidgetDict },
+        helvRefObj,
+      ]);
+      const task = new WorkerTask("test print");
+      partialEvaluator.xref = xref;
+
+      const annotation = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobalsMock,
+        idFactoryMock
+      );
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, { value: "test" });
+
+      const { opList } = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        RenderingIntentFlag.PRINT,
+        annotationStorage
+      );
+      expect(opList.fnArray).toContain(OPS.setFillRGBColor);
+      expect(opList.argsArray).toContain(["#ff0000"]);
+    });
+
+    it("should not use its own canvas when the field has a zero dimension (bug 2069428)", async function () {
+      textWidgetDict.set(
+        "Ff",
+        AnnotationFieldFlag.MULTILINE | AnnotationFieldFlag.READONLY
+      );
+      textWidgetDict.set("DA", "/Helv 0 Tf");
+      textWidgetDict.set("Rect", [0, 0, 0, 75000]);
+
+      const textWidgetRef = Ref.get(271, 0);
+      const xref = new XRefMock([
+        { ref: textWidgetRef, data: textWidgetDict },
+        helvRefObj,
+      ]);
+      const task = new WorkerTask("test display");
+      partialEvaluator.xref = xref;
+
+      const annotation = await AnnotationFactory.create(
+        xref,
+        textWidgetRef,
+        annotationGlobalsMock,
+        idFactoryMock
+      );
+      expect(annotation.data.hasOwnCanvas).toBeTrue();
+
+      const annotationStorage = new Map();
+      annotationStorage.set(annotation.data.id, {
+        value: "A".repeat(50000),
+      });
+
+      const { opList, separateCanvas } = await annotation.getOperatorList(
+        partialEvaluator,
+        task,
+        RenderingIntentFlag.DISPLAY,
+        annotationStorage
+      );
+      expect(opList.length).toEqual(0);
+      expect(separateCanvas).toBeFalse();
+      expect(annotation.data.hasOwnCanvas).toBeFalse();
     });
 
     it("should render comb for printing", async function () {


### PR DESCRIPTION
Auto-sizing tried line counts one by one, which was very slow for long text in narrow fields and could loop forever when there was no usable height.

Search for the line count instead, and skip text or canvases when the field is too small.