### PR TITLE
Shorten some Pattern-handling code a little bit

### DIFF
--- a/src/core/pattern.js
+++ b/src/core/pattern.js
@@ -178,22 +178,13 @@ class RadialAxialShading extends BaseShading {
     });
     this.bbox = lookupNormalRect(dict.getArray("BBox"), null);
 
-    let t0 = 0.0,
-      t1 = 1.0;
     const domainArr = dict.getArray("Domain");
-    if (isNumberArray(domainArr, 2)) {
-      [t0, t1] = domainArr;
-    }
+    const [t0, t1] = isNumberArray(domainArr, 2) ? domainArr : [0.0, 1.0];
 
-    let extendStart = false,
-      extendEnd = false;
     const extendArr = dict.getArray("Extend");
-    if (isBooleanArray(extendArr, 2)) {
-      [extendStart, extendEnd] = extendArr;
-    }
-
-    this.extendStart = extendStart;
-    this.extendEnd = extendEnd;
+    const [extendStart, extendEnd] = isBooleanArray(extendArr, 2)
+      ? extendArr
+      : [false, false];
 
     const fnObj = dict.getRaw("Function");
     const fn = pdfFunctionFactory.create(fnObj, /* parseArray = */ true);
@@ -321,8 +312,6 @@ class RadialAxialShading extends BaseShading {
       colorStops.at(-1)[0] -= BaseShading.SMALL_NUMBER;
       colorStops.push([1, background]);
     }
-
-    this.colorStops = colorStops;
   }
 
   getIR() {

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -13,8 +13,14 @@
  * limitations under the License.
  */
 
+import {
+  BBOX_INIT,
+  FormatError,
+  info,
+  unreachable,
+  Util,
+} from "../shared/util.js";
 import { drawMeshWithGPU, isGPUReady, loadMeshShader } from "./webgpu.js";
-import { FormatError, info, unreachable, Util } from "../shared/util.js";
 import { CanvasNestedDependencyTracker } from "./canvas_dependency_tracker.js";
 import { getCurrentTransform } from "./display_utils.js";
 
@@ -597,7 +603,7 @@ class TilingPattern {
   // as [width, height, offsetX, offsetY] in dims.
   updatePatternDims(clippedBBox, dims) {
     // Two diagonal corners aren't enough when the pattern matrix is rotated.
-    const bbox = [Infinity, Infinity, -Infinity, -Infinity];
+    const bbox = BBOX_INIT.slice();
     Util.axialAlignedBoundingBox(
       clippedBBox,
       Util.inverseTransform(this.patternBaseMatrix),


### PR DESCRIPTION
Also, remove a couple of unused class fields and don't needlessly set the `RadialAxialShading.protoype.colorStops` field again; note https://github.com/mozilla/pdf.js/blob/b2035eea9206b92ee7eba2c9e92e573a82167ff1/src/core/pattern.js#L206