### PR TITLE
Fix the DirectWrite rendering mode used by the reference tests on Windows

### DIFF
--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1088,6 +1088,9 @@ async function startBrowser({
       // Disable WebGPU (prevents log spam on Windows, and environments like
       // GitHub Actions don't expose GPUs anyway).
       "dom.webgpu.enabled": false,
+      // Don't derive the DirectWrite rendering mode from the system settings:
+      // the text rendering is otherwise not reproducible on Windows.
+      "gfx.font_rendering.cleartype_params.rendering_mode": 0,
       // It's helpful to see where the caret is.
       "accessibility.browsewithcaret": true,
       // Disable the newtabpage stuff.


### PR DESCRIPTION
With the default value of the pref, Firefox derives the rendering mode from the system settings and the text rendering differs from one run to the other on Windows, which makes hundreds of reference test pages fail in the GitHub CI for nothing. Forcing the mode makes it reproducible.