### PR TITLE
Remove the `ViewHistory.prototype.{get, set}` methods

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2822,7 +2822,7 @@ function onSidebarViewChanged({ view }) {
 
   if (this.isInitialViewSet) {
     // Only update the storage when the document has been loaded *and* rendered.
-    this.store?.set("sidebarView", view).catch(() => {
+    this.store?.setMultiple({ sidebarView: view }).catch(() => {
       // Unable to write to storage.
     });
   }
@@ -2852,7 +2852,7 @@ function onUpdateViewarea({ location }) {
 function onViewerModesChanged(name, evt) {
   if (this.isInitialViewSet && !this.pdfViewer.isInPresentationMode) {
     // Only update the storage when the document has been loaded *and* rendered.
-    this.store?.set(name, evt.mode).catch(() => {
+    this.store?.setMultiple({ [name]: evt.mode }).catch(() => {
       // Unable to write to storage.
     });
   }

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -79,12 +79,6 @@ class ViewHistory {
     return this._writeToStorage();
   }
 
-  async get(name, defaultValue) {
-    await this._initializedPromise;
-    const val = this.file[name];
-    return val !== undefined ? val : defaultValue;
-  }
-
   async getMultiple(properties) {
     await this._initializedPromise;
     const values = Object.create(null);

--- a/web/view_history.js
+++ b/web/view_history.js
@@ -65,12 +65,6 @@ class ViewHistory {
     return localStorage.getItem("pdfjs.history");
   }
 
-  async set(name, val) {
-    await this._initializedPromise;
-    this.file[name] = val;
-    return this._writeToStorage();
-  }
-
   async setMultiple(properties) {
     await this._initializedPromise;
     for (const name in properties) {


### PR DESCRIPTION
 - **Remove the unused `ViewHistory.prototype.get` method**

   This method is completely unused in the viewer, note the coverage data: https://app.codecov.io/gh/mozilla/pdf.js/commit/248bdcc235555ecf21f0b99f619e09eb5135241a/blob/web/view_history.js?dropdown=coverage#L82

 - **Remove the `ViewHistory.prototype.set` method, and replace its call-sites with `setMultiple` instead**

   The `ViewHistory.prototype.set` method is first of all not used a lot, and secondly it's not used in any hot code-paths[1].
   Hence we can use `setMultiple` consistently instead, which means that the `ViewHistory.prototype.set` method can be removed.

   ---

   [1] Only when opening/closing the sidebar or changing sidebar view, and when changing scroll/spread modes in the viewer.