### PR TITLE
Don't crash when a transfer function array contains /Identity entries

### DIFF
--- a/src/display/filter_factory.js
+++ b/src/display/filter_factory.js
@@ -157,27 +157,14 @@ class DOMFilterFactory extends BaseFilterFactory {
   }
 
   #createTables(maps) {
+    // A `null` map is an /Identity entry, no feFunc is needed for it.
+    const toTable = map => map && Array.from(map, v => v / 255).join(",");
     if (maps.length === 1) {
-      const mapR = maps[0];
-      const buffer = new Array(256);
-      for (let i = 0; i < 256; i++) {
-        buffer[i] = mapR[i] / 255;
-      }
-
-      const table = buffer.join(",");
+      const table = toTable(maps[0]);
       return [table, table, table];
     }
-
     const [mapR, mapG, mapB] = maps;
-    const bufferR = new Array(256);
-    const bufferG = new Array(256);
-    const bufferB = new Array(256);
-    for (let i = 0; i < 256; i++) {
-      bufferR[i] = mapR[i] / 255;
-      bufferG[i] = mapG[i] / 255;
-      bufferB[i] = mapB[i] / 255;
-    }
-    return [bufferR.join(","), bufferG.join(","), bufferB.join(",")];
+    return [toTable(mapR), toTable(mapG), toTable(mapB)];
   }
 
   #createUrl(id) {
@@ -606,6 +593,9 @@ class DOMFilterFactory extends BaseFilterFactory {
   }
 
   #appendFeFunc(feComponentTransfer, func, table) {
