### PR TITLE
Add a way to run the reference tests from a PR label

### DIFF
--- a/.github/workflows/ref_tests_makeref.yml
+++ b/.github/workflows/ref_tests_makeref.yml
@@ -1,0 +1,52 @@
+name: Update reference images
+# Every push to master asks mozilla/pdf.js.pdfs to regenerate the reference
+# images (Firefox, Linux + Windows) and commit the changes to
+# mozilla/pdf.js.refs, so that the references always track master.
+on:
+  push:
+    paths:
+      - 'gulpfile.mjs'
+      - 'external/**'
+      - 'package-lock.json'
+      - 'src/**'
+      - 'test/images/**'
+      - 'test/pdfs/**'
+      - 'test/resources/**'
+      - 'test/*.css'
+      - 'test/driver.js'
+      - 'test/test.mjs'
+      - 'test/test_manifest.json'
+      - 'test/test_slave.html'
+      - 'web/**'
+      - '.github/workflows/ref_tests_makeref.yml'
+    branches:
+      - master
+permissions:
+  contents: read
+
+jobs:
+  request:
+    if: github.repository == 'mozilla/pdf.js'
+    runs-on: ubuntu-latest
+    environment: sync_pdfs
+
+    steps:
+      - name: Generate app token for pdf.js.pdfs
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: mozilla
+          repositories: pdf.js.pdfs
+          permission-contents: write
+
+      - name: Dispatch the reference update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          payload=$(jq -nc --arg sha "$GITHUB_SHA" \
+            '{ event_type: "ref-tests-makeref", client_payload: { sha: $sha } }')
+          gh api repos/mozilla/pdf.js.pdfs/dispatches \
+            --method POST \
+            --input - <<< "$payload"

