### PR TITLE
[GeckoView] Add typed signatures (bug 2069485)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -262,6 +262,7 @@ function createWebpackAlias(defines) {
   } else if (defines.MOZCENTRAL) {
     if (defines.GECKOVIEW) {
       const gvAlias = {
+        "web-signature_manager": "web/signature_manager-geckoview.js",
         "web-toolbar": "web/toolbar-geckoview.js",
       };
       for (const key in viewerAlias) {

--- a/src/display/editor/toolbar.js
+++ b/src/display/editor/toolbar.js
@@ -193,6 +193,9 @@ class EditorToolbar {
   async addEditSignatureButton(signatureManager) {
     const button = (this.#signatureDescriptionButton =
       await signatureManager.renderEditButton(this.#editor));
+    if (!button) {
+      return;
+    }
     this.#addListenersToElement(button);
     this.#buttons.append(button, this.#divider);
   }

--- a/test/integration/geckoview_spec.mjs
+++ b/test/integration/geckoview_spec.mjs
@@ -1,0 +1,174 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  closePages,
+  getEditors,
+  getEditorSelector,
+  getRect,
+  getSerialized,
+  waitForNoElement,
+  waitForSelectedEditor,
+} from "./test_utils.mjs";
+
+function loadAndWait(filename, selector) {
+  return Promise.all(
+    global.integrationSessions.map(async session => {
+      const page = await session.browser.newPage();
+
+      // Keep locale-dependent checks deterministic.
+      await page.evaluateOnNewDocument(() => {
+        Object.defineProperty(navigator, "language", {
+          get() {
+            return "en-US";
+          },
+        });
+        Object.defineProperty(navigator, "languages", {
+          get() {
+            return ["en-US", "en"];
+          },
+        });
+      });
+
+      const { origin } = new URL(global.integrationBaseUrl);
+      await page.goto(
+        `${origin}/web/viewer-geckoview.html` +
+          `?file=/test/pdfs/${filename}#zoom=page-fit`
+      );
+      await page.bringToFront();
+      await page.waitForSelector(selector, { timeout: 0 });
+
+      return [session.name, page];
+    })
+  );
+}
+
+// Dispatch the viewer event derived from GeckoView's "addsignature" DOM event.
+function addSignature(page, text) {
+  return page.evaluate(txt => {
+    window.PDFViewerApplication.eventBus.dispatch("addsignature", {
+      source: window,
+      text: txt,
+    });
+  }, text);
+}
+
+describe("GeckoView viewer", () => {
+  describe("Typed signature", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait("empty.pdf", ".annotationEditorLayer");
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must add a signature in the middle of the page and let the user remove it", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await addSignature(page, "Hello");
+
+          const editorSelector = getEditorSelector(0);
+          await page.waitForSelector(editorSelector, { visible: true });
+          await waitForSelectedEditor(page, editorSelector);
+          await page.waitForSelector(
+            `.canvasWrapper > svg use[href="#path_0"]`
+          );
+
+          await page.waitForSelector(`${editorSelector} .resizer`);
+          await page.waitForSelector(
+            `${editorSelector} .editToolbar .deleteButton`
+          );
+
+          const editorRect = await getRect(page, editorSelector);
+          const layerRect = await getRect(
+            page,
+            ".page[data-page-number='1'] .annotationEditorLayer"
+          );
+          const editorCenter = [
+            editorRect.x + editorRect.width / 2,
+            editorRect.y + editorRect.height / 2,
+          ];
+          const layerCenter = [
+            layerRect.x + layerRect.width / 2,
+            layerRect.y + layerRect.height / 2,
+          ];
+          expect(Math.abs(editorCenter[0] - layerCenter[0]))
+            .withContext(`In ${browserName}`)
+            .toBeLessThan(2);
+          expect(Math.abs(editorCenter[1] - layerCenter[1]))
+            .withContext(`In ${browserName}`)
+            .toBeLessThan(2);
+
+          let serialized = await getSerialized(page);
+          expect(serialized.length).withContext(`In ${browserName}`).toEqual(1);
+          const { isSignature, areContours, accessibilityData, pageIndex } =
+            serialized[0];
+          expect(isSignature).withContext(`In ${browserName}`).toBeTrue();
+          expect(areContours).withContext(`In ${browserName}`).toBeTrue();
+          expect(pageIndex).withContext(`In ${browserName}`).toEqual(0);
+          expect(accessibilityData?.alt)
+            .withContext(`In ${browserName}`)
+            .toEqual("Hello");
+
+          // Exercise the already-active mode.
+          await addSignature(page, "World");
+
+          const secondEditorSelector = getEditorSelector(1);
+          await page.waitForSelector(secondEditorSelector, { visible: true });
+          await waitForSelectedEditor(page, secondEditorSelector);
+          expect(await getEditors(page, "signature"))
+            .withContext(`In ${browserName}`)
+            .toEqual([0, 1]);
+
+          await page.click(
+            `${secondEditorSelector} .editToolbar .deleteButton`
+          );
+          await waitForNoElement(page, secondEditorSelector);
+
+          serialized = await getSerialized(page);
+          expect(serialized.length).withContext(`In ${browserName}`).toEqual(1);
+          expect(serialized[0].accessibilityData?.alt)
+            .withContext(`In ${browserName}`)
+            .toEqual("Hello");
+        })
+      );
+    });
+
+    it("must ignore a signature without any text", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          await addSignature(page, "   ");
+          await addSignature(page, "PDF.js");
+
+          // Whitespace must not consume an editor id.
+          const editorSelector = getEditorSelector(0);
+          await page.waitForSelector(editorSelector, { visible: true });
+          expect(await getEditors(page, "signature"))
+            .withContext(`In ${browserName}`)
+            .toEqual([0]);
+
+          const serialized = await getSerialized(page);
+          expect(serialized.length).withContext(`In ${browserName}`).toEqual(1);
+          expect(serialized[0].accessibilityData?.alt)
+            .withContext(`In ${browserName}`)
+            .toEqual("PDF.js");
+        })
+      );
+    });
+  });
+});

