### PR TITLE
Use a "normal" import statement to access the `importPrintedAppearances` function, in the `src/core/worker.js` file (PR 21858 follow-up)

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -31,6 +31,7 @@ import { LocalPdfManager, NetworkPdfManager } from "./pdf_manager.js";
 import { MessageHandler, wrapReason } from "../shared/message_handler.js";
 import { AnnotationFactory } from "./annotation.js";
 import { clearGlobalCaches } from "./cleanup_helper.js";
+import { importPrintedAppearances } from "./editor/print_appearances.js";
 import { incrementalUpdate } from "./writer.js";
 import { PDFEditor } from "./editor/pdf_editor.js";
 import { PDFWorkerStream } from "./worker_stream.js";
@@ -705,10 +706,6 @@ class WorkerMessageHandler {
         if (!buffer) {
           return;
         }
-        const { importPrintedAppearances } =
-          typeof PDFJSDev === "undefined"
-            ? await import("./editor/print_appearances.js")
-            : await __eager_import__("./editor/print_appearances.js");
         const appearances = await importPrintedAppearances({
           buffer,
           changes,


### PR DESCRIPTION
Currently this code is accessed with a dynamic import, which has the unfortunate side-effect of inflating the size of the *built* `pdf.worker.mjs` file a whole lot.

Given the relatively small size of the `src/core/editor/print_appearances.js` file it really doesn't seem like an issue to just bundle that code unconditionally, and the existing pre-processor checks means that the `importPrintedAppearances` code will only be invoked in MOZCENTRAL builds.

*NOTE:* This patch reduces the size of the `gulp mozcentral` bundle by `96` kilo-bytes, which I think is way too much to ignore.