### PR TITLE
Remove the unused `@babel/runtime` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "devDependencies": {
         "@babel/core": "^8.0.1",
         "@babel/preset-env": "^8.0.2",
-        "@babel/runtime": "^8.0.0",
         "@eslint/json": "^2.0.1",
         "@fluent/bundle": "^0.19.1",
         "@fluent/dom": "^0.10.2",
@@ -2744,13 +2743,6 @@
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
       }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
-      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/template": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@babel/preset-env": "^8.0.2",
-    "@babel/runtime": "^8.0.0",
     "@eslint/json": "^2.0.1",
     "@fluent/bundle": "^0.19.1",
     "@fluent/dom": "^0.10.2",


### PR DESCRIPTION
It was added in the Babel 7 update (commit b46ec5195) as the helper library for `@babel/plugin-transform-runtime`. That plugin was removed in commit 6e3179994, when the Babel `targets`-option was introduced, but the runtime package itself was left behind. Nothing has used it since.