### PR TITLE
[GeckoView] Add Annotation Editor CSS (bug 2068989)

### DIFF
--- a/external/builder/builder.mjs
+++ b/external/builder/builder.mjs
@@ -43,9 +43,13 @@ function preprocess(inFilename, outFilename, defines) {
       // In Geckoview, we don't need some styles.
       const startComment = "/* Ignored in GECKOVIEW: begin */";
       const endComment = "/* Ignored in GECKOVIEW: end */";
-      const beginIndex = content.indexOf(startComment);
-      const endIndex = content.indexOf(endComment);
-      if (beginIndex >= 0 && endIndex > beginIndex) {
+
+      while (content.includes(startComment)) {
+        const beginIndex = content.indexOf(startComment);
+        const endIndex = content.indexOf(endComment);
+        if (endIndex < beginIndex) {
+          break;
+        }
         content =
           content.substring(0, beginIndex) +
           content.substring(endIndex + endComment.length);

--- a/external/builder/fixtures/css-geckoview-ignored-expected.css
+++ b/external/builder/fixtures/css-geckoview-ignored-expected.css
@@ -1,0 +1,15 @@
+.kept-first {
+  color: red;
+}
+
+
+
+.kept-second {
+  color: blue;
+}
+
+
+
+.kept-third {
+  color: black;
+}

--- a/external/builder/fixtures/css-geckoview-ignored.css
+++ b/external/builder/fixtures/css-geckoview-ignored.css
@@ -1,0 +1,23 @@
+.kept-first {
+  color: red;
+}
+
+/* Ignored in GECKOVIEW: begin */
+.dropped-first {
+  color: green;
+}
+/* Ignored in GECKOVIEW: end */
+
+.kept-second {
+  color: blue;
+}
+
+/* Ignored in GECKOVIEW: begin */
+.dropped-second {
+  color: yellow;
+}
+/* Ignored in GECKOVIEW: end */
+
+.kept-third {
+  color: black;
+}

--- a/external/builder/test-fixtures.mjs
+++ b/external/builder/test-fixtures.mjs
@@ -26,6 +26,7 @@ files.forEach(expectationFilename => {
   const defines = {
     TRUE: true,
     FALSE: false,
+    GECKOVIEW: true,
   };
   let out;
   try {

--- a/web/annotation_editor_layer_builder.css
+++ b/web/annotation_editor_layer_builder.css
@@ -14,9 +14,12 @@
  */
 
 @import url(draw_layer_builder.css);
+/* Ignored in GECKOVIEW: begin */
+
 @import url(toggle_button.css);
 @import url(signature_manager.css);
 @import url(comment_manager.css);
+/* Ignored in GECKOVIEW: end */
 
 :root {
   --editor-toolbar-vert-offset: 6px;
@@ -36,14 +39,17 @@
   --hover-outline: solid var(--outline-width) var(--hover-outline-color);
   --hover-outline-around: solid var(--outline-around-width)
     var(--hover-outline-around-color);
+  /* Ignored in GECKOVIEW: begin */
   --freetext-line-height: 1.35;
   --freetext-padding: 2px;
+  /* Ignored in GECKOVIEW: end */
   --resizer-bg-color: var(--outline-color);
   --resizer-size: 6px;
   --resizer-shift: calc(
     0px - (var(--outline-width) + var(--resizer-size)) / 2 -
       var(--outline-around-width)
   );
+  /* Ignored in GECKOVIEW: begin */
   --editorFreeText-editing-cursor: text;
   --editorInk-editing-cursor: url(images/cursor-editorInk.svg) 0 16, pointer;
   --editorHighlight-editing-cursor:
@@ -52,7 +58,9 @@
     url(images/cursor-editorFreeHighlight.svg) 1 18, pointer;
 
   --new-alt-text-warning-image: url(images/altText_warning.svg);
+  /* Ignored in GECKOVIEW: end */
 }
+/* Ignored in GECKOVIEW: begin */
 
 .textLayer {
   &.highlighting {
@@ -92,6 +100,7 @@
       url(images/cursor-editorFreeText.svg) 0 16, text;
   }
 }
+/* Ignored in GECKOVIEW: end */
 
 @media screen and (forced-colors: active) {
   :root {
@@ -162,6 +171,7 @@
     pointer-events: auto;
   }
 }
+/* Ignored in GECKOVIEW: begin */
 
 .annotationEditorLayer.freetextEditing {
   cursor: var(--editorFreeText-editing-cursor);
@@ -170,6 +180,7 @@
 .annotationEditorLayer.inkEditing {
   cursor: var(--editorInk-editing-cursor);
 }
+/* Ignored in GECKOVIEW: end */
 
 .annotationEditorLayer .draw {
   box-sizing: border-box;
@@ -259,6 +270,7 @@
     --editor-toolbar-shadow: 0 2px 6px 0 rgb(58 57 68 / 0.2);
     --editor-toolbar-height: 28px;
     --editor-toolbar-padding: 2px;
+    /* Ignored in GECKOVIEW: begin */
     --alt-text-done-color: var(
       --color-accent-attention,
       light-dark(#2ac3a2, #54ffbd)
@@ -266,6 +278,8 @@
     --alt-text-warning-color: light-dark(#0090ed, #80ebff);
     --alt-text-hover-done-color: var(--alt-text-done-color);
     --alt-text-hover-warning-color: var(--alt-text-warning-color);
+    /* Ignored in GECKOVIEW: end */
+    /* Ignored in GECKOVIEW: begin */
 
     /* Match Nova's panel surface and 32px toolbar controls. */
     /*#if MOZCENTRAL*/
@@ -281,6 +295,7 @@
       --alt-text-warning-color: var(--icon-color-information);
     }
     /*#endif*/
+    /* Ignored in GECKOVIEW: end */
 
     @media screen and (forced-colors: active) {
       --editor-toolbar-bg-color: var(--button-background-color, ButtonFace);
@@ -308,10 +323,12 @@
         ButtonBorder
       );
       --editor-toolbar-shadow: none;
+      /* Ignored in GECKOVIEW: begin */
       --alt-text-done-color: var(--editor-toolbar-fg-color);
       --alt-text-warning-color: var(--editor-toolbar-fg-color);
       --alt-text-hover-done-color: var(--editor-toolbar-hover-fg-color);
       --alt-text-hover-warning-color: var(--editor-toolbar-hover-fg-color);
+      /* Ignored in GECKOVIEW: end */
     }
 
     display: flex;
@@ -399,10 +416,12 @@
         &.highlightButton::before {
           mask-image: var(--editor-toolbar-highlight-image);
         }
+        /* Ignored in GECKOVIEW: begin */
 
         &.commentButton::before {
           mask-image: var(--comment-edit-button-icon);
         }
+        /* Ignored in GECKOVIEW: end */
 
         &.deleteButton::before {
           mask-image: var(--editor-toolbar-delete-image);
@@ -444,6 +463,7 @@
         }
         /*#endif*/
       }
+      /* Ignored in GECKOVIEW: begin */
 
       .altText {
         --alt-text-add-image: url(images/altText_add.svg);
@@ -564,6 +584,8 @@
           }
         }
       }
+      /* Ignored in GECKOVIEW: end */
+      /* Ignored in GECKOVIEW: begin */
 
       .comment {
         width: var(--editor-toolbar-height);
@@ -579,9 +601,11 @@
           height: 100%;
         }
       }
+      /* Ignored in GECKOVIEW: end */
     }
   }
 }
+/* Ignored in GECKOVIEW: begin */
 
 .annotationEditorLayer .freeTextEditor {
   padding: calc(var(--freetext-padding) * var(--total-scale-factor));
@@ -708,6 +732,7 @@
     }
   }
 }
+/* Ignored in GECKOVIEW: end */
 
 .annotationEditorLayer {
   :is(.freeTextEditor, .inkEditor, .stampEditor, .signatureEditor) {
@@ -891,6 +916,7 @@
     }
   }
 }
+/* Ignored in GECKOVIEW: begin */
 
 .dialog.altText {
   &::backdrop {
@@ -1557,3 +1583,4 @@
     }
   }
 }
+/* Ignored in GECKOVIEW: end */

--- a/web/pdf_viewer.css
+++ b/web/pdf_viewer.css
@@ -33,8 +33,8 @@
 @import url(text_layer_builder.css);
 @import url(annotation_layer_builder.css);
 @import url(xfa_layer_builder.css);
-/* Ignored in GECKOVIEW: begin */
 @import url(annotation_editor_layer_builder.css);
+/* Ignored in GECKOVIEW: begin */
 @import url(menu.css);
 @import url(tree.css);
 @import url(views_manager.css);


### PR DESCRIPTION
Adds CSS for the annotation editor into GeckoView. A follow-up is planned in bug 2061836 to update to the new grey style for Android.