### PR TITLE
Wait for editor focus before integration test input

### DIFF
--- a/test/integration/comment_spec.mjs
+++ b/test/integration/comment_spec.mjs
@@ -33,7 +33,6 @@ import {
   switchToEditor,
   waitAndClick,
   waitForBrowserTrip,
-  waitForEditorFocusSettled,
   waitForSerialized,
   waitForTimeout,
   waitForTooltipToBe,
@@ -887,10 +886,8 @@ describe("Comment", () => {
           const data = "Hello PDF.js World !!";
           await page.mouse.click(rect.x + 100, rect.y + 100);
           await page.waitForSelector(editorSelector, { visible: true });
-          await waitForEditorFocusSettled(page);
           await page.type(`${editorSelector} .internal`, data);
           await page.keyboard.press("Escape");
-          await waitForEditorFocusSettled(page);
 
           await page.waitForSelector(`${editorSelector} .editToolbar`, {
             visible: true,

--- a/test/integration/freetext_editor_spec.mjs
+++ b/test/integration/freetext_editor_spec.mjs
@@ -55,7 +55,6 @@ import {
   unselectEditor,
   waitForAnnotationEditorLayer,
   waitForAnnotationModeChanged,
-  waitForEditorFocusSettled,
   waitForPointerUp,
   waitForSelectedEditor,
   waitForSerialized,
@@ -71,7 +70,6 @@ const clearAll = clearEditors.bind(null, "freeText");
 const commit = async page => {
   await page.keyboard.press("Escape");
   await page.waitForSelector(".freeTextEditor.selectedEditor .overlay.enabled");
-  await waitForEditorFocusSettled(page);
 };
 
 const switchToFreeText = switchToEditor.bind(null, "FreeText");
@@ -103,7 +101,6 @@ const createFreeTextEditor = async ({
 
   await page.mouse.click(x, y);
   await page.waitForSelector(editorSelector, { visible: true });
-  await waitForEditorFocusSettled(page);
   if (data) {
     await page.type(`${editorSelector} .internal`, data);
   }

--- a/test/integration/highlight_editor_spec.mjs
+++ b/test/integration/highlight_editor_spec.mjs
@@ -39,7 +39,6 @@ import {
   unselectEditor,
   waitAndClick,
   waitForAnnotationModeChanged,
-  waitForEditorFocusSettled,
   waitForPointerUp,
   waitForSelectedEditor,
   waitForSerialized,
@@ -2881,7 +2880,6 @@ describe("Highlight Editor", () => {
           await page.waitForSelector(
             ".inkEditor.selectedEditor.draggable.disabled"
           );
-          await waitForEditorFocusSettled(page);
 
           await selectEditor(page, editorSelector0);
           for (let i = 0; i < 6; i++) {

--- a/test/integration/ink_editor_spec.mjs
+++ b/test/integration/ink_editor_spec.mjs
@@ -39,7 +39,6 @@ import {
   unselectEditor,
   waitForAnnotationModeChanged,
   waitForBrowserTrip,
-  waitForEditorFocusSettled,
   waitForNoElement,
   waitForPointerUp,
   waitForSelectedEditor,
@@ -1359,13 +1358,11 @@ describe("Should switch from an editor and mode to others by double clicking", (
           editorLayerRect.y + 200
         );
         await page.waitForSelector(freeTextSelector, { visible: true });
-        await waitForEditorFocusSettled(page);
         await page.type(`${freeTextSelector} .internal`, data);
         await page.keyboard.press("Escape");
         await page.waitForSelector(
           ".freeTextEditor.selectedEditor .overlay.enabled"
         );
-        await waitForEditorFocusSettled(page);
 
         await page.waitForSelector("#editorInkButton:not(.toggled)");
         let modeChangedHandle = await waitForAnnotationModeChanged(page);

--- a/test/integration/test_utils.mjs
+++ b/test/integration/test_utils.mjs
@@ -36,6 +36,7 @@ function loadAndWait(filename, selector, zoom, setups, options, viewport) {
   return Promise.all(
     global.integrationSessions.map(async session => {
       const page = await session.browser.newPage();
+      settleEditorBeforeInput(page);
 
       if (viewport) {
         await page.setViewport(viewport);
@@ -431,7 +432,6 @@ async function selectEditor(page, selector, count = 1) {
     { count }
   );
   await waitForSelectedEditor(page, selector);
-  await waitForEditorFocusSettled(page);
 }
 
 async function waitForSelectedEditor(page, selector) {
@@ -754,6 +754,25 @@ function waitForEditorFocusSettled(page) {
         setTimeout(() => setTimeout(resolve, 0), 0);
       })
   );
+}
+
+/**
+ * Make every keyboard/mouse input wait for the deferred editor changes first,
+ * so the tests don't have to care about them.
+ */
+function settleEditorBeforeInput(page) {
+  for (const [target, names] of [
+    [page.keyboard, ["down", "up", "press", "type", "sendCharacter"]],
+    [page.mouse, ["down", "click"]],
+  ]) {
+    for (const name of names) {
+      const method = target[name].bind(target);
+      target[name] = async (...args) => {
+        await waitForEditorFocusSettled(page);
+        return method(...args);
+      };
+    }
+  }
 }
 
 async function scrollIntoView(page, selector) {
@@ -1127,14 +1146,11 @@ function waitForPositionChange(page, selector, xy) {
 }
 
 async function moveEditor(page, selector, n, pressKey) {
-  await waitForEditorFocusSettled(page);
   let xy = await getXY(page, selector);
   for (let i = 0; i < n; i++) {
     const handle = await waitForEditorMovedInDOM(page);
     await pressKey();
     await awaitPromise(handle);
-    // `editormovedindom` is dispatched before focus is restored.
-    await waitForEditorFocusSettled(page);
     await waitForPositionChange(page, selector, xy);
     xy = await getXY(page, selector);
   }
@@ -1286,7 +1302,6 @@ export {
   waitForAnnotationModeChanged,
   waitForBrowserTrip,
   waitForDOMMutation,
-  waitForEditorFocusSettled,
   waitForEntryInStorage,
   waitForEvent,
   waitForNoElement,


### PR DESCRIPTION
Wrap Puppeteer keyboard and mouse input to let deferred editor focus changes settle first, replacing explicit waits.