### PR TITLE
Convert the `missingGlyphs`, used in the `Font` class, into a Set

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -293,7 +293,7 @@ class CMap {
       }
     } else {
       for (const i in map) {
-        callback(i, map[i]);
+        callback(+i, map[i]);
       }
     }
   }

--- a/src/core/fonts.js
+++ b/src/core/fonts.js
@@ -1343,7 +1343,7 @@ class Font {
           this.toUnicode.forEach(function (charCode, unicodeCharCode) {
             const cid = map[charCode];
             if (cidToGidMap[cid] === undefined) {
-              map[+charCode] = unicodeCharCode;
+              map[charCode] = unicodeCharCode;
             }
           });
         }
@@ -1351,7 +1351,7 @@ class Font {
 
       if (!(this.toUnicode instanceof IdentityToUnicodeMap)) {
         this.toUnicode.forEach(function (charCode, unicodeCharCode) {
-          map[+charCode] = unicodeCharCode;
+          map[charCode] = unicodeCharCode;
         });
       }
       this.toFontChar = map;
@@ -1386,7 +1386,7 @@ class Font {
         !(this.toUnicode instanceof IdentityToUnicodeMap)
       ) {
         this.toUnicode.forEach(function (charCode, unicodeCharCode) {
-          map[+charCode] = unicodeCharCode;
+          map[charCode] = unicodeCharCode;
         });
       }
       this.toFontChar = map;
@@ -1402,7 +1402,7 @@ class Font {
             unicodeCharCode = unicode;
           }
         }
-        map[+charCode] = unicodeCharCode;
+        map[charCode] = unicodeCharCode;
       });
 
       // Attempt to improve the glyph mapping for (some) composite fonts that
@@ -2267,7 +2267,7 @@ class Font {
         locaEntries,
         numGlyphs
       );
-      const missingGlyphs = Object.create(null);
+      const missingGlyphs = new Set();
       let writeOffset = 0;
       itemEncode(locaData, 0, writeOffset);
       for (i = 0, j = itemSize; i < numGlyphs; i++, j += itemSize) {
@@ -2283,7 +2283,7 @@ class Font {
             );
         const newLength = glyphProfile.length;
         if (newLength === 0) {
-          missingGlyphs[i] = true;
+          missingGlyphs.add(i);
         }
         if (glyphProfile.sizeOfInstructions > maxSizeOfInstructions) {
           maxSizeOfInstructions = glyphProfile.sizeOfInstructions;
@@ -2963,7 +2963,7 @@ class Font {
 
     sanitizeHead(tables.head, numGlyphs, isTrueType ? tables.loca.length : 0);
 
-    let missingGlyphs = Object.create(null);
+    let missingGlyphs = new Set();
     if (isTrueType) {
       const glyphsInfo = sanitizeGlyphLocations(
         tables.loca,
@@ -3032,7 +3032,7 @@ class Font {
 
     // Helper function to try to skip mapping of empty glyphs.
     function hasGlyph(glyphId) {
-      return !missingGlyphs[glyphId];
+      return !missingGlyphs.has(glyphId);
     }
 
     if (properties.composite) {

--- a/src/core/to_unicode_map.js
+++ b/src/core/to_unicode_map.js
@@ -28,7 +28,7 @@ class ToUnicodeMap {
 
   forEach(callback) {
     for (const charCode in this._map) {
-      callback(charCode, this._map[charCode].codePointAt(0));
+      callback(+charCode, this._map[charCode].codePointAt(0));
     }
   }
 

--- a/test/unit/jasmine-boot.js
+++ b/test/unit/jasmine-boot.js
@@ -107,6 +107,7 @@ async function initializePDFJS(callback) {
       "pdfjs-test/unit/struct_tree_spec.js",
       "pdfjs-test/unit/svg_factory_spec.js",
       "pdfjs-test/unit/text_layer_spec.js",
+      "pdfjs-test/unit/to_unicode_map_spec.js",
       "pdfjs-test/unit/touch_manager_spec.js",
       "pdfjs-test/unit/type1_parser_spec.js",
       "pdfjs-test/unit/ui_utils_spec.js",

--- a/test/unit/to_unicode_map_spec.js
+++ b/test/unit/to_unicode_map_spec.js
@@ -17,13 +17,14 @@ import { ToUnicodeMap } from "../../src/core/to_unicode_map.js";
 
 describe("ToUnicodeMap", () => {
   it("should correctly map Extension B characters using codePointAt", () => {
-    const cmap = { 0x20: "\uD840\uDC00" }; // Example Extension B character
+    const cmap = [];
+    cmap[0x20] = "\uD840\uDC00"; // Example Extension B character
     const toUnicodeMap = new ToUnicodeMap(cmap);
 
     const expected = 0x20000; // Unicode code point for the character
     let actual;
     toUnicodeMap.forEach((charCode, unicode) => {
-      if (charCode === (0x20).toString()) {
+      if (charCode === 0x20) {
         actual = unicode;
       }
     });


### PR DESCRIPTION
This seems like a more appropriate data-structure, rather than storing `true` values in a regular Object.

Also, fix existing inconsistencies in the `CMap.prototype.forEach` and `ToUnicodeMap.prototype.forEach` methods since they didn't always return integer charCodes. Note how various `forEach` call-sites previously did that manually, which seems like a "wrong" solution.