### PR TITLE
Keep editing disabled when switching documents

### DIFF
--- a/test/integration/viewer_spec.mjs
+++ b/test/integration/viewer_spec.mjs
@@ -2353,6 +2353,53 @@ describe("PDF viewer", () => {
     });
   });
 
+  describe("Editing stays disabled after opening another PDF (issue 21899)", () => {
+    let pages;
+
+    beforeEach(async () => {
+      pages = await loadAndWait(
+        "tracemonkey.pdf",
+        ".textLayer .endOfContent",
+        undefined,
+        undefined,
+        { annotationEditorMode: -1 }
+      );
+    });
+
+    afterEach(async () => {
+      await closePages(pages);
+    });
+
+    it("must not enable editing for the new document", async () => {
+      await Promise.all(
+        pages.map(async ([browserName, page]) => {
+          const isEditingDisabled = () =>
+            window.PDFViewerApplication.pdfViewer.annotationEditorMode === -1;
+
+          expect(await page.evaluate(isEditingDisabled))
+            .withContext(`In ${browserName}`)
+            .toBeTrue();
+
+          // Editor manager creation, if enabled, precedes "pagesinit".
+          const handle = await createPromise(page, resolve => {
+            window.PDFViewerApplication.eventBus.on("pagesinit", resolve, {
+              once: true,
+            });
+          });
+          const fileInput = await page.$("#fileInput");
+          await fileInput.uploadFile(
+            path.join(__dirname, "../pdfs/basicapi.pdf")
+          );
+          await awaitPromise(handle);
+
+          expect(await page.evaluate(isEditingDisabled))
+            .withContext(`In ${browserName}`)
+            .toBeTrue();
+        })
+      );
+    });
+  });
+
   describe("Preferences", () => {
     describe('handles "updatedPreference" event correctly', () => {
       let pages;

--- a/web/pdf_viewer.js
+++ b/web/pdf_viewer.js
@@ -909,7 +909,7 @@ class PDFViewer {
   }
 
   /**
-   * @param {PDFDocumentProxy} pdfDocument
+   * @param {PDFDocumentProxy|null} pdfDocument
    */
   setDocument(pdfDocument) {
     if (this.pdfDocument) {
@@ -924,7 +924,9 @@ class PDFViewer {
       this.#annotationEditorUIManager?.destroy();
       this.#annotationEditorUIManager = null;
 
-      this.#annotationEditorMode = AnnotationEditorType.NONE;
+      if (this.#annotationEditorMode !== AnnotationEditorType.DISABLE) {
+        this.#annotationEditorMode = AnnotationEditorType.NONE;
+      }
       this.#printingAllowed = true;
     }
 


### PR DESCRIPTION
setDocument() reset annotationEditorMode from DISABLE to NONE when clearing the current PDF, so the next PDF initialized an editor manager. Preserve DISABLE across documents.

Fixes #21899.