### PR TITLE
Fix intermittent failures in the `PDFDocumentProperties` tests (PR 21938 follow-up)

### DIFF
--- a/test/integration/document_properties_spec.mjs
+++ b/test/integration/document_properties_spec.mjs
@@ -52,20 +52,19 @@ async function closeDocumentProperties(page) {
 
 async function checkFieldProperties(page, expectedProps) {
   await page.waitForFunction(
-    `document.getElementById("fileSizeField").textContent !== "-"`
+    (fields, expected) => {
+      for (const name of fields) {
+        const field = document.getElementById(`${name}Field`);
+        if (field.textContent !== expected[name]) {
+          return false;
+        }
+      }
+      return true;
+    },
+    {},
+    FIELDS,
+    expectedProps
   );
-  const promises = [];
-
-  for (const name of FIELDS) {
-    promises.push(
-      page.evaluate(
-        n => [n, document.getElementById(`${n}Field`).textContent],
-        name
-      )
-    );
-  }
-  const props = Object.fromEntries(await Promise.all(promises));
-  expect(props).toEqual(expectedProps);
 }
 
 function getFieldDataLastUpdated(page) {


### PR DESCRIPTION
After PR #21938 the integration-tests have started failing intermittently, but only in Google Chrome, so let's wait for *all* fields explicitly rather than just one of them.