### PR TITLE
Fix the `Iterator.prototype.join` polyfill on engines without `Iterator`

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1154,9 +1154,16 @@ if (
 }
 
 // TODO: Remove this once `Iterator.prototype.join` is generally available.
-if (typeof Iterator.prototype.join !== "function") {
+// Note that `typeof` cannot guard a member expression, hence the `Iterator`
+// global must not be dereferenced directly since that throws a `ReferenceError`
+// on engines without it; `%IteratorPrototype%` is instead reachable through any
+// built-in iterator, and is the very same object as `Iterator.prototype`.
+const iteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([][Symbol.iterator]())
+);
+if (typeof iteratorPrototype.join !== "function") {
   // eslint-disable-next-line no-extend-native
-  Iterator.prototype.join = function (separator) {
+  iteratorPrototype.join = function (separator) {
     return [...this].join(separator);
   };
 }


### PR DESCRIPTION
### Steps to reproduce

On an engine that doesn't have the `Iterator` global (Chrome/WebView < 122, Firefox < 131, Safari < 18.4), importing any build throws while the module is being evaluated:

```js
delete globalThis.Iterator;                        // simulate such an engine
await import("pdfjs-dist@6.3.289/build/pdf.mjs");
// Uncaught ReferenceError: Iterator is not defined
```

### The problem

`src/shared/util.js` currently contains:

```js
// TODO: Remove this once `Iterator.prototype.join` is generally available.
if (typeof Iterator.prototype.join !== "function") {
  Iterator.prototype.join = function (separator) { ... };
}
```

`typeof` only protects a bare identifier; `Iterator.prototype` is evaluated first, so on such engines the module throws *while it is evaluated* and pdf.js becomes impossible to import at all — not just `join` being unavailable.

`Iterator.prototype.join` is not generally available yet (Chrome 153, Firefox 154, Safari TP), so the polyfill is currently load-bearing and cannot simply be skipped; it's needed by the two call-sites added in #21585, which both use built-in Map iterators:

- `data.values().join("")` — `src/core/xfa/factory.js`
- `CHARACTERS_TO_NORMALIZE.keys().join("")` — `web/pdf_find_controller.js`

Note that pdf.js already uses `Promise.withResolvers()` unguarded (Chrome 119 / Safari 17.4), so engines in that window (e.g. Safari 17.4–18.3, Chrome 119–121) are able to run pdf.js today; for them this is a regression that takes the whole library down.

### The fix

Polyfill `%IteratorPrototype%` instead, which is reachable through any built-in iterator and is the very same object as `Iterator.prototype` where the global exists:

```js
const iteratorPrototype = Object.getPrototypeOf(
  Object.getPrototypeOf([][Symbol.iterator]())
);
```

Behavior is unchanged on every engine — the only difference is that no global which may not exist is dereferenced anymore.

### Verification

Running the patched snippet in a Node `vm` realm, then exercising the call-site shapes (`map.keys().join("|")`, `map.values().join("")`, `Set.values().join(",")`, a generator's `.join("-")`):

- engine with `Iterator` but without `join` (current Chrome/Firefox/Node): all four work as before;
- engine without `Iterator` (`delete Iterator`): the module no longer throws and all four still work.

Real-world report: this broke the document preview of an app that bundles `pdfjs-dist` and runs in an Android-WebView based browser (HarmonyOS "Zhuoyitong" compatibility layer, no `Iterator`), where the `ReferenceError` takes down the entire client bundle at import.
