### PR TITLE
Run the "gets current workerSrc" unit-test in Node.js (PR 17055 follow-up)

### DIFF
--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -1189,11 +1189,7 @@ describe("api", function () {
     });
 
     it("gets current workerSrc", function () {
-      if (isNodeJS) {
-        pending("Worker is not supported in Node.js.");
-      }
-
-      const workerSrc = PDFWorker.workerSrc;
+      const { workerSrc } = PDFWorker;
       expect(typeof workerSrc).toEqual("string");
       expect(workerSrc).toEqual(GlobalWorkerOptions.workerSrc);
     });


### PR DESCRIPTION
Compared to all the other unit-tests in the "PDFWorker" describe-block this one doesn't actually depend on Workers being available, since it only checks basic API functionality.
The reason that this unit-test was disabled in Node.js is that prior to PR #17055 the `GlobalWorkerOptions.workerSrc` option wasn't guaranteed to be set there.