### PR TITLE
Make `Ref.fromString` more strict, by not accepting "bad" arguments

### DIFF
--- a/src/core/primitives.js
+++ b/src/core/primitives.js
@@ -309,23 +309,23 @@ class Ref {
     return this.#str;
   }
 
-  /**
-   * NOTE: This method is invoked a lot, hence `getOrInsertComputed` is
-   *       purposely *not* used to avoid creating unneeded callback functions.
-   */
   static fromString(str) {
-    const ref = RefCache.get(str);
+    let ref = RefCache.get(str);
     if (ref) {
       return ref;
     }
-    const m = /^(\d+)R(\d*)$/.exec(str);
-    if (!m || m[1] === "0") {
+    const m = /^([1-9]\d*)R([1-9]\d*)?$/.exec(str);
+    if (!m) {
       return null;
     }
-    return this.get(
+    // eslint-disable-next-line no-restricted-syntax
+    ref = new Ref(
+      str,
       /* num = */ parseInt(m[1], 10),
       /* gen = */ !m[2] ? 0 : parseInt(m[2], 10)
     );
+    RefCache.set(str, ref);
+    return ref;
   }
 
   /**

--- a/test/unit/primitives_spec.js
+++ b/test/unit/primitives_spec.js
@@ -477,18 +477,29 @@ describe("primitives", function () {
 
     it("should create reference from string representation", function () {
       expect(Ref.fromString("4R")).toBe(Ref.get(4, 0));
-      expect(Ref.fromString("4R0")).toBe(Ref.get(4, 0));
       expect(Ref.fromString("4R2")).toBe(Ref.get(4, 2));
       expect(Ref.fromString("4R8")).toBe(Ref.get(4, 8));
-      expect(Ref.fromString("04R08")).toBe(Ref.get(4, 8));
+      // Purposely test the same string again, to ensure that the fast-path
+      // for an already cached `Ref` instance is fully covered by tests.
+      expect(Ref.fromString("4R8")).toBe(Ref.get(4, 8));
+
+      expect(Ref.fromString("200R")).toBe(Ref.get(200, 0));
+      expect(Ref.fromString("200R10")).toBe(Ref.get(200, 10));
     });
 
     it("should not create reference from invalid string representation", function () {
-      expect(Ref.fromString("")).toBeNull();
-      expect(Ref.fromString("4")).toBeNull();
-      expect(Ref.fromString("R2")).toBeNull();
-      expect(Ref.fromString("0R2")).toBeNull();
-      expect(Ref.fromString("abc")).toBeNull();
+      for (const str of [
+        "",
+        "4",
+        "4R0",
+        "R2",
+        "0R2",
+        "04R08",
+        "fourRtwo",
+        "abc",
+      ]) {
+        expect(Ref.fromString(str)).toBeNull();
+      }
     });
   });
 


### PR DESCRIPTION
In hindsight the *second* commit of PR #21888, which was intended to improve how `Ref.fromString` handles "bad" arguments, seems wrong since that method now accepts arguments that don't agree fully with the string representation used in the `Ref.get` method.

The `Ref.fromString` method will now properly validate the argument, and "reject" (i.e. return `null`) unless it matches the expected format.