### PR TITLE
Add a software fallback for transfer maps

### DIFF
--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -259,6 +259,9 @@ class CanvasExtraState {
 
   transferMaps = "none";
 
+  // Software fallback for transfer maps when canvas filters are unavailable.
+  transferMapsFallback = null;
+
   minMax = F32_BBOX_INIT.slice();
 
   constructor(width, height) {
@@ -463,6 +466,64 @@ function resetCtxToDefault(ctx) {
   const { filter } = ctx;
   if (filter !== "none" && filter !== "") {
     ctx.filter = "none";
+  }
+}
+
+/**
+ * Applies transfer maps when canvas filters are unavailable.
+ * The SVG filters aren't available in all environments (especially in workers
+ * with OffscreenCanvas), so this class provides a fallback mechanism for
+ * applying transfer maps directly to canvas image data.
+ */
+class TransferMapsFallback {
+  #maps;
+
+  constructor(maps) {
+    // One map applies to R, G, and B; `null` maps are identities.
+    const [mapR, mapG = mapR, mapB = mapR] = maps;
+    const { identityMap } = TransferMapsFallback;
+    this.#maps = [
+      mapR || identityMap,
+      mapG || identityMap,
+      mapB || identityMap,
+    ];
+  }
+
+  static get identityMap() {
+    return shadow(
+      this,
+      "identityMap",
+      Uint8Array.from({ length: 256 }, (_, i) => i)
+    );
+  }
+
+  /**
+   * @param {string} color
+   * @returns {string}
+   */
+  applyToColor(color) {
+    if (typeof color !== "string" || !color.startsWith("#")) {
+      return color; // E.g. "transparent".
+    }
+    const [r, g, b] = getRGBA(color);
+    const [mapR, mapG, mapB] = this.#maps;
+    return Util.makeHexColor(mapR[r], mapG[g], mapB[b]);
+  }
+
+  applyToImageData({ data }) {
+    const [mapR, mapG, mapB] = this.#maps;
+    for (let i = 0, ii = data.length; i < ii; i += 4) {
+      data[i] = mapR[data[i]];
+      data[i + 1] = mapG[data[i + 1]];
+      data[i + 2] = mapB[data[i + 2]];
+    }
+  }
+
+  applyToCanvas(ctx) {
+    const { width, height } = ctx.canvas;
+    const imgData = ctx.getImageData(0, 0, width, height);
+    this.applyToImageData(imgData);
+    ctx.putImageData(imgData, 0, 0);
   }
 }
 
@@ -936,8 +997,9 @@ class CanvasGraphics {
   _createMaskCanvas(opIdx, img) {
     const ctx = this.ctx;
     const { width, height } = img;
-    const fillColor = this.current.fillColor;
     const isPatternFill = this.current.patternFill;
+    // Solid-color styles contain the transferred fallback value.
+    const fillColor = isPatternFill ? this.current.fillColor : ctx.fillStyle;
     const currentTransform = getCurrentTransform(ctx);
 
     let cache, cacheKey, scaled, maskCanvas;
@@ -1194,11 +1256,38 @@ class CanvasGraphics {
           this.tempSMask = null;
           this.checkSMaskState(opIdx);
           break;
-        case "TR":
+        case "TR": {
           this.dependencyTracker?.recordSimpleData("filter", opIdx);
-          this.ctx.filter = this.current.transferMaps =
-            this.filterFactory.addFilter(value);
+          let filter = this.filterFactory.addFilter(value);
+          this.ctx.filter = filter;
+          let fallback = null;
+          if (
+            value &&
+            // Fall back if no SVG filter was created or canvas filters are
+            // unavailable or rejected.
+            (filter === "none" ||
+              !FeatureTest.isCanvasFilterSupported ||
+              this.ctx.filter === "none" ||
+              this.ctx.filter === "")
+          ) {
+            this.ctx.filter = filter = "none";
+            fallback = new TransferMapsFallback(value);
+          }
+          this.current.transferMaps = filter;
+          if (fallback || this.current.transferMapsFallback) {
+            this.current.transferMapsFallback = fallback;
+            // Reapply the maps to the current solid colors.
+            if (!this.current.patternFill) {
+              this.ctx.fillStyle = this.#transferColor(this.current.fillColor);
+            }
+            if (!this.current.patternStroke) {
+              this.ctx.strokeStyle = this.#transferColor(
+                this.current.strokeColor
+              );
+            }
+          }
           break;
+        }
       }
     }
   }
@@ -3058,9 +3147,14 @@ class CanvasGraphics {
       pattern instanceof TilingPattern ? [0, 0, 0, 0] : null;
   }
 