--- a/test/integration/jasmine-boot.js
+++ b/test/integration/jasmine-boot.js
@@ -38,6 +38,7 @@ async function runTests(results) {
       "document_properties_spec.mjs",
       "find_spec.mjs",
       "freetext_editor_spec.mjs",
+      "geckoview_spec.mjs",
       "highlight_editor_spec.mjs",
       "ink_editor_spec.mjs",
       "presentation_mode_spec.mjs",

--- a/web/app.js
+++ b/web/app.js
@@ -572,19 +572,28 @@ const PDFViewerApplication = {
       });
     }
 
-    const signatureManager =
-      AppOptions.get("enableSignatureEditor") && appConfig.addSignatureDialog
-        ? new SignatureManager(
-            appConfig.addSignatureDialog,
-            appConfig.editSignatureDialog,
-            appConfig.annotationEditorParams?.editorSignatureAddSignature ||
-              null,
-            overlayManager,
-            l10n,
-            externalServices.createSignatureStorage(eventBus, abortSignal),
-            eventBus
-          )
-        : null;
+    let signatureManager = null;
+    if (AppOptions.get("enableSignatureEditor")) {
+      if (
+        typeof PDFJSDev === "undefined"
+          ? window.isGECKOVIEW
+          : PDFJSDev.test("GECKOVIEW")
+      ) {
+        if (annotationEditorMode !== AnnotationEditorType.DISABLE) {
+          signatureManager = new SignatureManager(eventBus, abortSignal);
+        }
+      } else if (appConfig.addSignatureDialog) {
+        signatureManager = new SignatureManager(
+          appConfig.addSignatureDialog,
+          appConfig.editSignatureDialog,
+          appConfig.annotationEditorParams?.editorSignatureAddSignature || null,
+          overlayManager,
+          l10n,
+          externalServices.createSignatureStorage(eventBus, abortSignal),
+          eventBus
+        );
+      }
+    }
 
     const commentManager =
       AppOptions.get("enableComment") && appConfig.editCommentDialog

--- a/web/firefoxcom.js
+++ b/web/firefoxcom.js
@@ -234,6 +234,20 @@ if (PDFJSDev.test("GECKOVIEW")) {
       );
     });
   })();
