### PR TITLE
fix: use a valid ARIA role for the viewer region

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -465,7 +465,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       <span data-l10n-id="pdfjs-editor-comment-button-label"></span>
                     </button>
                     <div class="editorParamsToolbar hidden menu" id="editorCommentParamsToolbar">
-                      <div id="editorCommentsSidebar" class="menuContainer comment sidebar" role="landmark" aria-labelledby="editorCommentsSidebarHeader">
+                      <div id="editorCommentsSidebar" class="menuContainer comment sidebar" role="region" aria-labelledby="editorCommentsSidebarHeader">
                         <div id="editorCommentsSidebarResizer" class="sidebarResizer" role="separator" aria-controls="editorCommentsSidebar" tabindex="0"></div>
                         <div id="editorCommentsSidebarHeader" role="heading" aria-level="2">
                           <span class="commentCount">


### PR DESCRIPTION
## Summary

Replace the invalid landmark role with the valid region role in the PDF.js viewer.

## Validation

HTML source assertions and git diff --check passed.

Closes #20114