### PR TITLE
Replace `kleur` with `util.styleText`

### DIFF
--- a/external/color_utils.mjs
+++ b/external/color_utils.mjs
@@ -13,13 +13,24 @@
  * limitations under the License.
  */
 
-import kleur from "kleur";
+import { styleText } from "util";
 
-// Kleur has one global switch, so use stdout for automatic TTY detection.
-kleur.enabled =
+// NO_COLOR overrides TTY detection, FORCE_COLOR, and GitHub Actions.
+const COLORS_ENABLED =
   !process.env.NO_COLOR &&
   (!!process.stdout.isTTY ||
     !!process.env.FORCE_COLOR ||
     process.env.GITHUB_ACTIONS === "true");
 
-export { kleur };
+/**
+ * @param {string | string[]} format - One or more `util.styleText` formats.
+ * @param {string} text
+ * @returns {string}
+ */
+function colorize(format, text) {
+  return COLORS_ENABLED
+    ? styleText(format, text, { validateStream: false })
+    : text;
+}
+
+export { colorize };

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -28,13 +28,13 @@ import { exec, execSync, spawn, spawnSync } from "child_process";
 import { finished, pipeline as runPipeline } from "stream/promises";
 import autoprefixer from "autoprefixer";
 import { buildPrefsSchema } from "./external/chromium/prefs.mjs";
+import { colorize } from "./external/color_utils.mjs";
 import crypto from "crypto";
 import fs from "fs";
 import gulp from "gulp";
 import hljs from "highlight.js";
 import istanbulCoverage from "istanbul-lib-coverage";
 import istanbulReportGenerator from "istanbul-reports";
-import { kleur } from "./external/color_utils.mjs";
 import layouts from "@metalsmith/layouts";
 import libReport from "istanbul-lib-report";
 import markdown from "@metalsmith/markdown";
@@ -516,9 +516,9 @@ function getErrorMessages(error) {
 }
 
 function reportBuildFailure(error) {
-  console.error(kleur.red(`\n### ${error?.message || "Build failed"}`));
+  console.error(colorize("red", `\n### ${error?.message || "Build failed"}`));
   for (const message of getErrorMessages(error)) {
-    console.error(kleur.red(message));
+    console.error(colorize("red", message));
   }
 }
 
@@ -2020,7 +2020,7 @@ function syncMozcentral() {
     console.log(`  deleted: ${filePath}`);
   }
   for (const filePath of stats.updated) {
-    console.log(kleur.green(`  updated: ${filePath}`));
+    console.log(colorize("green", `  updated: ${filePath}`));
   }
   console.log(
     `\n${stats.updated.length} file(s) updated, ` +

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "jasmine": "^7.0.0",
         "jsdoc": "^4.0.5",
         "jstransformer-nunjucks": "^1.2.0",
-        "kleur": "^4.1.5",
         "metalsmith": "^2.7.0",
         "metalsmith-html-relative": "^2.0.13",
         "ordered-read-streams": "^2.0.0",
@@ -9006,16 +9005,6 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.9"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/last-run": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "jasmine": "^7.0.0",
     "jsdoc": "^4.0.5",
     "jstransformer-nunjucks": "^1.2.0",
-    "kleur": "^4.1.5",
     "metalsmith": "^2.7.0",
     "metalsmith-html-relative": "^2.0.13",
     "ordered-read-streams": "^2.0.0",

--- a/test/color_utils.mjs
+++ b/test/color_utils.mjs
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
-import { kleur } from "../external/color_utils.mjs";
+import { colorize } from "../external/color_utils.mjs";
 
-const TEST_PASSED = kleur.green("TEST-PASS");
-const TEST_UNEXPECTED_FAIL = kleur.red().bold("TEST-UNEXPECTED-FAIL");
+const TEST_PASSED = colorize("green", "TEST-PASS");
+const TEST_UNEXPECTED_FAIL = colorize(["red", "bold"], "TEST-UNEXPECTED-FAIL");
 
 function colorBrowser(name) {
-  return kleur.cyan(name);
+  return colorize("cyan", name);
 }
 
 export { colorBrowser, TEST_PASSED, TEST_UNEXPECTED_FAIL };


### PR DESCRIPTION
All supported Node.js versions provide `util.styleText`. Preserve the existing color-enabling rules and the styles used by the build and test output.