+    if (!table) {
+      return;
+    }
     const feFunc = this.#document.createElementNS(SVG_NS, func);
     feFunc.setAttribute("type", "discrete");
     feFunc.setAttribute("tableValues", table);

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -885,23 +885,23 @@ class TilingPattern {
   }
 
   setFillAndStrokeStyleToContext(graphics, paintType, color) {
-    const context = graphics.ctx,
-      current = graphics.current;
-    current.patternFill = current.patternStroke = false;
     switch (paintType) {
       case PaintType.COLORED:
-        const { fillStyle, strokeStyle } = this.ctx;
-        context.fillStyle = current.fillColor = fillStyle;
-        context.strokeStyle = current.strokeColor = strokeStyle;
+        // The cell starts from the initial graphics state of its parent
+        // content stream (PDF 32000-1, 8.7.3.1), hence black and not the
+        // colours in effect when the pattern was selected.
+        color = "#000000";
         break;
       case PaintType.UNCOLORED:
-        context.fillStyle = context.strokeStyle = color;
-        // Set color needed by image masks (fixes issues 3226 and 8741).
-        current.fillColor = current.strokeColor = color;
         break;
       default:
         throw new FormatError(`Unsupported paint type: ${paintType}`);
     }
+    const { ctx, current } = graphics;
+    current.patternFill = current.patternStroke = false;
+    ctx.fillStyle = ctx.strokeStyle = color;
+    // Also needed by image masks (fixes issues 3226 and 8741).
+    current.fillColor = current.strokeColor = color;
   }
 
   isModifyingCurrentTransform() {

--- a/test/pdfs/.gitignore
+++ b/test/pdfs/.gitignore
@@ -957,3 +957,4 @@
 !issue20294_reduced.pdf
 !issue21878.pdf
 !nonembedded_type1_tounicode.pdf
+!transfer_maps.pdf

--- a/test/pdfs/transfer_maps.pdf
+++ b/test/pdfs/transfer_maps.pdf
@@ -1,0 +1,153 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200]
+   /Resources <<
+     /ExtGState << /GStr 4 0 R /GSid 5 0 R /GSmul 6 0 R /GSsq 16 0 R /GSpart 18 0 R >>
+     /Shading << /Sh1 8 0 R /Sh2 14 0 R >>
+     /XObject << /Fx1 9 0 R >>
+     /Pattern << /P1 10 0 R /P2 11 0 R /PSh 19 0 R /P3 20 0 R /P4 22 0 R >>
+     /ColorSpace << /CS0 [/Pattern /DeviceRGB] >>
+   >>
+   /Contents 12 0 R >>
+endobj
+4 0 obj
+<< /Type /ExtGState /TR 7 0 R >>
+endobj
+5 0 obj
+<< /Type /ExtGState /TR /Identity >>
+endobj
+6 0 obj
+<< /Type /ExtGState /BM /Multiply >>
+endobj
+7 0 obj
+<< /FunctionType 2 /Domain [0 1] /Range [0 1] /N 1 /C0 [1] /C1 [0] >>
+endobj
+8 0 obj
+<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [160 150 190 150]
+   /Function 13 0 R /Extend [true true] >>
+endobj
+9 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 200 200]
+   /Group << /S /Transparency /CS /DeviceRGB /I true >> /Length 26 >>
+stream
+0 0 1 rg 10 100 40 40 re f
+endstream
+endobj
+10 0 obj
+<< /PatternType 1 /PaintType 1 /TilingType 1 /BBox [0 0 10 10]
+   /XStep 10 /YStep 10 /Resources << >> /Length 23 >>
+stream
+0 0 1 rg 0 0 10 10 re f
+endstream
+endobj
+11 0 obj
+<< /PatternType 1 /PaintType 2 /TilingType 1 /BBox [0 0 10 10]
+   /XStep 10 /YStep 10 /Resources << >> /Length 14 >>
+stream
+0 0 10 10 re f
+endstream
+endobj
+12 0 obj
+<<  /Length 669 >>
+stream
+/GStr gs
+q 1 0 0 rg 10 150 40 40 re f Q
+q 40 0 0 40 60 150 cm BI /W 2 /H 2 /CS /RGB /BPC 8 /F /AHx ID
+ff0000ff0000ff0000ff0000>
+EI Q
+q 1 0 0 rg 40 0 0 40 110 150 cm BI /IM true /W 2 /H 2 /BPC 1 /F /AHx ID
+4080>
+EI Q
+q 160 150 30 40 re W n /Sh1 sh Q
+q /GSmul gs /Fx1 Do Q
+q /Pattern cs /P1 scn 60 100 40 40 re f Q
+q /CS0 cs 1 0 0 /P2 scn 110 100 40 40 re f Q
+q 1 0 0 rg /GSid gs 160 100 30 40 re f Q
+q 0 0 1 RG 10 w 10 70 m 50 70 l S Q
+q /GSsq gs 60 50 100 40 re W n /Sh2 sh Q
+q /GSpart gs 1 0 0 rg 170 50 20 40 re f Q
+q /Pattern cs /PSh scn 10 10 40 30 re f Q
+q 1 0 0 rg /Pattern cs /P3 scn 60 10 40 30 re f Q
+q 1 0 0 rg /Pattern cs /P4 scn /GSid gs 110 10 40 30 re f Q
+endstream
+endobj
+13 0 obj
+<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [1 0 0] /C1 [1 0 0] >>
+endobj
+14 0 obj
+<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [60 70 160 70]
+   /Function 15 0 R /Extend [true true] >>
+endobj
+15 0 obj
+<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0] /C1 [1 1 1] >>
+endobj
+16 0 obj
+<< /Type /ExtGState /TR 17 0 R >>
+endobj
+17 0 obj
+<< /FunctionType 2 /Domain [0 1] /Range [0 1] /N 2 /C0 [0] /C1 [1] >>
+endobj
+18 0 obj
+<< /Type /ExtGState /TR [/Identity 7 0 R /Identity /Identity] >>
+endobj
+19 0 obj
+<< /PatternType 2 /Shading 8 0 R >>
+endobj
+20 0 obj
+<< /PatternType 1 /PaintType 1 /TilingType 1 /BBox [0 0 10 10]
+   /XStep 10 /YStep 10
+   /Resources << /ExtGState << /GSmul 6 0 R >> /XObject << /Fx2 21 0 R >> >> /Length 17 >>
+stream
+/GSmul gs /Fx2 Do
+endstream
+endobj
+21 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 10 10]
+   /Group << /S /Transparency /CS /DeviceRGB /I true >> /Length 14 >>
+stream
+0 0 10 10 re f
+endstream
+endobj
+22 0 obj
+<< /PatternType 1 /PaintType 1 /TilingType 1 /BBox [0 0 10 10]
+   /XStep 10 /YStep 10 /Resources << >> /Length 14 >>
+stream
+0 0 10 10 re f
+endstream
+endobj
+xref
+0 23
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000516 00000 n 
+0000000564 00000 n 
+0000000616 00000 n 
+0000000668 00000 n 
+0000000753 00000 n 
+0000000878 00000 n 
+0000001060 00000 n 
+0000001234 00000 n 
+0000001399 00000 n 
+0000002121 00000 n 
+0000002202 00000 n 
+0000002325 00000 n 
+0000002406 00000 n 
+0000002456 00000 n 
+0000002542 00000 n 
+0000002623 00000 n 
+0000002675 00000 n 
+0000002903 00000 n 
+0000003072 00000 n 
+trailer
+<< /Size 23 /Root 1 0 R >>
+startxref
+3237
+%%EOF

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -14554,5 +14554,12 @@
     "md5": "0ab77bc45682d06b55499b95b42f907d",
     "rounds": 1,
     "type": "eq"
+  },
+  {
+    "id": "transfer_maps",
+    "file": "pdfs/transfer_maps.pdf",
+    "md5": "3b88d507cdaa55cf3379efea51880288",
+    "rounds": 1,
+    "type": "eq"
   }
 ]


### PR DESCRIPTION
The evaluator emits `null` for each /Identity entry of a four-function /TR array, but `DOMFilterFactory.#createTables` dereferenced it, which aborted the rendering of the whole page. A `null` map now simply gets no `feFunc` element, i.e. the identity for that channel.

The test file also showed that the cell of a coloured tiling pattern inherited the fill and stroke styles in effect when the pattern was selected. Per PDF 32000-1, 8.7.3.1, it starts from the graphics state at the beginning of the parent content stream, hence black, which is also what Acrobat, pdfium, xpdf, Ghostscript, Foxit and mupdf paint.