### PR TITLE
Avoid manual loops when generating some simple Arrays/TypedArrays

### DIFF
--- a/src/core/cmap.js
+++ b/src/core/cmap.js
@@ -422,11 +422,7 @@ class IdentityCMap extends CMap {
 
   getMap() {
     // Sometimes identity maps must be instantiated, but it's rare.
-    const map = new Array(0x10000);
-    for (let i = 0; i <= 0xffff; i++) {
-      map[i] = i;
-    }
-    return map;
+    return Array.from({ length: 0x10000 }, (_, i) => i);
   }
 
   get length() {

--- a/src/core/crypto.js
+++ b/src/core/crypto.js
@@ -56,12 +56,9 @@ class ARCFourCipher {
   b = 0;
 
   constructor(key) {
-    const s = new Uint8Array(256);
+    const s = Uint8Array.from({ length: 256 }, (_, i) => i);
     const keyLength = key.length;
 
-    for (let i = 0; i < 256; ++i) {
-      s[i] = i;
-    }
     for (let i = 0, j = 0; i < 256; ++i) {
       const tmp = s[i];
       j = (j + tmp + key[i % keyLength]) & 0xff;

--- a/src/core/lzw_stream.js
+++ b/src/core/lzw_stream.js
@@ -30,14 +30,13 @@ class LZWStream extends DecodeStream {
       codeLength: 9,
       nextCode: 258,
       dictionaryValues: new Uint8Array(maxLzwDictionarySize),
-      dictionaryLengths: new Uint16Array(maxLzwDictionarySize),
+      dictionaryLengths: new Uint16Array(maxLzwDictionarySize).fill(1, 0, 256),
       dictionaryPrevCodes: new Uint16Array(maxLzwDictionarySize),
       currentSequence: new Uint8Array(maxLzwDictionarySize),
       currentSequenceLength: 0,
     };
     for (let i = 0; i < 256; ++i) {
       lzwState.dictionaryValues[i] = i;
-      lzwState.dictionaryLengths[i] = 1;
     }
     this.lzwState = lzwState;
   }


### PR DESCRIPTION
Also, utilize `TypedArray.prototype.fill` in the `src/core/lzw_stream.js` file.