--- a/.github/workflows/ref_tests_request.yml
+++ b/.github/workflows/ref_tests_request.yml
@@ -1,0 +1,116 @@
+name: Request reference tests
+# Adding the `browsertest` label to a pull request asks mozilla/pdf.js.pdfs to
+# run the reference tests (Firefox, Linux + Windows) on the PR head. The label
+# is removed once the request has been sent, so re-adding it acts as a button.
+# The results are published to https://mozilla.github.io/pdf.js.refs/pr/<n>/
+# and posted as a comment on the PR.
+#
+# `pull_request_target` gives access to the secrets needed to dispatch to the
+# private repository; this workflow must therefore never check out or run any
+# code from the pull request. Since the dispatched tests run the PR code with
+# access to the private PDFs, only a user with write access to this repository
+# can request them, and only for pull requests opened in mozilla/pdf.js (the
+# receiving workflow checks the latter again on its side).
+#
+# The trigger is required to get the label event and the secrets for fork PRs;
+# every value taken from the event is passed through `env`, never interpolated.
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [labeled]
+permissions:
+  contents: read
+
+jobs:
+  request:
+    if: >-
+      github.repository == 'mozilla/pdf.js' &&
+      github.event.label.name == 'browsertest'
+    runs-on: ubuntu-latest
+    environment: sync_pdfs
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Remove the label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/labels/browsertest" \
+            --method DELETE --silent || true
+
+      - name: Check the requester's permission
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          set -euo pipefail
+          permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${SENDER}/permission" \
+            --jq .permission || echo none)"
+          case "$permission" in
+            admin|write)
+              echo "allowed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "allowed=false" >> "$GITHUB_OUTPUT"
+              echo "::error::${SENDER} has '${permission}' access; write access is required"
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+                --method POST --silent \
+                -f body=":no_entry_sign: Only users with write access can request the reference tests."
+              exit 1
+              ;;
+          esac
+
+      - name: Generate app token for pdf.js.pdfs
+        if: steps.check.outputs.allowed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: mozilla
+          repositories: pdf.js.pdfs
+          permission-contents: write
+
+      - name: Dispatch the reference tests
+        if: steps.check.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          payload=$(jq -nc \
+            --argjson pr "$PR" \
+            --arg sender "$SENDER" \
+            '{
+              event_type: "ref-tests",
+              client_payload: { pr: $pr, sender: $sender }
+            }')
+          gh api repos/mozilla/pdf.js.pdfs/dispatches \
+            --method POST \
+            --input - <<< "$payload"
+
+      - name: Acknowledge the request
+        if: steps.check.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          marker="<!-- ref-tests-report -->"
+          body="${marker}
+          ### Reference tests
+
+          :hourglass_flowing_sand: Running on \`${SHA}\`; the results will be posted here."
+          comment_id=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            --jq "[.[] | select(.body | startswith(\"${marker}\"))] | last | .id // empty" | tail -n1)
+          if [ -n "$comment_id" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              --method PATCH -f body="$body" --silent
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+              --method POST -f body="$body" --silent
+          fi

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -817,6 +817,8 @@ function runTests(testsName, { bot = false } = {}) {
           [
             { names: ["-t", "--testfilter"], hasValue: true },
             { names: ["-j", "--jobs"], hasValue: true },
+            { names: ["--shard"], hasValue: true },
+            { names: ["--summaryFile"], hasValue: true },
           ],
           args
         );
@@ -1118,6 +1120,8 @@ function makeRef(done, bot) {
     [
       { names: ["-t", "--testfilter"], hasValue: true },
       { names: ["-j", "--jobs"], hasValue: true },
+      { names: ["--shard"], hasValue: true },
+      { names: ["--summaryFile"], hasValue: true },
     ],
     args
   );

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -103,9 +103,11 @@ function parseOptions() {
       noPrompts: { type: "boolean", default: false },
       port: { type: "string", default: "0" },
       reftest: { type: "boolean", default: false },
+      shard: { type: "string", default: "" },
       statsDelay: { type: "string", default: "0" },
       statsFile: { type: "string", default: "" },
       strictVerify: { type: "boolean", default: false },
+      summaryFile: { type: "string", default: "" },
       testfilter: { type: "string", short: "t", multiple: true, default: [] },
       unitTest: { type: "boolean", default: false },
     },
@@ -158,10 +160,22 @@ function parseOptions() {
     );
   }
 
+  let shard = null;
+  if (values.shard) {
+    const match = /^(\d+)\/(\d+)$/.exec(values.shard);
+    const index = match ? parseInt(match[1], 10) : 0;
+    const count = match ? parseInt(match[2], 10) : 0;
+    if (!match || index < 1 || index > count) {
+      throw new Error("--shard must be of the form k/N with 1 <= k <= N.");
+    }
+    shard = { index, count };
+  }
+
   return {
     ...values,
     jobs: parseInt(values.jobs, 10) || 1,
     port: parseInt(values.port, 10) || 0,
+    shard,
     statsDelay: parseInt(values.statsDelay, 10) || 0,
   };
 }
@@ -270,6 +284,22 @@ async function startRefTest(masterMode, showRefImages) {
 
     if (options.statsFile) {
       fs.writeFileSync(options.statsFile, JSON.stringify(stats, null, 2));
+    }
+    if (options.summaryFile) {
+      fs.writeFileSync(
+        options.summaryFile,
+        JSON.stringify({
+          platform: os.platform(),
+          masterMode,
+          shard: options.shard,
+          numRuns,
+          numErrors,
+          numFBFFailures,
+          numEqFailures,
+          numEqNoSnapshot,
+          runtime,
+        })
+      );
     }
     if (masterMode) {
       if (numEqFailures + numEqNoSnapshot > 0) {
@@ -476,6 +506,10 @@ function getTestManifest() {
       console.error("Unrecognized test IDs: " + testFilter.join(" "));
       return undefined;
     }
+  }
+  if (options.shard) {
+    const { index, count } = options.shard;
+    manifest = manifest.filter((_, i) => i % count === index - 1);
   }
   return manifest;
 }


### PR DESCRIPTION
Adding the `browsertest` label to a PR dispatches a run to the private mozilla/pdf.js.pdfs repository, which runs the Firefox reference tests on Linux and Windows, sharded across several machines, and posts the results (with a link to the reftest analyzer hosted on mozilla/pdf.js.refs) as a comment. Every push to master dispatches a reference update in the same way.

The test runner gets a `--shard=k/N` option to split the manifest across machines and a `--summaryFile` option to write the final counts as JSON.