### PR TITLE
Move the the `interpolate` helper, such that it can be re-used more in `src/core/function.js` code

### DIFF
--- a/src/core/function.js
+++ b/src/core/function.js
@@ -100,6 +100,14 @@ function toNumberArray(arr) {
   return arr;
 }
 
+// See chapter 3, page 109 of the PDF reference
+function interpolate(x, xmin, xmax, ymin, ymax) {
+  // A degenerate `Domain` entry, e.g. `[0 0]`, occurs in real-world PDFs.
+  return xmin === xmax
+    ? ymin
+    : ymin + (x - xmin) * ((ymax - ymin) / (xmax - xmin));
+}
+
 class PDFFunction {
   static getSampleArray(size, outputSize, bps, stream) {
     let length = outputSize;
@@ -138,7 +146,7 @@ class PDFFunction {
       case FunctionType.EXPONENTIAL_INTERPOLATION:
         return this.constructInterpolated(factory, dict);
       case FunctionType.STITCHING:
-        return this.constructStiched(factory, dict);
+        return this.constructStitched(factory, dict);
       case FunctionType.POSTSCRIPT_CALCULATOR:
         return this.constructPostScript(factory, fn, dict);
     }
@@ -160,14 +168,6 @@ class PDFFunction {
   }
 
   static constructSampled(factory, fn, dict) {
-    // See chapter 3, page 109 of the PDF reference
-    function interpolate(x, xmin, xmax, ymin, ymax) {
-      // A degenerate `Domain` entry, e.g. `[0 0]`, occurs in real-world PDFs.
-      return xmin === xmax
-        ? ymin
-        : ymin + (x - xmin) * ((ymax - ymin) / (xmax - xmin));
-    }
-
     const domain = toNumberArray(dict.getArray("Domain"));
     const range = toNumberArray(dict.getArray("Range"));
 
@@ -290,7 +290,7 @@ class PDFFunction {
     };
   }
 
-  static constructStiched(factory, dict) {
+  static constructStitched(factory, dict) {
     const domain = toNumberArray(dict.getArray("Domain"));
 
     if (!domain) {
@@ -299,7 +299,7 @@ class PDFFunction {
 
     const inputSize = domain.length / 2;
     if (inputSize !== 1) {
-      throw new FormatError("Bad domain for stiched function");
+      throw new FormatError("Bad domain for stitched function");
     }
     const { xref } = factory;
 
@@ -312,7 +312,7 @@ class PDFFunction {
     const encode = toNumberArray(dict.getArray("Encode"));
     const tmpBuf = new Float32Array(1);
 
-    return function constructStichedFn(src, srcOffset, dest, destOffset) {
+    return function constructStitchedFn(src, srcOffset, dest, destOffset) {
       // Clamp to domain.
       const v = MathClamp(src[srcOffset], domain[0], domain[1]);
       // calculate which bound the value is in
@@ -328,16 +328,13 @@ class PDFFunction {
       const dmin = i > 0 ? bounds[i - 1] : domain[0];
       const dmax = i < length ? bounds[i] : domain[1];
 
-      const rmin = encode[2 * i];
-      const rmax = encode[2 * i + 1];
-
-      // Prevent the value from becoming NaN as a result
-      // of division by zero (fixes issue6113.pdf).
-      tmpBuf[0] =
-        dmin === dmax
-          ? rmin
-          : rmin + ((v - dmin) * (rmax - rmin)) / (dmax - dmin);
-
+      tmpBuf[0] = interpolate(
+        v,
+        dmin,
+        dmax,
+        /* rmin = */ encode[2 * i],
+        /* rmax = */ encode[2 * i + 1]
+      );
       // call the appropriate function
       fns[i](tmpBuf, 0, dest, destOffset);
     };


### PR DESCRIPTION
After PR #21891 the `interpolate` function is basically duplicated, since the stitched-handling currently inline effectively identical code.

Also, fix existing typos in a couple of method/function names ("Stiched" -> "Stitched").