### PR TITLE
Treat named XFA areas as transparent during data binding

### DIFF
--- a/src/core/xfa/bind.js
+++ b/src/core/xfa/bind.js
@@ -31,6 +31,7 @@ import {
   $isBindable,
   $isDataValue,
   $isDescendent,
+  $isTransparent,
   $namespaceId,
   $nodeName,
   $removeChild,
@@ -595,7 +596,7 @@ class Binder {
           }
         }
       } else {
-        if (!child.name) {
+        if (child[$isTransparent]()) {
           this._setAndBind(child, dataNode);
           continue;
         }

--- a/test/unit/xfa_serialize_data_spec.js
+++ b/test/unit/xfa_serialize_data_spec.js
@@ -13,12 +13,49 @@
  * limitations under the License.
  */
 
-import { $uid } from "../../src/core/xfa/symbol_utils.js";
+import { $data, $uid } from "../../src/core/xfa/symbol_utils.js";
+import { Binder } from "../../src/core/xfa/bind.js";
 import { DataHandler } from "../../src/core/xfa/data.js";
 import { searchNode } from "../../src/core/xfa/som.js";
 import { XFAParser } from "../../src/core/xfa/parser.js";
 
 describe("Data serializer", function () {
+  for (const mergeMode of ["consumeData", "matchTemplate"]) {
+    it(`should save fields in named areas (${mergeMode})`, function () {
+      const xml = `
+<xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/">
+  <template xmlns="http://www.xfa.org/schema/xfa-template/3.3/">
+    <subform name="root" mergeMode="${mergeMode}">
+      <subform name="header">
+        <area name="details"><field name="heading"/></area>
+      </subform>
+      <subform name="details">
+        <area name="group"><field name="body"/></area>
+      </subform>
+    </subform>
+  </template>
+  <xfa:datasets xmlns:xfa="http://www.xfa.org/schema/xfa-data/1.0/">
+    <xfa:data><root><header><heading>Title</heading></header><details><body/></details></root></xfa:data>
+  </xfa:datasets>
+</xdp:xdp>`;
+      const root = new XFAParser().parse(xml);
+      const binder = new Binder(root);
+      const form = binder.bind();
+      const data = binder.getData();
+      const field = searchNode(root, form, "root.details.body")[0];
+      const dataNode = searchNode(root, data, "root.details.body")[0];
+      expect(field[$data]).toBe(dataNode);
+
+      const storage = new Map([
+        [(field[$data] || field)[$uid], { value: "Saved text & more" }],
+      ]);
+      const serialized = new DataHandler(root, data).serialize(storage);
+      expect(serialized).toEqual(
+        '<xfa:datasets xmlns:xfa="http://www.xfa.org/schema/xfa-data/1.0/"><xfa:data><root><header><heading>Title</heading></header><details><body>Saved text &amp; more</body></details></root></xfa:data></xfa:datasets>'
+      );
+    });
+  }
+
   it("should serialize data with an annotationStorage", function () {
     const xml = `
 <?xml version="1.0"?>


### PR DESCRIPTION
Fixes #21904.

Named areas currently participate in implicit data binding. In the reported PDF, a header area consumes the data node intended for a later subform, leaving its text field unbound. Text entered there is consequently omitted when saving.

Use the existing transparency predicate when walking the form. Areas are transparent even when named, as specified by [XFA](https://pdfa.org/norm-refs/XFA-3_3.pdf), so their children bind in the enclosing data context. Explicit binding references keep their existing behavior.

The regression tests cover both consumeData and matchTemplate, checking field binding and saved XML. Both fail before the change; all 72 XFA unit tests pass afterward. `npx gulp lint` and `npx gulp generic-legacy` pass. I also loaded the original PDF from the issue through the public API, filled the affected field, saved and reopened it: the text now survives. The full browser reference suite was not run.