+
+  (function listenAddSignatureEvent() {
+    const handleEvent = function ({ detail }) {
+      if (!viewerApp.initialized) {
+        return;
+      }
+      viewerApp.eventBus.dispatch("addsignature", {
+        source: window,
+        text: detail?.text,
+      });
+    };
+
+    window.addEventListener("addsignature", handleEvent);
+  })();
 }
 
 class FirefoxComDataRangeTransport extends PDFDataRangeTransport {

--- a/web/signature_manager-geckoview.js
+++ b/web/signature_manager-geckoview.js
@@ -1,0 +1,135 @@
+/* Copyright 2026 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AnnotationEditorParamsType,
+  AnnotationEditorType,
+  SignatureExtractor,
+} from "pdfjs-lib";
+import { internalOpt } from "./internal_evt.js";
+
+// Initial height in page units.
+const DEFAULT_HEIGHT_IN_PAGE = 40;
+
+const SIGNATURE_FONT = Object.freeze({
+  fontFamily: "cursive",
+  fontStyle: "normal",
+  fontWeight: "400",
+});
+
+/** Converts GeckoView's typed-signature events into signature editors. */
+class SignatureManager {
+  #eventBus;
+
+  #mode = AnnotationEditorType.NONE;
+
+  #pendingSignatures = [];
+
+  constructor(eventBus, signal) {
+    this.#eventBus = eventBus;
+    const opts = { signal, ...internalOpt };
+    eventBus.on("addsignature", this.#onAddSignature.bind(this), opts);
+    eventBus.on(
+      "annotationeditormodechanged",
+      this.#onModeChanged.bind(this),
+      opts
+    );
+  }
+
+  #onAddSignature({ text }) {
+    const signatureData = SignatureManager.#getSignatureData(text);
+    if (!signatureData) {
+      return;
+    }
+    if (this.#mode === AnnotationEditorType.SIGNATURE) {
+      this.#createEditor(signatureData);
+      return;
+    }
+    // Wait for signature mode before creating the editor.
+    this.#pendingSignatures.push(signatureData);
+    this.#eventBus.dispatch("switchannotationeditormode", {
+      source: this,
+      mode: AnnotationEditorType.SIGNATURE,
+    });
+  }
+
+  #onModeChanged({ mode }) {
+    this.#mode = mode;
+    if (mode !== AnnotationEditorType.SIGNATURE) {
+      // Keep the pending signatures until we're in signature mode.
+      return;
+    }
+    const pendingSignatures = this.#pendingSignatures;
+    this.#pendingSignatures = [];
+    for (const signatureData of pendingSignatures) {
+      this.#createEditor(signatureData);
+    }
+  }
+
+  #createEditor(signatureData) {
+    this.#eventBus.dispatch("switchannotationeditorparams", {
+      source: this,
+      type: AnnotationEditorParamsType.CREATE,
+      value: { signatureData },
+    });
+  }
+
+  static #getSignatureData(text) {
+    text = typeof text === "string" ? text.trim() : "";
+    if (!text) {
+      return null;
+    }
+    // SignatureEditor.render() rebuilds the outline; only newCurves is kept.
+    const data = SignatureExtractor.extractContoursFromText(
+      text,
+      SIGNATURE_FONT,
+      /* pageWidth = */ 1,
+      /* pageHeight = */ 1,
+      /* rotation = */ 0,
+      /* innerMargin = */ 0
+    );
+    if (!data) {
+      return null;
+    }
+    const { newCurves, width, height } = data;
+    return {
+      lines: {
+        curves: newCurves.map(points => ({ points })),
+        width,
+        height,
+      },
+      mustSmooth: false,
+      areContours: true,
+      description: text,
+      uuid: null,
+      heightInPage: DEFAULT_HEIGHT_IN_PAGE,
+    };
+  }
+
+  getSignature() {}
+
+  loadSignatures() {}
+
+  /** GeckoView has no description editor. */
+  renderEditButton() {
+    return null;
+  }
+
+  destroy() {
+    this.#pendingSignatures.length = 0;
+  }
+}
+
+export { SignatureManager };

--- a/web/viewer-geckoview.html
+++ b/web/viewer-geckoview.html
@@ -87,7 +87,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           "web-preferences": "./genericcom.js",
           "web-print_service": "./pdf_print_service.js",
           "web-secondary_toolbar": "./stubs-geckoview.js",
-          "web-signature_manager": "./stubs-geckoview.js",
+          "web-signature_manager": "./signature_manager-geckoview.js",
           "web-digital_signature_properties_manager": "./digital_signature_properties_manager.js",
           "web-toolbar": "./toolbar-geckoview.js",
           "web-views_manager": "./stubs-geckoview.js"


### PR DESCRIPTION
Forward GeckoView's "addsignature" DOM event to the viewer. Convert non-empty text to contours, switch to signature mode when needed, and create a SignatureEditor at the visible center of the current annotation layer.

The GeckoView signature manager has no description-edit control, so the editor toolbar accepts a missing button.