### PR TITLE
Wait for the deferred focus changes in the editor integration tests

### DIFF
--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -54,6 +54,7 @@ import {
   unselectEditor,
   waitForAnnotationEditorLayer,
   waitForAnnotationModeChanged,
+  waitForEditorFocusSettled,
   waitForPointerUp,
   waitForSelectedEditor,
   waitForSerialized,
@@ -70,6 +71,7 @@ const clearAll = clearEditors.bind(null, "freeText");
 const commit = async page => {
   await page.keyboard.press("Escape");
   await page.waitForSelector(".freeTextEditor.selectedEditor .overlay.enabled");
+  await waitForEditorFocusSettled(page);
 };
 
 const switchToFreeText = switchToEditor.bind(null, "FreeText");
@@ -101,6 +103,7 @@ const createFreeTextEditor = async ({
 
   await page.mouse.click(x, y);
   await page.waitForSelector(editorSelector, { visible: true });
+  await waitForEditorFocusSettled(page);
   if (data) {
     await page.type(`${editorSelector} .internal`, data);
   }

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -39,6 +39,7 @@ import {
   unselectEditor,
   waitAndClick,
   waitForAnnotationModeChanged,
+  waitForEditorFocusSettled,
   waitForPointerUp,
   waitForSelectedEditor,
   waitForSerialized,
@@ -2882,6 +2883,7 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(
             ".inkEditor.selectedEditor.draggable.disabled"
           );
+          await waitForEditorFocusSettled(page);
 
           await selectEditor(page, editorSelector0);
           for (let i = 0; i < 6; i++) {

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -417,6 +417,7 @@ async function selectEditor(page, selector, count = 1) {
     { count }
   );
   await waitForSelectedEditor(page, selector);
+  await waitForEditorFocusSettled(page);
 }
 
 async function waitForSelectedEditor(page, selector) {
@@ -725,6 +726,20 @@ function waitForEditorMovedInDOM(page) {
       once: true,
     });
   });
+}
+
+/**
+ * Editor operations can queue zero-delay timers to move an editor in the DOM
+ * and then restore its focus. A tool change can also queue a timer to focus its
+ * selected editor. Wait through both timer turns before sending more input.
+ */
+function waitForEditorFocusSettled(page) {
+  return page.evaluate(
+    () =>
+      new Promise(resolve => {
+        setTimeout(() => setTimeout(resolve, 0), 0);
+      })
+  );
 }
 
 async function scrollIntoView(page, selector) {
@@ -1098,11 +1113,14 @@ function waitForPositionChange(page, selector, xy) {
 }
 
 async function moveEditor(page, selector, n, pressKey) {
+  await waitForEditorFocusSettled(page);
   let xy = await getXY(page, selector);
   for (let i = 0; i < n; i++) {
     const handle = await waitForEditorMovedInDOM(page);
     await pressKey();
     await awaitPromise(handle);
+    // `editormovedindom` is dispatched before focus is restored.
+    await waitForEditorFocusSettled(page);
     await waitForPositionChange(page, selector, xy);
     xy = await getXY(page, selector);
   }
@@ -1253,6 +1271,7 @@ export {
   waitForAnnotationModeChanged,
   waitForBrowserTrip,
   waitForDOMMutation,
+  waitForEditorFocusSettled,
   waitForEntryInStorage,
   waitForEvent,
   waitForNoElement,

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1013,14 +1013,6 @@ async function startBrowser({
   const printFile = path.join(tempDir, "print.pdf");
 
   if (browserName === "chrome") {
-    // Slow down protocol calls by the given number of milliseconds. In Chrome
-    // protocol calls are faster than in Firefox and thus trigger in quicker
-    // succession. This can cause intermittent failures because new protocol
-    // calls can run before events triggered by the previous protocol calls had
-    // a chance to be processed (essentially causing events to get lost). This
-    // value gives Chrome a more similar execution speed as Firefox.
-    options.slowMo = 2;
-
     options.args = [
       // Avoid crashing because no sandbox is shipped by default and we only run
       // our own trusted content in the scope of the tests (for more information


### PR DESCRIPTION
When an editor is added, moved or committed, it's moved in the DOM in a setTimeout and the focus is restored in a second one. Without the slowMo option for Chrome, the next Puppeteer command can run in between and be broken by the deferred focus change (e.g. a new empty FreeText editor is removed because it loses the focus).

So wait for those timeouts after creating, committing, selecting or moving an editor, and remove the slowMo option which isn't required anymore (see #21885).