+  #transferColor(color) {
+    return this.current.transferMapsFallback?.applyToColor(color) ?? color;
+  }
+
   setStrokeRGBColor(opIdx, color) {
     this.dependencyTracker?.recordSimpleData("strokeColor", opIdx);
-    this.ctx.strokeStyle = this.current.strokeColor = color;
+    this.current.strokeColor = color;
+    this.ctx.strokeStyle = this.#transferColor(color);
     this.current.patternStroke = false;
   }
 
@@ -3072,7 +3166,8 @@ class CanvasGraphics {
 
   setFillRGBColor(opIdx, color) {
     this.dependencyTracker?.recordSimpleData("fillColor", opIdx);
-    this.ctx.fillStyle = this.current.fillColor = color;
+    this.current.fillColor = color;
+    this.ctx.fillStyle = this.#transferColor(color);
     this.current.patternFill = false;
     this.current.tilingPatternDims = null;
   }
@@ -3337,7 +3432,8 @@ class CanvasGraphics {
       group.hasSoftMask &&
       currentCtx.globalAlpha === 1 &&
       currentCtx.globalCompositeOperation === "source-over" &&
-      this.current.transferMaps === "none";
+      this.current.transferMaps === "none" &&
+      !this.current.transferMapsFallback;
     if (needsBackdropCopy && (inSMaskMode || replaceBackdrop)) {
       // A non-isolated group that needs isolation (because of an inner blend
       // mode and/or a soft mask) can't use the direct path above, so it
@@ -3369,10 +3465,8 @@ class CanvasGraphics {
       //     non-1 group alpha would likewise mix the copied backdrop back in.
       //     Those groups keep the transparent canvas and blend against the
       //     real backdrop instead.
-      //   - isGray groups are grayscaled wholesale in endGroup, and an
-      //     inherited transfer filter (`transferMaps`) would be applied on
-      //     write-back, both of which would corrupt the copied backdrop, so
-      //     they're excluded too.
+      //   - isGray groups are grayscaled in endGroup, and inherited transfer
+      //     maps would also alter the copied backdrop.
       groupCtx.save();
       groupCtx.setTransform(1, 0, 0, 1, 0, 0);
       groupCtx.drawImage(currentCtx.canvas, -offsetX, -offsetY);
@@ -3501,6 +3595,8 @@ class CanvasGraphics {
       this.ctx.restore();
       const currentMtx = getCurrentTransform(this.ctx);
       this.restore(opIdx);
+      // Canvas filters run below; fallback maps must run here.
+      this.current.transferMapsFallback?.applyToCanvas(groupCtx);
       this.ctx.save();
       this.ctx.setTransform(...currentMtx);
       const dirtyBox = F32_BBOX_INIT.slice();
@@ -3879,8 +3975,9 @@ class CanvasGraphics {
     const started = this.#beginKnockoutElement(this.current.fillAlpha);
     const ctx = this.ctx;
 
-    const fillColor = this.current.fillColor;
     const isPatternFill = this.current.patternFill;
+    // Solid-color styles contain the transferred fallback value.
+    const fillColor = isPatternFill ? this.current.fillColor : ctx.fillStyle;
 
     this.dependencyTracker
       ?.resetBBox(opIdx)
@@ -3979,20 +4076,24 @@ class CanvasGraphics {
       ctx.filter = this.current.transferMaps;
       ctx.drawImage(ctx.canvas, 0, 0);
       ctx.filter = "none";
+    } else {
+      this.current.transferMapsFallback?.applyToCanvas(ctx);
     }
     return ctx.canvas;
   }
 
   applyTransferMapsToBitmap(imgData) {
-    if (this.current.transferMaps === "none") {
+    const { transferMaps, transferMapsFallback } = this.current;
+    if (transferMaps === "none" && !transferMapsFallback) {
       return { img: imgData.bitmap, canvasEntry: null };
     }
     const { bitmap, width, height } = imgData;
     const tmpCanvas = this.canvasFactory.create(width, height);
     const tmpCtx = tmpCanvas.context;
-    tmpCtx.filter = this.current.transferMaps;
+    tmpCtx.filter = transferMaps;
     tmpCtx.drawImage(bitmap, 0, 0);
     tmpCtx.filter = "none";
+    transferMapsFallback?.applyToCanvas(tmpCtx);
 
     return { img: tmpCanvas.canvas, canvasEntry: tmpCanvas };
   }
@@ -4087,8 +4188,12 @@ class CanvasGraphics {
     const ctx = this.ctx;
     let imgToPaint;
     let inlineImgCanvas = null;
-    if (imgData.bitmap) {
+    if (imgData.bitmap && !this.current.transferMapsFallback) {
       imgToPaint = imgData.bitmap;
+    } else if (imgData.bitmap) {
+      // Apply the fallback once before drawing the repeated copies.
+      ({ img: imgToPaint, canvasEntry: inlineImgCanvas } =
+        this.applyTransferMapsToBitmap(imgData));
     } else {
       const w = imgData.width;
       const h = imgData.height;

--- a/src/display/canvas_dependency_tracker.js
+++ b/src/display/canvas_dependency_tracker.js
@@ -1109,7 +1109,7 @@ const Dependencies = {
     "sameLineText",
   ],
   transform: ["transform"],
-  transformAndFill: ["transform", "fillColor"],
+  transformAndFill: ["transform", "filter", "fillColor"],
 };
 
 /**

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -178,10 +178,44 @@ class RadialAxialShadingPattern extends BaseShadingPattern {
     return grad;
   }
 
+  /** Rasterize a shading within its device-space bounding box. */
+  _createRasterPattern(ctx, owner, inverse, bbox, transform, transferMaps) {
+    // Limit the temporary canvas to `bbox` (see bug 1722807).
+    const width = Math.ceil(bbox[2] - bbox[0]) || 1;
+    const height = Math.ceil(bbox[3] - bbox[1]) || 1;
+
+    const tmpCanvas = owner.canvasFactory.create(width, height);
+
+    const tmpCtx = tmpCanvas.context;
+    tmpCtx.clearRect(0, 0, width, height);
+    tmpCtx.beginPath();
+    tmpCtx.rect(0, 0, width, height);
+    // Account for the `bbox` origin.
+    tmpCtx.translate(-bbox[0], -bbox[1]);
+    inverse = Util.transform(inverse, [1, 0, 0, 1, bbox[0], bbox[1]]);
+
+    tmpCtx.transform(...transform);
+    applyBoundingBox(tmpCtx, this._bbox);
+
+    if (this.areConic()) {
+      tmpCtx.fillStyle = this._createReversedGradient(tmpCtx);
+      tmpCtx.fill();
+    }
+    tmpCtx.fillStyle = this._createGradient(tmpCtx);
+    tmpCtx.fill();
+    // Apply maps after interpolation by filtering the raster, not the stops.
+    transferMaps?.applyToCanvas(tmpCtx);
+
+    const pattern = ctx.createPattern(tmpCanvas.canvas, "no-repeat");
+    owner.canvasFactory.destroy(tmpCanvas);
+    pattern.setTransform(new DOMMatrix(inverse));
+    return pattern;
+  }
+
   getPattern(ctx, owner, inverse, pathType) {
-    let pattern;
+    const transferMaps = owner.current.transferMapsFallback;
     if (pathType === PathType.STROKE || pathType === PathType.FILL) {
-      if (this.isOriginBased()) {
+      if (this.isOriginBased() && !transferMaps) {
         let transf = Util.transform(inverse, owner.baseTransform);
         if (this.matrix) {
           transf = Util.transform(transf, this.matrix);
@@ -211,65 +245,42 @@ class RadialAxialShadingPattern extends BaseShadingPattern {
         pathType,
         getCurrentTransform(ctx)
       ) || [0, 0, 0, 0];
-      // Create a canvas that is only as big as the current path. This doesn't
-      // allow us to cache the pattern, but it generally creates much smaller
-      // canvases and saves memory use. See bug 1722807 for an example.
-      const width = Math.ceil(ownerBBox[2] - ownerBBox[0]) || 1;
-      const height = Math.ceil(ownerBBox[3] - ownerBBox[1]) || 1;
-
-      const tmpCanvas = owner.canvasFactory.create(width, height);
-
-      const tmpCtx = tmpCanvas.context;
-      tmpCtx.clearRect(0, 0, tmpCtx.canvas.width, tmpCtx.canvas.height);
-      tmpCtx.beginPath();
-      tmpCtx.rect(0, 0, tmpCtx.canvas.width, tmpCtx.canvas.height);
-      // Non shading fill patterns are positioned relative to the base transform
-      // (usually the page's initial transform), but we may have created a
-      // smaller canvas based on the path, so we must account for the shift.
-      tmpCtx.translate(-ownerBBox[0], -ownerBBox[1]);
-      inverse = Util.transform(inverse, [
-        1,
-        0,
-        0,
-        1,
-        ownerBBox[0],
-        ownerBBox[1],
-      ]);
-
-      tmpCtx.transform(...owner.baseTransform);
-      if (this.matrix) {
-        tmpCtx.transform(...this.matrix);
-      }
-      applyBoundingBox(tmpCtx, this._bbox);
-
-      if (this.areConic()) {
-        tmpCtx.fillStyle = this._createReversedGradient(tmpCtx);
-        tmpCtx.fill();
-      }
-      tmpCtx.fillStyle = this._createGradient(tmpCtx);
-      tmpCtx.fill();
-
-      pattern = ctx.createPattern(tmpCanvas.canvas, "no-repeat");
-      owner.canvasFactory.destroy(tmpCanvas);
-      const domMatrix = new DOMMatrix(inverse);
-      pattern.setTransform(domMatrix);
-    } else {
-      // Shading fills are applied relative to the current matrix which is also
-      // how canvas gradients work, so there's no need to do anything special
-      // here.
-      if (this.areConic()) {
-        // Draw the reversed gradient first so the normal gradient can
-        // correctly overlay it (see _isCircleCenterOutside for details).
-        ctx.save();
-        applyBoundingBox(ctx, this._bbox);
-        ctx.fillStyle = this._createReversedGradient(ctx);
-        ctx.fillRect(-1e10, -1e10, 2e10, 2e10);
-        ctx.restore();
-      }
-      applyBoundingBox(ctx, this._bbox);
-      pattern = this._createGradient(ctx);
+      // Fill and stroke patterns use the owner's base transform.
+      const transform = this.matrix
+        ? Util.transform(owner.baseTransform, this.matrix)
+        : owner.baseTransform;
+      return this._createRasterPattern(
+        ctx,
+        owner,
+        inverse,
+        ownerBBox,
+        transform,
+        transferMaps
+      );
     }
-    return pattern;
+
+    // Direct gradients work unless the maps require a raster.
+    if (transferMaps && inverse) {
+      return this._createRasterPattern(
+        ctx,
+        owner,
+        inverse,
+        owner.current.clipBox,
+        getCurrentTransform(ctx),
+        transferMaps
+      );
+    }
+    if (this.areConic()) {
+      // Draw the reversed gradient first so the normal gradient can
+      // correctly overlay it (see _isCircleCenterOutside for details).
+      ctx.save();
+      applyBoundingBox(ctx, this._bbox);
+      ctx.fillStyle = this._createReversedGradient(ctx);
+      ctx.fillRect(-1e10, -1e10, 2e10, 2e10);
+      ctx.restore();
+    }
+    applyBoundingBox(ctx, this._bbox);
+    return this._createGradient(ctx);
   }
 }
 
@@ -393,7 +404,12 @@ class MeshShadingPattern extends BaseShadingPattern {
     loadMeshShader();
   }
 
-  _createMeshCanvas(combinedScale, backgroundColor, canvasFactory) {
+  _createMeshCanvas(
+    combinedScale,
+    backgroundColor,
+    canvasFactory,
+    transferMaps = null
+  ) {
     // we will increase scale on some weird factor to let antialiasing take
     // care of "rough" edges
     const EXPECTED_SCALE = 1.1;
@@ -472,6 +488,8 @@ class MeshShadingPattern extends BaseShadingPattern {
       }
       tmpCanvas.context.putImageData(data, BORDER_SIZE, BORDER_SIZE);
     }
+    // Filter the raster when using the software fallback.
+    transferMaps?.applyToCanvas(tmpCanvas.context);
 
     return {
       canvas: tmpCanvas.canvas,
@@ -507,7 +525,8 @@ class MeshShadingPattern extends BaseShadingPattern {
     const temporaryPatternCanvas = this._createMeshCanvas(
       scale,
       pathType === PathType.SHADING ? null : this._background,
-      owner.canvasFactory
+      owner.canvasFactory,
+      owner.current.transferMapsFallback
     );
 
     if (pathType !== PathType.SHADING) {
@@ -625,6 +644,8 @@ class TilingPattern {
       opIdx
     );
     graphics.groupLevel = owner.groupLevel;
+    // Inherit the owner's fallback while rendering the tile.
+    graphics.current.transferMapsFallback = owner.current.transferMapsFallback;
 
     this.setFillAndStrokeStyleToContext(graphics, this.paintType, this.color);
 
@@ -899,7 +920,9 @@ class TilingPattern {
     }
     const { ctx, current } = graphics;
     current.patternFill = current.patternStroke = false;
-    ctx.fillStyle = ctx.strokeStyle = color;
+    // Pre-transfer solid colors in fallback mode.
+    ctx.fillStyle = ctx.strokeStyle =
+      current.transferMapsFallback?.applyToColor(color) ?? color;
     // Also needed by image masks (fixes issues 3226 and 8741).
     current.fillColor = current.strokeColor = color;
   }

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -5534,6 +5534,89 @@ have written that much by now. So, here’s to squashing bugs.`);
       await loadingTask.destroy();
     });
 
+    it("applies the transfer function of the graphics state", async function () {
+      // The page applies transfer functions to fills, strokes, images,
+      // shadings, patterns, and groups. Node.js exercises the fallback.
+      const loadingTask = getDocument(
+        buildGetDocumentParams("transfer_maps.pdf")
+      );
+      const pdfDoc = await loadingTask.promise;
+      const pdfPage = await pdfDoc.getPage(1);
+      const viewport = pdfPage.getViewport({ scale: 1 });
+
+      const { canvasFactory } = pdfDoc;
+      const canvasAndCtx = canvasFactory.create(
+        viewport.width,
+        viewport.height
+      );
+      const renderTask = pdfPage.render({
+        canvas: canvasAndCtx.canvas,
+        viewport,
+      });
+      await renderTask.promise;
+
+      const getPixel = (x, y) =>
+        Array.from(canvasAndCtx.context.getImageData(x, y, 1, 1).data);
+      const CYAN = [0, 255, 255, 255],
+        YELLOW = [255, 255, 0, 255];
+      expect(getPixel(30, 30)).withContext("fill").toEqual(CYAN);
+      expect(getPixel(80, 30)).withContext("inline image").toEqual(CYAN);
+      // Two of the four mask pixels are painted.
+      expect(getPixel(120, 20)).withContext("image mask").toEqual(CYAN);
+      expect(getPixel(140, 40)).withContext("image mask").toEqual(CYAN);
+      expect(getPixel(140, 20))
+        .withContext("image mask")
+        .toEqual([255, 255, 255, 255]);
+      expect(getPixel(175, 30)).withContext("shading").toEqual(CYAN);
+      expect(getPixel(30, 80))
+        .withContext("transparency group")
+        .toEqual(YELLOW);
+      expect(getPixel(80, 80))
+        .withContext("colored tiling pattern")
+        .toEqual(YELLOW);
+      expect(getPixel(130, 80))
+        .withContext("uncolored tiling pattern")
+        .toEqual(CYAN);
+      // The transfer function was reset to /Identity before this fill.
+      expect(getPixel(175, 80))
+        .withContext("identity")
+        .toEqual([255, 0, 0, 255]);
+      expect(getPixel(30, 130)).withContext("stroke").toEqual(YELLOW);
+      expect(getPixel(30, 175)).withContext("shading pattern").toEqual(CYAN);
+      // P3 transfers the cell's initial black to white.
+      expect(getPixel(80, 175))
+        .withContext("colored tiling pattern with a group")
+        .toEqual([255, 255, 255, 255]);
+      // /Identity is set after selecting P4, so its black stays black.
+      expect(getPixel(130, 175))
+        .withContext("colored tiling pattern after a TR change")
+        .toEqual([0, 0, 0, 255]);
+      // Only the green component has an (inverting) transfer function.
+      expect(getPixel(180, 130))
+        .withContext("partial identity array")
+        .toEqual(YELLOW);
+      // A nonlinear map must be applied after gradient interpolation.
+      for (const [x, expected] of [
+        [85, 16],
+        [110, 65],
+        [135, 145],
+      ]) {
+        const [r, g, b, a] = getPixel(x, 130);
+        expect([g, b, a])
+          .withContext(`gradient at x=${x}`)
+          .toEqual([r, r, 255]);
+        expect(Math.abs(r - expected))
+          .withContext(`gradient at x=${x}`)
+          .toBeLessThanOrEqual(3);
+      }
+      expect(getPixel(5, 5))
+        .withContext("background")
+        .toEqual([255, 255, 255, 255]);
+
+      canvasFactory.destroy(canvasAndCtx);
+      await loadingTask.destroy();
+    });
+
     it("cleans up document resources during rendering of page", async function () {
       const loadingTask = getDocument(tracemonkeyGetDocumentParams);
       const pdfDoc = await loadingTask.promise;


### PR DESCRIPTION
Transfer functions use SVG filters through `ctx.filter`. When those filters are unavailable or rejected, map solid colors and raster pixels in software.

Apply the fallback to fills, strokes, images, masks, groups, shadings, and tiling patterns. Rasterize gradients first so nonlinear maps run after interpolation. Include filter state in image-mask dependencies and exclude fallback-mapped groups from backdrop copies.

Add pixel coverage with `transfer_maps.pdf`; Node.js exercises the fallback.