### PR TITLE
Use `@napi-rs/canvas` for PNG decoding in integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "metalsmith": "^2.7.0",
         "metalsmith-html-relative": "^2.0.13",
         "ordered-read-streams": "^2.0.0",
-        "pngjs": "^7.0.0",
         "postcss": "^8.5.26",
         "postcss-discard-comments": "^9.0.0",
         "postcss-values-parser": "^8.0.0",
@@ -10275,16 +10274,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "metalsmith": "^2.7.0",
     "metalsmith-html-relative": "^2.0.13",
     "ordered-read-streams": "^2.0.0",
-    "pngjs": "^7.0.0",
     "postcss": "^8.5.26",
     "postcss-discard-comments": "^9.0.0",
     "postcss-values-parser": "^8.0.0",

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -22,6 +22,7 @@ import {
   countSerialized,
   countStorageEntries,
   createPromise,
+  decodePNG,
   dragAndDrop,
   firstPageOnTop,
   getAnnotationSelector,
@@ -61,7 +62,6 @@ import {
   waitForTimeout,
   waitForUnselectedEditor,
 } from "./test_utils.mjs";
-import { PNG } from "pngjs";
 
 const selectAll = selectEditors.bind(null, "freeText");
 
@@ -1582,7 +1582,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(Buffer.from(editorPng));
+            const editorImage = await decodePNG(editorPng);
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -1610,7 +1610,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(Buffer.from(editorPng));
+            const editorImage = await decodePNG(editorPng);
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -1743,7 +1743,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(Buffer.from(editorPng));
+            const editorImage = await decodePNG(editorPng);
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,
@@ -1777,7 +1777,7 @@ describe("FreeText Editor", () => {
               clip: rect,
               type: "png",
             });
-            const editorImage = PNG.sync.read(Buffer.from(editorPng));
+            const editorImage = await decodePNG(editorPng);
             const editorFirstPix = getFirstPixel(
               editorImage.data,
               editorImage.width,

--- a/test/integration/signature_editor_spec.mjs
+++ b/test/integration/signature_editor_spec.mjs
@@ -17,6 +17,7 @@ import {
   awaitPromise,
   closePages,
   copy,
+  decodePNG,
   FSI,
   getEditorSelector,
   getRect,
@@ -29,7 +30,6 @@ import {
 } from "./test_utils.mjs";
 import fs from "fs";
 import path from "path";
-import { PNG } from "pngjs";
 
 const __dirname = import.meta.dirname;
 
@@ -624,11 +624,11 @@ describe("Signature Editor", () => {
       contentHeight = y1 - y0;
     }
 
-    beforeAll(() => {
+    beforeAll(async () => {
       const data = fs.readFileSync(
         path.join(__dirname, "../images/samplesignature.png")
       );
-      const png = PNG.sync.read(data);
+      const png = await decodePNG(data);
       getContentAspectRatio(png);
     });
 

--- a/test/integration/stamp_editor_spec.mjs
+++ b/test/integration/stamp_editor_spec.mjs
@@ -21,6 +21,7 @@ import {
   closePages,
   copy,
   copyToClipboard,
+  decodePNG,
   dragAndDrop,
   getAnnotationSelector,
   getEditorDimensions,
@@ -52,7 +53,6 @@ import {
 } from "./test_utils.mjs";
 import fs from "fs";
 import path from "path";
-import { PNG } from "pngjs";
 
 const __dirname = import.meta.dirname;
 
@@ -1406,7 +1406,7 @@ describe("Stamp Editor", () => {
           await page.waitForSelector("#secondaryToolbar", { visible: true });
           const secondary = await page.$("#secondaryToolbar");
           const png = await secondary.screenshot({ type: "png" });
-          const secondaryImage = PNG.sync.read(Buffer.from(png));
+          const secondaryImage = await decodePNG(png);
           const buffer = new Uint32Array(secondaryImage.data.buffer);
           expect(buffer.every(x => x === 0xff0000ff))
             .withContext(`In ${browserName}`)

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -13,10 +13,24 @@
  * limitations under the License.
  */
 
+import { createCanvas, loadImage } from "@napi-rs/canvas";
 import { mergeCoverageIntoGlobal } from "../coverage_utils.js";
 import os from "os";
 
 const isMac = os.platform() === "darwin";
+
+/**
+ * Decode PNG data into RGBA pixels.
+ * @param {Uint8Array} data
+ * @returns {Promise<{width: number, height: number, data: Uint8ClampedArray}>}
+ */
+async function decodePNG(data) {
+  const image = await loadImage(data);
+  const { width, height } = image;
+  const ctx = createCanvas(width, height).getContext("2d");
+  ctx.drawImage(image, 0, 0);
+  return { width, height, data: ctx.getImageData(0, 0, width, height).data };
+}
 
 function loadAndWait(filename, selector, zoom, setups, options, viewport) {
   return Promise.all(
@@ -1195,6 +1209,7 @@ export {
   countStorageEntries,
   createPromise,
   createPromiseWithArgs,
+  decodePNG,
   dragAndDrop,
   firstPageOnTop,
   FSI,

--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -17,6 +17,7 @@ import {
   awaitPromise,
   closePages,
   createPromise,
+  decodePNG,
   getRect,
   getSpanRectFromText,
   loadAndWait,
@@ -29,7 +30,6 @@ import {
   waitForPageRendered,
 } from "./test_utils.mjs";
 import path from "path";
-import { PNG } from "pngjs";
 
 const __dirname = import.meta.dirname;
 
@@ -479,7 +479,7 @@ describe("PDF viewer", () => {
 
             const element = await page.$(`.page[data-page-number="1"]`);
             const png = await element.screenshot({ type: "png" });
-            const pageImage = PNG.sync.read(Buffer.from(png));
+            const pageImage = await decodePNG(png);
             let buffer = new Uint32Array(pageImage.data.buffer);
 
             // Search for the first red pixel.


### PR DESCRIPTION
This removes the `pngjs` dependency.